### PR TITLE
[codex] Add dashboard activity detail drawer

### DIFF
--- a/mhm/src-tauri/src/commands/analytics.rs
+++ b/mhm/src-tauri/src/commands/analytics.rs
@@ -56,6 +56,11 @@ pub async fn get_recent_activity(
             text: format!("Check-in {} → {}", name, room_id),
             time,
             color: "bg-emerald-50".to_string(),
+            kind: "check_in".to_string(),
+            room_id: Some(room_id),
+            guest_name: Some(name),
+            occurred_at: time_str,
+            status_label: "Đã check-in".to_string(),
         });
     }
 
@@ -81,6 +86,11 @@ pub async fn get_recent_activity(
             text: format!("Check-out {} — Room {}", name, room_id),
             time,
             color: "bg-red-50".to_string(),
+            kind: "check_out".to_string(),
+            room_id: Some(room_id),
+            guest_name: Some(name),
+            occurred_at: time_str,
+            status_label: "Đã check-out".to_string(),
         });
     }
 
@@ -109,11 +119,16 @@ pub async fn get_recent_activity(
             text: format!("{} — Room {}", label, room_id),
             time,
             color: "bg-amber-50".to_string(),
+            kind: "housekeeping".to_string(),
+            room_id: Some(room_id),
+            guest_name: None,
+            occurred_at: time_str,
+            status_label: label.to_string(),
         });
     }
 
