### PR TITLE
[codex] ship best-effort apple silicon mac releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,7 @@ jobs:
       - name: Build Windows updater artifacts
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
+          CAPYINN_ENABLE_UPDATER: "true"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
@@ -355,6 +356,7 @@ jobs:
       - name: Build Linux updater artifacts
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
+          CAPYINN_ENABLE_UPDATER: "true"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
@@ -448,6 +450,10 @@ jobs:
           config.bundle = {
             ...(config.bundle || {}),
             createUpdaterArtifacts: true,
+            macOS: {
+              ...(config.bundle?.macOS || {}),
+              signingIdentity: "-",
+            },
           };
 
           config.plugins = {
@@ -464,6 +470,7 @@ jobs:
       - name: Build macOS Apple Silicon updater artifacts
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
+          CAPYINN_ENABLE_UPDATER: "true"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
@@ -510,123 +517,6 @@ jobs:
           name: release-meta-macos-aarch64
           path: release-meta/darwin-aarch64.json
 
-  build-macos-x86_64:
-    needs:
-      - verify-version
-      - verify-app
-    runs-on: macos-15-intel
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: mhm/package-lock.json
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            mhm/src-tauri -> target
-
-      - name: Install frontend dependencies
-        working-directory: mhm
-        run: npm ci
-
-      - name: Validate updater configuration
-        shell: bash
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_UPDATER_PUBLIC_KEY: ${{ vars.TAURI_UPDATER_PUBLIC_KEY }}
-        run: |
-          [ -n "${TAURI_SIGNING_PRIVATE_KEY}" ] || { echo "TAURI_SIGNING_PRIVATE_KEY is required for release builds"; exit 1; }
-          [ -n "${TAURI_UPDATER_PUBLIC_KEY}" ] || { echo "TAURI_UPDATER_PUBLIC_KEY is required for generated updater config"; exit 1; }
-
-      - name: Prepare release config
-        shell: bash
-        working-directory: mhm
-        env:
-          TAURI_UPDATER_PUBLIC_KEY: ${{ vars.TAURI_UPDATER_PUBLIC_KEY }}
-        run: |
-          node <<'NODE'
-          const fs = require("fs");
-          const path = require("path");
-
-          const configPath = path.join("src-tauri", "tauri.conf.json");
-          const releaseConfigPath = path.join("src-tauri", "tauri.release.conf.json");
-          const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-
-          config.bundle = {
-            ...(config.bundle || {}),
-            createUpdaterArtifacts: true,
-          };
-
-          config.plugins = {
-            ...(config.plugins || {}),
-            updater: {
-              ...(config.plugins?.updater || {}),
-              pubkey: process.env.TAURI_UPDATER_PUBLIC_KEY,
-            },
-          };
-
-          fs.writeFileSync(releaseConfigPath, `${JSON.stringify(config, null, 2)}\n`);
-          NODE
-
-      - name: Build macOS Intel updater artifacts
-        uses: tauri-apps/tauri-action@action-v0.6.2
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          projectPath: ${{ env.PROJECT_PATH }}
-          args: --bundles app,dmg --config ${{ env.RELEASE_CONFIG_PATH }}
-
-      - name: Collect macOS Intel asset metadata
-        shell: bash
-        env:
-          APP_VERSION: ${{ needs.verify-version.outputs.app_version }}
-        run: |
-          mkdir -p release-assets/macos-x86_64 release-meta
-          asset_file="$(find mhm/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app.tar.gz' | head -n 1)"
-          sig_file="$(find mhm/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app.tar.gz.sig' | head -n 1)"
-          dmg_file="$(find mhm/src-tauri/target/release/bundle/dmg -maxdepth 1 -name '*.dmg' | head -n 1)"
-
-          [ -n "$asset_file" ] && [ -n "$sig_file" ] && [ -n "$dmg_file" ]
-
-          updater_name="CapyInn_${APP_VERSION}_x64.app.tar.gz"
-          updater_sig_name="${updater_name}.sig"
-          dmg_name="CapyInn_${APP_VERSION}_x64.dmg"
-
-          cp "$asset_file" "release-assets/macos-x86_64/${updater_name}"
-          cp "$sig_file" "release-assets/macos-x86_64/${updater_sig_name}"
-          cp "$dmg_file" "release-assets/macos-x86_64/${dmg_name}"
-
-          cat > release-meta/darwin-x86_64.json <<JSON
-          {
-            "platformKey": "darwin-x86_64",
-            "assetName": "${updater_name}",
-            "signature": "$(tr -d '\r\n' < "$sig_file")"
-          }
-          JSON
-
-      - name: Upload macOS Intel release assets
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-macos-x86_64
-          path: release-assets/macos-x86_64/*
-
-      - name: Upload macOS Intel release metadata
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-meta-macos-x86_64
-          path: release-meta/darwin-x86_64.json
-
   publish-release:
     needs:
       - verify-version
@@ -634,7 +524,6 @@ jobs:
       - build-windows
       - build-linux-x86_64
       - build-macos-aarch64
-      - build-macos-x86_64
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -677,7 +566,6 @@ jobs:
             path.join("release-downloads", "release-meta-linux", "linux-x86_64.json"),
             path.join("release-downloads", "release-meta-windows", "windows-x86_64.json"),
             path.join("release-downloads", "release-meta-macos-aarch64", "darwin-aarch64.json"),
-            path.join("release-downloads", "release-meta-macos-x86_64", "darwin-x86_64.json"),
           ];
 
           const platforms = {};
@@ -716,7 +604,6 @@ jobs:
               release-downloads/release-linux \
               release-downloads/release-windows \
               release-downloads/release-macos-aarch64 \
-              release-downloads/release-macos-x86_64 \
               -maxdepth 1 -type f -printf '%f\n' | sort
           )"
           duplicate_names="$(printf '%s\n' "$asset_names" | uniq -d)"
@@ -726,6 +613,36 @@ jobs:
             printf '%s\n' "$duplicate_names"
             exit 1
           fi
+
+      - name: Generate release notes
+        shell: bash
+        run: |
+          cat > release-downloads/release-notes.md <<'EOF'
+          ## Downloads
+
+          - Linux: download the `.AppImage`.
+          - Windows: download the `.exe` installer.
+          - macOS (Apple Silicon): download the `.dmg` asset, open it, and drag CapyInn into Applications.
+          - The macOS `.app.tar.gz` asset is for the in-app updater only and is not meant for manual installation.
+
+          ## macOS first launch
+
+          This macOS build is distributed without Apple notarization.
+
+          If macOS blocks the app on first launch:
+
+          1. Move CapyInn to `/Applications`.
+          2. Try `Right click > Open`.
+          3. If macOS still says the app is damaged or cannot be opened, run:
+
+             ```bash
+             xattr -dr com.apple.quarantine /Applications/CapyInn.app
+             ```
+
+          ## macOS updates
+
+          In-app updates on macOS are best-effort in this release channel. If an update fails or macOS blocks the refreshed app, download the latest Apple Silicon `.dmg` from this release and reinstall over the existing app.
+          EOF
 
       - name: Verify release payload exists before publish
         shell: bash
@@ -738,9 +655,7 @@ jobs:
           ls release-downloads/release-macos-aarch64/*.app.tar.gz
           ls release-downloads/release-macos-aarch64/*.sig
           ls release-downloads/release-macos-aarch64/*.dmg
-          ls release-downloads/release-macos-x86_64/*.app.tar.gz
-          ls release-downloads/release-macos-x86_64/*.sig
-          ls release-downloads/release-macos-x86_64/*.dmg
+          test -f release-downloads/release-notes.md
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
@@ -748,6 +663,7 @@ jobs:
           tag_name: ${{ needs.verify-version.outputs.tag_name }}
           name: CapyInn v${{ needs.verify-version.outputs.app_version }}
           prerelease: ${{ needs.verify-version.outputs.is_prerelease == 'true' }}
+          body_path: release-downloads/release-notes.md
           files: |
             release-downloads/release-linux/*.AppImage
             release-downloads/release-linux/*.sig
@@ -756,7 +672,4 @@ jobs:
             release-downloads/release-macos-aarch64/*.app.tar.gz
             release-downloads/release-macos-aarch64/*.sig
             release-downloads/release-macos-aarch64/*.dmg
-            release-downloads/release-macos-x86_64/*.app.tar.gz
-            release-downloads/release-macos-x86_64/*.sig
-            release-downloads/release-macos-x86_64/*.dmg
             release-downloads/latest.json

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -6,7 +6,7 @@ The workflow now runs in four stages:
 
 1. `verify-version` checks that the tag matches the version in `mhm/package.json`, `mhm/src-tauri/tauri.conf.json`, and `mhm/src-tauri/Cargo.toml`.
 2. `verify-app` runs the shared validation pass before any release artifacts are built.
-3. `build-linux-x86_64`, `build-windows`, `build-macos-aarch64`, and `build-macos-x86_64` each build one platform and emit per-platform metadata with the asset name and embedded updater signature.
+3. `build-linux-x86_64`, `build-windows`, and `build-macos-aarch64` each build one production platform and emit per-platform metadata with the asset name and embedded updater signature.
 4. `publish-release` downloads every build artifact, generates the canonical `latest.json`, verifies the full release payload exists, and only then creates the GitHub Release.
 
 ## Release trigger
@@ -85,7 +85,6 @@ Pushing `vX.Y.Z` produces a single GitHub Release containing:
 - a Linux `.AppImage` and its `.sig`
 - a Windows NSIS installer and its `.sig`
 - a macOS Apple Silicon `.app.tar.gz` updater package, its `.sig`, and a manual-install `.dmg`
-- a macOS Intel `.app.tar.gz` updater package, its `.sig`, and a manual-install `.dmg`
 - one canonical `latest.json`
 
 The generated `latest.json` keeps an explicit platform contract:
@@ -93,9 +92,8 @@ The generated `latest.json` keeps an explicit platform contract:
 - `linux-x86_64`
 - `windows-x86_64`
 - `darwin-aarch64`
-- `darwin-x86_64`
 
-Each manifest entry uses an immutable asset URL in the form `https://github.com/<owner>/<repo>/releases/download/vX.Y.Z/<asset-name>`. Mutable `releases/latest/...` URLs are intentionally rejected by the generator, and duplicate asset URLs across platform keys are rejected as invalid.
+Each manifest entry uses an immutable asset URL in the form `https://github.com/<owner>/<repo>/releases/download/vX.Y.Z/<asset-name>`. Mutable `releases/latest/...` URLs are intentionally rejected by the generator.
 
 ## Generated release config
 
@@ -103,21 +101,27 @@ The workflow creates `mhm/src-tauri/tauri.release.conf.json` inside CI for each 
 
 - enables `bundle.createUpdaterArtifacts`
 - injects `plugins.updater.pubkey` from `TAURI_UPDATER_PUBLIC_KEY`
+- sets `bundle.macOS.signingIdentity` to `-` on the Apple Silicon macOS job so CI produces an ad-hoc signed app bundle without paid Apple signing credentials
 - adds Windows signing metadata when a certificate thumbprint is available
+- runs the Tauri build with `CAPYINN_ENABLE_UPDATER=true` so the app only registers updater support in release builds that include the updater key
 
 Nothing in the checked-in Tauri config needs to carry release-only signing state.
+
+Local `tauri dev` and ad-hoc `tauri build` runs intentionally keep the updater plugin disabled unless you export `CAPYINN_ENABLE_UPDATER=true` and build against a config that already includes `plugins.updater.pubkey`. This avoids startup panics from partial updater configuration in non-release builds.
 
 ## Runtime behavior
 
 - Windows: the app downloads the update, shows `Restart to update / Later`, and exits into the installer flow when the user confirms.
 - macOS: the app downloads the update, shows `Restart to update / Later`, and installs plus relaunches when the user confirms.
+- macOS direct-download installs use the Apple Silicon `.dmg`. The `.app.tar.gz` file remains an updater artifact and is not intended for manual installation.
+- macOS distribution in this repository is intentionally best-effort: the Apple Silicon app is ad-hoc signed but not notarized, so Gatekeeper may still require `Right click > Open` or quarantine removal on first launch.
 
 ## What the workflow does
 
 1. Verifies version alignment across package, Tauri, Cargo, and tag metadata.
 2. Runs the shared verification pass before any release build starts.
-3. Builds Linux, Windows, macOS Apple Silicon, and macOS Intel artifacts in isolated jobs.
+3. Builds Linux, Windows, and macOS Apple Silicon artifacts in isolated jobs.
 4. Collects per-platform metadata so the final publish job can assemble immutable manifest URLs.
-5. Renames macOS updater assets per architecture before upload so GitHub Release asset URLs stay unique.
-6. Generates `latest.json` with `mhm/scripts/generate-latest-json.mjs`.
-7. Creates the GitHub Release only after every asset and `latest.json` are present.
+5. Generates `latest.json` with `mhm/scripts/generate-latest-json.mjs`.
+6. Generates GitHub Release notes that tell macOS users to install from the Apple Silicon `.dmg` and explain the Gatekeeper fallback path.
+7. Creates the GitHub Release only after every asset, `latest.json`, and the generated release notes are present.

--- a/mhm/scripts/generate-latest-json.mjs
+++ b/mhm/scripts/generate-latest-json.mjs
@@ -6,7 +6,6 @@ const REQUIRED_PLATFORM_KEYS = [
   "linux-x86_64",
   "windows-x86_64",
   "darwin-aarch64",
-  "darwin-x86_64",
 ];
 
 function assertNonEmptyString(value, fieldName) {

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex, Once};
 use std::time::Duration;
 
 static LOG_INIT: Once = Once::new();
+const UPDATER_ENABLE_ENV: &str = "CAPYINN_ENABLE_UPDATER";
 
 struct GatewayRuntimeState {
     runtime: Mutex<Option<tokio::runtime::Runtime>>,
@@ -80,6 +81,17 @@ fn init_logging() {
     });
 }
 
+fn updater_enabled_from_env(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn updater_enabled() -> bool {
+    updater_enabled_from_env(std::env::var(UPDATER_ENABLE_ENV).ok().as_deref())
+}
+
 /// Run the Tauri GUI application with MCP Gateway
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -91,9 +103,16 @@ pub fn run() {
         .setup(|app| {
             #[cfg(desktop)]
             {
-                app.handle()
-                    .plugin(tauri_plugin_updater::Builder::new().build())
-                    .expect("failed to register updater plugin");
+                if updater_enabled() {
+                    app.handle()
+                        .plugin(tauri_plugin_updater::Builder::new().build())
+                        .expect("failed to register updater plugin");
+                } else {
+                    info!(
+                        "Updater plugin disabled because {} is not enabled for this build",
+                        UPDATER_ENABLE_ENV
+                    );
+                }
             }
 
             let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
@@ -276,4 +295,24 @@ async fn gateway_get_status(
         "port": port,
         "has_api_keys": has_keys,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::updater_enabled_from_env;
+
+    #[test]
+    fn updater_stays_disabled_without_an_explicit_release_flag() {
+        assert!(!updater_enabled_from_env(None));
+        assert!(!updater_enabled_from_env(Some("")));
+        assert!(!updater_enabled_from_env(Some("false")));
+    }
+
+    #[test]
+    fn updater_accepts_common_truthy_release_flags() {
+        assert!(updater_enabled_from_env(Some("1")));
+        assert!(updater_enabled_from_env(Some("true")));
+        assert!(updater_enabled_from_env(Some("YES")));
+        assert!(updater_enabled_from_env(Some(" on ")));
+    }
 }

--- a/mhm/src/App.tsx
+++ b/mhm/src/App.tsx
@@ -92,6 +92,7 @@ export default function App() {
     (!bootstrap?.app_lock_enabled || isAuthenticated);
   const appUpdate = useAppUpdateController({
     enabled: shellReady,
+    supported: __UPDATER_ENABLED__,
     currentVersion: __APP_VERSION__,
   });
 

--- a/mhm/src/hooks/useAppUpdateController.test.tsx
+++ b/mhm/src/hooks/useAppUpdateController.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { relaunch } from "@/__mocks__/tauri-process";
 import {
+  check,
   clearMockUpdate,
   setMockAvailableUpdate,
   setMockCheckError,
@@ -33,7 +34,7 @@ describe("useAppUpdateController", () => {
     setMockAvailableUpdate({ version: "0.2.0" });
 
     const { result } = renderHook(() =>
-      useAppUpdateController({ enabled: true, currentVersion: "0.1.0" }),
+      useAppUpdateController({ enabled: true, supported: true, currentVersion: "0.1.0" }),
     );
 
     await act(async () => {
@@ -65,7 +66,7 @@ describe("useAppUpdateController", () => {
     });
 
     const { result } = renderHook(() =>
-      useAppUpdateController({ enabled: true, currentVersion: "0.1.0" }),
+      useAppUpdateController({ enabled: true, supported: true, currentVersion: "0.1.0" }),
     );
 
     await act(async () => {
@@ -89,7 +90,7 @@ describe("useAppUpdateController", () => {
     setMockAvailableUpdate({ version: "0.2.0" });
 
     const { result } = renderHook(() =>
-      useAppUpdateController({ enabled: true, currentVersion: "0.1.0" }),
+      useAppUpdateController({ enabled: true, supported: true, currentVersion: "0.1.0" }),
     );
 
     await act(async () => {
@@ -112,7 +113,7 @@ describe("useAppUpdateController", () => {
     setMockAvailableUpdate({ version: "0.2.0" });
 
     const { result } = renderHook(() =>
-      useAppUpdateController({ enabled: true, currentVersion: "0.1.0" }),
+      useAppUpdateController({ enabled: true, supported: true, currentVersion: "0.1.0" }),
     );
 
     await act(async () => {
@@ -139,7 +140,7 @@ describe("useAppUpdateController", () => {
     });
 
     const { result } = renderHook(() =>
-      useAppUpdateController({ enabled: true, currentVersion: "0.1.0", timeoutMs: 30_000 }),
+      useAppUpdateController({ enabled: true, supported: true, currentVersion: "0.1.0", timeoutMs: 30_000 }),
     );
 
     await act(async () => {
@@ -160,7 +161,7 @@ describe("useAppUpdateController", () => {
     setMockCheckError(new Error("manifest 404"));
 
     const { result } = renderHook(() =>
-      useAppUpdateController({ enabled: true, currentVersion: "0.1.0" }),
+      useAppUpdateController({ enabled: true, supported: true, currentVersion: "0.1.0" }),
     );
 
     await act(async () => {
@@ -172,5 +173,19 @@ describe("useAppUpdateController", () => {
       await result.current.checkForUpdates({ silent: false });
     });
     expect(result.current.errorMessage).toMatch(/404/i);
+  });
+
+  it("does not call the updater plugin when the current build does not support updater", async () => {
+    const { result } = renderHook(() =>
+      useAppUpdateController({ enabled: true, supported: false, currentVersion: "0.1.0" }),
+    );
+
+    await act(async () => {
+      await result.current.checkForUpdates({ silent: false });
+    });
+
+    expect(check).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.errorMessage).toBeNull();
   });
 });

--- a/mhm/src/hooks/useAppUpdateController.ts
+++ b/mhm/src/hooks/useAppUpdateController.ts
@@ -8,6 +8,7 @@ type Update = NonNullable<Awaited<ReturnType<typeof check>>>;
 
 interface UseAppUpdateControllerOptions {
     enabled: boolean;
+    supported: boolean;
     currentVersion: string;
     timeoutMs?: number;
 }
@@ -69,6 +70,7 @@ function mapInstallFailure(error: unknown): { phase: AppUpdatePhase; message: st
 
 export function useAppUpdateController({
     enabled,
+    supported,
     currentVersion,
     timeoutMs = DEFAULT_TIMEOUT_MS,
 }: UseAppUpdateControllerOptions): AppUpdateState & {
@@ -85,7 +87,12 @@ export function useAppUpdateController({
     const [restartPromptOpen, setRestartPromptOpen] = useState(false);
     const [pendingUpdate, setPendingUpdate] = useState<Update | null>(null);
 
-    const canCheck = enabled && phase !== "checking" && phase !== "downloading" && phase !== "installing";
+    const canCheck =
+        supported &&
+        enabled &&
+        phase !== "checking" &&
+        phase !== "downloading" &&
+        phase !== "installing";
 
     async function checkForUpdates({ silent }: CheckOptions) {
         if (!canCheck) {
@@ -169,6 +176,7 @@ export function useAppUpdateController({
 
     return useMemo(
         () => ({
+            supported,
             phase,
             currentVersion,
             availableVersion,
@@ -193,6 +201,7 @@ export function useAppUpdateController({
             openRestartPrompt,
             phase,
             restartPromptOpen,
+            supported,
         ],
     );
 }

--- a/mhm/src/pages/settings/SoftwareUpdateSection.tsx
+++ b/mhm/src/pages/settings/SoftwareUpdateSection.tsx
@@ -7,6 +7,7 @@ export default function SoftwareUpdateSection() {
     update.phase === "checking" ||
     update.phase === "downloading" ||
     update.phase === "installing";
+  const updatesUnavailable = !update.supported;
 
   return (
     <div className="space-y-6 max-w-lg">
@@ -33,7 +34,7 @@ export default function SoftwareUpdateSection() {
         <Button
           variant="outline"
           onClick={() => void update.checkForUpdates({ silent: false })}
-          disabled={isBusy}
+          disabled={isBusy || updatesUnavailable}
         >
           Check for updates
         </Button>
@@ -49,7 +50,13 @@ export default function SoftwareUpdateSection() {
 
       {update.errorMessage && <p className="text-xs text-rose-600">{update.errorMessage}</p>}
 
-      {!update.availableVersion && update.phase === "idle" && (
+      {updatesUnavailable && (
+        <p className="text-xs text-brand-muted">
+          Updates are only available in release builds that include the updater signing key.
+        </p>
+      )}
+
+      {!updatesUnavailable && !update.availableVersion && update.phase === "idle" && (
         <p className="text-xs text-emerald-600">You are on the latest version.</p>
       )}
     </div>

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -212,6 +212,7 @@ export type AppUpdatePhase =
   | "error";
 
 export interface AppUpdateState {
+  supported: boolean;
   phase: AppUpdatePhase;
   currentVersion: string;
   availableVersion: string | null;

--- a/mhm/src/vite-env.d.ts
+++ b/mhm/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __UPDATER_ENABLED__: boolean;
 
 declare module "@tauri-apps/plugin-updater" {
     export interface Update {

--- a/mhm/tests/scripts/generate-latest-json.test.ts
+++ b/mhm/tests/scripts/generate-latest-json.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildLatestManifest } from "../../scripts/generate-latest-json.mjs";
 
 describe("buildLatestManifest", () => {
-  it("builds a single manifest with all required production targets", () => {
+  it("builds a single manifest with the supported production updater targets", () => {
     const manifest = buildLatestManifest({
       version: "0.2.0",
       notes: "Release body",
@@ -12,10 +12,6 @@ describe("buildLatestManifest", () => {
         "linux-x86_64": {
           signature: "linux-sig",
           url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn_0.2.0_amd64.AppImage",
-        },
-        "darwin-x86_64": {
-          signature: "mac-intel-sig",
-          url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn-x64.app.tar.gz",
         },
         "windows-x86_64": {
           signature: "windows-sig",
@@ -45,17 +41,12 @@ describe("buildLatestManifest", () => {
           signature: "mac-arm-sig",
           url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn.app.tar.gz",
         },
-        "darwin-x86_64": {
-          signature: "mac-intel-sig",
-          url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn-x64.app.tar.gz",
-        },
       },
     });
     expect(Object.keys(manifest.platforms)).toEqual([
       "linux-x86_64",
       "windows-x86_64",
       "darwin-aarch64",
-      "darwin-x86_64",
     ]);
   });
 
@@ -78,10 +69,6 @@ describe("buildLatestManifest", () => {
             signature: "sig",
             url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn.app.tar.gz",
           },
-          "darwin-x86_64": {
-            signature: "sig",
-            url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn-x64.app.tar.gz",
-          },
         },
       }),
     ).toThrow(/immutable/i);
@@ -98,17 +85,13 @@ describe("buildLatestManifest", () => {
             signature: "sig",
             url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn_0.2.0_amd64.AppImage",
           },
-          "darwin-aarch64": {
-            signature: "sig",
-            url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn.app.tar.gz",
-          },
           "windows-x86_64": {
             signature: "sig",
             url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/app.exe",
           },
         },
       }),
-    ).toThrow(/missing required platform key: darwin-x86_64/i);
+    ).toThrow(/missing required platform key: darwin-aarch64/i);
   });
 
   it("rejects malformed manifests with empty signatures", () => {
@@ -130,16 +113,12 @@ describe("buildLatestManifest", () => {
             signature: "sig",
             url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn.app.tar.gz",
           },
-          "darwin-x86_64": {
-            signature: "sig",
-            url: "https://github.com/chuanman2707/CapyInn/releases/download/v0.2.0/CapyInn-x64.app.tar.gz",
-          },
         },
       }),
     ).toThrow(/signature/i);
   });
 
-  it("rejects manifests that reuse the same asset URL across platforms", () => {
+  it("rejects manifests that still include the retired Intel macOS updater target", () => {
     expect(() =>
       buildLatestManifest({
         version: "0.2.0",
@@ -164,6 +143,6 @@ describe("buildLatestManifest", () => {
           },
         },
       }),
-    ).toThrow(/duplicate asset url/i);
+    ).toThrow(/unexpected platform key: darwin-x86_64/i);
   });
 });

--- a/mhm/vite.config.ts
+++ b/mhm/vite.config.ts
@@ -4,11 +4,15 @@ import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
 const host = process.env.TAURI_DEV_HOST;
+const updaterEnabled = ["1", "true", "yes", "on"].includes(
+  (process.env.CAPYINN_ENABLE_UPDATER ?? "").toLowerCase(),
+);
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? "0.0.0"),
+    __UPDATER_ENABLED__: JSON.stringify(updaterEnabled),
   },
   plugins: [react(), tailwindcss()],
   resolve: {

--- a/mhm/vitest.config.ts
+++ b/mhm/vitest.config.ts
@@ -5,6 +5,7 @@ import path from "path";
 export default defineConfig({
     define: {
         __APP_VERSION__: JSON.stringify("0.1.0"),
+        __UPDATER_ENABLED__: JSON.stringify(true),
     },
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
## Summary
- disable the updater plugin unless `CAPYINN_ENABLE_UPDATER=true` so local/dev mac builds stop panicking when `plugins.updater.pubkey` is missing
- keep macOS releases Apple Silicon only, publish a manual-install `.dmg`, and retain the updater `.app.tar.gz` for best-effort in-app updates
- generate GitHub release notes with Gatekeeper fallback steps and document the ad-hoc signing release contract

## Why
The current macOS path had two separate problems:
- local or ad-hoc builds could crash at startup because the app always registered the Tauri updater plugin even when the release-only updater `pubkey` was absent
- the release workflow still targeted Intel macOS and did not provide clear manual-install guidance for unsigned Apple Silicon builds

## Validation
- `npm test -- tests/scripts/generate-latest-json.test.ts`
- `npm test -- src/hooks/useAppUpdateController.test.tsx`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml updater_`
- `npm run build`
- `cargo check --manifest-path mhm/src-tauri/Cargo.toml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml ok"'`
- `git diff --check`