### PR TITLE
Fix clippy::unnecessary-sort-by in groups.rs

### DIFF
--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -297,7 +297,7 @@ pub async fn auto_assign_rooms(
     }
 
     let mut floors_sorted: Vec<(i32, Vec<&Room>)> = floor_groups.into_iter().collect();
-    floors_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    floors_sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     let mut assignments = Vec::new();
     let needed = req.room_count as usize;


### PR DESCRIPTION
Fixes a clippy warning `unnecessary-sort-by` in `groups.rs` by replacing a custom closure with `sort_by_key` and `std::cmp::Reverse`.

---
*PR created automatically by Jules for task [10895054607373868912](https://jules.google.com/task/10895054607373868912) started by @chuanman2707*