### PR TITLE
[codex] fix Intel macOS release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,7 +392,7 @@ jobs:
     needs:
       - verify-version
       - verify-app
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed
- switch the `build-macos-x86_64` release job from `macos-13` to `macos-15-intel`

## Why
- the release workflow was leaving `build-macos-x86_64` queued indefinitely because the job requested the retired `macos-13` hosted runner label
- GitHub never assigned a runner to that job, so the release could not finish

## Impact
- Intel macOS release builds target a currently supported GitHub-hosted runner label
- the release workflow can proceed to the Intel artifact build and final publish stage again

## Validation
- parsed `.github/workflows/release.yml` after the edit and confirmed `jobs.build-macos-x86_64.runs-on == macos-15-intel`
- checked the isolated worktree diff to confirm the PR contains only the workflow label change

## Root cause
- `.github/workflows/release.yml` still used `runs-on: macos-13` for the Intel macOS release job even though that runner label has been retired