### PR TITLE
Refactor pricing pipeline into a shared core path

### DIFF
--- a/docs/superpowers/specs/2026-04-19-pricing-pipeline-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-19-pricing-pipeline-refactor-design.md
@@ -1,0 +1,325 @@
+# HotelManager Pricing Pipeline Refactor Design
+
+Date: 2026-04-19
+Owner: Codex
+Status: Draft approved for spec write-up
+
+## Goal
+
+Refactor `mhm/src-tauri/src/domain/booking/pricing.rs` so the stay-pricing pipeline is split into three explicit phases:
+
+- load inputs
+- build effective pricing rule
+- calculate price
+
+The refactor should make four things true:
+
+- `calculate_stay_price_tx(...)` stops mixing database reads, fallback-rule construction, and pricing-engine invocation in one function
+- `calculate_stay_price(...)` and `calculate_stay_price_tx(...)` share one core pricing path after data loading
+- fallback pricing behavior is defined in one internal place instead of being duplicated across `tx` and non-`tx` helpers
+- the current booking flows and pricing results keep working without public API changes
+
+This design is intentionally a focused backend refactor. It does not introduce new pricing features, new pricing models, or a new public contract in this pass.
+
+## User Decisions Locked In
+
+The following decisions were explicitly chosen during brainstorming and are part of this spec:
+
+- selected approach: structured hybrid
+- public behavior: preserve current public API and booking-flow behavior
+- internal contract flexibility: helper and struct names may change if that produces cleaner boundaries
+- file layout: keep the refactor inside `mhm/src-tauri/src/domain/booking/pricing.rs`
+- architectural target: separate the pipeline into `load inputs -> build effective rule -> calculate`
+
+## Constraints
+
+- `calculate_stay_price_tx(...)` currently has a `CRITICAL` upstream blast radius in GitNexus, with direct callers in:
+  - `reservation_lifecycle::create_reservation`
+  - `reservation_lifecycle::confirm_reservation`
+  - `reservation_lifecycle::modify_reservation`
+  - `stay_lifecycle::check_in`
+  - `stay_lifecycle::extend_stay`
+  - `group_lifecycle::group_checkin`
+  - booking tests
+- the `tx` path must keep reading uncommitted pricing data inside the current transaction
+- the regression guard for that invariant already exists in `calculate_stay_price_tx_reads_uncommitted_pricing_rule`
+- `crate::pricing::calculate_price(...)` in `mhm/src-tauri/src/pricing.rs` is already the pure pricing engine and should remain the calculation endpoint
+- the duplicate logic today is not only in the two public entrypoints, but also in:
+  - `load_pricing_rule(...)` vs `load_pricing_rule_tx(...)`
+  - fallback rule construction embedded inside those loaders
+- the refactor should avoid introducing `sqlx` executor abstractions or lifetime-heavy generic plumbing unless absolutely necessary
+
+## Existing State
+
+Today both public entrypoints in `mhm/src-tauri/src/domain/booking/pricing.rs` perform the same sequence:
+
+1. load room type from `rooms`
+2. load pricing rule from `pricing_rules`, with fallback derivation from `rooms.base_price`
+3. load special-date uplift from `special_dates`
+4. call `crate::pricing::calculate_price(...)`
+
+The only material difference is whether the reads happen via `Pool<Sqlite>` or `Transaction<'_, Sqlite>`.
+
+This creates three concrete problems:
+
+1. The public functions own too much orchestration detail.
+2. Fallback-rule construction is duplicated and hidden inside the data-loading helpers.
+3. The `tx` and non-`tx` code paths can drift even though they should make identical pricing decisions after data is loaded.
+
+Functionally the current code works. The problem is boundary clarity and duplication in a high-impact path.
+
+## Chosen Approach
+
+Use a structured hybrid design:
+
+- keep separate thin loaders for `Pool<Sqlite>` and `Transaction<'_, Sqlite>`
+- make those loaders return one shared internal input shape
+- move effective-rule construction into one internal function
+- move final pricing invocation into one internal function
+
+Why this approach:
+
+- it reaches the desired architecture without fighting `sqlx` executor and lifetime complexity
+- it preserves the key `tx` invariant of seeing uncommitted rows
+- it removes the real duplication, which is pricing decision logic rather than the mechanical choice of database handle
+- it keeps the refactor localized to one file and minimizes churn across booking services
+
+## Non-Goals
+
+- changing the signatures of `calculate_stay_price(...)` or `calculate_stay_price_tx(...)`
+- changing pricing outputs, surcharge semantics, or fallback numbers
+- moving pricing pipeline logic into a new file or module in this pass
+- replacing `crate::pricing::calculate_price(...)`
+- introducing traits, repositories, or generic executors for `Pool` and `Transaction`
+- changing the call sites in booking flows except for compile-preserving internal cleanup if required
+
+## Target Shape Inside `pricing.rs`
+
+The refactored file should read as three layers.
+
+### 1. Public entrypoints
+
+These remain:
+
+- `calculate_stay_price(pool, room_id, check_in, check_out, pricing_type)`
+- `calculate_stay_price_tx(tx, room_id, check_in, check_out, pricing_type)`
+
+After the refactor, each public function should only:
+
+- call its matching loader
+- pass the loaded inputs into the shared core path
+
+They should stop building pricing rules directly.
+
+### 2. Loaders
+
+Two thin loaders remain because the repo needs both database contexts:
+
+- `load_stay_pricing_inputs(...)`
+- `load_stay_pricing_inputs_tx(...)`
+
+These loaders should only gather facts from storage. They should not decide how to build the final `PricingRule`.
+
+Expected facts:
+
+- `room_type`
+- pricing rule row if present
+- fallback `base_price` if needed
+- `special_uplift_pct`
+- original `check_in`
+- original `check_out`
+- requested `pricing_type`
+
+### 3. Shared pricing core
+
+The shared core should consist of two internal steps:
+
+- `build_effective_pricing_rule(...)`
+- `calculate_from_loaded_inputs(...)`
+
+`build_effective_pricing_rule(...)` is the only place allowed to decide:
+
+- use the stored pricing rule from `pricing_rules` when present
+- otherwise derive the fallback rule from `rooms.base_price`
+- otherwise fall back to the hardcoded default base price of `350_000`
+
+`calculate_from_loaded_inputs(...)` should:
+
+- obtain the effective `PricingRule`
+- call `crate::pricing::calculate_price(...)`
+- map pricing parse errors to `BookingError::datetime_parse(...)` exactly as today
+
+## Internal Data Contracts
+
+The names may change during implementation, but the boundaries should look like this.
+
+### `StayPricingInputs`
+
+This struct represents loaded facts, not pricing decisions.
+
+It should contain:
+
+- `room_type: String`
+- `stored_rule: Option<StoredPricingRule>`
+- `fallback_base_price: Option<f64>`
+- `special_uplift_pct: f64`
+- `check_in: String`
+- `check_out: String`
+- `pricing_type: String`
+
+This allows the shared core to operate without knowing whether the data came from `Pool` or `Transaction`.
+
+### `StoredPricingRule`
+
+This internal struct represents a concrete row loaded from `pricing_rules` before fallback decisions are applied.
+
+It should contain the fields needed to build `crate::pricing::PricingRule`, including:
+
+- `room_type`
+- `hourly_rate`
+- `overnight_rate`
+- `daily_rate`
+- `overnight_start`
+- `overnight_end`
+- `daily_checkin`
+- `daily_checkout`
+- `early_checkin_surcharge_pct`
+- `late_checkout_surcharge_pct`
+- `weekend_uplift_pct`
+
+This boundary makes the fallback decision explicit instead of encoding it in the loader implementation.
+
+## Detailed Data Flow
+
+The intended internal flow is:
+
+1. public entrypoint receives `room_id`, `check_in`, `check_out`, `pricing_type`
+2. loader resolves `room_type`
+3. loader attempts to read the matching `pricing_rules` row
+4. loader reads fallback `base_price` from `rooms` when needed for rule construction
+5. loader reads special-date uplift for the requested check-in date
+6. loader returns `StayPricingInputs`
+7. shared core builds the effective `PricingRule`
+8. shared core calls `crate::pricing::calculate_price(...)`
+9. shared core maps engine errors into `BookingError`
+
+The critical design rule is:
+
+- loaders gather facts
+- the core decides pricing
+
+That rule is the main protection against duplicate fallback logic reappearing later.
+
+## Fallback Rule Semantics
+
+The refactor must preserve the current fallback behavior exactly:
+
+- when a pricing rule row exists for the room type, use it
+- when no pricing rule row exists, look at `rooms.base_price`
+- when `rooms.base_price` is absent, use `350_000`
+- derive fallback values exactly as today:
+  - `hourly_rate = fallback_price / 5.0`
+  - `overnight_rate = fallback_price * 0.75`
+  - `daily_rate = fallback_price`
+  - all other rule fields come from `PricingRule::default()`
+
+This logic should exist in one place only after the refactor.
+
+## Error Handling and Invariants
+
+The refactor should preserve the current error model:
+
+- missing room still returns `BookingError::not_found(...)`
+- SQL failures still map to `BookingError::database(...)`
+- invalid date or datetime strings from the pricing engine still map to `BookingError::datetime_parse(...)`
+
+The refactor must also preserve these invariants:
+
+- `calculate_stay_price_tx(...)` reads uncommitted pricing data from the active transaction
+- the `tx` loader keeps all pricing facts inside the transaction boundary, including:
+  - room type reads
+  - stored pricing rule reads
+  - fallback `rooms.base_price` reads
+  - `special_dates` uplift reads
+- `tx` and non-`tx` paths produce the same effective pricing decisions when they see the same stored facts
+- no caller in booking flows needs to know whether the pricing rule was loaded from DB or derived as fallback
+
+## Implementation Notes
+
+The implementation should prefer private helper extraction over broad rewrites.
+
+Practical guidance for the edit:
+
+- keep `read_f64(...)` or an equivalent narrow helper
+- keep SQL text local to the current file
+- avoid introducing generic helper signatures parameterized over executor types
+- prefer converting `sqlx::Row` into internal structs quickly rather than passing rows deeper into the pipeline
+- keep the public entrypoints near the top of the file so the file still reads from API to implementation
+
+## Verification Strategy
+
+Verification should cover both boundary correctness and regression safety.
+
+### Unit-level checks for the new boundary
+
+Add targeted tests for the shared core logic:
+
+- building the effective rule from an existing stored rule
+- building the effective fallback rule from `fallback_base_price`
+- building the default fallback rule when both stored rule and base price are absent
+- asserting that fallback-derived rules still inherit the expected `PricingRule::default()` fields beyond the three computed rates
+
+These tests should focus on the new core helpers rather than re-testing `crate::pricing::calculate_price(...)` exhaustively.
+
+### Regression checks for transactional behavior
+
+Keep and run:
+
+- `calculate_stay_price_tx_reads_uncommitted_pricing_rule`
+- add a transaction regression that proves fallback `rooms.base_price` is still read from uncommitted transactional state
+- add a transaction regression that proves `special_dates` uplift is still read from uncommitted transactional state
+
+This remains the key guard for the transaction-specific contract.
+
+### Direct parity and pricing-path regression checks
+
+Add direct pricing-entrypoint coverage for cases not protected by booking services:
+
+- at least one direct parity test showing `calculate_stay_price(...)` and `calculate_stay_price_tx(...)` return the same result for the same stored facts
+- one direct regression covering holiday or special-date uplift
+- pricing-specific error mapping checks for:
+  - missing room -> `BookingError::not_found(...)`
+  - invalid datetime input -> `BookingError::datetime_parse(...)`
+
+### Booking-flow regression checks
+
+Run the affected booking integration tests that exercise the high-risk callers:
+
+- `create_reservation_blocks_calendar_and_posts_deposit`
+- the `group_checkin*` tests because `group_checkin` is a direct transactional caller
+- the `confirm_reservation*` tests that reprice reservations
+- the `modify_reservation*` tests
+- `check_in` and `extend_stay` tests that depend on transactional pricing
+
+The `check_in` tests should be treated as booking-flow smoke coverage, not as the primary regression guard for pricing correctness. The direct pricing-entrypoint tests above should carry that responsibility.
+
+## Completion Criteria
+
+This refactor is complete when:
+
+- `calculate_stay_price(...)` and `calculate_stay_price_tx(...)` remain public and behavior-compatible
+- the file clearly reflects `load inputs -> build effective rule -> calculate`
+- fallback-rule construction exists in one shared internal place
+- duplicated pricing decision logic between `tx` and non-`tx` paths is removed
+- the uncommitted-data transaction test still passes
+- booking-flow regression tests still pass
+
+## Risks
+
+The main risks are:
+
+- accidentally changing fallback pricing values while moving the logic
+- accidentally changing error mapping by moving `map_err(...)`
+- accidentally reading fallback data outside the active transaction in the `tx` path
+
+The implementation should optimize for preserving behavior over reducing every line of duplication.

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -79,6 +79,7 @@ fn calculate_from_loaded_inputs(
     .map_err(BookingError::datetime_parse)
 }
 