-    // Sort by time descending and limit
-    activities.sort_by(|a, b| b.time.cmp(&a.time));
+    // Sort by full timestamp descending to keep cross-day ordering stable.
+    activities.sort_by(|a, b| b.occurred_at.cmp(&a.occurred_at));
     activities.truncate(limit as usize);
 
     Ok(activities)

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -396,6 +396,11 @@ pub struct ActivityItem {
     pub text: String,
     pub time: String,
     pub color: String,
+    pub kind: String,
+    pub room_id: Option<String>,
+    pub guest_name: Option<String>,
+    pub occurred_at: String,
+    pub status_label: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/mhm/src/components/ActivityDetailDrawer.tsx
+++ b/mhm/src/components/ActivityDetailDrawer.tsx
@@ -1,0 +1,109 @@
+import { Activity, ArrowRight, Clock3, DoorOpen, UserRound } from "lucide-react";
+
+import InfoItem from "@/components/shared/InfoItem";
+import Section from "@/components/shared/Section";
+import SlideDrawer from "@/components/shared/SlideDrawer";
+import { Button } from "@/components/ui/button";
+import type { ActivityItem } from "@/types";
+
+interface ActivityDetailDrawerProps {
+    open: boolean;
+    activity: ActivityItem | null;
+    onClose: () => void;
+    onOpenRoom?: (roomId: string) => void;
+}
+
+const KIND_LABELS: Record<NonNullable<ActivityItem["kind"]>, string> = {
+    check_in: "Check-in",
+    check_out: "Check-out",
+    housekeeping: "Housekeeping",
+};
+
+function getKindLabel(kind?: ActivityItem["kind"]) {
+    return kind ? KIND_LABELS[kind] : "Hoạt động";
+}
+
+function formatOccurredAt(value?: string) {
+    if (!value) return "—";
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return value;
+    }
+
+    return parsed.toLocaleString("vi-VN", {
+        hour: "2-digit",
+        minute: "2-digit",
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+    });
+}
+
+export default function ActivityDetailDrawer({
+    open,
+    activity,
+    onClose,
+    onOpenRoom,
+}: ActivityDetailDrawerProps) {
+    if (!open || !activity) return null;
+
+    return (
+        <SlideDrawer
+            open={open}
+            onClose={onClose}
+            width="w-[420px]"
+            title="Chi tiết hoạt động"
+            subtitle={getKindLabel(activity.kind)}
+        >
+            <div className="flex-1 overflow-y-auto p-6 space-y-4">
+                <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+                    <div className="flex items-start gap-3">
+                        <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 text-base ${activity.color || "bg-slate-100"}`}>
+                            {activity.icon}
+                        </div>
+                        <div className="min-w-0">
+                            <p className="text-base font-semibold text-brand-text leading-snug">{activity.text}</p>
+                            <p className="text-sm text-brand-muted mt-1">{activity.status_label || getKindLabel(activity.kind)}</p>
+                        </div>
+                    </div>
+                </div>
+
+                <Section icon={Activity} title="Tổng quan">
+                    <div className="grid grid-cols-2 gap-4">
+                        <InfoItem label="Loại" value={getKindLabel(activity.kind)} />
+                        <InfoItem label="Trạng thái" value={activity.status_label || "Cập nhật"} />
+                        <InfoItem label="Giờ hiển thị" value={activity.time || "—"} />
+                        <InfoItem label="Ghi nhận lúc" value={formatOccurredAt(activity.occurred_at)} />
+                    </div>
+                </Section>
+
+                <Section icon={UserRound} title="Liên quan">
+                    <div className="grid grid-cols-2 gap-4">
+                        <InfoItem label="Khách" value={activity.guest_name || "—"} />
+                        <InfoItem label="Phòng" value={activity.room_id || "—"} />
+                    </div>
+                </Section>
+
+                {activity.room_id ? (
+                    <Section icon={DoorOpen} title="Điều hướng">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="w-full justify-between cursor-pointer"
+                            onClick={() => onOpenRoom?.(activity.room_id!)}
+                        >
+                            Mở phòng {activity.room_id}
+                            <ArrowRight />
+                        </Button>
+                    </Section>
+                ) : null}
+
+                <div className="flex items-center gap-2 text-xs text-brand-muted">
+                    <Clock3 size={14} />
+                    Dữ liệu lấy từ activity feed của dashboard overview.
+                </div>
+            </div>
+        </SlideDrawer>
+    );
+}

--- a/mhm/src/pages/Dashboard.tsx
+++ b/mhm/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useHotelStore } from "../stores/useHotelStore";
+import ActivityDetailDrawer from "@/components/ActivityDetailDrawer";
 import UnifiedRoomCard from "../components/UnifiedRoomCard";
 import RoomDrawer from "../components/RoomDrawer";
 import StatCard from "@/components/shared/StatCard";
@@ -22,6 +23,7 @@ export default function Dashboard() {
   const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
   const [roomAvailability, setRoomAvailability] = useState<Record<string, string | null>>({});
   const [drawerRoomId, setDrawerRoomId] = useState<string | null>(null);
+  const [selectedActivity, setSelectedActivity] = useState<ActivityItem | null>(null);
 
   useEffect(() => {
     fetchRooms();
@@ -65,6 +67,11 @@ export default function Dashboard() {
     setDrawerRoomId(null);
     fetchRooms();
     fetchStats();
+  };
+
+  const handleActivityRoomOpen = (roomId: string) => {
+    setSelectedActivity(null);
+    setDrawerRoomId(roomId);
   };
 
   return (
@@ -215,7 +222,12 @@ export default function Dashboard() {
           </div>
           <div className="flex-1 space-y-3 overflow-y-auto pr-1">
             {activities.length > 0 ? activities.map((item, i) => (
-              <div key={i} className="flex items-start gap-3 p-2.5 rounded-xl hover:bg-slate-50/50 transition-colors">
+              <button
+                key={`${item.kind ?? "activity"}-${item.occurred_at ?? item.time}-${i}`}
+                type="button"
+                onClick={() => setSelectedActivity(item)}
+                className="w-full flex items-start gap-3 p-2.5 rounded-xl hover:bg-slate-50/50 transition-colors text-left cursor-pointer"
+              >
                 <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 text-sm ${item.color}`}>
                   {item.icon}
                 </div>
@@ -223,7 +235,7 @@ export default function Dashboard() {
                   <p className="text-sm font-medium text-brand-text leading-tight">{item.text}</p>
                   <p className="text-[11px] text-brand-muted mt-0.5">{item.time}</p>
                 </div>
-              </div>
+              </button>
             )) : (
               <EmptyState message="Chưa có hoạt động nào" />
             )}
