### PR TITLE
🧪 [testing improvement] Add unit tests for i18n translation functions

### DIFF
--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -297,7 +297,7 @@ pub async fn auto_assign_rooms(
     }
 
     let mut floors_sorted: Vec<(i32, Vec<&Room>)> = floor_groups.into_iter().collect();
-    floors_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    floors_sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     let mut assignments = Vec::new();
     let needed = req.room_count as usize;

--- a/mhm/src/lib/i18n.test.ts
+++ b/mhm/src/lib/i18n.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { setLocale, getLocale, t, type Locale } from "./i18n";
+
+describe("i18n", () => {
+    beforeEach(() => {
+        // Reset localStorage and locale before each test
+        localStorage.clear();
+        setLocale("vi");
+    });
+
+    describe("locale management", () => {
+        it("should return the default locale (vi)", () => {
+            expect(getLocale()).toBe("vi");
+        });
+
+        it("should update the locale and store it in localStorage", () => {
+            setLocale("en");
+            expect(getLocale()).toBe("en");
+            expect(localStorage.getItem("locale")).toBe("en");
+
+            setLocale("vi");
+            expect(getLocale()).toBe("vi");
+            expect(localStorage.getItem("locale")).toBe("vi");
+        });
+    });
+
+    describe("translation function (t)", () => {
+        it("should return the translated string for a valid key in the default locale", () => {
+            setLocale("vi");
+            expect(t("nav.dashboard")).toBe("Dashboard");
+            expect(t("nav.reservations")).toBe("Đặt phòng");
+        });
+
+        it("should return the translated string for a valid key when the locale is changed", () => {
+            setLocale("en");
+            expect(t("nav.reservations")).toBe("Reservations");
+            expect(t("guests.total")).toBe("Total Guests");
+        });
+
+        it("should fall back to returning the key if it is not found", () => {
+            expect(t("unknown.key")).toBe("unknown.key");
+            expect(t("another.missing.key")).toBe("another.missing.key");
+        });
+
+        it("should fallback to 'vi' if current locale translation is somehow missing", () => {
+            // Force a non-existent locale to test the fallback behavior
+            setLocale("fr" as Locale);
+            expect(t("nav.reservations")).toBe("Đặt phòng"); // Should fallback to "vi"
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests were added for the internationalization (i18n) functions in `mhm/src/lib/i18n.ts`, including `t()`, `setLocale()`, and `getLocale()`.

📊 **Coverage:** What scenarios are now tested
- Locale state management (default locale, updating locale, and localStorage integration).
- `t()` function translating standard keys.
- `t()` function responding correctly when locale is changed.
- `t()` falling back to the translation key when a key is not found.
- `t()` falling back to default language (`vi`) when the translation for the current locale is missing.

✨ **Result:** The improvement in test coverage
The critical `t` function used heavily throughout the app is now fully unit tested, improving coverage and preventing regressions during future refactors or translation updates.

---
*PR created automatically by Jules for task [11278824115162357285](https://jules.google.com/task/11278824115162357285) started by @chuanman2707*