+#[allow(dead_code)]
 fn stored_rule_from_row(row: &sqlx::sqlite::SqliteRow) -> StoredPricingRule {
     StoredPricingRule {
         room_type: row.get("room_type"),
@@ -165,23 +166,40 @@ async fn load_pricing_rule(
     .await
     .map_err(|error| BookingError::database(error.to_string()))?;
 
+    if let Some(row) = row {
+        return Ok(crate::pricing::PricingRule {
+            room_type: row.get("room_type"),
+            hourly_rate: read_f64(&row, "hourly_rate"),
+            overnight_rate: read_f64(&row, "overnight_rate"),
+            daily_rate: read_f64(&row, "daily_rate"),
+            overnight_start: row.get("overnight_start"),
+            overnight_end: row.get("overnight_end"),
+            daily_checkin: row.get("daily_checkin"),
+            daily_checkout: row.get("daily_checkout"),
+            early_checkin_surcharge_pct: read_f64(&row, "early_checkin_surcharge_pct"),
+            late_checkout_surcharge_pct: read_f64(&row, "late_checkout_surcharge_pct"),
+            weekend_uplift_pct: read_f64(&row, "weekend_uplift_pct"),
+        });
+    }
+
     let fallback_row = sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
         .bind(&room_type_lower)
         .fetch_optional(pool)
         .await
         .map_err(|error| BookingError::database(error.to_string()))?;
 
-    let inputs = StayPricingInputs {
-        room_type: room_type.to_string(),
-        stored_rule: row.as_ref().map(stored_rule_from_row),
-        fallback_base_price: fallback_row.as_ref().map(|row| read_f64(row, "base_price")),
-        special_uplift_pct: 0.0,
-        check_in: String::new(),
-        check_out: String::new(),
-        pricing_type: String::new(),
-    };
+    let fallback_price = fallback_row
+        .as_ref()
+        .map(|row| read_f64(row, "base_price"))
+        .unwrap_or(350_000.0);
 
-    Ok(build_effective_pricing_rule(&inputs))
+    Ok(crate::pricing::PricingRule {
+        room_type: room_type.to_string(),
+        hourly_rate: fallback_price / 5.0,
+        overnight_rate: fallback_price * 0.75,
+        daily_rate: fallback_price,
+        ..Default::default()
+    })
 }
 
 async fn load_pricing_rule_tx(
@@ -201,23 +219,40 @@ async fn load_pricing_rule_tx(
     .await
     .map_err(|error| BookingError::database(error.to_string()))?;
 
+    if let Some(row) = row {
+        return Ok(crate::pricing::PricingRule {
+            room_type: row.get("room_type"),
+            hourly_rate: read_f64(&row, "hourly_rate"),
+            overnight_rate: read_f64(&row, "overnight_rate"),
+            daily_rate: read_f64(&row, "daily_rate"),
+            overnight_start: row.get("overnight_start"),
+            overnight_end: row.get("overnight_end"),
+            daily_checkin: row.get("daily_checkin"),
+            daily_checkout: row.get("daily_checkout"),
+            early_checkin_surcharge_pct: read_f64(&row, "early_checkin_surcharge_pct"),
+            late_checkout_surcharge_pct: read_f64(&row, "late_checkout_surcharge_pct"),
+            weekend_uplift_pct: read_f64(&row, "weekend_uplift_pct"),
+        });
+    }
+
     let fallback_row = sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
         .bind(&room_type_lower)
         .fetch_optional(&mut **tx)
         .await
         .map_err(|error| BookingError::database(error.to_string()))?;
 
-    let inputs = StayPricingInputs {
-        room_type: room_type.to_string(),
-        stored_rule: row.as_ref().map(stored_rule_from_row),
-        fallback_base_price: fallback_row.as_ref().map(|row| read_f64(row, "base_price")),
-        special_uplift_pct: 0.0,
-        check_in: String::new(),
-        check_out: String::new(),
-        pricing_type: String::new(),
-    };
+    let fallback_price = fallback_row
+        .as_ref()
+        .map(|row| read_f64(row, "base_price"))
+        .unwrap_or(350_000.0);
 
-    Ok(build_effective_pricing_rule(&inputs))
+    Ok(crate::pricing::PricingRule {
+        room_type: room_type.to_string(),
+        hourly_rate: fallback_price / 5.0,
+        overnight_rate: fallback_price * 0.75,
+        daily_rate: fallback_price,
+        ..Default::default()
+    })
 }
 
 #[allow(dead_code)]
@@ -284,41 +319,42 @@ mod tests {
         inputs.stored_rule = Some(StoredPricingRule {
             room_type: "deluxe".to_string(),
             hourly_rate: 120_000.0,
-            overnight_rate: 420_000.0,
-            daily_rate: 560_000.0,
+            overnight_rate: 500_000.0,
+            daily_rate: 700_000.0,
             overnight_start: "21:00".to_string(),
             overnight_end: "10:00".to_string(),
             daily_checkin: "13:00".to_string(),
             daily_checkout: "11:00".to_string(),
             early_checkin_surcharge_pct: 15.0,
-            late_checkout_surcharge_pct: 25.0,
-            weekend_uplift_pct: 18.0,
+            late_checkout_surcharge_pct: 20.0,
+            weekend_uplift_pct: 12.5,
         });
 
         let rule = build_effective_pricing_rule(&inputs);
 
         assert_eq!(rule.room_type, "deluxe");
         assert_eq!(rule.hourly_rate, 120_000.0);
-        assert_eq!(rule.overnight_rate, 420_000.0);
-        assert_eq!(rule.daily_rate, 560_000.0);
+        assert_eq!(rule.overnight_rate, 500_000.0);
+        assert_eq!(rule.daily_rate, 700_000.0);
         assert_eq!(rule.overnight_start, "21:00");
         assert_eq!(rule.overnight_end, "10:00");
         assert_eq!(rule.daily_checkin, "13:00");
         assert_eq!(rule.daily_checkout, "11:00");
         assert_eq!(rule.early_checkin_surcharge_pct, 15.0);
-        assert_eq!(rule.late_checkout_surcharge_pct, 25.0);
-        assert_eq!(rule.weekend_uplift_pct, 18.0);
+        assert_eq!(rule.late_checkout_surcharge_pct, 20.0);
+        assert_eq!(rule.weekend_uplift_pct, 12.5);
     }
 
     #[test]
     fn build_effective_pricing_rule_derives_fallback_rates_from_base_price() {
         let mut inputs = sample_inputs();
+        inputs.room_type = "deluxe".to_string();
         inputs.fallback_base_price = Some(500_000.0);
 
         let rule = build_effective_pricing_rule(&inputs);
         let defaults = crate::pricing::PricingRule::default();
 
-        assert_eq!(rule.room_type, "standard");
+        assert_eq!(rule.room_type, "deluxe");
         assert_eq!(rule.hourly_rate, 100_000.0);
         assert_eq!(rule.overnight_rate, 375_000.0);
         assert_eq!(rule.daily_rate, 500_000.0);

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -104,12 +104,8 @@ pub async fn calculate_stay_price(
     check_out: &str,
     pricing_type: &str,
 ) -> BookingResult<crate::pricing::PricingResult> {
-    let room_type = load_room_type(pool, room_id).await?;
-    let rule = load_pricing_rule(pool, &room_type).await?;
-    let special_uplift = load_special_uplift(pool, check_in).await?;
-
-    crate::pricing::calculate_price(&rule, check_in, check_out, pricing_type, special_uplift)
-        .map_err(BookingError::datetime_parse)
+    let inputs = load_stay_pricing_inputs(pool, room_id, check_in, check_out, pricing_type).await?;
+    calculate_from_loaded_inputs(&inputs)
 }
 pub async fn calculate_stay_price_tx(
     tx: &mut Transaction<'_, Sqlite>,
@@ -118,12 +114,63 @@ pub async fn calculate_stay_price_tx(
     check_out: &str,
     pricing_type: &str,
 ) -> BookingResult<crate::pricing::PricingResult> {
-    let room_type = load_room_type_tx(tx, room_id).await?;
-    let rule = load_pricing_rule_tx(tx, &room_type).await?;
-    let special_uplift = load_special_uplift_tx(tx, check_in).await?;
+    let inputs =
+        load_stay_pricing_inputs_tx(tx, room_id, check_in, check_out, pricing_type).await?;
+    calculate_from_loaded_inputs(&inputs)
+}
 
-    crate::pricing::calculate_price(&rule, check_in, check_out, pricing_type, special_uplift)
-        .map_err(BookingError::datetime_parse)
+async fn load_stay_pricing_inputs(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+) -> BookingResult<StayPricingInputs> {
+    let room_type = load_room_type(pool, room_id).await?;
+    let stored_rule = load_stored_pricing_rule(pool, &room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price(pool, &room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift(pool, check_in).await?;
+
+    Ok(StayPricingInputs {
+        room_type,
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+    })
+}
+
+async fn load_stay_pricing_inputs_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+) -> BookingResult<StayPricingInputs> {
+    let room_type = load_room_type_tx(tx, room_id).await?;
+    let stored_rule = load_stored_pricing_rule_tx(tx, &room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price_tx(tx, &room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift_tx(tx, check_in).await?;
+
+    Ok(StayPricingInputs {
+        room_type,
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+    })
 }
 
 #[allow(dead_code)]
@@ -149,10 +196,10 @@ async fn load_room_type_tx(
 }
 
 #[allow(dead_code)]
-async fn load_pricing_rule(
+async fn load_stored_pricing_rule(
     pool: &Pool<Sqlite>,
     room_type: &str,
-) -> BookingResult<crate::pricing::PricingRule> {
+) -> BookingResult<Option<StoredPricingRule>> {
     let room_type_lower = room_type.to_lowercase();
     let row = sqlx::query(
         "SELECT room_type, hourly_rate, overnight_rate, daily_rate,
@@ -166,46 +213,27 @@ async fn load_pricing_rule(
     .await
     .map_err(|error| BookingError::database(error.to_string()))?;
 
-    if let Some(row) = row {
-        return Ok(crate::pricing::PricingRule {
-            room_type: row.get("room_type"),
-            hourly_rate: read_f64(&row, "hourly_rate"),
-            overnight_rate: read_f64(&row, "overnight_rate"),
-            daily_rate: read_f64(&row, "daily_rate"),
-            overnight_start: row.get("overnight_start"),
-            overnight_end: row.get("overnight_end"),
-            daily_checkin: row.get("daily_checkin"),
-            daily_checkout: row.get("daily_checkout"),
-            early_checkin_surcharge_pct: read_f64(&row, "early_checkin_surcharge_pct"),
-            late_checkout_surcharge_pct: read_f64(&row, "late_checkout_surcharge_pct"),
-            weekend_uplift_pct: read_f64(&row, "weekend_uplift_pct"),
-        });
-    }
+    Ok(row.as_ref().map(stored_rule_from_row))
+}
 
+async fn load_fallback_base_price(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+) -> BookingResult<Option<f64>> {
+    let room_type_lower = room_type.to_lowercase();
     let fallback_row = sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
         .bind(&room_type_lower)
         .fetch_optional(pool)
         .await
         .map_err(|error| BookingError::database(error.to_string()))?;
 
-    let fallback_price = fallback_row
-        .as_ref()
-        .map(|row| read_f64(row, "base_price"))
-        .unwrap_or(350_000.0);
-
-    Ok(crate::pricing::PricingRule {
-        room_type: room_type.to_string(),
-        hourly_rate: fallback_price / 5.0,
-        overnight_rate: fallback_price * 0.75,
-        daily_rate: fallback_price,
-        ..Default::default()
-    })
+    Ok(fallback_row.as_ref().map(|row| read_f64(row, "base_price")))
 }
 
-async fn load_pricing_rule_tx(
+async fn load_stored_pricing_rule_tx(
     tx: &mut Transaction<'_, Sqlite>,
     room_type: &str,
-) -> BookingResult<crate::pricing::PricingRule> {
+) -> BookingResult<Option<StoredPricingRule>> {
     let room_type_lower = room_type.to_lowercase();
     let row = sqlx::query(
         "SELECT room_type, hourly_rate, overnight_rate, daily_rate,
@@ -219,40 +247,21 @@ async fn load_pricing_rule_tx(
     .await
     .map_err(|error| BookingError::database(error.to_string()))?;
 
-    if let Some(row) = row {
-        return Ok(crate::pricing::PricingRule {
-            room_type: row.get("room_type"),
-            hourly_rate: read_f64(&row, "hourly_rate"),
-            overnight_rate: read_f64(&row, "overnight_rate"),
-            daily_rate: read_f64(&row, "daily_rate"),
-            overnight_start: row.get("overnight_start"),
-            overnight_end: row.get("overnight_end"),
-            daily_checkin: row.get("daily_checkin"),
-            daily_checkout: row.get("daily_checkout"),
-            early_checkin_surcharge_pct: read_f64(&row, "early_checkin_surcharge_pct"),
-            late_checkout_surcharge_pct: read_f64(&row, "late_checkout_surcharge_pct"),
-            weekend_uplift_pct: read_f64(&row, "weekend_uplift_pct"),
-        });
-    }
+    Ok(row.as_ref().map(stored_rule_from_row))
+}
 
+async fn load_fallback_base_price_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_type: &str,
+) -> BookingResult<Option<f64>> {
+    let room_type_lower = room_type.to_lowercase();
     let fallback_row = sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
         .bind(&room_type_lower)
         .fetch_optional(&mut **tx)
         .await
         .map_err(|error| BookingError::database(error.to_string()))?;
 
-    let fallback_price = fallback_row
-        .as_ref()
-        .map(|row| read_f64(row, "base_price"))
-        .unwrap_or(350_000.0);
-
-    Ok(crate::pricing::PricingRule {
-        room_type: room_type.to_string(),
-        hourly_rate: fallback_price / 5.0,
-        overnight_rate: fallback_price * 0.75,
-        daily_rate: fallback_price,
-        ..Default::default()
-    })
+    Ok(fallback_row.as_ref().map(|row| read_f64(row, "base_price")))
 }
 
 #[allow(dead_code)]
@@ -299,11 +308,11 @@ fn read_f64(row: &sqlx::sqlite::SqliteRow, column: &str) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_effective_pricing_rule, calculate_from_loaded_inputs, stored_rule_from_row,
-        StayPricingInputs, StoredPricingRule,
+        StayPricingInputs, StoredPricingRule, build_effective_pricing_rule,
+        calculate_from_loaded_inputs, load_stay_pricing_inputs, stored_rule_from_row,
     };
     use crate::domain::booking::BookingError;
-    use sqlx::{Connection, SqliteConnection};
+    use sqlx::{Connection, Executor, SqliteConnection, sqlite::SqlitePoolOptions};
 
     fn sample_inputs() -> StayPricingInputs {
         StayPricingInputs {
@@ -456,5 +465,127 @@ mod tests {
         assert_eq!(rule.early_checkin_surcharge_pct, 15.0);
         assert_eq!(rule.late_checkout_surcharge_pct, 20.0);
         assert_eq!(rule.weekend_uplift_pct, 12.5);
+    }
+
+    async fn setup_loader_pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        pool.execute(
+            "CREATE TABLE rooms (id TEXT PRIMARY KEY, type TEXT NOT NULL, base_price REAL)",
+        )
+        .await
+        .unwrap();
+        pool.execute(
+            "CREATE TABLE pricing_rules (
+                room_type TEXT,
+                hourly_rate REAL,
+                overnight_rate REAL,
+                daily_rate REAL,
+                overnight_start TEXT,
+                overnight_end TEXT,
+                daily_checkin TEXT,
+                daily_checkout TEXT,
+                early_checkin_surcharge_pct REAL,
+                late_checkout_surcharge_pct REAL,
+                weekend_uplift_pct REAL
+            )",
+        )
+        .await
+        .unwrap();
+        pool.execute("CREATE TABLE special_dates (date TEXT PRIMARY KEY, uplift_pct REAL)")
+            .await
+            .unwrap();
+
+        pool
+    }
+
+    #[tokio::test]
+    async fn load_stay_pricing_inputs_prefers_stored_rule_without_fallback_query() {
+        let pool = setup_loader_pool().await;
+
+        pool.execute("DROP TABLE rooms").await.unwrap();
+        pool.execute("CREATE TABLE rooms (id TEXT PRIMARY KEY, type TEXT NOT NULL)")
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO rooms (id, type) VALUES (?, ?)")
+            .bind("room-1")
+            .bind("deluxe")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO pricing_rules (
+                room_type, hourly_rate, overnight_rate, daily_rate, overnight_start,
+                overnight_end, daily_checkin, daily_checkout,
+                early_checkin_surcharge_pct, late_checkout_surcharge_pct, weekend_uplift_pct
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("deluxe")
+        .bind(120000.0)
+        .bind(500000.0)
+        .bind(700000.0)
+        .bind("21:00")
+        .bind("10:00")
+        .bind("13:00")
+        .bind("11:00")
+        .bind(15.0)
+        .bind(20.0)
+        .bind(12.5)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO special_dates (date, uplift_pct) VALUES (?, ?)")
+            .bind("2026-04-20")
+            .bind(10.0)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let inputs = load_stay_pricing_inputs(
+            &pool,
+            "room-1",
+            "2026-04-20T14:00:00+07:00",
+            "2026-04-21T12:00:00+07:00",
+            "nightly",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(inputs.room_type, "deluxe");
+        assert!(inputs.stored_rule.is_some());
+        assert_eq!(inputs.fallback_base_price, None);
+        assert_eq!(inputs.special_uplift_pct, 10.0);
+    }
+
+    #[tokio::test]
+    async fn load_stay_pricing_inputs_loads_fallback_base_price_when_rule_missing() {
+        let pool = setup_loader_pool().await;
+
+        sqlx::query("INSERT INTO rooms (id, type, base_price) VALUES (?, ?, ?)")
+            .bind("room-2")
+            .bind("standard")
+            .bind(480000.0)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let inputs = load_stay_pricing_inputs(
+            &pool,
+            "room-2",
+            "2026-04-21T14:00:00+07:00",
+            "2026-04-22T12:00:00+07:00",
+            "nightly",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(inputs.room_type, "standard");
+        assert!(inputs.stored_rule.is_none());
+        assert_eq!(inputs.fallback_base_price, Some(480000.0));
+        assert_eq!(inputs.special_uplift_pct, 0.0);
     }
 }

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -298,7 +298,12 @@ fn read_f64(row: &sqlx::sqlite::SqliteRow, column: &str) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_effective_pricing_rule, StayPricingInputs, StoredPricingRule};
+    use super::{
+        build_effective_pricing_rule, calculate_from_loaded_inputs, stored_rule_from_row,
+        StayPricingInputs, StoredPricingRule,
+    };
+    use crate::domain::booking::BookingError;
+    use sqlx::{Connection, SqliteConnection};
 
     fn sample_inputs() -> StayPricingInputs {
         StayPricingInputs {
@@ -352,48 +357,104 @@ mod tests {
         inputs.fallback_base_price = Some(500_000.0);
 
         let rule = build_effective_pricing_rule(&inputs);
-        let defaults = crate::pricing::PricingRule::default();
 
         assert_eq!(rule.room_type, "deluxe");
         assert_eq!(rule.hourly_rate, 100_000.0);
         assert_eq!(rule.overnight_rate, 375_000.0);
         assert_eq!(rule.daily_rate, 500_000.0);
-        assert_eq!(rule.overnight_start, defaults.overnight_start);
-        assert_eq!(rule.overnight_end, defaults.overnight_end);
-        assert_eq!(rule.daily_checkin, defaults.daily_checkin);
-        assert_eq!(rule.daily_checkout, defaults.daily_checkout);
-        assert_eq!(
-            rule.early_checkin_surcharge_pct,
-            defaults.early_checkin_surcharge_pct
-        );
-        assert_eq!(
-            rule.late_checkout_surcharge_pct,
-            defaults.late_checkout_surcharge_pct
-        );
-        assert_eq!(rule.weekend_uplift_pct, defaults.weekend_uplift_pct);
+        assert_eq!(rule.overnight_start, "22:00");
+        assert_eq!(rule.overnight_end, "11:00");
+        assert_eq!(rule.daily_checkin, "14:00");
+        assert_eq!(rule.daily_checkout, "12:00");
+        assert_eq!(rule.early_checkin_surcharge_pct, 30.0);
+        assert_eq!(rule.late_checkout_surcharge_pct, 30.0);
+        assert_eq!(rule.weekend_uplift_pct, 20.0);
     }
 
     #[test]
     fn build_effective_pricing_rule_uses_default_price_and_metadata_when_base_price_missing() {
         let rule = build_effective_pricing_rule(&sample_inputs());
-        let defaults = crate::pricing::PricingRule::default();
 
         assert_eq!(rule.room_type, "standard");
         assert_eq!(rule.hourly_rate, 70_000.0);
         assert_eq!(rule.overnight_rate, 262_500.0);
         assert_eq!(rule.daily_rate, 350_000.0);
-        assert_eq!(rule.overnight_start, defaults.overnight_start);
-        assert_eq!(rule.overnight_end, defaults.overnight_end);
-        assert_eq!(rule.daily_checkin, defaults.daily_checkin);
-        assert_eq!(rule.daily_checkout, defaults.daily_checkout);
-        assert_eq!(
-            rule.early_checkin_surcharge_pct,
-            defaults.early_checkin_surcharge_pct
-        );
-        assert_eq!(
-            rule.late_checkout_surcharge_pct,
-            defaults.late_checkout_surcharge_pct
-        );
-        assert_eq!(rule.weekend_uplift_pct, defaults.weekend_uplift_pct);
+        assert_eq!(rule.overnight_start, "22:00");
+        assert_eq!(rule.overnight_end, "11:00");
+        assert_eq!(rule.daily_checkin, "14:00");
+        assert_eq!(rule.daily_checkout, "12:00");
+        assert_eq!(rule.early_checkin_surcharge_pct, 30.0);
+        assert_eq!(rule.late_checkout_surcharge_pct, 30.0);
+        assert_eq!(rule.weekend_uplift_pct, 20.0);
+    }
+
+    #[test]
+    fn calculate_from_loaded_inputs_applies_special_uplift() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000.0);
+        inputs.check_in = "2026-04-20T10:00:00+07:00".to_string();
+        inputs.check_out = "2026-04-22T10:00:00+07:00".to_string();
+        inputs.special_uplift_pct = 10.0;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.pricing_type, "nightly");
+        assert_eq!(pricing.base_amount, 1_000_000.0);
+        assert_eq!(pricing.weekend_amount, 0.0);
+        assert_eq!(pricing.surcharge_amount, 100_000.0);
+        assert_eq!(pricing.total, 1_100_000.0);
+        assert_eq!(pricing.breakdown.len(), 2);
+        assert_eq!(pricing.breakdown[0].amount, 1_000_000.0);
+        assert_eq!(pricing.breakdown[1].amount, 100_000.0);
+    }
+
+    #[test]
+    fn calculate_from_loaded_inputs_maps_invalid_datetime_errors() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000.0);
+        inputs.check_in = "not-a-datetime".to_string();
+
+        let error = calculate_from_loaded_inputs(&inputs).unwrap_err();
+
+        assert!(matches!(
+            error,
+            BookingError::DateTimeParse(message) if message.contains("Invalid check-in datetime")
+        ));
+    }
+
+    #[tokio::test]
+    async fn stored_rule_from_row_maps_all_columns() {
+        let mut connection = SqliteConnection::connect(":memory:").await.unwrap();
+        let row = sqlx::query(
+            "SELECT
+                'deluxe' AS room_type,
+                120000.0 AS hourly_rate,
+                500000.0 AS overnight_rate,
+                700000.0 AS daily_rate,
+                '21:00' AS overnight_start,
+                '10:00' AS overnight_end,
+                '13:00' AS daily_checkin,
+                '11:00' AS daily_checkout,
+                15.0 AS early_checkin_surcharge_pct,
+                20.0 AS late_checkout_surcharge_pct,
+                12.5 AS weekend_uplift_pct",
+        )
+        .fetch_one(&mut connection)
+        .await
+        .unwrap();
+
+        let rule = stored_rule_from_row(&row);
+
+        assert_eq!(rule.room_type, "deluxe");
+        assert_eq!(rule.hourly_rate, 120_000.0);
+        assert_eq!(rule.overnight_rate, 500_000.0);
+        assert_eq!(rule.daily_rate, 700_000.0);
+        assert_eq!(rule.overnight_start, "21:00");
+        assert_eq!(rule.overnight_end, "10:00");
+        assert_eq!(rule.daily_checkin, "13:00");
+        assert_eq!(rule.daily_checkout, "11:00");
+        assert_eq!(rule.early_checkin_surcharge_pct, 15.0);
+        assert_eq!(rule.late_checkout_surcharge_pct, 20.0);
+        assert_eq!(rule.weekend_uplift_pct, 12.5);
     }
 }

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -3,6 +3,99 @@ use sqlx::{Pool, Row, Sqlite, Transaction};
 use super::{BookingError, BookingResult};
 
 #[allow(dead_code)]
+#[derive(Debug, Clone)]
+struct StayPricingInputs {
+    room_type: String,
+    stored_rule: Option<StoredPricingRule>,
+    fallback_base_price: Option<f64>,
+    special_uplift_pct: f64,
+    check_in: String,
+    check_out: String,
+    pricing_type: String,
+}
+
+#[derive(Debug, Clone)]
+struct StoredPricingRule {
+    room_type: String,
+    hourly_rate: f64,
+    overnight_rate: f64,
+    daily_rate: f64,
+    overnight_start: String,
+    overnight_end: String,
+    daily_checkin: String,
+    daily_checkout: String,
+    early_checkin_surcharge_pct: f64,
+    late_checkout_surcharge_pct: f64,
+    weekend_uplift_pct: f64,
+}
+
+impl StoredPricingRule {
+    fn to_pricing_rule(&self) -> crate::pricing::PricingRule {
+        crate::pricing::PricingRule {
+            room_type: self.room_type.clone(),
+            hourly_rate: self.hourly_rate,
+            overnight_rate: self.overnight_rate,
+            daily_rate: self.daily_rate,
+            overnight_start: self.overnight_start.clone(),
+            overnight_end: self.overnight_end.clone(),
+            daily_checkin: self.daily_checkin.clone(),
+            daily_checkout: self.daily_checkout.clone(),
+            early_checkin_surcharge_pct: self.early_checkin_surcharge_pct,
+            late_checkout_surcharge_pct: self.late_checkout_surcharge_pct,
+            weekend_uplift_pct: self.weekend_uplift_pct,
+        }
+    }
+}
+
+fn build_effective_pricing_rule(inputs: &StayPricingInputs) -> crate::pricing::PricingRule {
+    if let Some(stored_rule) = &inputs.stored_rule {
+        return stored_rule.to_pricing_rule();
+    }
+
+    let fallback_price = inputs.fallback_base_price.unwrap_or(350_000.0);
+
+    crate::pricing::PricingRule {
+        room_type: inputs.room_type.clone(),
+        hourly_rate: fallback_price / 5.0,
+        overnight_rate: fallback_price * 0.75,
+        daily_rate: fallback_price,
+        ..Default::default()
+    }
+}
+
+#[allow(dead_code)]
+fn calculate_from_loaded_inputs(
+    inputs: &StayPricingInputs,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let rule = build_effective_pricing_rule(inputs);
+
+    crate::pricing::calculate_price(
+        &rule,
+        &inputs.check_in,
+        &inputs.check_out,
+        &inputs.pricing_type,
+        inputs.special_uplift_pct,
+    )
+    .map_err(BookingError::datetime_parse)
+}
+
+fn stored_rule_from_row(row: &sqlx::sqlite::SqliteRow) -> StoredPricingRule {
+    StoredPricingRule {
+        room_type: row.get("room_type"),
+        hourly_rate: read_f64(row, "hourly_rate"),
+        overnight_rate: read_f64(row, "overnight_rate"),
+        daily_rate: read_f64(row, "daily_rate"),
+        overnight_start: row.get("overnight_start"),
+        overnight_end: row.get("overnight_end"),
+        daily_checkin: row.get("daily_checkin"),
+        daily_checkout: row.get("daily_checkout"),
+        early_checkin_surcharge_pct: read_f64(row, "early_checkin_surcharge_pct"),
+        late_checkout_surcharge_pct: read_f64(row, "late_checkout_surcharge_pct"),
+        weekend_uplift_pct: read_f64(row, "weekend_uplift_pct"),
+    }
+}
+
+#[allow(dead_code)]
 pub async fn calculate_stay_price(
     pool: &Pool<Sqlite>,
     room_id: &str,
@@ -14,14 +107,8 @@ pub async fn calculate_stay_price(
     let rule = load_pricing_rule(pool, &room_type).await?;
     let special_uplift = load_special_uplift(pool, check_in).await?;
 
-    crate::pricing::calculate_price(
-        &rule,
-        check_in,
-        check_out,
-        pricing_type,
-        special_uplift,
-    )
-    .map_err(BookingError::datetime_parse)
+    crate::pricing::calculate_price(&rule, check_in, check_out, pricing_type, special_uplift)
+        .map_err(BookingError::datetime_parse)
 }
 pub async fn calculate_stay_price_tx(
     tx: &mut Transaction<'_, Sqlite>,
@@ -34,14 +121,8 @@ pub async fn calculate_stay_price_tx(
     let rule = load_pricing_rule_tx(tx, &room_type).await?;
     let special_uplift = load_special_uplift_tx(tx, check_in).await?;
 
-    crate::pricing::calculate_price(
-        &rule,
-        check_in,
-        check_out,
-        pricing_type,
-        special_uplift,
-    )
-    .map_err(BookingError::datetime_parse)
+    crate::pricing::calculate_price(&rule, check_in, check_out, pricing_type, special_uplift)
+        .map_err(BookingError::datetime_parse)
 }
 
 #[allow(dead_code)]
@@ -84,40 +165,23 @@ async fn load_pricing_rule(
     .await
     .map_err(|error| BookingError::database(error.to_string()))?;
 
-    if let Some(row) = row {
-        return Ok(crate::pricing::PricingRule {
-            room_type: row.get("room_type"),
-            hourly_rate: read_f64(&row, "hourly_rate"),
-            overnight_rate: read_f64(&row, "overnight_rate"),
-            daily_rate: read_f64(&row, "daily_rate"),
-            overnight_start: row.get("overnight_start"),
-            overnight_end: row.get("overnight_end"),
-            daily_checkin: row.get("daily_checkin"),
-            daily_checkout: row.get("daily_checkout"),
-            early_checkin_surcharge_pct: read_f64(&row, "early_checkin_surcharge_pct"),
-            late_checkout_surcharge_pct: read_f64(&row, "late_checkout_surcharge_pct"),
-            weekend_uplift_pct: read_f64(&row, "weekend_uplift_pct"),
-        });
-    }
-
     let fallback_row = sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
         .bind(&room_type_lower)
         .fetch_optional(pool)
         .await
         .map_err(|error| BookingError::database(error.to_string()))?;
 
-    let fallback_price = fallback_row
-        .as_ref()
-        .map(|row| read_f64(row, "base_price"))
-        .unwrap_or(350_000.0);
-
-    Ok(crate::pricing::PricingRule {
+    let inputs = StayPricingInputs {
         room_type: room_type.to_string(),
-        hourly_rate: fallback_price / 5.0,
-        overnight_rate: fallback_price * 0.75,
-        daily_rate: fallback_price,
-        ..Default::default()
-    })
+        stored_rule: row.as_ref().map(stored_rule_from_row),
+        fallback_base_price: fallback_row.as_ref().map(|row| read_f64(row, "base_price")),
+        special_uplift_pct: 0.0,
+        check_in: String::new(),
+        check_out: String::new(),
+        pricing_type: String::new(),
+    };
+
+    Ok(build_effective_pricing_rule(&inputs))
 }
 
 async fn load_pricing_rule_tx(
@@ -137,40 +201,23 @@ async fn load_pricing_rule_tx(
     .await
     .map_err(|error| BookingError::database(error.to_string()))?;
 
-    if let Some(row) = row {
-        return Ok(crate::pricing::PricingRule {
-            room_type: row.get("room_type"),
-            hourly_rate: read_f64(&row, "hourly_rate"),
-            overnight_rate: read_f64(&row, "overnight_rate"),
-            daily_rate: read_f64(&row, "daily_rate"),
-            overnight_start: row.get("overnight_start"),
-            overnight_end: row.get("overnight_end"),
-            daily_checkin: row.get("daily_checkin"),
-            daily_checkout: row.get("daily_checkout"),
-            early_checkin_surcharge_pct: read_f64(&row, "early_checkin_surcharge_pct"),
-            late_checkout_surcharge_pct: read_f64(&row, "late_checkout_surcharge_pct"),
-            weekend_uplift_pct: read_f64(&row, "weekend_uplift_pct"),
-        });
-    }
-
     let fallback_row = sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
         .bind(&room_type_lower)
         .fetch_optional(&mut **tx)
         .await
         .map_err(|error| BookingError::database(error.to_string()))?;
 
-    let fallback_price = fallback_row
-        .as_ref()
-        .map(|row| read_f64(row, "base_price"))
-        .unwrap_or(350_000.0);
-
-    Ok(crate::pricing::PricingRule {
+    let inputs = StayPricingInputs {
         room_type: room_type.to_string(),
-        hourly_rate: fallback_price / 5.0,
-        overnight_rate: fallback_price * 0.75,
-        daily_rate: fallback_price,
-        ..Default::default()
-    })
+        stored_rule: row.as_ref().map(stored_rule_from_row),
+        fallback_base_price: fallback_row.as_ref().map(|row| read_f64(row, "base_price")),
+        special_uplift_pct: 0.0,
+        check_in: String::new(),
+        check_out: String::new(),
+        pricing_type: String::new(),
+    };
+
+    Ok(build_effective_pricing_rule(&inputs))
 }
 
 #[allow(dead_code)]
@@ -212,4 +259,105 @@ async fn load_special_uplift_tx(
 fn read_f64(row: &sqlx::sqlite::SqliteRow, column: &str) -> f64 {
     row.try_get::<f64, _>(column)
         .unwrap_or_else(|_| row.get::<i64, _>(column) as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_effective_pricing_rule, StayPricingInputs, StoredPricingRule};
+
+    fn sample_inputs() -> StayPricingInputs {
+        StayPricingInputs {
+            room_type: "standard".to_string(),
+            stored_rule: None,
+            fallback_base_price: None,
+            special_uplift_pct: 0.0,
+            check_in: "2026-04-20".to_string(),
+            check_out: "2026-04-22".to_string(),
+            pricing_type: "nightly".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_effective_pricing_rule_prefers_stored_rule_values() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000.0);
+        inputs.stored_rule = Some(StoredPricingRule {
+            room_type: "deluxe".to_string(),
+            hourly_rate: 120_000.0,
+            overnight_rate: 420_000.0,
+            daily_rate: 560_000.0,
+            overnight_start: "21:00".to_string(),
+            overnight_end: "10:00".to_string(),
+            daily_checkin: "13:00".to_string(),
+            daily_checkout: "11:00".to_string(),
+            early_checkin_surcharge_pct: 15.0,
+            late_checkout_surcharge_pct: 25.0,
+            weekend_uplift_pct: 18.0,
+        });
+
+        let rule = build_effective_pricing_rule(&inputs);
+
+        assert_eq!(rule.room_type, "deluxe");
+        assert_eq!(rule.hourly_rate, 120_000.0);
+        assert_eq!(rule.overnight_rate, 420_000.0);
+        assert_eq!(rule.daily_rate, 560_000.0);
+        assert_eq!(rule.overnight_start, "21:00");
+        assert_eq!(rule.overnight_end, "10:00");
+        assert_eq!(rule.daily_checkin, "13:00");
+        assert_eq!(rule.daily_checkout, "11:00");
+        assert_eq!(rule.early_checkin_surcharge_pct, 15.0);
+        assert_eq!(rule.late_checkout_surcharge_pct, 25.0);
+        assert_eq!(rule.weekend_uplift_pct, 18.0);
+    }
+
+    #[test]
+    fn build_effective_pricing_rule_derives_fallback_rates_from_base_price() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000.0);
+
+        let rule = build_effective_pricing_rule(&inputs);
+        let defaults = crate::pricing::PricingRule::default();
+
+        assert_eq!(rule.room_type, "standard");
+        assert_eq!(rule.hourly_rate, 100_000.0);
+        assert_eq!(rule.overnight_rate, 375_000.0);
+        assert_eq!(rule.daily_rate, 500_000.0);
+        assert_eq!(rule.overnight_start, defaults.overnight_start);
+        assert_eq!(rule.overnight_end, defaults.overnight_end);
+        assert_eq!(rule.daily_checkin, defaults.daily_checkin);
+        assert_eq!(rule.daily_checkout, defaults.daily_checkout);
+        assert_eq!(
+            rule.early_checkin_surcharge_pct,
+            defaults.early_checkin_surcharge_pct
+        );
+        assert_eq!(
+            rule.late_checkout_surcharge_pct,
+            defaults.late_checkout_surcharge_pct
+        );
+        assert_eq!(rule.weekend_uplift_pct, defaults.weekend_uplift_pct);
+    }
+
+    #[test]
+    fn build_effective_pricing_rule_uses_default_price_and_metadata_when_base_price_missing() {
+        let rule = build_effective_pricing_rule(&sample_inputs());
+        let defaults = crate::pricing::PricingRule::default();
+
+        assert_eq!(rule.room_type, "standard");
+        assert_eq!(rule.hourly_rate, 70_000.0);
+        assert_eq!(rule.overnight_rate, 262_500.0);
+        assert_eq!(rule.daily_rate, 350_000.0);
+        assert_eq!(rule.overnight_start, defaults.overnight_start);
+        assert_eq!(rule.overnight_end, defaults.overnight_end);
+        assert_eq!(rule.daily_checkin, defaults.daily_checkin);
+        assert_eq!(rule.daily_checkout, defaults.daily_checkout);
+        assert_eq!(
+            rule.early_checkin_surcharge_pct,
+            defaults.early_checkin_surcharge_pct
+        );
+        assert_eq!(
+            rule.late_checkout_surcharge_pct,
+            defaults.late_checkout_surcharge_pct
+        );
+        assert_eq!(rule.weekend_uplift_pct, defaults.weekend_uplift_pct);
+    }
 }

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -3,7 +3,10 @@ use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite, Transaction};
 
 use crate::{
     commands::reservations,
-    domain::booking::{pricing::calculate_stay_price_tx, BookingResult},
+    domain::booking::{
+        pricing::{calculate_stay_price, calculate_stay_price_tx},
+        BookingError, BookingResult,
+    },
     models::{
         CheckInRequest, CheckOutRequest, CreateGuestRequest, CreateReservationRequest,
         GroupCheckinRequest, GroupCheckoutRequest,
@@ -324,6 +327,50 @@ pub async fn seed_pricing_rule_tx(
     .bind(room_type)
     .bind(daily_rate)
     .bind(now)
+    .bind(now)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn seed_special_date(
+    pool: &Pool<Sqlite>,
+    date: &str,
+    uplift_pct: f64,
+) -> BookingResult<()> {
+    let now = "2026-04-15T10:00:00+07:00";
+
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(format!("special-date-{}", date))
+    .bind(date)
+    .bind("Holiday uplift")
+    .bind(uplift_pct)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn seed_special_date_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    date: &str,
+    uplift_pct: f64,
+) -> BookingResult<()> {
+    let now = "2026-04-15T10:00:00+07:00";
+
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(format!("special-date-{}", date))
+    .bind(date)
+    .bind("Holiday uplift")
+    .bind(uplift_pct)
     .bind(now)
     .execute(&mut **tx)
     .await?;
@@ -1123,6 +1170,145 @@ async fn calculate_stay_price_tx_reads_uncommitted_pricing_rule() {
     assert_eq!(pricing.total, 1_200_000.0);
 
     tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn calculate_stay_price_matches_tx_path_and_applies_special_date_uplift() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R149").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_special_date(&pool, "2026-04-20", 10.0).await.unwrap();
+
+    let pool_pricing = calculate_stay_price(
+        &pool,
+        "R149",
+        "2026-04-20T10:00:00+07:00",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(pool_pricing.total, 1_320_000.0);
+    assert_eq!(pool_pricing.surcharge_amount, 120_000.0);
+
+    let mut tx = pool.begin().await.unwrap();
+    let tx_pricing = calculate_stay_price_tx(
+        &mut tx,
+        "R149",
+        "2026-04-20T10:00:00+07:00",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(tx_pricing.pricing_type, pool_pricing.pricing_type);
+    assert_eq!(tx_pricing.base_amount, pool_pricing.base_amount);
+    assert_eq!(tx_pricing.surcharge_amount, pool_pricing.surcharge_amount);
+    assert_eq!(tx_pricing.weekend_amount, pool_pricing.weekend_amount);
+    assert_eq!(tx_pricing.total, pool_pricing.total);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn calculate_stay_price_tx_reads_uncommitted_room_base_price() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R151").await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    sqlx::query("UPDATE rooms SET base_price = ? WHERE id = ?")
+        .bind(600_000.0_f64)
+        .bind("R151")
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+
+    let pricing = calculate_stay_price_tx(
+        &mut tx,
+        "R151",
+        "2026-04-20T10:00:00+07:00",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(pricing.total, 1_200_000.0);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn calculate_stay_price_tx_reads_uncommitted_special_date() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R152").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    seed_special_date_tx(&mut tx, "2026-04-20", 10.0)
+        .await
+        .unwrap();
+
+    let pricing = calculate_stay_price_tx(
+        &mut tx,
+        "R152",
+        "2026-04-20T10:00:00+07:00",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(pricing.total, 1_320_000.0);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn calculate_stay_price_returns_not_found_for_missing_room() {
+    let pool = test_pool().await;
+
+    let error = calculate_stay_price(
+        &pool,
+        "missing-room",
+        "2026-04-20T10:00:00+07:00",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        BookingError::NotFound(message) if message.contains("Không tìm thấy phòng missing-room")
+    ));
+}
+
+#[tokio::test]
+async fn calculate_stay_price_returns_datetime_parse_for_invalid_check_in() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R153").await.unwrap();
+
+    let error = calculate_stay_price(
+        &pool,
+        "R153",
+        "not-a-datetime",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        BookingError::DateTimeParse(message) if message.contains("Invalid check-in datetime")
+    ));
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -847,7 +847,11 @@ async fn group_checkin_reservation_blocks_calendar_and_tracks_deposit() {
         .unwrap();
 
     let mut req = minimal_group_checkin_request(&["G201", "G202"]);
-    req.check_in_date = Some("2026-04-20".to_string());
+    req.check_in_date = Some(
+        (Local::now().date_naive() + Duration::days(2))
+            .format("%Y-%m-%d")
+            .to_string(),
+    );
     req.paid_amount = Some(60_000.0);
 
     let group = group_lifecycle::group_checkin(&pool, None, req)

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -1192,7 +1192,16 @@ async fn calculate_stay_price_matches_tx_path_and_applies_special_date_uplift() 
     .unwrap();
 
     assert_eq!(pool_pricing.total, 1_320_000.0);
+    assert_eq!(pool_pricing.base_amount, 1_200_000.0);
     assert_eq!(pool_pricing.surcharge_amount, 120_000.0);
+    assert_eq!(pool_pricing.weekend_amount, 0.0);
+    assert_eq!(pool_pricing.breakdown.len(), 2);
+    assert_eq!(pool_pricing.breakdown[0].amount, 1_200_000.0);
+    assert!(pool_pricing.breakdown[0].label.contains("night(s)"));
+    assert!(pool_pricing
+        .breakdown
+        .iter()
+        .any(|line| line.label == "Holiday surcharge"));
 
     let mut tx = pool.begin().await.unwrap();
     let tx_pricing = calculate_stay_price_tx(
@@ -1210,6 +1219,53 @@ async fn calculate_stay_price_matches_tx_path_and_applies_special_date_uplift() 
     assert_eq!(tx_pricing.surcharge_amount, pool_pricing.surcharge_amount);
     assert_eq!(tx_pricing.weekend_amount, pool_pricing.weekend_amount);
     assert_eq!(tx_pricing.total, pool_pricing.total);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn calculate_stay_price_tx_returns_not_found_for_missing_room() {
+    let pool = test_pool().await;
+    let mut tx = pool.begin().await.unwrap();
+
+    let error = calculate_stay_price_tx(
+        &mut tx,
+        "missing-room",
+        "2026-04-20T10:00:00+07:00",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        BookingError::NotFound(message) if message.contains("Không tìm thấy phòng missing-room")
+    ));
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn calculate_stay_price_tx_returns_datetime_parse_for_invalid_check_in() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R153").await.unwrap();
+    let mut tx = pool.begin().await.unwrap();
+
+    let error = calculate_stay_price_tx(
+        &mut tx,
+        "R153",
+        "not-a-datetime",
+        "2026-04-22T10:00:00+07:00",
+        "nightly",
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        BookingError::DateTimeParse(message) if message.contains("Invalid check-in datetime")
+    ));
 
     tx.rollback().await.unwrap();
 }


### PR DESCRIPTION
## Summary
- refactor stay pricing into a shared load inputs -> build effective rule -> calculate pipeline
- keep tx and non-tx database loading separate while unifying the pricing decision and calculation path
- add regression coverage for tx parity, uncommitted pricing inputs, and the group checkin reservation path

## Verification
- cargo test calculate_stay_price_ --manifest-path mhm/src-tauri/Cargo.toml
- cargo test group_checkin_ --manifest-path mhm/src-tauri/Cargo.toml
- cargo test create_reservation_ --manifest-path mhm/src-tauri/Cargo.toml