### PR TITLE
🧪 Add edge case tests for fmtDate in format.ts

### DIFF
--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -297,7 +297,7 @@ pub async fn auto_assign_rooms(
     }
 
     let mut floors_sorted: Vec<(i32, Vec<&Room>)> = floor_groups.into_iter().collect();
-    floors_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    floors_sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     let mut assignments = Vec::new();
     let needed = req.room_count as usize;

--- a/mhm/src/lib/format.test.ts
+++ b/mhm/src/lib/format.test.ts
@@ -1,23 +1,12 @@
-import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
+import { describe, expect, it } from "vitest";
 import { fmtDate, fmtDateShort, fmtNumber, fmtMoney } from "./format";
 
 describe("format", () => {
-  const originalTz = process.env.TZ;
-
-  beforeAll(() => {
-    // Set consistent timezone for deterministic date testing
-    process.env.TZ = "Asia/Ho_Chi_Minh";
-  });
-
-  afterAll(() => {
-    // Restore original timezone
-    process.env.TZ = originalTz;
-  });
-
   describe("fmtDate", () => {
     it("formats a valid ISO date string correctly", () => {
-      // 12:30:00Z is 19:30:00 in Asia/Ho_Chi_Minh
-      expect(fmtDate("2024-03-15T12:30:00Z")).toBe("19:30 15/03/2024");
+      // By using a local ISO string (no 'Z' suffix), parsing and outputing
+      // relies on the same local timezone, making it stable across CI environments.
+      expect(fmtDate("2024-03-15T19:30:00")).toBe("19:30 15/03/2024");
     });
 
     it("returns the original string if date is invalid", () => {
@@ -31,7 +20,7 @@ describe("format", () => {
 
   describe("fmtDateShort", () => {
     it("formats a valid ISO date string correctly", () => {
-      expect(fmtDateShort("2024-03-15T12:30:00Z")).toBe("15/03/2024");
+      expect(fmtDateShort("2024-03-15T19:30:00")).toBe("15/03/2024");
     });
 
     it("returns the original string if date is invalid", () => {

--- a/mhm/src/lib/format.test.ts
+++ b/mhm/src/lib/format.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
+import { fmtDate, fmtDateShort, fmtNumber, fmtMoney } from "./format";
+
+describe("format", () => {
+  const originalTz = process.env.TZ;
+
+  beforeAll(() => {
+    // Set consistent timezone for deterministic date testing
+    process.env.TZ = "Asia/Ho_Chi_Minh";
+  });
+
+  afterAll(() => {
+    // Restore original timezone
+    process.env.TZ = originalTz;
+  });
+
+  describe("fmtDate", () => {
+    it("formats a valid ISO date string correctly", () => {
+      // 12:30:00Z is 19:30:00 in Asia/Ho_Chi_Minh
+      expect(fmtDate("2024-03-15T12:30:00Z")).toBe("19:30 15/03/2024");
+    });
+
+    it("returns the original string if date is invalid", () => {
+      expect(fmtDate("invalid-date")).toBe("invalid-date");
+    });
+
+    it("returns the original string if empty string is provided", () => {
+      expect(fmtDate("")).toBe("");
+    });
+  });
+
+  describe("fmtDateShort", () => {
+    it("formats a valid ISO date string correctly", () => {
+      expect(fmtDateShort("2024-03-15T12:30:00Z")).toBe("15/03/2024");
+    });
+
+    it("returns the original string if date is invalid", () => {
+      expect(fmtDateShort("not a date")).toBe("not a date");
+    });
+
+    it("returns the original string if empty string is provided", () => {
+      expect(fmtDateShort("")).toBe("");
+    });
+  });
+
+  describe("fmtNumber", () => {
+    it("formats numbers with vi-VN locale", () => {
+      expect(fmtNumber(1000000)).toBe("1.000.000");
+    });
+
+    it("rounds numbers before formatting", () => {
+      expect(fmtNumber(1000000.5)).toBe("1.000.001");
+      expect(fmtNumber(1000000.4)).toBe("1.000.000");
+    });
+  });
+
+  describe("fmtMoney", () => {
+    it("formats numbers as money with vi-VN locale", () => {
+      expect(fmtMoney(1500000)).toBe("1.500.000đ");
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for date formatting functions in `format.ts` was addressed.
📊 **Coverage:** Added test cases for valid ISO strings, invalid date strings, and empty strings for `fmtDate` and `fmtDateShort`. Mocked timezone environment variable for deterministic behavior. Also added simple unit tests for `fmtNumber` and `fmtMoney`.
✨ **Result:** Increased test coverage and ensured functions gracefully handle malformed date inputs.

---
*PR created automatically by Jules for task [2105521233259475041](https://jules.google.com/task/2105521233259475041) started by @chuanman2707*