@@ -232,9 +244,15 @@ export default function Dashboard() {
 
       </div>
 
+      <ActivityDetailDrawer
+        open={!!selectedActivity}
+        activity={selectedActivity}
+        onClose={() => setSelectedActivity(null)}
+        onOpenRoom={handleActivityRoomOpen}
+      />
+
       {/* Room Drawer */}
       <RoomDrawer open={!!drawerRoomId} onClose={handleDrawerClose} roomId={drawerRoomId} />
     </div >
   );
 }
-

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -270,6 +270,11 @@ export interface ActivityItem {
   text: string;
   time: string;
   color: string;
+  kind?: "check_in" | "check_out" | "housekeeping";
+  room_id?: string | null;
+  guest_name?: string | null;
+  occurred_at?: string;
+  status_label?: string;
 }
 
 export interface ExpenseItem {

--- a/mhm/tests/e2e/02-dashboard.test.tsx
+++ b/mhm/tests/e2e/02-dashboard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, waitFor } from "../helpers/render-app";
+import userEvent from "@testing-library/user-event";
 import Dashboard from "@/pages/Dashboard";
 import { setMockResponse, clearMockResponses, invoke } from "@test-mocks/tauri-core";
 import { useHotelStore } from "@/stores/useHotelStore";
@@ -26,7 +27,17 @@ describe("02 — Dashboard", () => {
         setMockResponse("get_rooms", () => mockRooms);
         setMockResponse("get_dashboard_stats", () => mockStats);
         setMockResponse("get_recent_activity", () => [
-            { icon: "🔑", text: "Check-in phòng 2A — Nguyễn Văn A", time: "10:30", color: "green" },
+            {
+                icon: "🔑",
+                text: "Check-in phòng 2A — Nguyễn Văn A",
+                time: "10:30",
+                color: "green",
+                kind: "check_in",
+                room_id: "2A",
+                guest_name: "Nguyễn Văn A",
+                occurred_at: "2026-03-15T10:30:00",
+                status_label: "Đã check-in",
+            },
         ]);
         setMockResponse("get_revenue_stats", () => ({
             total_revenue: 1200000,
@@ -103,5 +114,23 @@ describe("02 — Dashboard", () => {
         // Find and click a room card — rooms are rendered via RoomCard
         // The room name "1A" should be clickable
         screen.getByText("1A");
+    });
+
+    it("opens activity detail drawer when clicking an activity item", async () => {
+        const user = userEvent.setup();
+
+        render(<Dashboard />);
+
+        const activityButton = await screen.findByRole("button", {
+            name: /check-in phòng 2a — nguyễn văn a/i,
+        });
+
+        await user.click(activityButton);
+
+        expect(screen.getByText("Chi tiết hoạt động")).toBeInTheDocument();
+        expect(screen.getAllByText("Đã check-in").length).toBeGreaterThan(0);
+        expect(screen.getByText("Ghi nhận lúc")).toBeInTheDocument();
+        expect(screen.getByText("Điều hướng")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /mở phòng 2a/i })).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## What changed
- made dashboard activity rows clickable instead of static display-only items
- added a reusable `ActivityDetailDrawer` built on top of the existing `SlideDrawer` pattern
- expanded `get_recent_activity` payloads with structured metadata (`kind`, `room_id`, `guest_name`, `occurred_at`, `status_label`) so the UI can render real activity details without parsing display text
- sorted recent activity by full timestamp instead of just `HH:MM` to keep ordering stable across days
- added a dashboard test covering `click activity -> open detail drawer`

## Why
The overview activity feed had no interaction model and no structured data behind each row, so clicking an item could not show a meaningful detail panel. This change fixes the root issue by carrying activity metadata through the backend and reusing the app's existing right-drawer detail pattern.

## User impact
- users can click an activity item in Dashboard Overview and see its detail drawer
- room-related activities include a direct action to open the linked room drawer
- the interaction stays consistent with the rest of the app's drawer-based detail flows

## Validation
- `npm test -- tests/e2e/02-dashboard.test.tsx` (verified in the main workspace on the same commit before cherry-pick)
- `cargo check`
- `npm run build` (verified in the main workspace on the same commit before cherry-pick)

## Notes
A previous PR was created from a dirty branch with unrelated commits. This PR is the clean branch containing only the activity/dashboard interaction change.