### PR TITLE
[codex] Add checkout settlement flow

### DIFF
--- a/mhm/src-tauri/src/commands/invoices.rs
+++ b/mhm/src-tauri/src/commands/invoices.rs
@@ -24,7 +24,7 @@ pub async fn do_generate_invoice(
     // Fetch booking
     let b = sqlx::query(
         "SELECT b.id, b.room_id, b.primary_guest_id, b.check_in_at, b.expected_checkout,
-                b.nights, b.total_price, b.paid_amount, b.status, b.notes,
+                b.actual_checkout, b.nights, b.total_price, b.paid_amount, b.status, b.notes,
                 b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout,
                 b.pricing_snapshot, b.pricing_type,
                 r.name as room_name, r.type as room_type, r.base_price,
@@ -80,33 +80,65 @@ pub async fn do_generate_invoice(
     let guest_phone: Option<String> = b.get("guest_phone");
     let nights: i32 = b.get("nights");
     let total_price: f64 = get_f64(&b, "total_price");
+    let paid_amount: f64 = get_f64(&b, "paid_amount");
     let deposit_amount: f64 = b.try_get::<f64, _>("deposit_amount").unwrap_or(0.0);
     let notes: Option<String> = b.get("notes");
+    let pricing_snapshot: Option<String> = b.get("pricing_snapshot");
+
+    let checkout_settlement = pricing_snapshot
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| value.get("checkout_settlement").cloned());
+
+    let settlement_label = checkout_settlement
+        .as_ref()
+        .and_then(|value| value.get("label").cloned())
+        .and_then(|value| value.as_str().map(str::to_string));
+    let settlement_mode = checkout_settlement
+        .as_ref()
+        .and_then(|value| value.get("mode").cloned())
+        .and_then(|value| value.as_str().map(str::to_string));
+    let settlement_reporting_checkout = checkout_settlement
+        .as_ref()
+        .and_then(|value| value.get("reporting_checkout").cloned())
+        .and_then(|value| value.as_str().map(str::to_string));
 
     let check_in: String = b
         .try_get::<String, _>("scheduled_checkin")
         .ok()
         .or_else(|| Some(b.get::<String, _>("check_in_at")))
         .unwrap();
-    let check_out: String = b
-        .try_get::<String, _>("scheduled_checkout")
-        .ok()
-        .or_else(|| Some(b.get::<String, _>("expected_checkout")))
-        .unwrap();
+    let scheduled_checkout = b.try_get::<Option<String>, _>("scheduled_checkout").ok().flatten();
+    let expected_checkout = b.try_get::<String, _>("expected_checkout").ok();
+    let actual_checkout = b.try_get::<Option<String>, _>("actual_checkout").ok().flatten();
+    let check_out: String = if settlement_mode.as_deref() == Some("booked_nights") {
+        settlement_reporting_checkout
+            .or(scheduled_checkout)
+            .or(expected_checkout)
+            .or(actual_checkout)
+            .unwrap_or_default()
+    } else {
+        actual_checkout
+            .or(scheduled_checkout)
+            .or(expected_checkout)
+            .unwrap_or_default()
+    };
 
-    // Build pricing breakdown — always use fresh English labels
+    // Keep invoice wording aligned with the settlement metadata when checkout finalized with
+    // an explicit settlement mode.
     let per_night = if nights > 0 {
         total_price / nights as f64
     } else {
         total_price
     };
     let breakdown: Vec<crate::pricing::PricingLine> = vec![crate::pricing::PricingLine {
-        label: format!("{} night(s) x {}d", nights, per_night as i64),
+        label: settlement_label
+            .unwrap_or_else(|| format!("{} night(s) x {}d", nights, per_night as i64)),
         amount: total_price,
     }];
 
     let subtotal = total_price;
-    let balance_due = total_price - deposit_amount;
+    let balance_due = (total_price - paid_amount).max(0.0);
 
     // Generate invoice number: INV-YYYYMMDD-XXX
     let today = chrono::Local::now().format("%Y%m%d").to_string();
@@ -246,7 +278,7 @@ pub async fn get_invoice(
 
 #[cfg(test)]
 mod tests {
-    use super::do_generate_invoice;
+    use super::{do_generate_invoice, do_get_invoice};
     use crate::app_identity;
     use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
 
@@ -356,5 +388,125 @@ mod tests {
         assert_eq!(invoice.hotel_name, app_identity::APP_NAME);
         assert_eq!(invoice.hotel_address, "");
         assert_eq!(invoice.hotel_phone, "");
+    }
+
+    #[tokio::test]
+    async fn generate_invoice_prefers_actual_checkout_and_settlement_label() {
+        let pool = test_pool().await;
+        seed_invoice_booking(&pool, "booking-settled").await;
+
+        sqlx::query(
+            "UPDATE bookings
+             SET status = 'checked_out',
+                 actual_checkout = '2026-04-20T18:00:00+07:00',
+                 nights = 1,
+                 total_price = 500000,
+                 paid_amount = 500000,
+                 pricing_snapshot = ?
+             WHERE id = ?",
+        )
+        .bind(r#"{"checkout_settlement":{"label":"Thanh toán theo số đêm thực tế"}}"#)
+        .bind("booking-settled")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let invoice = do_generate_invoice(&pool, "booking-settled")
+            .await
+            .unwrap();
+
+        assert_eq!(invoice.check_out, "2026-04-20T18:00:00+07:00");
+        assert_eq!(invoice.total, 500_000.0);
+        assert_eq!(invoice.balance_due, 0.0);
+        assert_eq!(
+            invoice.pricing_breakdown[0].label,
+            "Thanh toán theo số đêm thực tế"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_invoice_booked_nights_uses_billed_checkout_boundary() {
+        let pool = test_pool().await;
+        seed_invoice_booking(&pool, "booking-booked-nights").await;
+
+        sqlx::query(
+            "UPDATE bookings
+             SET status = 'checked_out',
+                 expected_checkout = '2026-04-26T10:00:00+07:00',
+                 actual_checkout = '2026-04-22T09:00:00+07:00',
+                 nights = 5,
+                 total_price = 2500000,
+                 paid_amount = 2500000,
+                 pricing_snapshot = ?
+             WHERE id = ?",
+        )
+        .bind(
+            r#"{"checkout_settlement":{"mode":"booked_nights","label":"Thanh toán theo số đêm đã đặt","reporting_checkout":"2026-04-25"}}"#,
+        )
+        .bind("booking-booked-nights")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let invoice = do_generate_invoice(&pool, "booking-booked-nights")
+            .await
+            .unwrap();
+
+        assert_eq!(invoice.check_out, "2026-04-25");
+        assert_eq!(
+            invoice.pricing_breakdown[0].label,
+            "Thanh toán theo số đêm đã đặt"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_invoice_uses_paid_amount_not_deposit_amount_for_balance_due() {
+        let pool = test_pool().await;
+        seed_invoice_booking(&pool, "booking-balance").await;
+
+        sqlx::query(
+            "UPDATE bookings
+             SET total_price = 500000, paid_amount = 500000, deposit_amount = 100000
+             WHERE id = ?",
+        )
+        .bind("booking-balance")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let invoice = do_generate_invoice(&pool, "booking-balance")
+            .await
+            .unwrap();
+
+        assert_eq!(invoice.balance_due, 0.0);
+    }
+
+    #[tokio::test]
+    async fn get_invoice_returns_none_when_no_invoice_exists() {
+        let pool = test_pool().await;
+        seed_invoice_booking(&pool, "booking-2").await;
+
+        let invoice = do_get_invoice(&pool, "booking-2")
+            .await
+            .expect("lookup should succeed");
+
+        assert!(invoice.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_invoice_returns_existing_invoice() {
+        let pool = test_pool().await;
+        seed_invoice_booking(&pool, "booking-3").await;
+        let generated = do_generate_invoice(&pool, "booking-3")
+            .await
+            .expect("invoice should be generated");
+
+        let invoice = do_get_invoice(&pool, "booking-3")
+            .await
+            .expect("lookup should succeed")
+            .expect("invoice should exist");
+
+        assert_eq!(invoice.invoice_number, generated.invoice_number);
+        assert_eq!(invoice.booking_id, "booking-3");
     }
 }

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -178,6 +178,17 @@ pub async fn check_out(
     Ok(())
 }
 
+#[allow(dead_code)]
+#[tauri::command]
+pub async fn preview_checkout_settlement(
+    state: State<'_, AppState>,
+    req: CheckoutSettlementPreviewRequest,
+) -> Result<CheckoutSettlementPreview, String> {
+    stay_lifecycle::preview_checkout_settlement(&state.db, req)
+        .await
+        .map_err(|error| error.to_string())
+}
+
 // ─── Extend Stay ───
 
 #[tauri::command]

--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -22,6 +22,7 @@ pub struct HotelTools {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{GetSettingsInput, HotelTools};
     use crate::app_identity;

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -152,6 +152,7 @@ pub fn run() {
             commands::rooms::check_in,
             commands::rooms::get_room_detail,
             commands::rooms::check_out,
+            commands::rooms::preview_checkout_settlement,
             commands::rooms::extend_stay,
             commands::rooms::get_housekeeping_tasks,
             commands::rooms::update_housekeeping,

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -199,10 +199,33 @@ pub struct CheckInRequest {
     pub pricing_type: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckoutSettlementMode {
+    ActualNights,
+    Hourly,
+    BookedNights,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CheckOutRequest {
     pub booking_id: String,
-    pub final_paid: Option<f64>,
+    pub settlement_mode: CheckoutSettlementMode,
+    pub final_total: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckoutSettlementPreviewRequest {
+    pub booking_id: String,
+    pub settlement_mode: CheckoutSettlementMode,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CheckoutSettlementPreview {
+    pub settlement_mode: CheckoutSettlementMode,
+    pub settled_nights: i32,
+    pub recommended_total: f64,
+    pub explanation: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/mhm/src-tauri/src/queries/booking/audit_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/audit_queries.rs
@@ -29,17 +29,19 @@ pub async fn load_night_audit_snapshot(
         .fetch_one(pool)
         .await?;
 
-    let rooms_sold: (i32,) = sqlx::query_as(
+    let occupancy_checkout = revenue_queries::occupancy_checkout_date_sql("");
+    let rooms_sold_query = format!(
         "SELECT COUNT(DISTINCT room_id)
          FROM bookings
          WHERE status IN ('active', 'checked_out')
            AND DATE(check_in_at) < DATE(?1, '+1 day')
-           AND DATE(COALESCE(actual_checkout, expected_checkout)) > DATE(?2)",
-    )
-    .bind(audit_date)
-    .bind(audit_date)
-    .fetch_one(pool)
-    .await?;
+           AND DATE({occupancy_checkout}) > DATE(?2)"
+    );
+    let rooms_sold: (i32,) = sqlx::query_as(&rooms_sold_query)
+        .bind(audit_date)
+        .bind(audit_date)
+        .fetch_one(pool)
+        .await?;
 
     let occupancy_pct = if total_rooms.0 > 0 {
         (rooms_sold.0 as f64 / total_rooms.0 as f64 * 100.0).round()
@@ -93,12 +95,19 @@ pub async fn load_booking_export_rows(
     from_date: &str,
     to_date: &str,
 ) -> Result<Vec<BookingExportRow>, sqlx::Error> {
-    let rows = sqlx::query(
+    let reporting_checkout = revenue_queries::recognized_checkout_date_sql("b.");
+    let export_checkout = format!(
+        "CASE
+            WHEN b.status = 'checked_out' THEN {reporting_checkout}
+            ELSE b.expected_checkout
+        END"
+    );
+    let rows = sqlx::query(&format!(
         "SELECT b.id, b.room_id,
                 COALESCE(g.full_name, '') AS guest_name,
                 COALESCE(g.doc_number, '') AS doc_number,
                 COALESCE(g.phone, '') AS phone,
-                b.check_in_at, b.expected_checkout, COALESCE(b.actual_checkout, '') AS actual_checkout,
+                b.check_in_at, {export_checkout} AS expected_checkout, COALESCE(b.actual_checkout, '') AS actual_checkout,
                 b.nights, b.total_price,
                 COALESCE(charges.charge_total, 0) AS charge_total,
                 COALESCE(fees.cancellation_fee_total, 0) AS cancellation_fee_total,
@@ -127,8 +136,22 @@ pub async fn load_booking_export_rows(
              FROM folio_lines
              GROUP BY booking_id
          ) folio ON folio.booking_id = b.id
-         WHERE DATE(b.check_in_at) BETWEEN DATE(?) AND DATE(?)
-         ORDER BY b.check_in_at DESC",
+         WHERE (
+                b.status = 'checked_out'
+                AND DATE({reporting_checkout}) BETWEEN DATE(?1) AND DATE(?2)
+            )
+            OR (
+                b.status != 'checked_out'
+                AND DATE(b.check_in_at) BETWEEN DATE(?1) AND DATE(?2)
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM transactions tx
+                WHERE tx.booking_id = b.id
+                  AND tx.type = 'cancellation_fee'
+                  AND DATE(tx.created_at) BETWEEN DATE(?1) AND DATE(?2)
+            )
+         ORDER BY b.check_in_at DESC")
     )
     .bind(from_date)
     .bind(to_date)

--- a/mhm/src-tauri/src/queries/booking/revenue_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/revenue_queries.rs
@@ -289,17 +289,19 @@ pub async fn load_daily_revenue(
 }
 
 async fn load_rooms_sold(pool: &Pool<Sqlite>, from: &str, to: &str) -> Result<i32, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as(
+    let occupancy_checkout = occupancy_checkout_date_sql("");
+    let query = format!(
         "SELECT COUNT(DISTINCT room_id)
          FROM bookings
          WHERE status IN ('active', 'checked_out')
            AND DATE(check_in_at) < DATE(?1, '+1 day')
-           AND DATE(COALESCE(actual_checkout, expected_checkout)) > DATE(?2)",
-    )
-    .bind(to)
-    .bind(from)
-    .fetch_one(pool)
-    .await?;
+           AND DATE({occupancy_checkout}) > DATE(?2)"
+    );
+    let row: (i64,) = sqlx::query_as(&query)
+        .bind(to)
+        .bind(from)
+        .fetch_one(pool)
+        .await?;
 
     Ok(row.0 as i32)
 }
@@ -309,19 +311,19 @@ async fn load_room_nights_sold(
     from: &str,
     to: &str,
 ) -> Result<f64, sqlx::Error> {
-    let row: (f64,) = sqlx::query_as(
+    let recognized_checkout = recognized_checkout_date_sql("");
+    let row: (f64,) = sqlx::query_as(&format!(
         "SELECT CAST(COALESCE(SUM(
             MAX(
                 0,
-                JULIANDAY(MIN(DATE(COALESCE(actual_checkout, expected_checkout)), DATE(?1, '+1 day'))) -
+                JULIANDAY(MIN(DATE({recognized_checkout}), DATE(?1, '+1 day'))) -
                 JULIANDAY(MAX(DATE(check_in_at), DATE(?2)))
             )
          ), 0) AS REAL)
          FROM bookings
-         WHERE status IN ('active', 'checked_out')
-           AND DATE(check_in_at) < DATE(?1, '+1 day')
-           AND DATE(COALESCE(actual_checkout, expected_checkout)) > DATE(?2)",
-    )
+         WHERE {}",
+        recognized_room_revenue_filter_sql(""),
+    ))
     .bind(to)
     .bind(from)
     .fetch_one(pool)
@@ -336,13 +338,34 @@ fn normalize_date(value: &str) -> NaiveDate {
         .expect("revenue query dates should always be normalized")
 }
 
+pub(crate) fn recognized_checkout_date_sql(column_prefix: &str) -> String {
+    format!(
+        "COALESCE(
+            DATE(json_extract({column_prefix}pricing_snapshot, '$.checkout_settlement.reporting_checkout')),
+            DATE(COALESCE({column_prefix}actual_checkout, {column_prefix}expected_checkout))
+        )"
+    )
+}
+
+pub(crate) fn occupancy_checkout_date_sql(column_prefix: &str) -> String {
+    format!(
+        "CASE
+            WHEN json_extract({column_prefix}pricing_snapshot, '$.checkout_settlement.mode') IN ('actual_nights', 'hourly')
+                 AND DATE(COALESCE({column_prefix}actual_checkout, {column_prefix}expected_checkout)) <= DATE({column_prefix}check_in_at)
+            THEN DATE({column_prefix}check_in_at, '+1 day')
+            ELSE DATE(COALESCE({column_prefix}actual_checkout, {column_prefix}expected_checkout))
+        END"
+    )
+}
+
 fn recognized_room_revenue_amount_sql(column_prefix: &str) -> String {
+    let recognized_checkout = recognized_checkout_date_sql(column_prefix);
     format!(
         "CASE
             WHEN {column_prefix}nights > 0 THEN {column_prefix}total_price * (
                 MAX(
                     0,
-                    JULIANDAY(MIN(DATE(COALESCE({column_prefix}actual_checkout, {column_prefix}expected_checkout)), DATE(?1, '+1 day'))) -
+                    JULIANDAY(MIN(DATE({recognized_checkout}), DATE(?1, '+1 day'))) -
                     JULIANDAY(MAX(DATE({column_prefix}check_in_at), DATE(?2)))
                 )
             ) / {column_prefix}nights
@@ -352,9 +375,10 @@ fn recognized_room_revenue_amount_sql(column_prefix: &str) -> String {
 }
 
 fn recognized_room_revenue_filter_sql(column_prefix: &str) -> String {
+    let recognized_checkout = recognized_checkout_date_sql(column_prefix);
     format!(
         "{column_prefix}status IN ('active', 'checked_out')
          AND DATE({column_prefix}check_in_at) < DATE(?1, '+1 day')
-         AND DATE(COALESCE({column_prefix}actual_checkout, {column_prefix}expected_checkout)) > DATE(?2)"
+         AND DATE({recognized_checkout}) > DATE(?2)"
     )
 }

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -243,6 +243,7 @@ fn settlement_explanation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn checkout_settlement_snapshot(
     settlement_mode: CheckoutSettlementMode,
     original_nights: i32,

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1,9 +1,12 @@
-use chrono::{Duration, Local, NaiveDate};
+use chrono::{DateTime, Duration, Local, NaiveDate};
 use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::{
     domain::booking::{pricing::calculate_stay_price_tx, BookingError, BookingResult},
-    models::{status, Booking, CheckInRequest, CheckOutRequest},
+    models::{
+        status, Booking, CheckInRequest, CheckOutRequest, CheckoutSettlementMode,
+        CheckoutSettlementPreview, CheckoutSettlementPreviewRequest,
+    },
 };
 
 use super::{
@@ -152,17 +155,135 @@ pub async fn check_in(
     .await
 }
 
-pub async fn check_out(pool: &Pool<Sqlite>, req: CheckOutRequest) -> BookingResult<()> {
-    let mut tx = begin_tx(pool).await?;
+#[allow(dead_code)]
+struct CheckoutSettlementComputation {
+    room_id: String,
+    original_nights: i32,
+    actual_nights: i32,
+    settled_nights: i32,
+    original_total: f64,
+    recommended_total: f64,
+    already_paid: f64,
+    explanation: String,
+    reporting_checkout: String,
+}
 
-    let booking =
-        sqlx::query("SELECT room_id, paid_amount FROM bookings WHERE id = ? AND status = ?")
-            .bind(&req.booking_id)
-            .bind(status::booking::ACTIVE)
-            .fetch_optional(&mut *tx)
-            .await?;
+fn settlement_mode_label(mode: CheckoutSettlementMode) -> &'static str {
+    match mode {
+        CheckoutSettlementMode::ActualNights => "Thanh toán theo số đêm thực tế",
+        CheckoutSettlementMode::Hourly => "Thanh toán theo giờ",
+        CheckoutSettlementMode::BookedNights => "Thanh toán theo số đêm đã đặt",
+    }
+}
 
-    let booking = booking.ok_or_else(|| {
+fn actual_nights_for_checkout(
+    check_in_at: &str,
+    actual_checkout: DateTime<Local>,
+) -> BookingResult<i32> {
+    let check_in_date = parse_booking_datetime(check_in_at)?.date_naive();
+    let checkout_date = actual_checkout.date_naive();
+
+    Ok((checkout_date - check_in_date).num_days().max(1) as i32)
+}
+
+fn settlement_boundary_for(check_in_at: &str, settled_nights: i32) -> BookingResult<String> {
+    let check_in_dt = parse_booking_datetime(check_in_at)?;
+    Ok((check_in_dt + Duration::days(settled_nights as i64)).to_rfc3339())
+}
+
+fn reporting_checkout_for(
+    check_in_at: &str,
+    settled_nights: i32,
+    actual_checkout: DateTime<Local>,
+    settlement_mode: CheckoutSettlementMode,
+) -> BookingResult<String> {
+    let check_in_dt = parse_booking_datetime(check_in_at)?;
+    let check_in_date = check_in_dt.date_naive();
+
+    let report_date = match settlement_mode {
+        CheckoutSettlementMode::BookedNights => {
+            check_in_date + Duration::days(settled_nights as i64)
+        }
+        CheckoutSettlementMode::ActualNights | CheckoutSettlementMode::Hourly => {
+            let checkout_date = actual_checkout.date_naive();
+            if checkout_date <= check_in_date {
+                check_in_date + Duration::days(1)
+            } else {
+                checkout_date
+            }
+        }
+    };
+
+    Ok(report_date.format("%Y-%m-%d").to_string())
+}
+
+fn settlement_explanation(
+    settlement_mode: CheckoutSettlementMode,
+    settled_nights: i32,
+    recommended_total: f64,
+) -> String {
+    match settlement_mode {
+        CheckoutSettlementMode::Hourly => {
+            "Thanh toán theo giờ: nhập tay số tiền quyết toán".to_string()
+        }
+        CheckoutSettlementMode::ActualNights | CheckoutSettlementMode::BookedNights => {
+            let nightly_rate = if settled_nights > 0 {
+                recommended_total / settled_nights as f64
+            } else {
+                recommended_total
+            };
+
+            format!(
+                "{}: {} đêm x {:.0}đ",
+                settlement_mode_label(settlement_mode),
+                settled_nights,
+                nightly_rate
+            )
+        }
+    }
+}
+
+fn checkout_settlement_snapshot(
+    settlement_mode: CheckoutSettlementMode,
+    original_nights: i32,
+    actual_nights: i32,
+    settled_nights: i32,
+    reporting_checkout: &str,
+    original_total: f64,
+    settled_total: f64,
+    manual_override: bool,
+) -> String {
+    serde_json::json!({
+        "checkout_settlement": {
+            "mode": settlement_mode,
+            "label": settlement_mode_label(settlement_mode),
+            "reporting_checkout": reporting_checkout,
+            "original_nights": original_nights,
+            "actual_nights": actual_nights,
+            "settled_nights": settled_nights,
+            "original_total": original_total,
+            "settled_total": settled_total,
+            "manual_override": manual_override,
+        }
+    })
+    .to_string()
+}
+
+async fn preview_checkout_settlement_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    req: &CheckoutSettlementPreviewRequest,
+    now: DateTime<Local>,
+) -> BookingResult<CheckoutSettlementComputation> {
+    let booking = sqlx::query(
+        "SELECT room_id, check_in_at, nights, total_price, paid_amount,
+                COALESCE(pricing_type, 'nightly') AS pricing_type
+         FROM bookings WHERE id = ? AND status = ?",
+    )
+    .bind(&req.booking_id)
+    .bind(status::booking::ACTIVE)
+    .fetch_optional(&mut **tx)
+    .await?
+    .ok_or_else(|| {
         BookingError::not_found(format!(
             "Không tìm thấy booking đang active {}",
             req.booking_id
@@ -170,27 +291,159 @@ pub async fn check_out(pool: &Pool<Sqlite>, req: CheckOutRequest) -> BookingResu
     })?;
 
     let room_id: String = booking.get("room_id");
+    let check_in_at: String = booking.get("check_in_at");
+    let pricing_type: String = booking.get("pricing_type");
+    let original_nights: i32 = booking.get("nights");
+    let original_total = read_f64_or_zero(&booking, "total_price");
     let already_paid = read_f64_or_zero(&booking, "paid_amount");
+    let actual_nights = actual_nights_for_checkout(&check_in_at, now)?;
 
-    if let Some(final_paid) = req.final_paid {
-        let delta = final_paid - already_paid;
-        if delta > 0.0 {
-            record_payment_tx(&mut tx, &req.booking_id, delta, "Thanh toán khi check-out").await?;
+    let (settled_nights, recommended_total) = match req.settlement_mode {
+        CheckoutSettlementMode::ActualNights => {
+            let settled_nights = actual_nights.max(1);
+            let settlement_boundary = settlement_boundary_for(&check_in_at, settled_nights)?;
+            let pricing = calculate_stay_price_tx(
+                tx,
+                &room_id,
+                &check_in_at,
+                &settlement_boundary,
+                &pricing_type,
+            )
+            .await?;
+            (settled_nights, pricing.total)
         }
+        CheckoutSettlementMode::BookedNights => (original_nights.max(1), original_total),
+        CheckoutSettlementMode::Hourly => (1, original_total),
+    };
+
+    let explanation =
+        settlement_explanation(req.settlement_mode, settled_nights, recommended_total);
+    let reporting_checkout =
+        reporting_checkout_for(&check_in_at, settled_nights, now, req.settlement_mode)?;
+
+    Ok(CheckoutSettlementComputation {
+        room_id,
+        original_nights,
+        actual_nights,
+        settled_nights,
+        original_total,
+        recommended_total,
+        already_paid,
+        explanation,
+        reporting_checkout,
+    })
+}
+
+#[allow(dead_code)]
+pub async fn preview_checkout_settlement(
+    pool: &Pool<Sqlite>,
+    req: CheckoutSettlementPreviewRequest,
+) -> BookingResult<CheckoutSettlementPreview> {
+    preview_checkout_settlement_at(pool, req, Local::now()).await
+}
+
+#[allow(dead_code)]
+pub async fn preview_checkout_settlement_at(
+    pool: &Pool<Sqlite>,
+    req: CheckoutSettlementPreviewRequest,
+    now: DateTime<Local>,
+) -> BookingResult<CheckoutSettlementPreview> {
+    let mut tx = begin_tx(pool).await?;
+    let settlement = preview_checkout_settlement_tx(&mut tx, &req, now).await?;
+
+    tx.rollback().await.map_err(BookingError::from)?;
+
+    Ok(CheckoutSettlementPreview {
+        settlement_mode: req.settlement_mode,
+        settled_nights: settlement.settled_nights,
+        recommended_total: settlement.recommended_total,
+        explanation: settlement.explanation,
+    })
+}
+
+pub async fn check_out(pool: &Pool<Sqlite>, req: CheckOutRequest) -> BookingResult<()> {
+    check_out_at(pool, req, Local::now()).await
+}
+
+pub async fn check_out_at(
+    pool: &Pool<Sqlite>,
+    req: CheckOutRequest,
+    now: DateTime<Local>,
+) -> BookingResult<()> {
+    if req.final_total < 0.0 {
+        return Err(BookingError::validation(
+            "Tổng quyết toán phải lớn hơn hoặc bằng 0".to_string(),
+        ));
     }
 
-    let actual_checkout = Local::now().to_rfc3339();
+    let mut tx = begin_tx(pool).await?;
+    let preview_req = CheckoutSettlementPreviewRequest {
+        booking_id: req.booking_id.clone(),
+        settlement_mode: req.settlement_mode,
+    };
+    let settlement = preview_checkout_settlement_tx(&mut tx, &preview_req, now).await?;
+    let actual_checkout = now.to_rfc3339();
 
-    sqlx::query("UPDATE bookings SET status = ?, actual_checkout = ? WHERE id = ?")
+    if settlement.already_paid > req.final_total {
+        return Err(BookingError::validation(
+            "Overpaid booking requires refund handling before checkout".to_string(),
+        ));
+    }
+
+    let charge_delta = req.final_total - settlement.original_total;
+    if charge_delta.abs() > f64::EPSILON {
+        let adjustment_note = if charge_delta < 0.0 {
+            "Điều chỉnh giảm tiền phòng khi quyết toán check-out"
+        } else {
+            "Điều chỉnh tăng tiền phòng khi quyết toán check-out"
+        };
+
+        record_charge_tx(
+            &mut tx,
+            &req.booking_id,
+            charge_delta,
+            adjustment_note,
+            actual_checkout.clone(),
+        )
+        .await?;
+    }
+
+    let payment_delta = req.final_total - settlement.already_paid;
+    if payment_delta > f64::EPSILON {
+        record_payment_tx(&mut tx, &req.booking_id, payment_delta, "Thanh toán khi check-out")
+            .await?;
+    }
+
+    let manual_override = (req.final_total - settlement.recommended_total).abs() > f64::EPSILON;
+    let pricing_snapshot = checkout_settlement_snapshot(
+        req.settlement_mode,
+        settlement.original_nights,
+        settlement.actual_nights,
+        settlement.settled_nights,
+        &settlement.reporting_checkout,
+        settlement.original_total,
+        req.final_total,
+        manual_override,
+    );
+
+    sqlx::query(
+        "UPDATE bookings
+         SET status = ?, actual_checkout = ?, nights = ?, total_price = ?, paid_amount = ?, pricing_snapshot = ?
+         WHERE id = ?",
+    )
         .bind(status::booking::CHECKED_OUT)
         .bind(&actual_checkout)
+        .bind(settlement.settled_nights)
+        .bind(req.final_total)
+        .bind(req.final_total)
+        .bind(pricing_snapshot)
         .bind(&req.booking_id)
         .execute(&mut *tx)
         .await?;
 
     sqlx::query("UPDATE rooms SET status = ? WHERE id = ?")
         .bind(status::room::CLEANING)
-        .bind(&room_id)
+        .bind(&settlement.room_id)
         .execute(&mut *tx)
         .await?;
 
@@ -199,7 +452,7 @@ pub async fn check_out(pool: &Pool<Sqlite>, req: CheckOutRequest) -> BookingResu
          VALUES (?, ?, 'needs_cleaning', ?, ?)",
     )
     .bind(uuid::Uuid::new_v4().to_string())
-    .bind(&room_id)
+    .bind(&settlement.room_id)
     .bind(&actual_checkout)
     .bind(&actual_checkout)
     .execute(&mut *tx)

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -1,11 +1,12 @@
-use chrono::{Duration, Local};
+use chrono::{Duration, Local, TimeZone};
 use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite, Transaction};
 
 use crate::{
     commands::reservations,
     domain::booking::{pricing::calculate_stay_price_tx, BookingResult},
     models::{
-        CheckInRequest, CheckOutRequest, CreateGuestRequest, CreateReservationRequest,
+        CheckInRequest, CheckOutRequest, CheckoutSettlementMode,
+        CheckoutSettlementPreviewRequest, CreateGuestRequest, CreateReservationRequest,
         GroupCheckinRequest, GroupCheckoutRequest,
     },
     queries::booking::{audit_queries, billing_queries, revenue_queries},
@@ -388,6 +389,35 @@ pub async fn seed_active_booking(
         "INSERT INTO room_calendar (room_id, date, booking_id, status) VALUES (?, '2026-04-15', ?, 'occupied')",
     )
     .bind(room_id)
+    .bind(booking_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn seed_active_booking_with_terms(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    room_id: &str,
+    check_in_at: &str,
+    expected_checkout: &str,
+    nights: i64,
+    total_price: f64,
+    paid_amount: Option<f64>,
+) -> BookingResult<()> {
+    seed_active_booking(pool, booking_id, room_id).await?;
+
+    sqlx::query(
+        "UPDATE bookings
+         SET check_in_at = ?, expected_checkout = ?, nights = ?, total_price = ?, paid_amount = ?
+         WHERE id = ?",
+    )
+    .bind(check_in_at)
+    .bind(expected_checkout)
+    .bind(nights)
+    .bind(total_price)
+    .bind(paid_amount)
     .bind(booking_id)
     .execute(pool)
     .await?;
@@ -1735,64 +1765,586 @@ async fn check_in_posts_charge_and_marks_room_occupied() {
 }
 
 #[tokio::test]
-async fn check_out_allows_outstanding_balance_if_final_paid_absent() {
+async fn check_out_settles_same_day_actual_nights_to_minimum_one_night() {
     let pool = test_pool().await;
-    seed_room(&pool, "R202").await.unwrap();
-    seed_active_booking(&pool, "B202", "R202").await.unwrap();
-
-    stay_lifecycle::check_out(
+    seed_room(&pool, "R410").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000.0).await.unwrap();
+    seed_active_booking_with_terms(
         &pool,
-        CheckOutRequest {
-            booking_id: "B202".to_string(),
-            final_paid: None,
-        },
+        "B410",
+        "R410",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
     )
     .await
     .unwrap();
 
-    let booking =
-        sqlx::query("SELECT status, actual_checkout, paid_amount FROM bookings WHERE id = ?")
-            .bind("B202")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(booking.get::<String, _>("status"), "checked_out");
-    assert!(booking
-        .get::<Option<String>, _>("actual_checkout")
-        .is_some());
-    assert_eq!(booking.get::<Option<f64>, _>("paid_amount"), None);
-
-    let payment_count: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'payment'",
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B410".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 20, 18, 0, 0)
+            .single()
+            .unwrap(),
     )
-    .bind("B202")
+    .await
+    .unwrap();
+
+    assert_eq!(preview.settled_nights, 1);
+    assert_eq!(preview.recommended_total, 500_000.0);
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B410".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+            final_total: preview.recommended_total,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 20, 18, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query(
+        "SELECT nights, total_price, paid_amount, pricing_snapshot
+         FROM bookings WHERE id = ?",
+    )
+    .bind("B410")
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(payment_count.0, 0);
 
-    let room = sqlx::query("SELECT status FROM rooms WHERE id = ?")
-        .bind("R202")
+    assert_eq!(booking.get::<i64, _>("nights"), 1);
+    assert_eq!(booking.get::<f64, _>("total_price"), 500_000.0);
+    assert_eq!(booking.get::<f64, _>("paid_amount"), 500_000.0);
+    assert!(booking
+        .get::<Option<String>, _>("pricing_snapshot")
+        .unwrap()
+        .contains("\"reporting_checkout\""));
+}
+
+#[tokio::test]
+async fn check_out_keeps_active_booking_values_for_booked_nights_mode() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R411").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B411",
+        "R411",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(1_000_000.0),
+    )
+    .await
+    .unwrap();
+
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B411".to_string(),
+            settlement_mode: CheckoutSettlementMode::BookedNights,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.settled_nights, 5);
+    assert_eq!(preview.recommended_total, 2_500_000.0);
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B411".to_string(),
+            settlement_mode: CheckoutSettlementMode::BookedNights,
+            final_total: preview.recommended_total,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query("SELECT nights, total_price, paid_amount FROM bookings WHERE id = ?")
+        .bind("B411")
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(room.get::<String, _>("status"), "cleaning");
 
-    let housekeeping_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM housekeeping WHERE room_id = ?")
-            .bind("R202")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(housekeeping_count.0, 1);
+    assert_eq!(booking.get::<i64, _>("nights"), 5);
+    assert_eq!(booking.get::<f64, _>("total_price"), 2_500_000.0);
+    assert_eq!(booking.get::<f64, _>("paid_amount"), 2_500_000.0);
+}
 
-    let calendar_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
-            .bind("B202")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(calendar_count.0, 0);
+#[tokio::test]
+async fn check_out_booked_nights_enforces_minimum_one_night_for_corrupted_booking() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R413").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B413",
+        "R413",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-20T12:00:00+07:00",
+        0,
+        0.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B413".to_string(),
+            settlement_mode: CheckoutSettlementMode::BookedNights,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 20, 12, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.settled_nights, 1);
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B413".to_string(),
+            settlement_mode: CheckoutSettlementMode::BookedNights,
+            final_total: 0.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 20, 12, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query("SELECT nights FROM bookings WHERE id = ?")
+        .bind("B413")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(booking.get::<i64, _>("nights"), 1);
+}
+
+#[tokio::test]
+async fn check_out_actual_nights_uses_early_checkout_nights() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R414").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000.0).await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B414",
+        "R414",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B414".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.settled_nights, 2);
+    assert_eq!(preview.recommended_total, 1_000_000.0);
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B414".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+            final_total: preview.recommended_total,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B414")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(booking.get::<i64, _>("nights"), 2);
+    assert_eq!(booking.get::<f64, _>("total_price"), 1_000_000.0);
+}
+
+#[tokio::test]
+async fn check_out_hourly_persists_manual_settlement() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R415").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B415",
+        "R415",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B415".to_string(),
+            settlement_mode: CheckoutSettlementMode::Hourly,
+            final_total: 500_000.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 20, 10, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query(
+        "SELECT nights, total_price, paid_amount, pricing_snapshot
+         FROM bookings WHERE id = ?",
+    )
+    .bind("B415")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let pricing_snapshot = booking
+        .get::<Option<String>, _>("pricing_snapshot")
+        .unwrap();
+    let pricing_snapshot: serde_json::Value = serde_json::from_str(&pricing_snapshot).unwrap();
+
+    assert_eq!(booking.get::<i64, _>("nights"), 1);
+    assert_eq!(booking.get::<f64, _>("total_price"), 500_000.0);
+    assert_eq!(booking.get::<f64, _>("paid_amount"), 500_000.0);
+    assert_eq!(
+        pricing_snapshot["checkout_settlement"]["mode"],
+        serde_json::json!("hourly")
+    );
+    assert_eq!(
+        pricing_snapshot["checkout_settlement"]["settled_total"],
+        serde_json::json!(500_000.0)
+    );
+}
+
+#[tokio::test]
+async fn check_out_hourly_multi_day_stay_still_persists_one_night() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R419").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B419",
+        "R419",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B419".to_string(),
+            settlement_mode: CheckoutSettlementMode::Hourly,
+            final_total: 500_000.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B419")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(booking.get::<i64, _>("nights"), 1);
+    assert_eq!(booking.get::<f64, _>("total_price"), 500_000.0);
+}
+
+#[tokio::test]
+async fn check_out_persists_manual_override_when_final_total_differs_from_recommendation() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R416").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000.0).await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B416",
+        "R416",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(300_000.0),
+    )
+    .await
+    .unwrap();
+
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B416".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.recommended_total, 1_000_000.0);
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B416".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+            final_total: 800_000.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let booking = sqlx::query(
+        "SELECT total_price, paid_amount, pricing_snapshot
+         FROM bookings WHERE id = ?",
+    )
+    .bind("B416")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let pricing_snapshot = booking
+        .get::<Option<String>, _>("pricing_snapshot")
+        .unwrap();
+    let pricing_snapshot: serde_json::Value = serde_json::from_str(&pricing_snapshot).unwrap();
+
+    assert_eq!(booking.get::<f64, _>("total_price"), 800_000.0);
+    assert_eq!(booking.get::<f64, _>("paid_amount"), 800_000.0);
+    assert_eq!(
+        pricing_snapshot["checkout_settlement"]["manual_override"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        pricing_snapshot["checkout_settlement"]["settled_total"],
+        serde_json::json!(800_000.0)
+    );
+}
+
+#[tokio::test]
+async fn check_out_writes_charge_adjustment_ledger_when_settled_total_drops() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R417").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000.0).await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B417",
+        "R417",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(800_000.0),
+    )
+    .await
+    .unwrap();
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B417".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+            final_total: 800_000.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let adjustment = sqlx::query(
+        "SELECT amount, note FROM transactions
+         WHERE booking_id = ? AND type = 'charge' AND note LIKE 'Điều chỉnh %'
+         LIMIT 1",
+    )
+    .bind("B417")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let payment_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM transactions
+         WHERE booking_id = ? AND type = 'payment'"
+    )
+    .bind("B417")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(adjustment.get::<f64, _>("amount"), -1_700_000.0);
+    assert_eq!(
+        adjustment.get::<String, _>("note"),
+        "Điều chỉnh giảm tiền phòng khi quyết toán check-out"
+    );
+    assert_eq!(payment_count.0, 0);
+}
+
+#[tokio::test]
+async fn check_out_writes_payment_delta_ledger_when_collecting_extra_payment() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R418").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B418",
+        "R418",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(1_000_000.0),
+    )
+    .await
+    .unwrap();
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B418".to_string(),
+            settlement_mode: CheckoutSettlementMode::BookedNights,
+            final_total: 2_500_000.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let payment = sqlx::query(
+        "SELECT amount, note FROM transactions
+         WHERE booking_id = ? AND type = 'payment'
+         ORDER BY created_at DESC
+         LIMIT 1",
+    )
+    .bind("B418")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let booking = sqlx::query("SELECT paid_amount FROM bookings WHERE id = ?")
+        .bind("B418")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let charge_adjustment_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM transactions
+         WHERE booking_id = ? AND type = 'charge' AND note LIKE 'Điều chỉnh %'"
+    )
+    .bind("B418")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(payment.get::<f64, _>("amount"), 1_500_000.0);
+    assert_eq!(
+        payment.get::<String, _>("note"),
+        "Thanh toán khi check-out"
+    );
+    assert_eq!(booking.get::<f64, _>("paid_amount"), 2_500_000.0);
+    assert_eq!(charge_adjustment_count.0, 0);
+}
+
+#[tokio::test]
+async fn check_out_rejects_overpaid_booking_until_refund_flow_exists() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R412").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B412",
+        "R412",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(700_000.0),
+    )
+    .await
+    .unwrap();
+
+    let error = stay_lifecycle::check_out_at(
+        &pool,
+        CheckOutRequest {
+            booking_id: "B412".to_string(),
+            settlement_mode: CheckoutSettlementMode::Hourly,
+            final_total: 500_000.0,
+        },
+        chrono::Local
+            .with_ymd_and_hms(2026, 4, 20, 12, 0, 0)
+            .single()
+            .unwrap(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("refund"));
 }
 
 #[tokio::test]
@@ -1948,6 +2500,336 @@ async fn revenue_queries_include_cancellation_fees_in_recognized_revenue() {
     assert_eq!(cancelled_row.charge_total, 0.0);
     assert_eq!(cancelled_row.cancellation_fee_total, 50_000.0);
     assert_eq!(cancelled_row.recognized_revenue, 50_000.0);
+}
+
+#[tokio::test]
+async fn same_day_checkout_settlement_counts_one_room_sold_and_full_revenue() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R420").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B420",
+        "R420",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "UPDATE bookings
+         SET status = 'checked_out',
+             actual_checkout = '2026-04-20T18:00:00+07:00',
+             nights = 1,
+             total_price = 500000,
+             paid_amount = 500000,
+             pricing_snapshot = ?
+         WHERE id = ?",
+    )
+    .bind(r#"{"checkout_settlement":{"mode":"actual_nights","reporting_checkout":"2026-04-21","settled_nights":1,"settled_total":500000}}"#)
+    .bind("B420")
+    .execute(&pool)
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B420",
+        250_000.0,
+        "charge",
+        "Room charge",
+        "2026-04-20T08:00:00+07:00",
+    )
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B420",
+        -1_750_000.0,
+        "charge",
+        "Điều chỉnh checkout settlement",
+        "2026-04-20T18:00:00+07:00",
+    )
+    .await
+    .unwrap();
+
+    let stats = revenue_queries::load_revenue_stats(&pool, "2026-04-20", "2026-04-20")
+        .await
+        .unwrap();
+    let audit = audit_queries::load_night_audit_snapshot(&pool, "2026-04-20")
+        .await
+        .unwrap();
+
+    assert_eq!(stats.total_revenue, 500_000.0);
+    assert_eq!(stats.rooms_sold, 1);
+    assert_eq!(audit.room_revenue, 500_000.0);
+    assert_eq!(audit.rooms_sold, 1);
+}
+
+#[tokio::test]
+async fn booked_nights_settlement_uses_reporting_checkout_for_financial_revenue() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R421").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B421",
+        "R421",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(2_500_000.0),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "UPDATE bookings
+         SET status = 'checked_out',
+             actual_checkout = '2026-04-22T09:00:00+07:00',
+             pricing_snapshot = ?
+         WHERE id = ?",
+    )
+    .bind(r#"{"checkout_settlement":{"mode":"booked_nights","reporting_checkout":"2026-04-25","settled_nights":5,"settled_total":2500000}}"#)
+    .bind("B421")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let revenue = revenue_queries::load_room_revenue(&pool, "2026-04-20", "2026-04-24")
+        .await
+        .unwrap();
+
+    assert_eq!(revenue, 2_500_000.0);
+}
+
+#[tokio::test]
+async fn checkout_settlement_updates_booking_export_rows() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R422").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B422",
+        "R422",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "UPDATE bookings
+         SET status = 'checked_out',
+             actual_checkout = '2026-04-20T18:00:00+07:00',
+             nights = 1,
+             total_price = 500000,
+             paid_amount = 500000,
+             pricing_snapshot = ?
+         WHERE id = ?",
+    )
+    .bind(r#"{"checkout_settlement":{"mode":"actual_nights","reporting_checkout":"2026-04-21","settled_nights":1,"settled_total":500000}}"#)
+    .bind("B422")
+    .execute(&pool)
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B422",
+        2_500_000.0,
+        "charge",
+        "Room charge",
+        "2026-04-20T08:00:00+07:00",
+    )
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B422",
+        -2_000_000.0,
+        "charge",
+        "Điều chỉnh checkout settlement",
+        "2026-04-20T18:00:00+07:00",
+    )
+    .await
+    .unwrap();
+
+    let export_rows = audit_queries::load_booking_export_rows(&pool, "2026-04-01", "2026-04-30")
+        .await
+        .unwrap();
+    let row = export_rows.iter().find(|row| row.id == "B422").unwrap();
+
+    assert_eq!(row.room_price, 500_000.0);
+    assert_eq!(row.charge_total, 500_000.0);
+    assert_eq!(row.recognized_revenue, 500_000.0);
+}
+
+#[tokio::test]
+async fn checkout_settlement_export_rows_follow_reporting_checkout_boundary() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R423").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B423",
+        "R423",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "UPDATE bookings
+         SET status = 'checked_out',
+             actual_checkout = '2026-04-20T18:00:00+07:00',
+             nights = 1,
+             total_price = 500000,
+             paid_amount = 500000,
+             pricing_snapshot = ?
+         WHERE id = ?",
+    )
+    .bind(r#"{"checkout_settlement":{"mode":"actual_nights","reporting_checkout":"2026-04-21","settled_nights":1,"settled_total":500000}}"#)
+    .bind("B423")
+    .execute(&pool)
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B423",
+        2_500_000.0,
+        "charge",
+        "Room charge",
+        "2026-04-20T08:00:00+07:00",
+    )
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B423",
+        -2_000_000.0,
+        "charge",
+        "Điều chỉnh checkout settlement",
+        "2026-04-20T18:00:00+07:00",
+    )
+    .await
+    .unwrap();
+
+    let export_rows = audit_queries::load_booking_export_rows(&pool, "2026-04-21", "2026-04-21")
+        .await
+        .unwrap();
+    let row = export_rows.iter().find(|row| row.id == "B423").unwrap();
+
+    assert_eq!(row.expected_checkout, "2026-04-21");
+    assert_eq!(row.actual_checkout, "2026-04-20T18:00:00+07:00");
+}
+
+#[tokio::test]
+async fn checkout_settlement_export_rows_exclude_original_checkin_window_after_shift() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R424").await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B424",
+        "R424",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000.0,
+        Some(0.0),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "UPDATE bookings
+         SET status = 'checked_out',
+             actual_checkout = '2026-04-20T18:00:00+07:00',
+             nights = 1,
+             total_price = 500000,
+             paid_amount = 500000,
+             pricing_snapshot = ?
+         WHERE id = ?",
+    )
+    .bind(r#"{"checkout_settlement":{"mode":"actual_nights","reporting_checkout":"2026-04-21","settled_nights":1,"settled_total":500000}}"#)
+    .bind("B424")
+    .execute(&pool)
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B424",
+        2_500_000.0,
+        "charge",
+        "Room charge",
+        "2026-04-20T08:00:00+07:00",
+    )
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B424",
+        -2_000_000.0,
+        "charge",
+        "Điều chỉnh checkout settlement",
+        "2026-04-20T18:00:00+07:00",
+    )
+    .await
+    .unwrap();
+
+    let export_rows = audit_queries::load_booking_export_rows(&pool, "2026-04-20", "2026-04-20")
+        .await
+        .unwrap();
+    let row = export_rows.iter().find(|row| row.id == "B424");
+
+    assert!(row.is_none());
+}
+
+#[tokio::test]
+async fn cancellation_fee_export_uses_transaction_period_when_checkin_is_future() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R425").await.unwrap();
+    seed_booked_reservation(&pool, "B425", "R425")
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "UPDATE bookings
+         SET check_in_at = '2026-05-20',
+             expected_checkout = '2026-05-22',
+             scheduled_checkin = '2026-05-20',
+             scheduled_checkout = '2026-05-22',
+             status = 'cancelled'
+         WHERE id = ?",
+    )
+    .bind("B425")
+    .execute(&pool)
+    .await
+    .unwrap();
+    seed_transaction(
+        &pool,
+        "B425",
+        50_000.0,
+        "cancellation_fee",
+        "Retained deposit",
+        "2026-04-15T14:00:00+07:00",
+    )
+    .await
+    .unwrap();
+
+    let export_rows = audit_queries::load_booking_export_rows(&pool, "2026-04-15", "2026-04-15")
+        .await
+        .unwrap();
+    let row = export_rows.iter().find(|row| row.id == "B425").unwrap();
+
+    assert_eq!(row.cancellation_fee_total, 50_000.0);
+    assert_eq!(row.recognized_revenue, 50_000.0);
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -396,6 +396,7 @@ pub async fn seed_active_booking(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn seed_active_booking_with_terms(
     pool: &Pool<Sqlite>,
     booking_id: &str,
@@ -830,7 +831,11 @@ async fn group_checkin_reservation_blocks_calendar_and_tracks_deposit() {
         .unwrap();
 
     let mut req = minimal_group_checkin_request(&["G201", "G202"]);
-    req.check_in_date = Some("2026-04-20".to_string());
+    req.check_in_date = Some(
+        (Local::now().date_naive() + Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string(),
+    );
     req.paid_amount = Some(60_000.0);
 
     let group = group_lifecycle::group_checkin(&pool, None, req)

--- a/mhm/src/components/CheckoutSettlementModal.test.tsx
+++ b/mhm/src/components/CheckoutSettlementModal.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+
+import CheckoutSettlementModal from "./CheckoutSettlementModal";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const booking = {
+    id: "B500",
+    room_id: "101",
+    primary_guest_id: "G1",
+    check_in_at: "2026-04-20T08:00:00+07:00",
+    expected_checkout: "2026-04-25T12:00:00+07:00",
+    nights: 5,
+    total_price: 2500000,
+    paid_amount: 0,
+    status: "active" as const,
+    created_at: "2026-04-20T08:00:00+07:00",
+};
+
+describe("CheckoutSettlementModal", () => {
+    beforeEach(() => {
+        vi.mocked(invoke).mockReset();
+    });
+
+    it("loads the default actual-nights preview from the backend", async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            settlement_mode: "actual_nights",
+            settled_nights: 1,
+            recommended_total: 500000,
+            explanation: "Thanh toán theo số đêm thực tế: 1 đêm",
+        });
+
+        render(
+            <CheckoutSettlementModal
+                open
+                roomId="101"
+                booking={booking}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+            />
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Thanh toán theo số đêm thực tế: 1 đêm")
+            ).toBeInTheDocument();
+        });
+        expect(screen.getByDisplayValue("500000")).toBeInTheDocument();
+    });
+
+    it("requests a fresh preview when switching to hourly mode", async () => {
+        const user = userEvent.setup();
+        vi.mocked(invoke)
+            .mockResolvedValueOnce({
+                settlement_mode: "actual_nights",
+                settled_nights: 1,
+                recommended_total: 500000,
+                explanation: "Thanh toán theo số đêm thực tế: 1 đêm",
+            })
+            .mockResolvedValueOnce({
+                settlement_mode: "hourly",
+                settled_nights: 1,
+                recommended_total: 300000,
+                explanation: "Thanh toán theo giờ: nhập tay số tiền quyết toán",
+            });
+
+        render(
+            <CheckoutSettlementModal
+                open
+                roomId="101"
+                booking={booking}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByDisplayValue("500000")).toBeInTheDocument());
+        await user.click(screen.getByRole("button", { name: "Theo giờ" }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Thanh toán theo giờ: nhập tay số tiền quyết toán")
+            ).toBeInTheDocument();
+        });
+        expect(screen.getByDisplayValue("300000")).toBeInTheDocument();
+        expect(invoke).toHaveBeenCalledWith("preview_checkout_settlement", {
+            req: { booking_id: "B500", settlement_mode: "hourly" },
+        });
+    });
+
+    it("keeps a manual override after the preview is loaded", async () => {
+        const user = userEvent.setup();
+        vi.mocked(invoke).mockResolvedValue({
+            settlement_mode: "actual_nights",
+            settled_nights: 1,
+            recommended_total: 500000,
+            explanation: "Thanh toán theo số đêm thực tế: 1 đêm",
+        });
+
+        render(
+            <CheckoutSettlementModal
+                open
+                roomId="101"
+                booking={booking}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByDisplayValue("500000")).toBeInTheDocument());
+        const input = screen.getByLabelText("Thanh toán cuối");
+        await user.clear(input);
+        await user.type(input, "200000");
+
+        expect(screen.getByDisplayValue("200000")).toBeInTheDocument();
+    });
+
+    it("blocks confirm when the booking is already overpaid for the requested total", async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            settlement_mode: "actual_nights",
+            settled_nights: 1,
+            recommended_total: 500000,
+            explanation: "Thanh toán theo số đêm thực tế: 1 đêm",
+        });
+
+        render(
+            <CheckoutSettlementModal
+                open
+                roomId="101"
+                booking={{ ...booking, paid_amount: 700000 }}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByDisplayValue("500000")).toBeInTheDocument());
+        expect(screen.getByText(/refund/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Xác nhận" })).toBeDisabled();
+    });
+});

--- a/mhm/src/components/CheckoutSettlementModal.tsx
+++ b/mhm/src/components/CheckoutSettlementModal.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import InfoItem from "@/components/shared/InfoItem";
+import Modal from "@/components/ui/Modal";
+import { fmtMoney } from "@/lib/format";
+import type {
+    Booking,
+    CheckoutSettlementMode,
+    CheckoutSettlementPayload,
+    CheckoutSettlementPreview,
+} from "@/types";
+
+interface CheckoutSettlementModalProps {
+    open: boolean;
+    roomId: string;
+    booking: Booking;
+    onClose: () => void;
+    onConfirm: (payload: CheckoutSettlementPayload) => Promise<void> | void;
+}
+
+const MODE_OPTIONS: Array<{ value: CheckoutSettlementMode; label: string }> = [
+    { value: "actual_nights", label: "Thực tế" },
+    { value: "hourly", label: "Theo giờ" },
+    { value: "booked_nights", label: "Đã đặt" },
+];
+
+export default function CheckoutSettlementModal({
+    open,
+    roomId,
+    booking,
+    onClose,
+    onConfirm,
+}: CheckoutSettlementModalProps) {
+    const [settlementMode, setSettlementMode] = useState<CheckoutSettlementMode>("actual_nights");
+    const [preview, setPreview] = useState<CheckoutSettlementPreview | null>(null);
+    const [finalTotal, setFinalTotal] = useState(0);
+    const [loadingPreview, setLoadingPreview] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const manualOverrideRef = useRef(false);
+
+    useEffect(() => {
+        if (!open) {
+            setSettlementMode("actual_nights");
+            setPreview(null);
+            setFinalTotal(0);
+            setLoadingPreview(false);
+            setSubmitting(false);
+            manualOverrideRef.current = false;
+        }
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        let cancelled = false;
+        manualOverrideRef.current = false;
+        setLoadingPreview(true);
+
+        invoke<CheckoutSettlementPreview>("preview_checkout_settlement", {
+            req: {
+                booking_id: booking.id,
+                settlement_mode: settlementMode,
+            },
+        })
+            .then((nextPreview) => {
+                if (cancelled) {
+                    return;
+                }
+                setPreview(nextPreview);
+                if (!manualOverrideRef.current) {
+                    setFinalTotal(nextPreview.recommended_total);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setPreview(null);
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setLoadingPreview(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [open, booking.id, settlementMode]);
+
+    if (!open) {
+        return null;
+    }
+
+    const overpaid = booking.paid_amount > finalTotal;
+    const confirmDisabled =
+        loadingPreview || submitting || preview === null || finalTotal < 0 || overpaid;
+
+    const handleConfirm = async () => {
+        if (confirmDisabled) {
+            return;
+        }
+
+        setSubmitting(true);
+        try {
+            await onConfirm({ settlementMode, finalTotal });
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Modal title="Xác nhận Check-out">
+            <div className="space-y-3 text-[13px]">
+                <InfoItem label="Phòng" value={roomId} variant="block" />
+                <InfoItem label="Đã trả" value={fmtMoney(booking.paid_amount)} variant="block" />
+                <InfoItem label="Tổng đã đặt" value={fmtMoney(booking.total_price)} variant="block" />
+
+                <div className="space-y-2">
+                    <span className="text-[11px] text-slate-400 font-medium block">Cách tính</span>
+                    <div className="grid grid-cols-3 gap-2">
+                        {MODE_OPTIONS.map((option) => {
+                            const active = settlementMode === option.value;
+                            return (
+                                <button
+                                    key={option.value}
+                                    type="button"
+                                    onClick={() => setSettlementMode(option.value)}
+                                    className={
+                                        active
+                                            ? "rounded-xl border border-blue-500 bg-blue-50 px-3 py-2 font-semibold text-blue-600 cursor-pointer"
+                                            : "rounded-xl border border-slate-200 px-3 py-2 text-slate-600 cursor-pointer"
+                                    }
+                                >
+                                    {option.label}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <p className="rounded-xl bg-slate-50 px-3 py-2 text-slate-600 min-h-11">
+                    {loadingPreview ? "Đang tính lại..." : preview?.explanation ?? ""}
+                </p>
+
+                <div>
+                    <label
+                        htmlFor="checkout-final-total"
+                        className="text-[11px] text-slate-400 font-medium block mb-1"
+                    >
+                        Thanh toán cuối
+                    </label>
+                    <input
+                        id="checkout-final-total"
+                        type="number"
+                        value={finalTotal}
+                        onChange={(event) => {
+                            manualOverrideRef.current = true;
+                            setFinalTotal(Number(event.target.value));
+                        }}
+                        className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-slate-900 text-[13px] focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500"
+                    />
+                </div>
+
+                {overpaid && (
+                    <p className="text-[12px] font-medium text-red-600">
+                        Booking đã overpaid. Hãy xử lý refund trước khi checkout.
+                    </p>
+                )}
+            </div>
+
+            <div className="flex gap-2.5 mt-5">
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="flex-1 py-2.5 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-xl text-[13px] font-medium cursor-pointer transition-colors"
+                >
+                    Hủy
+                </button>
+                <button
+                    type="button"
+                    onClick={handleConfirm}
+                    disabled={confirmDisabled}
+                    className="flex-1 py-2.5 bg-red-600 hover:bg-red-700 disabled:bg-slate-300 text-white rounded-xl text-[13px] font-semibold cursor-pointer transition-colors disabled:cursor-not-allowed"
+                >
+                    Xác nhận
+                </button>
+            </div>
+        </Modal>
+    );
+}

--- a/mhm/src/components/RoomDetailPanel.test.tsx
+++ b/mhm/src/components/RoomDetailPanel.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RoomDetailPanel from "./RoomDetailPanel";
+
+const checkOut = vi.fn();
+
+vi.mock("@/components/CheckoutSettlementModal", () => ({
+    default: ({ open }: { open: boolean }) =>
+        open ? <div data-testid="checkout-settlement-modal" /> : null,
+}));
+
+vi.mock("@/stores/useHotelStore", () => ({
+    useHotelStore: () => ({
+        checkOut,
+        extendStay: vi.fn(),
+        getStayInfoText: vi.fn(),
+        setTab: vi.fn(),
+        setCheckinOpen: vi.fn(),
+        loading: false,
+    }),
+}));
+
+vi.mock("@/hooks/useInvoiceDialog", () => ({
+    useInvoiceDialog: () => ({
+        invoiceOpen: false,
+        invoiceData: null,
+        invoiceLoading: false,
+        openInvoice: vi.fn(),
+        closeInvoice: vi.fn(),
+    }),
+}));
+
+describe("RoomDetailPanel checkout settlement", () => {
+    beforeEach(() => {
+        checkOut.mockReset();
+    });
+
+    it("opens the shared checkout settlement modal from the detail page", async () => {
+        const user = userEvent.setup();
+
+        render(
+            <RoomDetailPanel
+                mode="page"
+                roomDetail={{
+                    room: {
+                        id: "101",
+                        name: "101",
+                        type: "standard",
+                        floor: 1,
+                        has_balcony: false,
+                        base_price: 500000,
+                        status: "occupied",
+                    },
+                    booking: {
+                        id: "B600",
+                        room_id: "101",
+                        primary_guest_id: "G1",
+                        check_in_at: "2026-04-20T08:00:00+07:00",
+                        expected_checkout: "2026-04-25T12:00:00+07:00",
+                        nights: 5,
+                        total_price: 2500000,
+                        paid_amount: 0,
+                        status: "active",
+                        created_at: "2026-04-20T08:00:00+07:00",
+                    },
+                    guests: [],
+                }}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: /check-out/i }));
+
+        expect(screen.getByTestId("checkout-settlement-modal")).toBeInTheDocument();
+    });
+});

--- a/mhm/src/components/RoomDetailPanel.tsx
+++ b/mhm/src/components/RoomDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { toast } from "sonner";
 
 import InvoiceDialog from "@/components/InvoiceDialog";
+import CheckoutSettlementModal from "@/components/CheckoutSettlementModal";
 import InfoItem from "@/components/shared/InfoItem";
 import ActionBtn from "@/components/shared/ActionBtn";
 import PaymentBlock from "@/components/shared/PaymentBlock";
@@ -24,9 +25,8 @@ import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtDate, fmtDateShort, fmtMoney } from "@/lib/format";
-import Modal from "@/components/ui/Modal";
 import { useHotelStore } from "@/stores/useHotelStore";
-import type { RoomWithBooking } from "@/types";
+import type { CheckoutSettlementPayload, RoomWithBooking } from "@/types";
 
 interface RoomDetailPanelProps {
   mode: "page" | "sheet";
@@ -50,7 +50,6 @@ export default function RoomDetailPanel({
     loading,
   } = useHotelStore();
   const [showCheckout, setShowCheckout] = useState(false);
-  const [finalPaid, setFinalPaid] = useState(0);
   const [copied, setCopied] = useState(false);
   const { invoiceOpen, invoiceData, invoiceLoading, openInvoice, closeInvoice } = useInvoiceDialog();
 
@@ -87,10 +86,13 @@ export default function RoomDetailPanel({
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const handleCheckout = async () => {
+  const handleCheckoutConfirm = async ({
+    settlementMode,
+    finalTotal,
+  }: CheckoutSettlementPayload) => {
     if (!booking) return;
     try {
-      await checkOut(booking.id, finalPaid || undefined);
+      await checkOut(booking.id, settlementMode, finalTotal);
       setShowCheckout(false);
       toast.success("Check-out thành công!");
       if (mode === "sheet") {
@@ -198,10 +200,7 @@ export default function RoomDetailPanel({
                 {invoiceLoading ? "Đang tạo..." : "📄 Invoice"}
               </Button>
               <button
-                onClick={() => {
-                  setFinalPaid(booking.total_price);
-                  setShowCheckout(true);
-                }}
+                onClick={() => setShowCheckout(true)}
                 className="flex items-center justify-center gap-2 py-3 bg-red-600 hover:bg-red-700 text-white rounded-xl font-semibold text-[13px] transition-colors cursor-pointer"
               >
                 <LogOut size={15} /> Check-out
@@ -265,37 +264,14 @@ export default function RoomDetailPanel({
     <>
       {mode === "page" ? pageContent : sheetContent}
 
-      {showCheckout && booking && (
-        <Modal title="Xác nhận Check-out">
-          <div className="space-y-3 text-[13px]">
-            <InfoItem label="Phòng" value={room.id} variant="block" />
-            <InfoItem label="Tổng tiền" value={fmtMoney(booking.total_price)} variant="block" />
-            <InfoItem label="Đã trả" value={fmtMoney(booking.paid_amount)} variant="block" />
-            <div>
-              <label className="text-[11px] text-slate-400 font-medium block mb-1">Thanh toán cuối</label>
-              <input
-                type="number"
-                value={finalPaid}
-                onChange={(event) => setFinalPaid(Number(event.target.value))}
-                className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-slate-900 text-[13px] focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500"
-              />
-            </div>
-          </div>
-          <div className="flex gap-2.5 mt-5">
-            <button
-              onClick={() => setShowCheckout(false)}
-              className="flex-1 py-2.5 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-xl text-[13px] font-medium cursor-pointer transition-colors"
-            >
-              Hủy
-            </button>
-            <button
-              onClick={handleCheckout}
-              className="flex-1 py-2.5 bg-red-600 hover:bg-red-700 text-white rounded-xl text-[13px] font-semibold cursor-pointer transition-colors"
-            >
-              Xác nhận
-            </button>
-          </div>
-        </Modal>
+      {booking && (
+        <CheckoutSettlementModal
+          open={showCheckout}
+          roomId={room.id}
+          booking={booking}
+          onClose={() => setShowCheckout(false)}
+          onConfirm={handleCheckoutConfirm}
+        />
       )}
 
       <InvoiceDialog

--- a/mhm/src/components/RoomDrawer.test.tsx
+++ b/mhm/src/components/RoomDrawer.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RoomDrawer from "./RoomDrawer";
+
+const { invoke } = vi.hoisted(() => ({
+    invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("@/components/CheckoutSettlementModal", () => ({
+    default: ({ open }: { open: boolean }) =>
+        open ? <div data-testid="checkout-settlement-modal" /> : null,
+}));
+vi.mock("@/stores/useHotelStore", () => ({
+    useHotelStore: () => ({
+        checkOut: vi.fn(),
+        extendStay: vi.fn(),
+        getStayInfoText: vi.fn(),
+        setCheckinOpen: vi.fn(),
+        fetchRooms: vi.fn(),
+        updateHousekeeping: vi.fn(),
+    }),
+}));
+vi.mock("@/hooks/useInvoiceDialog", () => ({
+    useInvoiceDialog: () => ({
+        invoiceOpen: false,
+        invoiceData: null,
+        invoiceLoading: false,
+        openInvoice: vi.fn(),
+        closeInvoice: vi.fn(),
+    }),
+}));
+
+describe("RoomDrawer checkout settlement", () => {
+    beforeEach(() => {
+        invoke.mockReset();
+    });
+
+    it("opens the shared checkout settlement modal from the drawer", async () => {
+        const user = userEvent.setup();
+        invoke
+            .mockResolvedValueOnce({
+                room: {
+                    id: "101",
+                    name: "101",
+                    type: "standard",
+                    floor: 1,
+                    has_balcony: false,
+                    base_price: 500000,
+                    status: "occupied",
+                },
+                booking: {
+                    id: "B601",
+                    room_id: "101",
+                    primary_guest_id: "G1",
+                    check_in_at: "2026-04-20T08:00:00+07:00",
+                    expected_checkout: "2026-04-25T12:00:00+07:00",
+                    nights: 5,
+                    total_price: 2500000,
+                    paid_amount: 0,
+                    status: "active",
+                    created_at: "2026-04-20T08:00:00+07:00",
+                },
+                guests: [],
+            })
+            .mockResolvedValueOnce([]);
+
+        render(<RoomDrawer open onClose={vi.fn()} roomId="101" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /check-out/i })).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole("button", { name: /check-out/i }));
+
+        expect(screen.getByTestId("checkout-settlement-modal")).toBeInTheDocument();
+    });
+});

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -14,6 +14,7 @@ import {
 import { toast } from "sonner";
 
 import InvoiceDialog from "@/components/InvoiceDialog";
+import CheckoutSettlementModal from "@/components/CheckoutSettlementModal";
 import InfoItem from "@/components/shared/InfoItem";
 import ActionBtn from "@/components/shared/ActionBtn";
 import RoomGuestsSection from "@/components/shared/RoomGuestsSection";
@@ -22,11 +23,10 @@ import StatusBadge from "@/components/shared/StatusBadge";
 import SlideDrawer from "@/components/shared/SlideDrawer";
 import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
-import Modal from "@/components/ui/Modal";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtDateShort, fmtMoney } from "@/lib/format";
 import { useHotelStore } from "@/stores/useHotelStore";
-import type { RoomWithBooking, HousekeepingTask } from "@/types";
+import type { CheckoutSettlementPayload, RoomWithBooking, HousekeepingTask } from "@/types";
 
 interface RoomDrawerProps {
     open: boolean;
@@ -47,7 +47,6 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
     const [roomDetail, setRoomDetail] = useState<RoomWithBooking | null>(null);
     const [housekeepingTask, setHousekeepingTask] = useState<HousekeepingTask | null>(null);
     const [showCheckout, setShowCheckout] = useState(false);
-    const [finalPaid, setFinalPaid] = useState(0);
     const [copied, setCopied] = useState(false);
     const [fetching, setFetching] = useState(false);
     const { invoiceOpen, invoiceData, invoiceLoading, openInvoice, closeInvoice } = useInvoiceDialog();
@@ -102,10 +101,13 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         setTimeout(() => setCopied(false), 2000);
     };
 
-    const handleCheckout = async () => {
+    const handleCheckoutConfirm = async ({
+        settlementMode,
+        finalTotal,
+    }: CheckoutSettlementPayload) => {
         if (!booking) return;
         try {
-            await checkOut(booking.id, finalPaid || undefined);
+            await checkOut(booking.id, settlementMode, finalTotal);
             setShowCheckout(false);
             toast.success("Check-out thành công!");
             handleClose();
@@ -262,10 +264,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
                 <ActionBtn icon={CalendarPlus} label="Extend +1 đêm" onClick={handleExtend} variant="blue" />
             </div>
             <button
-                onClick={() => {
-                    setFinalPaid(booking.total_price);
-                    setShowCheckout(true);
-                }}
+                onClick={() => setShowCheckout(true)}
                 className="w-full flex items-center justify-center gap-2 py-3 bg-red-600 hover:bg-red-700 text-white rounded-xl font-semibold text-[13px] transition-colors cursor-pointer"
             >
                 <LogOut size={15} /> Check-out
@@ -314,38 +313,14 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
                 </div>
             </SlideDrawer>
 
-            {/* Checkout Modal */}
-            {showCheckout && booking && (
-                <Modal title="Xác nhận Check-out">
-                    <div className="space-y-3 text-[13px]">
-                        <InfoItem label="Phòng" value={room.id} variant="block" />
-                        <InfoItem label="Tổng tiền" value={fmtMoney(booking.total_price)} variant="block" />
-                        <InfoItem label="Đã trả" value={fmtMoney(booking.paid_amount)} variant="block" />
-                        <div>
-                            <label className="text-[11px] text-slate-400 font-medium block mb-1">Thanh toán cuối</label>
-                            <input
-                                type="number"
-                                value={finalPaid}
-                                onChange={(event) => setFinalPaid(Number(event.target.value))}
-                                className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-slate-900 text-[13px] focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500"
-                            />
-                        </div>
-                    </div>
-                    <div className="flex gap-2.5 mt-5">
-                        <button
-                            onClick={() => setShowCheckout(false)}
-                            className="flex-1 py-2.5 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-xl text-[13px] font-medium cursor-pointer transition-colors"
-                        >
-                            Hủy
-                        </button>
-                        <button
-                            onClick={handleCheckout}
-                            className="flex-1 py-2.5 bg-red-600 hover:bg-red-700 text-white rounded-xl text-[13px] font-semibold cursor-pointer transition-colors"
-                        >
-                            Xác nhận
-                        </button>
-                    </div>
-                </Modal>
+            {booking && (
+                <CheckoutSettlementModal
+                    open={showCheckout}
+                    roomId={room.id}
+                    booking={booking}
+                    onClose={() => setShowCheckout(false)}
+                    onConfirm={handleCheckoutConfirm}
+                />
             )}
 
             <InvoiceDialog

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -14,6 +14,7 @@ import type {
   AddGroupServiceRequest,
   GroupService,
   AutoAssignResult,
+  CheckoutSettlementMode,
   GroupInvoiceData,
 } from "@/types";
 
@@ -34,7 +35,11 @@ interface HotelStore {
   setTab: (tab: HotelTab) => void;
   setCheckinOpen: (open: boolean, roomId?: string | null) => void;
   checkIn: (roomId: string, guests: CheckInGuestInput[], nights: number, paidAmount?: number, source?: string, notes?: string) => Promise<void>;
-  checkOut: (bookingId: string, finalPaid?: number) => Promise<void>;
+  checkOut: (
+    bookingId: string,
+    settlementMode: CheckoutSettlementMode,
+    finalTotal: number,
+  ) => Promise<void>;
   extendStay: (bookingId: string) => Promise<void>;
   fetchHousekeeping: () => Promise<void>;
   updateHousekeeping: (taskId: string, status: string, note?: string) => Promise<void>;
@@ -109,10 +114,16 @@ export const useHotelStore = create<HotelStore>((set, get) => {
       }
     },
 
-    checkOut: async (bookingId, finalPaid) => {
+    checkOut: async (bookingId, settlementMode, finalTotal) => {
       beginAction();
       try {
-        await invoke("check_out", { req: { booking_id: bookingId, final_paid: finalPaid } });
+        await invoke("check_out", {
+          req: {
+            booking_id: bookingId,
+            settlement_mode: settlementMode,
+            final_total: finalTotal,
+          },
+        });
         await get().fetchRooms();
         await get().fetchStats();
         set({ activeTab: "dashboard" });

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -55,6 +55,20 @@ export interface Booking {
   created_at: string;
 }
 
+export type CheckoutSettlementMode = "actual_nights" | "hourly" | "booked_nights";
+
+export interface CheckoutSettlementPreview {
+  settlement_mode: CheckoutSettlementMode;
+  settled_nights: number;
+  recommended_total: number;
+  explanation: string;
+}
+
+export interface CheckoutSettlementPayload {
+  settlementMode: CheckoutSettlementMode;
+  finalTotal: number;
+}
+
 export interface RoomWithBooking {
   room: Room;
   booking: Booking | null;

--- a/mhm/tests/e2e/05-checkout.test.tsx
+++ b/mhm/tests/e2e/05-checkout.test.tsx
@@ -27,17 +27,17 @@ describe("05 — Check-out Flow", () => {
     it("check_out calls correct invoke command", async () => {
         setMockResponse("check_out", () => undefined);
 
-        await useHotelStore.getState().checkOut("booking-1", 400000);
+        await useHotelStore.getState().checkOut("booking-1", "hourly", 400000);
 
         expect(invoke).toHaveBeenCalledWith("check_out", {
-            req: { booking_id: "booking-1", final_paid: 400000 },
+            req: { booking_id: "booking-1", settlement_mode: "hourly", final_total: 400000 },
         });
     });
 
     it("refreshes rooms and stats after checkout", async () => {
         setMockResponse("check_out", () => undefined);
 
-        await useHotelStore.getState().checkOut("booking-1");
+        await useHotelStore.getState().checkOut("booking-1", "actual_nights", 500000);
 
         // Should refresh data
         expect(invoke).toHaveBeenCalledWith("get_rooms");
@@ -48,7 +48,7 @@ describe("05 — Check-out Flow", () => {
         setMockResponse("check_out", () => undefined);
 
         useHotelStore.setState({ activeTab: "rooms" });
-        await useHotelStore.getState().checkOut("booking-1");
+        await useHotelStore.getState().checkOut("booking-1", "actual_nights", 500000);
 
         expect(useHotelStore.getState().activeTab).toBe("dashboard");
     });
@@ -59,19 +59,19 @@ describe("05 — Check-out Flow", () => {
         });
 
         await expect(
-            useHotelStore.getState().checkOut("nonexistent")
+            useHotelStore.getState().checkOut("nonexistent", "actual_nights", 500000)
         ).rejects.toThrow("Booking not found");
 
         expect(useHotelStore.getState().loading).toBe(false);
     });
 
-    it("checkout with no final_paid sends undefined", async () => {
+    it("checkout sends the requested settlement payload", async () => {
         setMockResponse("check_out", () => undefined);
 
-        await useHotelStore.getState().checkOut("booking-1");
+        await useHotelStore.getState().checkOut("booking-1", "booked_nights", 2500000);
 
         expect(invoke).toHaveBeenCalledWith("check_out", {
-            req: { booking_id: "booking-1", final_paid: undefined },
+            req: { booking_id: "booking-1", settlement_mode: "booked_nights", final_total: 2500000 },
         });
     });
 });

--- a/mhm/tests/e2e/13-store-hardening.test.ts
+++ b/mhm/tests/e2e/13-store-hardening.test.ts
@@ -48,7 +48,7 @@ describe("13 — Store Hardening", () => {
 
         expect(useHotelStore.getState().loading).toBe(true);
 
-        await useHotelStore.getState().checkOut("booking-1");
+        await useHotelStore.getState().checkOut("booking-1", "actual_nights", 500000);
 
         expect(useHotelStore.getState().loading).toBe(true);
 


### PR DESCRIPTION
## Summary
- add backend checkout settlement modes and preview flow so checkout can settle by actual nights, booked nights, or hourly override
- align invoice, revenue, audit, and booking export behavior with settlement metadata and add regression coverage for early checkout and cancellation-fee edge cases
- replace the duplicated checkout confirmation UI with one shared settlement modal and update the store contract/tests to use the new payload

## Validation
- `npm test -- CheckoutSettlementModal.test.tsx RoomDetailPanel.test.tsx RoomDrawer.test.tsx tests/e2e/05-checkout.test.tsx tests/e2e/13-store-hardening.test.ts`
- `npm run build`
- `cargo test check_out_ --manifest-path mhm/src-tauri/Cargo.toml`
- `cargo test generate_invoice_ --manifest-path mhm/src-tauri/Cargo.toml`
- `cargo test checkout_settlement_ --manifest-path mhm/src-tauri/Cargo.toml`
- `cargo test revenue_queries_include_cancellation_fees_in_recognized_revenue --manifest-path mhm/src-tauri/Cargo.toml`

## Notes
- this PR targets `codex/Pricing-modify` so the diff is isolated to the checkout settlement work only
- the local worktree still contains unrelated unstaged changes outside this PR scope