### PR TITLE
[codex] Standardize FE/BE error handling

### DIFF
--- a/docs/superpowers/specs/2026-04-21-standardize-error-codes-design.md
+++ b/docs/superpowers/specs/2026-04-21-standardize-error-codes-design.md
@@ -1,0 +1,483 @@
+# CapyInn Standardize FE/BE Error Codes Design
+
+## Summary
+
+CapyInn will standardize frontend and backend error handling around one shared error contract at the Tauri command boundary.
+
+From this point forward, the product should stop treating command failures as free-form strings that each screen interprets differently. Instead, backend commands will return a consistent error payload with:
+
+- `code`
+- `message`
+- `kind`
+- `support_id`
+
+Phase 1 will focus on user-facing errors that operators actually need to understand on screen. Those errors will receive stable, domain-specific codes such as `AUTH_INVALID_PIN` or `GROUP_NOT_ENOUGH_VACANT_ROOMS`.
+
+Unexpected lower-level failures such as database, filesystem, or runtime issues will still be debuggable, but they will no longer leak raw technical detail into the UI. The frontend will show a generic system message plus a `support_id`, while backend logging keeps the original root cause for diagnosis.
+
+The rollout will start with shared infrastructure, then apply it to `auth`, `permission`, `room management`, and selected `booking/group` flows before expanding to the rest of the app.
+
+## Goals
+
+- Make user-visible errors consistent across screens instead of relying on ad hoc `String(err)` handling.
+- Give predictable, stable error codes to the most common business and validation failures.
+- Preserve support and debugging ability for system failures by attaching a `support_id`.
+- Centralize frontend command-error parsing so screens stop implementing their own string handling.
+- Create a reliable foundation for later work in issue `#30`, including crash dashboarding, monitoring, and error aggregation by code.
+
+## Non-Goals
+
+- No attempt to standardize every command and every failure path in one release.
+- No attempt in Phase 1 to expose raw database, filesystem, or network failure details directly to operators.
+- No full observability platform in this design. Crash dashboard, DB monitoring, command failure monitoring, and correlation IDs remain separate follow-up work under the parent roadmap.
+- No rewrite of all existing UI error presentations in one sweep if a screen is outside the selected rollout domains.
+- No guarantee that all old free-form backend errors disappear immediately; Phase 1 is intentionally incremental.
+
+## Current Baseline
+
+Current repository behavior is inconsistent at both layers.
+
+Backend baseline:
+
+- many public Tauri commands currently return `Result<_, String>`
+- expected business failures and unexpected runtime failures are mixed together as plain strings
+- several commands return custom Vietnamese business messages, while many others forward `sqlx`, filesystem, or runtime errors using `to_string()`
+
+Frontend baseline:
+
+- many screens call `invoke(...)` directly
+- many screens display errors through `toast.error(String(err))` or similar one-off logic
+- some screens swallow failures entirely and fall back to empty state
+- there is no shared parser or normalizer for Tauri command failures
+
+This means the same logical failure can be:
+
+- shown with different wording on different screens
+- hidden completely
+- impossible to aggregate cleanly by type
+- hard to distinguish from a real system failure
+
+The crash-reporting work from PR `#27` is also a concrete example of why this matters: command failures around submit, cleanup, export, and retry behavior are still handled with local ad hoc logic instead of a shared contract.
+
+## Chosen Approach
+
+CapyInn will standardize errors at the backend command boundary rather than trying to patch the problem in each screen.
+
+The selected approach has three parts:
+
+1. Backend introduces one shared application error model.
+2. Every migrated Tauri command converts failures into that shared model before rejecting to the frontend.
+3. Frontend introduces one shared command wrapper that parses the rejection into a reusable app error object.
+
+This is the preferred approach because it fixes the source of inconsistency instead of teaching each screen to decode fragile free-form strings.
+
+Rejected alternatives:
+
+- frontend-only mapping of existing strings:
+  fast to start, but brittle and impossible to trust long term because backend wording changes would silently break error handling
+- domain-by-domain formats with no shared envelope:
+  easier to start, but likely to drift and recreate inconsistency under different names
+- full-app big-bang migration:
+  too much blast radius for a first rollout, given the current number of commands and call sites
+
+## Standard Error Contract
+
+Every migrated command failure should resolve to the same external shape:
+
+- `code`: stable machine-readable identifier
+- `message`: short user-facing message that is safe to show directly
+- `kind`: one of `user` or `system`
+- `support_id`: nullable reference ID for support/debug lookup
+
+Expected behavior:
+
+- `user` errors:
+  use a domain-specific `code`
+  use a clear message
+  set `support_id` to `null`
+- `system` errors:
+  use a system-level `code`
+  use a generic safe message
+  include `support_id`
+
+Phase 1 should keep system codes intentionally narrow. Unless a migrated flow has a strong reason to distinguish one infrastructure failure class from another, the default system code should be `SYSTEM_INTERNAL_ERROR`.
+
+Example user-facing payloads:
+
+```json
+{
+  "code": "AUTH_INVALID_PIN",
+  "message": "Mã PIN không đúng",
+  "kind": "user",
+  "support_id": null
+}
+```
+
+```json
+{
+  "code": "SYSTEM_INTERNAL_ERROR",
+  "message": "Có lỗi hệ thống, vui lòng thử lại",
+  "kind": "system",
+  "support_id": "SUP-9J4K2Q"
+}
+```
+
+Phase 1 removes that ambiguity for migrated commands: the backend command boundary must reject with one JSON-serialized error string produced by a shared backend helper. The frontend wrapper for migrated commands must parse that JSON string into the app-level error object. Migrated commands must not mix object-shaped and string-shaped rejections.
+
+## Backend Error Model
+
+### Shared Types
+
+Backend should introduce a shared error module used by migrated command code.
+
+The model should include:
+
+- one internal app error type representing known business failures and wrapped system failures
+- one serializable response shape matching the external contract
+- one helper for generating `support_id` values for system failures
+
+The internal model should keep enough structure to distinguish:
+
+- validation or business-rule failures that deserve stable, specific codes
+- permission failures
+- authentication failures
+- wrapped lower-level runtime failures
+
+The internal model must preserve the original lower-level error for logging even when the UI receives only the generic system message.
+
+### Mapping Rules
+
+Mapping rules for migrated commands:
+
+- if the failure is expected and meaningful to the operator:
+  map it to a stable domain code
+- if the failure comes from lower-level infrastructure:
+  log the original error, generate `support_id`, map to a generic system response
+
+Classification is based on business meaning, not the technical layer where the failure surfaced. If a known operator-facing condition is detected through a lower-level mechanism such as a database uniqueness violation, missing row, or invalid state discovered inside a service call, the command must reclassify that failure into the correct stable domain code instead of passing it through as a generic system failure.
+
+Examples:
+
+- invalid PIN:
+  `AUTH_INVALID_PIN`
+- missing current user:
+  `AUTH_NOT_AUTHENTICATED`
+- admin-only action denied:
+  `AUTH_FORBIDDEN`
+- room already exists:
+  `ROOM_ALREADY_EXISTS`
+- cannot delete occupied room:
+  `ROOM_DELETE_OCCUPIED`
+- requested room count exceeds vacant supply:
+  `GROUP_NOT_ENOUGH_VACANT_ROOMS`
+- unexpected DB lock or file rename failure:
+  `SYSTEM_INTERNAL_ERROR` plus `support_id`
+
+### Support ID Rules
+
+`support_id` exists for traceability, not for user interpretation.
+
+Rules:
+
+- required for `system` errors in migrated flows
+- always present in the external contract
+- `null` for `user` errors
+- unique enough for practical support lookup
+- logged together with:
+  command name
+  domain error code
+  underlying root cause
+  relevant safe identifiers such as `room_id`, `booking_id`, or `group_id`
+
+The UI should show the `support_id` as part of the generic system failure message whenever the value is non-null so support can use what the operator sees on screen.
+
+## Error Code Naming
+
+Phase 1 should use specific codes rather than broad category codes.
+
+Naming rule:
+
+- uppercase
+- domain prefix first
+- scenario second
+
+Examples:
+
+- `AUTH_INVALID_PIN`
+- `AUTH_NOT_AUTHENTICATED`
+- `AUTH_FORBIDDEN`
+- `ROOM_ALREADY_EXISTS`
+- `ROOM_NOT_FOUND`
+- `ROOM_DELETE_OCCUPIED`
+- `ROOM_DELETE_ACTIVE_BOOKING`
+- `GROUP_INVALID_ROOM_COUNT`
+- `GROUP_NOT_ENOUGH_VACANT_ROOMS`
+- `BOOKING_NOT_FOUND`
+- `BOOKING_INVALID_STATE`
+
+Phase 1 should keep the code list curated instead of auto-generating codes from messages. New codes should be added deliberately when a migrated flow introduces a genuinely distinct operator-facing outcome.
+
+### Canonical Registry
+
+Phase 1 should keep one canonical checked-in registry of externally visible error codes at `mhm/shared/error-codes.json`.
+
+Rules:
+
+- every user-facing code emitted by backend must appear in that registry
+- frontend branching logic should only use codes listed in that registry
+- Rust and TypeScript may each define local helpers or types, but tests must fail if a code is emitted or consumed outside the registry
+
+This keeps the code list curated in one place without requiring a full code-generation pipeline in the first rollout.
+
+## Frontend Handling Model
+
+### Shared Invoke Wrapper
+
+Frontend should add one shared command wrapper that becomes the preferred path for migrated screens.
+
+Its responsibilities:
+
+- call Tauri commands
+- normalize command rejection payloads into one frontend app error object
+- return success payloads unchanged
+- preserve `code`, `message`, `kind`, and `support_id` for callers
+
+This wrapper should be the only place where the app knows how to interpret backend command failures.
+
+If the wrapper receives a rejection that does not match the standard migrated contract, it must fall back to one safe synthesized app error instead of trying to infer meaning from raw string text. In Phase 1, that fallback should behave like a generic `system` error with `code = SYSTEM_INTERNAL_ERROR`, a generic safe message, and `support_id = null`. This fallback is only a safety net for accidental misuse, not the intended path for unmigrated commands.
+
+### Shared Error Presentation
+
+Frontend should also add a small reusable helper for deciding how to show errors.
+
+Expected behavior:
+
+- for `user` errors:
+  show `message` directly
+- for `system` errors:
+  show generic message plus `support_id`
+
+This still allows screen-specific behavior when needed.
+
+Examples:
+
+- login screen can use `AUTH_INVALID_PIN` to mark the form as invalid
+- room management can use `ROOM_ALREADY_EXISTS` to keep the form open and highlight the duplication problem
+- group booking can use `GROUP_NOT_ENOUGH_VACANT_ROOMS` to preserve the current input and ask the operator to reduce room count
+
+The important rule is that screen-specific behavior must key off the normalized `code`, not raw error strings.
+
+### Migration Rule
+
+Migrated screens should stop doing any of the following directly:
+
+- `toast.error(String(err))`
+- `toast.error("prefix: " + err)`
+- parsing raw command failure strings locally
+- swallowing command failures without a deliberate reason
+
+If a screen needs fallback handling for a command that has not been migrated yet, that fallback should remain local until its backend command joins the new contract.
+
+The key rule is that migration happens per interaction, not per whole screen. A screen may temporarily contain both old and new command paths, but one user interaction must use exactly one strategy:
+
+- migrated interaction:
+  migrated backend command plus shared wrapper plus normalized code handling
+- unmigrated interaction:
+  legacy backend command plus local fallback handling
+
+The project should avoid hybrid logic where the same interaction partly depends on standard codes and partly depends on legacy string parsing.
+
+## Phase 1 Scope
+
+Phase 1 covers the shared infrastructure plus a focused set of command domains.
+
+### In Scope
+
+- shared backend error module
+- shared frontend command-error wrapper
+- shared frontend error presentation helper
+- migrated `auth` errors
+- migrated permission errors
+- migrated `room management` user-facing errors
+- migrated selected `booking` and `group` user-facing errors
+
+### Recommended First Commands
+
+- `login`
+- `list_users`
+- `create_user`
+- `create_room`
+- `delete_room`
+- `create_room_type`
+- `auto_assign_rooms`
+- selected `check_in`, `check_out`, `group_checkin`, and `group_checkout` failures that already have clear business meanings
+
+### Explicitly Out of Scope for Phase 1
+
+- full migration of all commands that still return `Result<_, String>`
+- crash dashboard implementation
+- command failure monitoring pipeline
+- database error monitoring pipeline
+- cross-request correlation IDs
+- retrofitting every existing screen before the shared infrastructure is proven stable
+
+## Rollout Plan
+
+The rollout should be incremental.
+
+### Step 1: Shared Infrastructure
+
+Add the backend and frontend shared error pieces first without trying to convert the whole app.
+
+Deliverables:
+
+- shared backend error definitions and serializers
+- shared frontend wrapper and app-error types
+- shared UI helper for operator-safe error display
+
+### Step 2: Authentication And Permission
+
+Migrate the easiest and highest-signal flows first.
+
+Target outcomes:
+
+- in migrated auth flows, wrong PIN becomes `AUTH_INVALID_PIN`
+- in migrated auth flows, missing session becomes `AUTH_NOT_AUTHENTICATED`
+- in migrated permission-gated flows touched in Phase 1, admin-only denials become `AUTH_FORBIDDEN`
+
+This gives a narrow first success case that is easy to test and verify.
+
+### Step 3: Room Management
+
+Migrate predictable room-management failures.
+
+Target outcomes:
+
+- duplicate room ID
+- room missing
+- delete blocked by occupancy
+- delete blocked by active booking
+- duplicate room type
+
+These are good candidates because they already represent clear business conditions that operators understand.
+
+### Step 4: Booking And Group Flows
+
+Expand to booking and group operations with the clearest operator-facing failures first.
+
+Target outcomes:
+
+- invalid room count
+- not enough vacant rooms
+- invalid booking state for check-in or checkout
+- missing booking or missing group references where applicable
+
+### Step 5: Wider Adoption
+
+Once the shared path is stable:
+
+- replace direct `invoke(...)` use in migrated screens with the shared wrapper
+- remove leftover string-based error display from those screens
+- inventory remaining commands and screens for later waves
+
+## Testing Strategy
+
+### Backend Tests
+
+Backend tests should assert that migrated failures map to the right external contract.
+
+Required checks:
+
+- known user-facing failures return the expected `code`
+- known user-facing failures return the intended safe `message`
+- system failures return `kind = system`
+- system failures generate `support_id`
+- raw infrastructure failure detail is not leaked into the external user message
+
+### Frontend Tests
+
+Frontend tests should assert that the wrapper and screens behave consistently.
+
+Required checks:
+
+- wrapper normalizes backend command failures into one reusable error shape
+- `user` errors show the backend message directly
+- `system` errors show generic message plus `support_id`
+- migrated screens no longer rely on `String(err)` formatting
+
+Priority migrated-screen tests:
+
+- login screen
+- room management flows
+- selected group booking flows
+
+### Repository Hygiene Checks
+
+After each migration wave, the implementation should search for leftover patterns such as:
+
+- `toast.error(String(`
+- `String(err)`
+- `String(error)`
+- command-specific free-form parsing in components or stores
+
+Those checks are important because a partial migration that leaves string parsing spread across the UI will recreate the original problem.
+
+## Risks And Mitigations
+
+### Risk: Mixed Old And New Error Paths Cause Confusion
+
+If only part of the app uses the shared contract, teams may assume the whole app is already standardized when it is not.
+
+Mitigation:
+
+- clearly mark migrated flows
+- convert selected vertical slices fully, not half way
+- keep a tracked inventory of remaining old-style command paths
+
+### Risk: Too Many Specific Codes Too Early
+
+If every small variation gets a new code immediately, the list becomes noisy and hard to govern.
+
+Mitigation:
+
+- only create a new code when it represents a distinct operator action or decision
+- keep generic system handling for unexpected low-level failures in Phase 1
+
+### Risk: Frontend Starts Depending On Message Text Again
+
+If screens branch on `message` instead of `code`, the standardization effort fails.
+
+Mitigation:
+
+- treat `code` as the only branching key
+- treat `message` as display text only
+
+### Risk: Support ID Exists But Is Not Logged With Enough Context
+
+If `support_id` is shown to operators but logs do not capture the same ID with safe command context, support still cannot diagnose issues.
+
+Mitigation:
+
+- make `support_id` generation and logging part of the shared backend path, not an optional per-command behavior
+
+## Success Criteria
+
+Phase 1 is successful when all of the following are true:
+
+- migrated commands stop rejecting with free-form strings
+- migrated screens stop displaying raw `String(err)` output
+- common operator-facing failures in `auth`, `room`, and selected `booking/group` flows show stable messages and stable codes
+- system failures in migrated flows show a generic safe message plus `support_id`
+- backend logs keep enough context to trace a displayed `support_id` back to the underlying failure
+- the project has a credible base for later observability work under issue `#30`
+
+## Implementation Exit State
+
+At the end of this design's implementation plan, CapyInn should have:
+
+- one shared backend error contract
+- one shared frontend command-error wrapper
+- one shared frontend error-display rule
+- a proven first rollout across the selected high-value flows
+
+This is intentionally the foundation layer for the larger stability and observability roadmap, not the entire roadmap itself.

--- a/docs/superpowers/specs/2026-04-21-standardize-error-codes-design.md
+++ b/docs/superpowers/specs/2026-04-21-standardize-error-codes-design.md
@@ -32,6 +32,8 @@ The rollout will start with shared infrastructure, then apply it to `auth`, `per
 - No full observability platform in this design. Crash dashboard, DB monitoring, command failure monitoring, and correlation IDs remain separate follow-up work under the parent roadmap.
 - No rewrite of all existing UI error presentations in one sweep if a screen is outside the selected rollout domains.
 - No guarantee that all old free-form backend errors disappear immediately; Phase 1 is intentionally incremental.
+- No multi-field validation contract in Phase 1.
+- No transient-versus-persistent system-error taxonomy beyond `SYSTEM_INTERNAL_ERROR` in Phase 1.
 
 ## Current Baseline
 
@@ -67,7 +69,7 @@ The selected approach has three parts:
 
 1. Backend introduces one shared application error model.
 2. Every migrated Tauri command converts failures into that shared model before rejecting to the frontend.
-3. Frontend introduces one shared command wrapper that parses the rejection into a reusable app error object.
+3. Frontend introduces one shared command wrapper that normalizes the rejected serialized error object into a reusable app error object.
 
 This is the preferred approach because it fixes the source of inconsistency instead of teaching each screen to decode fragile free-form strings.
 
@@ -88,6 +90,8 @@ Every migrated command failure should resolve to the same external shape:
 - `message`: short user-facing message that is safe to show directly
 - `kind`: one of `user` or `system`
 - `support_id`: nullable reference ID for support/debug lookup
+
+Phase 1 treats `kind` as a closed enum with exactly two values: `user` and `system`. Any future expansion requires a follow-up design decision because frontend branching and reporting assumptions depend on this binary split.
 
 Expected behavior:
 
@@ -122,7 +126,36 @@ Example user-facing payloads:
 }
 ```
 
-Phase 1 removes that ambiguity for migrated commands: the backend command boundary must reject with one JSON-serialized error string produced by a shared backend helper. The frontend wrapper for migrated commands must parse that JSON string into the app-level error object. Migrated commands must not mix object-shaped and string-shaped rejections.
+For migrated commands, the backend command boundary must reject with one native Tauri serialized error object produced by a shared backend helper. The frontend wrapper for migrated commands must treat that object shape as the contract and must not rely on parsing legacy string payloads.
+
+Forward-compatibility rule:
+
+- frontend must ignore unknown extra fields on the error object
+- Phase 1 does not add a `version` field yet
+- future contract additions must preserve existing field meanings
+
+### Message Source And Localization
+
+Phase 1 keeps `message` on the backend contract as the default display text.
+
+Rules:
+
+- backend is the source of truth for the default operator-facing message
+- Phase 1 messages are written for the current Vietnamese operator experience
+- frontend may later override message display by `code` for localization, but that is not required in Phase 1
+- `code` remains the stable machine key; `message` remains display text only
+
+### Field-Level Validation
+
+Phase 1 intentionally supports one primary error per failed interaction.
+
+Rules:
+
+- one failed command returns one `code` and one `message`
+- multi-field validation payloads are out of scope for Phase 1
+- if a command can fail for several validation reasons at once, it should return the most actionable primary failure for the current interaction
+
+This avoids over-designing the contract before the first shared path is proven.
 
 ## Backend Error Model
 
@@ -145,6 +178,18 @@ The internal model should keep enough structure to distinguish:
 
 The internal model must preserve the original lower-level error for logging even when the UI receives only the generic system message.
 
+### Existing Domain Error Types
+
+Phase 1 does not remove existing domain-local error types such as [error.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/domain/booking/error.rs).
+
+Rules:
+
+- domain and service layers may keep using local error types such as `BookingError`
+- the shared FE/BE contract is enforced at the command boundary, not by forcing every internal module to use the same Rust enum immediately
+- migrated commands must convert domain-local errors into the shared external app error shape before returning to Tauri
+
+This avoids creating two external contracts while still letting existing domain code evolve incrementally.
+
 ### Mapping Rules
 
 Mapping rules for migrated commands:
@@ -155,6 +200,8 @@ Mapping rules for migrated commands:
   log the original error, generate `support_id`, map to a generic system response
 
 Classification is based on business meaning, not the technical layer where the failure surfaced. If a known operator-facing condition is detected through a lower-level mechanism such as a database uniqueness violation, missing row, or invalid state discovered inside a service call, the command must reclassify that failure into the correct stable domain code instead of passing it through as a generic system failure.
+
+For existing booking-domain code, that means local variants such as `BookingError::Conflict`, `BookingError::NotFound`, and `BookingError::Validation` are not returned to the frontend directly. Each migrated command must map them into the correct external `code` for that interaction. `BookingError::Database` and `BookingError::DateTimeParse` may still be reclassified into domain codes if the command has enough context; otherwise they fall back to `SYSTEM_INTERNAL_ERROR`.
 
 Examples:
 
@@ -190,6 +237,30 @@ Rules:
   relevant safe identifiers such as `room_id`, `booking_id`, or `group_id`
 
 The UI should show the `support_id` as part of the generic system failure message whenever the value is non-null so support can use what the operator sees on screen.
+
+Support IDs must be backend-issued. The frontend wrapper must not invent synthetic `support_id` values for unmigrated or malformed failures, because that would create lookup IDs with no authoritative backend log record.
+
+### Logging And Lookup
+
+Phase 1 uses the existing Rust `log` facade and `env_logger` stack already initialized in [lib.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/lib.rs:79) for developer visibility, but it also needs one deterministic local support log for packaged runtime troubleshooting.
+
+Step 1 should therefore add a shared backend logging path that writes one structured JSON line per migrated `system` error to a local diagnostics file under the app runtime diagnostics directory.
+
+Each record should include at least:
+
+- timestamp
+- `support_id`
+- command name
+- external `code`
+- root cause string
+- safe context fields such as `room_id`, `booking_id`, or `group_id` when available
+
+Phase 1 support lookup is local-first:
+
+- developers can inspect normal app logs during development
+- operators or support can use the on-screen `support_id` to locate the matching JSON line in the exported local diagnostics logs
+
+Centralized aggregation remains follow-up work under the broader observability roadmap.
 
 ## Error Code Naming
 
@@ -228,6 +299,14 @@ Rules:
 - Rust and TypeScript may each define local helpers or types, but tests must fail if a code is emitted or consumed outside the registry
 
 This keeps the code list curated in one place without requiring a full code-generation pipeline in the first rollout.
+
+Enforcement mechanism for Phase 1:
+
+- a Rust test loads the registry JSON using a repository-relative path and asserts that exported backend code constants are listed there
+- a TypeScript test loads the same registry JSON and asserts that frontend code unions or constants match it
+- CI runs both tests so drift fails the build before runtime
+
+The registry path is intentionally outside both `src/` trees so it can remain the single checked-in source of truth for both Rust and TypeScript.
 
 ## Frontend Handling Model
 
@@ -287,6 +366,17 @@ The key rule is that migration happens per interaction, not per whole screen. A 
 
 The project should avoid hybrid logic where the same interaction partly depends on standard codes and partly depends on legacy string parsing.
 
+### Crash Reporting Integration
+
+Phase 1 does not add automatic command-failure submission to Sentry or turn every command error into a crash-report event.
+
+However, it should reserve two compatibility rules with the crash-reporting work already shipped in PR `#27`:
+
+- if frontend code deliberately reports a migrated failure through the existing browser-side Sentry path, it should attach `code` and `support_id` as tags or extra fields
+- if a crash or exported diagnostics bundle captures recent migrated command-failure context, `code` and `support_id` should be included when available
+
+This keeps the new error contract compatible with future observability work without expanding Phase 1 into a full remote monitoring pipeline.
+
 ## Phase 1 Scope
 
 Phase 1 covers the shared infrastructure plus a focused set of command domains.
@@ -334,10 +424,17 @@ Deliverables:
 - shared backend error definitions and serializers
 - shared frontend wrapper and app-error types
 - shared UI helper for operator-safe error display
+- canonical error-code registry at `mhm/shared/error-codes.json`
+- backend structured support-log writer for migrated `system` errors
+- Rust and TypeScript registry-drift tests wired into CI
 
 ### Step 2: Authentication And Permission
 
 Migrate the easiest and highest-signal flows first.
+
+Prerequisite:
+
+- refactor [mod.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/mod.rs:29) helpers `require_admin_user` and `require_admin` so migrated permission-gated flows stop returning raw Vietnamese `String` errors and instead return the shared auth or permission error type
 
 Target outcomes:
 
@@ -364,6 +461,12 @@ These are good candidates because they already represent clear business conditio
 ### Step 4: Booking And Group Flows
 
 Expand to booking and group operations with the clearest operator-facing failures first.
+
+Rules for booking-domain migration:
+
+- existing `BookingError` remains the internal domain and service error type in Phase 1
+- migrated booking and group commands are responsible for mapping `BookingError` variants to the shared external contract at the command boundary
+- no booking-domain command may expose raw `BookingError` display text directly once that interaction is migrated
 
 Target outcomes:
 

--- a/docs/superpowers/specs/2026-04-21-standardize-error-codes-design.md
+++ b/docs/superpowers/specs/2026-04-21-standardize-error-codes-design.md
@@ -122,7 +122,7 @@ Example user-facing payloads:
   "code": "SYSTEM_INTERNAL_ERROR",
   "message": "Có lỗi hệ thống, vui lòng thử lại",
   "kind": "system",
-  "support_id": "SUP-9J4K2Q"
+  "support_id": "SUP-9F4A2C1D"
 }
 ```
 
@@ -133,6 +133,8 @@ Forward-compatibility rule:
 - frontend must ignore unknown extra fields on the error object
 - Phase 1 does not add a `version` field yet
 - future contract additions must preserve existing field meanings
+- Phase 1 treats the field set `{code, message, kind, support_id}` as the closed required contract for migrated interactions
+- reserve `details` as a future optional field name, but do not emit or consume it in Phase 1
 
 ### Message Source And Localization
 
@@ -230,6 +232,8 @@ Rules:
 - always present in the external contract
 - `null` for `user` errors
 - unique enough for practical support lookup
+- format: `SUP-` plus 8 uppercase hexadecimal characters generated backend-side from a UUIDv4 or equivalent random source
+- uniqueness target: best-effort uniqueness for local packaged-runtime diagnostics volume; Phase 1 does not attempt cross-install global uniqueness
 - logged together with:
   command name
   domain error code
@@ -244,7 +248,7 @@ Support IDs must be backend-issued. The frontend wrapper must not invent synthet
 
 Phase 1 uses the existing Rust `log` facade and `env_logger` stack already initialized in [lib.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/lib.rs:79) for developer visibility, but it also needs one deterministic local support log for packaged runtime troubleshooting.
 
-Step 1 should therefore add a shared backend logging path that writes one structured JSON line per migrated `system` error to a local diagnostics file under the app runtime diagnostics directory.
+Step 1 should therefore add a shared backend logging path that writes one structured JSON line per migrated `system` error to `<runtime_root>/diagnostics/support-errors.jsonl`, where `runtime_root` is the existing path returned by [app_identity::runtime_root()](/Users/binhan/HotelManager/mhm/src-tauri/src/app_identity.rs:10).
 
 Each record should include at least:
 
@@ -254,6 +258,11 @@ Each record should include at least:
 - external `code`
 - root cause string
 - safe context fields such as `room_id`, `booking_id`, or `group_id` when available
+
+Phase 1 log-writer rules:
+
+- append writes must be serialized through one shared process-local mutex or equivalent single-writer path so concurrent command failures do not interleave JSON lines
+- Phase 1 does not add file rotation or truncation; operational volume is expected to stay small enough for one append-only JSONL file
 
 Phase 1 support lookup is local-first:
 
@@ -274,23 +283,24 @@ Naming rule:
 
 Examples:
 
-- `AUTH_INVALID_PIN`
-- `AUTH_NOT_AUTHENTICATED`
-- `AUTH_FORBIDDEN`
-- `ROOM_ALREADY_EXISTS`
-- `ROOM_NOT_FOUND`
-- `ROOM_DELETE_OCCUPIED`
-- `ROOM_DELETE_ACTIVE_BOOKING`
-- `GROUP_INVALID_ROOM_COUNT`
-- `GROUP_NOT_ENOUGH_VACANT_ROOMS`
-- `BOOKING_NOT_FOUND`
-- `BOOKING_INVALID_STATE`
+- `AUTH_INVALID_PIN` (`user`)
+- `AUTH_NOT_AUTHENTICATED` (`user`)
+- `AUTH_FORBIDDEN` (`user`)
+- `ROOM_ALREADY_EXISTS` (`user`)
+- `ROOM_NOT_FOUND` (`user`)
+- `ROOM_DELETE_OCCUPIED` (`user`)
+- `ROOM_DELETE_ACTIVE_BOOKING` (`user`)
+- `GROUP_INVALID_ROOM_COUNT` (`user`)
+- `GROUP_NOT_ENOUGH_VACANT_ROOMS` (`user`)
+- `BOOKING_NOT_FOUND` (`user`)
+- `BOOKING_INVALID_STATE` (`user`)
+- `SYSTEM_INTERNAL_ERROR` (`system`)
 
 Phase 1 should keep the code list curated instead of auto-generating codes from messages. New codes should be added deliberately when a migrated flow introduces a genuinely distinct operator-facing outcome.
 
 ### Canonical Registry
 
-Phase 1 should keep one canonical checked-in registry of externally visible error codes at `mhm/shared/error-codes.json`.
+Phase 1 should keep one canonical checked-in registry of externally visible error codes at `mhm/shared/error-codes.json`. The `mhm/shared/` directory does not exist yet and should be created as part of Step 1.
 
 Rules:
 
@@ -323,7 +333,14 @@ Its responsibilities:
 
 This wrapper should be the only place where the app knows how to interpret backend command failures.
 
-If the wrapper receives a rejection that does not match the standard migrated contract, it must fall back to one safe synthesized app error instead of trying to infer meaning from raw string text. In Phase 1, that fallback should behave like a generic `system` error with `code = SYSTEM_INTERNAL_ERROR`, a generic safe message, and `support_id = null`. This fallback is only a safety net for accidental misuse, not the intended path for unmigrated commands.
+If the wrapper receives a rejection that does not match the standard migrated contract, it must fall back to one safe synthesized app error instead of trying to infer meaning from raw string text. For Phase 1, a payload counts as contract-shaped only when all of the following are true:
+
+- `code` exists and is a string
+- `message` exists and is a string
+- `kind` exists and is exactly `user` or `system`
+- `support_id` is either `null`, a string, or missing
+
+Anything else must fall back to one synthesized generic `system` error with `code = SYSTEM_INTERNAL_ERROR`, a generic safe message, and `support_id = null`. This fallback is only a safety net for accidental misuse, not the intended path for unmigrated commands.
 
 ### Shared Error Presentation
 
@@ -435,6 +452,7 @@ Migrate the easiest and highest-signal flows first.
 Prerequisite:
 
 - refactor [mod.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/mod.rs:29) helpers `require_admin_user` and `require_admin` so migrated permission-gated flows stop returning raw Vietnamese `String` errors and instead return the shared auth or permission error type
+- update existing tests that assert raw string failures from those helpers, including the current [commands/mod.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/mod.rs:66) helper tests
 
 Target outcomes:
 
@@ -513,6 +531,8 @@ Priority migrated-screen tests:
 - login screen
 - room management flows
 - selected group booking flows
+
+Phase 1 should also include at least one end-to-end or UI-integration path per migrated domain so the backend contract, frontend wrapper, and user-facing presentation are exercised together instead of only in isolated unit layers.
 
 ### Repository Hygiene Checks
 

--- a/mhm/scripts/verify/native-smoke.mjs
+++ b/mhm/scripts/verify/native-smoke.mjs
@@ -41,6 +41,7 @@ const { child, logPath } = await spawnLoggedProcess(
   {
     cwd,
     env: {
+      CAPYINN_ENABLE_UPDATER: "1",
       CAPYINN_SMOKE_READY_FILE: readyFile,
     },
   },

--- a/mhm/scripts/verify/quick.mjs
+++ b/mhm/scripts/verify/quick.mjs
@@ -9,11 +9,50 @@ await run(
     "test",
     "--",
     "src/lib/appError.test.ts",
+    "src/pages/settings/useRoomConfig.test.tsx",
+    "src/components/GroupCheckinSheet.test.tsx",
     "src/App.updateFlow.test.tsx",
     "src/hooks/useAppUpdateController.test.tsx",
     "tests/e2e/01-login.test.tsx",
+    "tests/e2e/03-checkin.test.tsx",
+    "tests/e2e/05-checkout.test.tsx",
     "tests/e2e/08-settings.test.tsx",
   ],
+  { cwd },
+);
+
+await run(
+  "app-error-tests",
+  "cargo",
+  ["test", "--manifest-path", "src-tauri/Cargo.toml", "app_error::tests::", "--", "--nocapture"],
+  { cwd },
+);
+
+await run(
+  "command-helper-tests",
+  "cargo",
+  ["test", "--manifest-path", "src-tauri/Cargo.toml", "commands::tests::", "--", "--nocapture"],
+  { cwd },
+);
+
+await run(
+  "room-management-tests",
+  "cargo",
+  ["test", "--manifest-path", "src-tauri/Cargo.toml", "commands::room_management::tests::", "--", "--nocapture"],
+  { cwd },
+);
+
+await run(
+  "stay-group-mapping-tests",
+  "cargo",
+  ["test", "--manifest-path", "src-tauri/Cargo.toml", "commands::rooms::tests::", "--", "--nocapture"],
+  { cwd },
+);
+
+await run(
+  "group-mapping-tests",
+  "cargo",
+  ["test", "--manifest-path", "src-tauri/Cargo.toml", "commands::groups::tests::", "--", "--nocapture"],
   { cwd },
 );
 

--- a/mhm/scripts/verify/quick.mjs
+++ b/mhm/scripts/verify/quick.mjs
@@ -8,8 +8,10 @@ await run(
   [
     "test",
     "--",
+    "src/lib/appError.test.ts",
     "src/App.updateFlow.test.tsx",
     "src/hooks/useAppUpdateController.test.tsx",
+    "tests/e2e/01-login.test.tsx",
     "tests/e2e/08-settings.test.tsx",
   ],
   { cwd },

--- a/mhm/shared/error-codes.json
+++ b/mhm/shared/error-codes.json
@@ -1,0 +1,102 @@
+[
+  {
+    "code": "AUTH_INVALID_PIN",
+    "kind": "user",
+    "defaultMessage": "Mã PIN không đúng"
+  },
+  {
+    "code": "AUTH_NOT_AUTHENTICATED",
+    "kind": "user",
+    "defaultMessage": "Chưa đăng nhập"
+  },
+  {
+    "code": "AUTH_FORBIDDEN",
+    "kind": "user",
+    "defaultMessage": "Không có quyền thực hiện. Yêu cầu quyền Admin."
+  },
+  {
+    "code": "ROOM_ALREADY_EXISTS",
+    "kind": "user",
+    "defaultMessage": "Phòng đã tồn tại"
+  },
+  {
+    "code": "ROOM_NOT_FOUND",
+    "kind": "user",
+    "defaultMessage": "Phòng không tồn tại"
+  },
+  {
+    "code": "ROOM_DELETE_OCCUPIED",
+    "kind": "user",
+    "defaultMessage": "Không thể xóa phòng đang có khách"
+  },
+  {
+    "code": "ROOM_DELETE_ACTIVE_BOOKING",
+    "kind": "user",
+    "defaultMessage": "Không thể xóa phòng có booking đang hoạt động"
+  },
+  {
+    "code": "ROOM_TYPE_ALREADY_EXISTS",
+    "kind": "user",
+    "defaultMessage": "Loại phòng đã tồn tại"
+  },
+  {
+    "code": "ROOM_TYPE_NOT_FOUND",
+    "kind": "user",
+    "defaultMessage": "Loại phòng không tồn tại"
+  },
+  {
+    "code": "ROOM_TYPE_IN_USE",
+    "kind": "user",
+    "defaultMessage": "Không thể xóa loại phòng đang được sử dụng"
+  },
+  {
+    "code": "GROUP_INVALID_ROOM_COUNT",
+    "kind": "user",
+    "defaultMessage": "Số phòng phải lớn hơn 0"
+  },
+  {
+    "code": "GROUP_NOT_ENOUGH_VACANT_ROOMS",
+    "kind": "user",
+    "defaultMessage": "Không đủ phòng trống"
+  },
+  {
+    "code": "GROUP_NOT_FOUND",
+    "kind": "user",
+    "defaultMessage": "Không tìm thấy đoàn"
+  },
+  {
+    "code": "GROUP_CHECKOUT_SELECTION_REQUIRED",
+    "kind": "user",
+    "defaultMessage": "Phải chọn ít nhất 1 phòng để checkout"
+  },
+  {
+    "code": "BOOKING_NOT_FOUND",
+    "kind": "user",
+    "defaultMessage": "Không tìm thấy booking"
+  },
+  {
+    "code": "BOOKING_INVALID_STATE",
+    "kind": "user",
+    "defaultMessage": "Booking hiện không ở trạng thái hợp lệ cho thao tác này"
+  },
+  {
+    "code": "BOOKING_GUEST_REQUIRED",
+    "kind": "user",
+    "defaultMessage": "Phải có ít nhất 1 khách"
+  },
+  {
+    "code": "BOOKING_INVALID_NIGHTS",
+    "kind": "user",
+    "defaultMessage": "Số đêm phải lớn hơn 0"
+  },
+  {
+    "code": "BOOKING_INVALID_SETTLEMENT_TOTAL",
+    "kind": "user",
+    "defaultMessage": "Tổng quyết toán phải lớn hơn hoặc bằng 0"
+  },
+  {
+    "code": "SYSTEM_INTERNAL_ERROR",
+    "kind": "system",
+    "defaultMessage": "Có lỗi hệ thống, vui lòng thử lại"
+  }
+]

--- a/mhm/src-tauri/Cargo.lock
+++ b/mhm/src-tauri/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "capyinn"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "axum",
  "chrono",

--- a/mhm/src-tauri/src/app_error.rs
+++ b/mhm/src-tauri/src/app_error.rs
@@ -1,0 +1,384 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::app_identity;
+use crate::support_log::{self, SupportErrorRecord};
+
+pub mod codes {
+    pub const AUTH_INVALID_PIN: &str = "AUTH_INVALID_PIN";
+    pub const AUTH_NOT_AUTHENTICATED: &str = "AUTH_NOT_AUTHENTICATED";
+    pub const AUTH_FORBIDDEN: &str = "AUTH_FORBIDDEN";
+    pub const ROOM_ALREADY_EXISTS: &str = "ROOM_ALREADY_EXISTS";
+    pub const ROOM_NOT_FOUND: &str = "ROOM_NOT_FOUND";
+    pub const ROOM_DELETE_OCCUPIED: &str = "ROOM_DELETE_OCCUPIED";
+    pub const ROOM_DELETE_ACTIVE_BOOKING: &str = "ROOM_DELETE_ACTIVE_BOOKING";
+    pub const ROOM_TYPE_ALREADY_EXISTS: &str = "ROOM_TYPE_ALREADY_EXISTS";
+    pub const ROOM_TYPE_NOT_FOUND: &str = "ROOM_TYPE_NOT_FOUND";
+    pub const ROOM_TYPE_IN_USE: &str = "ROOM_TYPE_IN_USE";
+    pub const GROUP_INVALID_ROOM_COUNT: &str = "GROUP_INVALID_ROOM_COUNT";
+    pub const GROUP_NOT_ENOUGH_VACANT_ROOMS: &str = "GROUP_NOT_ENOUGH_VACANT_ROOMS";
+    pub const GROUP_NOT_FOUND: &str = "GROUP_NOT_FOUND";
+    pub const GROUP_CHECKOUT_SELECTION_REQUIRED: &str = "GROUP_CHECKOUT_SELECTION_REQUIRED";
+    pub const BOOKING_NOT_FOUND: &str = "BOOKING_NOT_FOUND";
+    pub const BOOKING_INVALID_STATE: &str = "BOOKING_INVALID_STATE";
+    pub const BOOKING_GUEST_REQUIRED: &str = "BOOKING_GUEST_REQUIRED";
+    pub const BOOKING_INVALID_NIGHTS: &str = "BOOKING_INVALID_NIGHTS";
+    pub const BOOKING_INVALID_SETTLEMENT_TOTAL: &str = "BOOKING_INVALID_SETTLEMENT_TOTAL";
+    pub const SYSTEM_INTERNAL_ERROR: &str = "SYSTEM_INTERNAL_ERROR";
+
+    pub const ALL: &[&str] = &[
+        AUTH_INVALID_PIN,
+        AUTH_NOT_AUTHENTICATED,
+        AUTH_FORBIDDEN,
+        ROOM_ALREADY_EXISTS,
+        ROOM_NOT_FOUND,
+        ROOM_DELETE_OCCUPIED,
+        ROOM_DELETE_ACTIVE_BOOKING,
+        ROOM_TYPE_ALREADY_EXISTS,
+        ROOM_TYPE_NOT_FOUND,
+        ROOM_TYPE_IN_USE,
+        GROUP_INVALID_ROOM_COUNT,
+        GROUP_NOT_ENOUGH_VACANT_ROOMS,
+        GROUP_NOT_FOUND,
+        GROUP_CHECKOUT_SELECTION_REQUIRED,
+        BOOKING_NOT_FOUND,
+        BOOKING_INVALID_STATE,
+        BOOKING_GUEST_REQUIRED,
+        BOOKING_INVALID_NIGHTS,
+        BOOKING_INVALID_SETTLEMENT_TOTAL,
+        SYSTEM_INTERNAL_ERROR,
+    ];
+}
+
+pub const GENERIC_SYSTEM_ERROR_MESSAGE: &str = "Có lỗi hệ thống, vui lòng thử lại";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AppErrorKind {
+    User,
+    System,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandError {
+    pub code: String,
+    pub message: String,
+    pub kind: AppErrorKind,
+    pub support_id: Option<String>,
+}
+
+pub type CommandResult<T> = Result<T, CommandError>;
+
+fn ensure_registered_code(code: &'static str) -> &'static str {
+    assert!(
+        codes::ALL.contains(&code),
+        "unregistered command error code: {code}"
+    );
+    code
+}
+
+impl CommandError {
+    pub fn user(code: &'static str, message: impl Into<String>) -> Self {
+        let code = ensure_registered_code(code);
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            kind: AppErrorKind::User,
+            support_id: None,
+        }
+    }
+
+    pub fn system(code: &'static str, message: impl Into<String>) -> Self {
+        let code = ensure_registered_code(code);
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            kind: AppErrorKind::System,
+            support_id: Some(generate_support_id()),
+        }
+    }
+
+    pub fn with_support_id(
+        code: &'static str,
+        message: impl Into<String>,
+        support_id: impl Into<String>,
+    ) -> Self {
+        let code = ensure_registered_code(code);
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            kind: AppErrorKind::System,
+            support_id: Some(support_id.into()),
+        }
+    }
+}
+
+pub fn generate_support_id() -> String {
+    let raw = uuid::Uuid::new_v4().simple().to_string();
+    format!("SUP-{}", raw[..8].to_ascii_uppercase())
+}
+
+pub fn log_system_error(
+    command_name: &str,
+    root_cause: impl AsRef<str>,
+    context: Value,
+) -> CommandError {
+    let root_cause = root_cause.as_ref();
+    let support_id = generate_support_id();
+    let record = SupportErrorRecord::new(
+        command_name,
+        codes::SYSTEM_INTERNAL_ERROR,
+        root_cause,
+        support_id.clone(),
+        context,
+    );
+    let context_json = serde_json::to_string(&record.context).unwrap_or_else(|_| "{}".to_string());
+
+    log::error!(
+        "system error [{}] {}: {} | context={}",
+        support_id,
+        command_name,
+        root_cause,
+        context_json
+    );
+
+    if let Some(runtime_root) = app_identity::runtime_root_opt() {
+        if let Err(error) = support_log::append_support_error_record(&runtime_root, &record) {
+            log::error!(
+                "failed to write support error record for {}: {}",
+                command_name,
+                error
+            );
+        }
+    } else {
+        log::error!(
+            "unable to resolve runtime root for support error record from {}",
+            command_name
+        );
+    }
+
+    CommandError::with_support_id(
+        codes::SYSTEM_INTERNAL_ERROR,
+        GENERIC_SYSTEM_ERROR_MESSAGE,
+        support_id,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn user_error_serializes_to_the_expected_contract_shape() {
+        let error = CommandError::user(codes::AUTH_INVALID_PIN, "Mã PIN không đúng");
+        let serialized = serde_json::to_value(&error).expect("serialize command error");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "code": codes::AUTH_INVALID_PIN,
+                "message": "Mã PIN không đúng",
+                "kind": "user",
+                "support_id": null,
+            })
+        );
+    }
+
+    #[test]
+    fn system_error_serializes_support_id_in_the_expected_format() {
+        let error = CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            "Có lỗi hệ thống, vui lòng thử lại",
+        );
+        let support_id = error
+            .support_id
+            .clone()
+            .expect("system errors carry support ids");
+
+        assert_eq!(support_id.len(), 12);
+        assert!(support_id.starts_with("SUP-"));
+        assert!(support_id[4..]
+            .chars()
+            .all(|character| character.is_ascii_digit() || matches!(character, 'A'..='F')));
+
+        let serialized = serde_json::to_value(&error).expect("serialize command error");
+        assert_eq!(serialized["kind"], "system");
+        assert_eq!(serialized["support_id"], support_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "unregistered command error code")]
+    fn rejects_unregistered_command_error_code() {
+        let _ = CommandError::user("NOT_REGISTERED", "boom");
+    }
+
+    #[test]
+    fn registry_matches_the_exported_code_constants() {
+        #[derive(Deserialize)]
+        struct RegistryEntry {
+            code: String,
+            kind: AppErrorKind,
+            #[serde(rename = "defaultMessage")]
+            default_message: String,
+        }
+
+        let registry_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../shared/error-codes.json");
+        let registry: Vec<RegistryEntry> =
+            serde_json::from_str(&fs::read_to_string(&registry_path).expect("read registry"))
+                .expect("parse registry");
+        let expected = vec![
+            (
+                codes::AUTH_INVALID_PIN,
+                AppErrorKind::User,
+                "Mã PIN không đúng",
+            ),
+            (
+                codes::AUTH_NOT_AUTHENTICATED,
+                AppErrorKind::User,
+                "Chưa đăng nhập",
+            ),
+            (
+                codes::AUTH_FORBIDDEN,
+                AppErrorKind::User,
+                "Không có quyền thực hiện. Yêu cầu quyền Admin.",
+            ),
+            (
+                codes::ROOM_ALREADY_EXISTS,
+                AppErrorKind::User,
+                "Phòng đã tồn tại",
+            ),
+            (
+                codes::ROOM_NOT_FOUND,
+                AppErrorKind::User,
+                "Phòng không tồn tại",
+            ),
+            (
+                codes::ROOM_DELETE_OCCUPIED,
+                AppErrorKind::User,
+                "Không thể xóa phòng đang có khách",
+            ),
+            (
+                codes::ROOM_DELETE_ACTIVE_BOOKING,
+                AppErrorKind::User,
+                "Không thể xóa phòng có booking đang hoạt động",
+            ),
+            (
+                codes::ROOM_TYPE_ALREADY_EXISTS,
+                AppErrorKind::User,
+                "Loại phòng đã tồn tại",
+            ),
+            (
+                codes::ROOM_TYPE_NOT_FOUND,
+                AppErrorKind::User,
+                "Loại phòng không tồn tại",
+            ),
+            (
+                codes::ROOM_TYPE_IN_USE,
+                AppErrorKind::User,
+                "Không thể xóa loại phòng đang được sử dụng",
+            ),
+            (
+                codes::GROUP_INVALID_ROOM_COUNT,
+                AppErrorKind::User,
+                "Số phòng phải lớn hơn 0",
+            ),
+            (
+                codes::GROUP_NOT_ENOUGH_VACANT_ROOMS,
+                AppErrorKind::User,
+                "Không đủ phòng trống",
+            ),
+            (
+                codes::GROUP_NOT_FOUND,
+                AppErrorKind::User,
+                "Không tìm thấy đoàn",
+            ),
+            (
+                codes::GROUP_CHECKOUT_SELECTION_REQUIRED,
+                AppErrorKind::User,
+                "Phải chọn ít nhất 1 phòng để checkout",
+            ),
+            (
+                codes::BOOKING_NOT_FOUND,
+                AppErrorKind::User,
+                "Không tìm thấy booking",
+            ),
+            (
+                codes::BOOKING_INVALID_STATE,
+                AppErrorKind::User,
+                "Booking hiện không ở trạng thái hợp lệ cho thao tác này",
+            ),
+            (
+                codes::BOOKING_GUEST_REQUIRED,
+                AppErrorKind::User,
+                "Phải có ít nhất 1 khách",
+            ),
+            (
+                codes::BOOKING_INVALID_NIGHTS,
+                AppErrorKind::User,
+                "Số đêm phải lớn hơn 0",
+            ),
+            (
+                codes::BOOKING_INVALID_SETTLEMENT_TOTAL,
+                AppErrorKind::User,
+                "Tổng quyết toán phải lớn hơn hoặc bằng 0",
+            ),
+            (
+                codes::SYSTEM_INTERNAL_ERROR,
+                AppErrorKind::System,
+                GENERIC_SYSTEM_ERROR_MESSAGE,
+            ),
+        ];
+
+        assert_eq!(registry.len(), expected.len());
+        for (entry, (code, kind, default_message)) in registry.iter().zip(expected.iter()) {
+            assert_eq!(entry.code, *code);
+            assert_eq!(entry.kind, *kind);
+            assert_eq!(entry.default_message, *default_message);
+        }
+        assert!(registry
+            .iter()
+            .all(|entry| !entry.default_message.is_empty()));
+    }
+
+    #[test]
+    fn log_system_error_returns_generic_system_contract_and_writes_support_record() {
+        let _guard = crate::runtime_config::env_lock().lock().unwrap();
+        let runtime_root =
+            std::env::temp_dir().join(format!("capyinn-log-system-error-{}", uuid::Uuid::new_v4()));
+
+        std::env::set_var("CAPYINN_RUNTIME_ROOT", &runtime_root);
+        let error = log_system_error(
+            "login",
+            "database offline",
+            json!({ "room_id": "R101", "booking_id": "B202" }),
+        );
+        std::env::remove_var("CAPYINN_RUNTIME_ROOT");
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert_eq!(error.message, GENERIC_SYSTEM_ERROR_MESSAGE);
+        assert_eq!(error.kind, AppErrorKind::System);
+        let support_id = error.support_id.expect("support id");
+        assert!(support_id.starts_with("SUP-"));
+
+        let log_path = runtime_root
+            .join("diagnostics")
+            .join("support-errors.jsonl");
+        let contents = fs::read_to_string(&log_path).expect("support log contents");
+        let parsed: serde_json::Value =
+            serde_json::from_str(contents.trim()).expect("support log json");
+        assert_eq!(parsed["command"], "login");
+        assert_eq!(parsed["code"], codes::SYSTEM_INTERNAL_ERROR);
+        assert_eq!(parsed["root_cause"], "database offline");
+        assert_eq!(parsed["context"]["room_id"], "R101");
+        assert_eq!(parsed["context"]["booking_id"], "B202");
+        assert!(parsed.get("room_id").is_none());
+        assert!(parsed.get("booking_id").is_none());
+        assert_eq!(parsed["support_id"], support_id);
+
+        let _ = fs::remove_dir_all(&runtime_root);
+    }
+}

--- a/mhm/src-tauri/src/commands/auth.rs
+++ b/mhm/src-tauri/src/commands/auth.rs
@@ -1,27 +1,36 @@
-use sqlx::Row;
-use tauri::State;
+use super::{get_f64, get_user, require_admin, AppState};
+use crate::app_error::{codes, log_system_error, CommandError, CommandResult};
 use crate::models::*;
-use super::{AppState, get_f64, get_user, require_admin};
-
+use sqlx::Row;
+use serde_json::json;
+use tauri::State;
 
 // ═══════════════════════════════════════════════
 // Phase 1: Auth & RBAC Commands
 // ═══════════════════════════════════════════════
 
 #[tauri::command]
-pub async fn login(state: State<'_, AppState>, req: LoginRequest) -> Result<LoginResponse, String> {
-    use sha2::{Sha256, Digest};
+pub async fn login(
+    state: State<'_, AppState>,
+    req: LoginRequest,
+) -> CommandResult<LoginResponse> {
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(req.pin.as_bytes());
     let pin_hash = format!("{:x}", hasher.finalize());
 
     let row = sqlx::query(
-        "SELECT id, name, role, active, created_at FROM users WHERE pin_hash = ? AND active = 1"
+        "SELECT id, name, role, active, created_at FROM users WHERE pin_hash = ? AND active = 1",
     )
     .bind(&pin_hash)
-    .fetch_optional(&state.db).await.map_err(|e| e.to_string())?;
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|error| log_system_error("login", error.to_string(), json!({ "step": "fetch_user" })))?;
 
-    let row = row.ok_or("Mã PIN không đúng".to_string())?;
+    let row = match row {
+        Some(row) => row,
+        None => return Err(CommandError::user(codes::AUTH_INVALID_PIN, "Mã PIN không đúng")),
+    };
 
     let user = User {
         id: row.get("id"),
@@ -32,9 +41,14 @@ pub async fn login(state: State<'_, AppState>, req: LoginRequest) -> Result<Logi
     };
 
     // Store in AppState
-    if let Ok(mut current) = state.current_user.lock() {
-        *current = Some(user.clone());
-    }
+    let mut current = state.current_user.lock().map_err(|error| {
+        log_system_error(
+            "login",
+            error.to_string(),
+            json!({ "step": "store_current_user" }),
+        )
+    })?;
+    *current = Some(user.clone());
 
     Ok(LoginResponse { user })
 }
@@ -53,28 +67,40 @@ pub async fn get_current_user(state: State<'_, AppState>) -> Result<Option<User>
 }
 
 #[tauri::command]
-pub async fn list_users(state: State<'_, AppState>) -> Result<Vec<User>, String> {
+pub async fn list_users(state: State<'_, AppState>) -> CommandResult<Vec<User>> {
     require_admin(&state)?;
 
-    let rows = sqlx::query("SELECT id, name, role, active, created_at FROM users ORDER BY created_at")
-        .fetch_all(&state.db).await.map_err(|e| e.to_string())?;
+    let rows =
+        sqlx::query("SELECT id, name, role, active, created_at FROM users ORDER BY created_at")
+            .fetch_all(&state.db)
+            .await
+            .map_err(|error| {
+                log_system_error("list_users", error.to_string(), json!({ "step": "fetch_users" }))
+            })?;
 
-    Ok(rows.iter().map(|r| User {
-        id: r.get("id"),
-        name: r.get("name"),
-        role: r.get("role"),
-        active: r.get::<i32, _>("active") == 1,
-        created_at: r.get("created_at"),
-    }).collect())
+    Ok(rows
+        .iter()
+        .map(|r| User {
+            id: r.get("id"),
+            name: r.get("name"),
+            role: r.get("role"),
+            active: r.get::<i32, _>("active") == 1,
+            created_at: r.get("created_at"),
+        })
+        .collect())
 }
 
 #[tauri::command]
-pub async fn create_user(state: State<'_, AppState>, req: CreateUserRequest) -> Result<User, String> {
+pub async fn create_user(
+    state: State<'_, AppState>,
+    req: CreateUserRequest,
+) -> CommandResult<User> {
     require_admin(&state)?;
 
-    use sha2::{Sha256, Digest};
+    let CreateUserRequest { name, pin, role } = req;
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
-    hasher.update(req.pin.as_bytes());
+    hasher.update(pin.as_bytes());
     let pin_hash = format!("{:x}", hasher.finalize());
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -82,15 +108,27 @@ pub async fn create_user(state: State<'_, AppState>, req: CreateUserRequest) -> 
 
     sqlx::query(
         "INSERT INTO users (id, name, pin_hash, role, active, created_at)
-         VALUES (?, ?, ?, ?, 1, ?)"
+         VALUES (?, ?, ?, ?, 1, ?)",
     )
-    .bind(&id).bind(&req.name).bind(&pin_hash).bind(&req.role).bind(&now)
-    .execute(&state.db).await.map_err(|e| e.to_string())?;
+    .bind(&id)
+    .bind(&name)
+    .bind(&pin_hash)
+    .bind(&role)
+    .bind(&now)
+    .execute(&state.db)
+    .await
+    .map_err(|error| {
+        log_system_error(
+            "create_user",
+            error.to_string(),
+            json!({ "step": "insert_user", "name": &name, "role": &role }),
+        )
+    })?;
 
     Ok(User {
         id,
-        name: req.name,
-        role: req.role,
+        name,
+        role,
         active: true,
         created_at: now,
     })
@@ -99,7 +137,10 @@ pub async fn create_user(state: State<'_, AppState>, req: CreateUserRequest) -> 
 // ─── Search Guest by Phone (Quick Check-in) ───
 
 #[tauri::command]
-pub async fn search_guest_by_phone(state: State<'_, AppState>, phone: String) -> Result<Vec<GuestSummary>, String> {
+pub async fn search_guest_by_phone(
+    state: State<'_, AppState>,
+    phone: String,
+) -> Result<Vec<GuestSummary>, String> {
     if phone.len() < 3 {
         return Ok(vec![]);
     }
@@ -116,18 +157,23 @@ pub async fn search_guest_by_phone(state: State<'_, AppState>, phone: String) ->
          WHERE g.phone LIKE ?
          GROUP BY g.id
          ORDER BY last_visit DESC
-         LIMIT 5"
+         LIMIT 5",
     )
     .bind(&pattern)
-    .fetch_all(&state.db).await.map_err(|e| e.to_string())?;
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| e.to_string())?;
 
-    Ok(rows.iter().map(|r| GuestSummary {
-        id: r.get("id"),
-        full_name: r.get("full_name"),
-        doc_number: r.get("doc_number"),
-        nationality: r.get("nationality"),
-        total_stays: r.get::<i32, _>("total_stays"),
-        total_spent: get_f64(r, "total_spent"),
-        last_visit: r.get("last_visit"),
-    }).collect())
+    Ok(rows
+        .iter()
+        .map(|r| GuestSummary {
+            id: r.get("id"),
+            full_name: r.get("full_name"),
+            doc_number: r.get("doc_number"),
+            nationality: r.get("nationality"),
+            total_stays: r.get::<i32, _>("total_stays"),
+            total_spent: get_f64(r, "total_spent"),
+            last_visit: r.get("last_visit"),
+        })
+        .collect())
 }

--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -1,10 +1,72 @@
 use super::{emit_db_update, get_f64, get_user_id, AppState};
-use crate::models::*;
+use crate::{
+    app_error::{codes, log_system_error, CommandError, CommandResult},
+    domain::booking::BookingError,
+    models::*,
+};
 use crate::services::booking::group_lifecycle;
+use serde_json::{json, Value};
 use sqlx::{Pool, Row, Sqlite};
 use tauri::State;
 
 // ─── Group Booking Commands ───
+
+fn map_group_error(command_name: &str, error: BookingError, context: Value) -> CommandError {
+    match error {
+        BookingError::Validation(message) if message == "Phải chọn ít nhất 1 phòng để checkout" => {
+            CommandError::user(codes::GROUP_CHECKOUT_SELECTION_REQUIRED, message)
+        }
+        BookingError::Validation(message)
+            if message == "Phải chọn ít nhất 1 phòng" || message == "Số phòng phải > 0" =>
+        {
+            CommandError::user(codes::GROUP_INVALID_ROOM_COUNT, message)
+        }
+        BookingError::Validation(message) if message == "Số đêm phải > 0" => {
+            CommandError::user(codes::BOOKING_INVALID_NIGHTS, message)
+        }
+        BookingError::NotFound(message) if message.starts_with("Phòng ") => {
+            CommandError::user(codes::ROOM_NOT_FOUND, message)
+        }
+        BookingError::NotFound(message) if message.starts_with("Không tìm thấy group ") => {
+            CommandError::user(codes::GROUP_NOT_FOUND, message)
+        }
+        BookingError::NotFound(message)
+            if message.starts_with("Booking ") && message.contains("không tìm thấy") =>
+        {
+            CommandError::user(codes::BOOKING_NOT_FOUND, message)
+        }
+        BookingError::Validation(message) | BookingError::Conflict(message) => {
+            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+        }
+        BookingError::NotFound(message)
+        | BookingError::Database(message)
+        | BookingError::DateTimeParse(message) => log_system_error(command_name, message, context),
+    }
+}
+
+fn map_auto_assign_error(command_name: &str, message: String, context: Value) -> CommandError {
+    if message == "Số phòng phải > 0" {
+        return CommandError::user(codes::GROUP_INVALID_ROOM_COUNT, message);
+    }
+    if message.starts_with("Chỉ có ") && message.contains(" phòng trống, cần ") {
+        return CommandError::user(codes::GROUP_NOT_ENOUGH_VACANT_ROOMS, message);
+    }
+    log_system_error(command_name, message, context)
+}
+
+fn map_group_detail_error(group_id: &str, error: sqlx::Error) -> CommandError {
+    match error {
+        sqlx::Error::RowNotFound => CommandError::user(
+            codes::GROUP_NOT_FOUND,
+            format!("Không tìm thấy group {}", group_id),
+        ),
+        other => log_system_error(
+            "get_group_detail",
+            other.to_string(),
+            json!({ "group_id": group_id }),
+        ),
+    }
+}
 
 /// Check-in a group: creates booking_groups + N bookings atomically
 #[tauri::command]
@@ -12,10 +74,16 @@ pub async fn group_checkin(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: GroupCheckinRequest,
-) -> Result<BookingGroup, String> {
+) -> CommandResult<BookingGroup> {
+    let error_context = json!({
+        "group_name": req.group_name.clone(),
+        "room_count": req.room_ids.len(),
+        "nights": req.nights,
+        "master_room_id": req.master_room_id.clone(),
+    });
     let group = group_lifecycle::group_checkin(&state.db, get_user_id(&state), req)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| map_group_error("group_checkin", error, error_context))?;
     emit_db_update(&app, "rooms");
     emit_db_update(&app, "groups");
     Ok(group)
@@ -27,10 +95,15 @@ pub async fn group_checkout(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: GroupCheckoutRequest,
-) -> Result<(), String> {
+) -> CommandResult<()> {
+    let error_context = json!({
+        "group_id": req.group_id.clone(),
+        "booking_count": req.booking_ids.len(),
+        "final_paid": req.final_paid,
+    });
     group_lifecycle::group_checkout(&state.db, req)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| map_group_error("group_checkout", error, error_context))?;
     emit_db_update(&app, "rooms");
     emit_db_update(&app, "groups");
 
@@ -44,15 +117,14 @@ pub async fn group_checkout(
 }
 
 /// Get group detail with bookings, services, totals
-pub async fn do_get_group_detail(
+async fn load_group_detail(
     pool: &Pool<Sqlite>,
     group_id: &str,
-) -> Result<GroupDetailResponse, String> {
+) -> Result<GroupDetailResponse, sqlx::Error> {
     let row = sqlx::query("SELECT * FROM booking_groups WHERE id = ?")
         .bind(group_id)
         .fetch_one(pool)
-        .await
-        .map_err(|e| e.to_string())?;
+        .await?;
 
     let group = BookingGroup {
         id: row.get("id"),
@@ -80,7 +152,8 @@ pub async fn do_get_group_detail(
          ORDER BY r.floor, r.id"
     )
     .bind(group_id)
-    .fetch_all(pool).await.map_err(|e| e.to_string())?;
+    .fetch_all(pool)
+    .await?;
 
     let bookings: Vec<BookingWithGuest> = booking_rows
         .iter()
@@ -110,8 +183,7 @@ pub async fn do_get_group_detail(
         sqlx::query("SELECT * FROM group_services WHERE group_id = ? ORDER BY created_at")
             .bind(group_id)
             .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?;
+            .await?;
 
     let services: Vec<GroupService> = service_rows
         .iter()
@@ -144,12 +216,23 @@ pub async fn do_get_group_detail(
     })
 }
 
+pub async fn do_get_group_detail(
+    pool: &Pool<Sqlite>,
+    group_id: &str,
+) -> Result<GroupDetailResponse, String> {
+    load_group_detail(pool, group_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
 #[tauri::command]
 pub async fn get_group_detail(
     state: State<'_, AppState>,
     group_id: String,
-) -> Result<GroupDetailResponse, String> {
-    do_get_group_detail(&state.db, &group_id).await
+) -> CommandResult<GroupDetailResponse> {
+    load_group_detail(&state.db, &group_id)
+        .await
+        .map_err(|error| map_group_detail_error(&group_id, error))
 }
 
 /// List all groups, optionally filtered by status
@@ -254,9 +337,13 @@ pub async fn remove_group_service(
 pub async fn auto_assign_rooms(
     state: State<'_, AppState>,
     req: AutoAssignRequest,
-) -> Result<AutoAssignResult, String> {
+) -> CommandResult<AutoAssignResult> {
     if req.room_count <= 0 {
-        return Err("Số phòng phải > 0".to_string());
+        return Err(map_auto_assign_error(
+            "auto_assign_rooms",
+            "Số phòng phải > 0".to_string(),
+            json!({ "room_count": req.room_count, "room_type": req.room_type }),
+        ));
     }
 
     let rows = if let Some(ref rt) = req.room_type {
@@ -264,12 +351,24 @@ pub async fn auto_assign_rooms(
             .bind(rt)
             .fetch_all(&state.db)
             .await
-            .map_err(|e| e.to_string())?
+            .map_err(|error| {
+                log_system_error(
+                    "auto_assign_rooms",
+                    error.to_string(),
+                    json!({ "room_count": req.room_count, "room_type": req.room_type }),
+                )
+            })?
     } else {
         sqlx::query("SELECT * FROM rooms WHERE status = 'vacant' ORDER BY floor, id")
             .fetch_all(&state.db)
             .await
-            .map_err(|e| e.to_string())?
+            .map_err(|error| {
+                log_system_error(
+                    "auto_assign_rooms",
+                    error.to_string(),
+                    json!({ "room_count": req.room_count, "room_type": req.room_type }),
+                )
+            })?
     };
 
     let vacant_rooms: Vec<Room> = rows
@@ -288,10 +387,18 @@ pub async fn auto_assign_rooms(
         .collect();
 
     if vacant_rooms.len() < req.room_count as usize {
-        return Err(format!(
-            "Chỉ có {} phòng trống, cần {} phòng",
-            vacant_rooms.len(),
-            req.room_count
+        return Err(map_auto_assign_error(
+            "auto_assign_rooms",
+            format!(
+                "Chỉ có {} phòng trống, cần {} phòng",
+                vacant_rooms.len(),
+                req.room_count
+            ),
+            json!({
+                "available_rooms": vacant_rooms.len(),
+                "requested_rooms": req.room_count,
+                "room_type": req.room_type,
+            }),
         ));
     }
 
@@ -400,4 +507,92 @@ pub async fn generate_group_invoice(
     group_id: String,
 ) -> Result<GroupInvoiceData, String> {
     do_generate_group_invoice(&state.db, &group_id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_auto_assign_error, map_group_detail_error, map_group_error};
+    use crate::app_error::{codes, AppErrorKind};
+    use crate::domain::booking::BookingError;
+    use serde_json::json;
+
+    #[test]
+    fn map_group_error_maps_missing_group_to_shared_contract() {
+        let error = map_group_error(
+            "group_checkin",
+            BookingError::not_found("Không tìm thấy group group-1"),
+            json!({ "group_id": "group-1" }),
+        );
+
+        assert_eq!(error.code, codes::GROUP_NOT_FOUND);
+        assert_eq!(error.message, "Không tìm thấy group group-1");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_group_error_maps_checkout_selection_required_to_shared_code() {
+        let error = map_group_error(
+            "group_checkout",
+            BookingError::validation("Phải chọn ít nhất 1 phòng để checkout"),
+            json!({ "group_id": "group-1" }),
+        );
+
+        assert_eq!(error.code, codes::GROUP_CHECKOUT_SELECTION_REQUIRED);
+        assert_eq!(error.message, "Phải chọn ít nhất 1 phòng để checkout");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_group_error_maps_invalid_room_count_to_shared_code() {
+        let error = map_group_error(
+            "group_checkin",
+            BookingError::validation("Phải chọn ít nhất 1 phòng"),
+            json!({ "group_id": "group-1" }),
+        );
+
+        assert_eq!(error.code, codes::GROUP_INVALID_ROOM_COUNT);
+        assert_eq!(error.message, "Phải chọn ít nhất 1 phòng");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_auto_assign_error_maps_invalid_room_count_to_shared_code() {
+        let error = map_auto_assign_error(
+            "auto_assign_rooms",
+            "Số phòng phải > 0".to_string(),
+            json!({ "room_count": 0 }),
+        );
+
+        assert_eq!(error.code, codes::GROUP_INVALID_ROOM_COUNT);
+        assert_eq!(error.message, "Số phòng phải > 0");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_auto_assign_error_maps_insufficient_vacancy_to_shared_code() {
+        let error = map_auto_assign_error(
+            "auto_assign_rooms",
+            "Chỉ có 1 phòng trống, cần 3 phòng".to_string(),
+            json!({ "room_count": 3 }),
+        );
+
+        assert_eq!(error.code, codes::GROUP_NOT_ENOUGH_VACANT_ROOMS);
+        assert_eq!(error.message, "Chỉ có 1 phòng trống, cần 3 phòng");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_group_detail_error_maps_missing_group_rows_to_shared_code() {
+        let error = map_group_detail_error("group-404", sqlx::Error::RowNotFound);
+
+        assert_eq!(error.code, codes::GROUP_NOT_FOUND);
+        assert_eq!(error.message, "Không tìm thấy group group-404");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
 }

--- a/mhm/src-tauri/src/commands/mod.rs
+++ b/mhm/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+use crate::app_error::{codes, CommandError, CommandResult};
 use crate::models::*;
 use sqlx::{Pool, Row, Sqlite};
 use std::sync::{Arc, Mutex};
@@ -26,16 +27,27 @@ pub(crate) fn get_user_id(state: &State<'_, AppState>) -> Option<String> {
     get_user(state).map(|u| u.id)
 }
 
-pub(crate) fn require_admin_user(user: Option<User>) -> Result<User, String> {
-    let user = user.ok_or("Chưa đăng nhập".to_string())?;
+pub(crate) fn require_admin_user(user: Option<User>) -> CommandResult<User> {
+    let user = user.ok_or_else(|| {
+        CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập")
+    })?;
     if user.role != "admin" {
-        return Err("Không có quyền thực hiện. Yêu cầu quyền Admin.".to_string());
+        return Err(CommandError::user(
+            codes::AUTH_FORBIDDEN,
+            "Không có quyền thực hiện. Yêu cầu quyền Admin.",
+        ));
     }
     Ok(user)
 }
 
-pub(crate) fn require_admin(state: &State<'_, AppState>) -> Result<User, String> {
+pub(crate) fn require_admin(state: &State<'_, AppState>) -> CommandResult<User> {
     require_admin_user(get_user(state))
+}
+
+impl From<CommandError> for String {
+    fn from(error: CommandError) -> Self {
+        error.message
+    }
 }
 
 pub(crate) fn emit_db_update(app: &tauri::AppHandle, entity: &str) {
@@ -74,6 +86,7 @@ pub use rooms::{do_get_dashboard_stats, do_get_room_detail, do_get_rooms};
 #[cfg(test)]
 mod tests {
     use super::require_admin_user;
+    use crate::app_error::{codes, AppErrorKind};
     use crate::models::User;
 
     fn mock_user(role: &str) -> User {
@@ -89,14 +102,20 @@ mod tests {
     #[test]
     fn require_admin_user_rejects_missing_user() {
         let error = require_admin_user(None).expect_err("missing user must be rejected");
-        assert_eq!(error, "Chưa đăng nhập");
+        assert_eq!(error.code, codes::AUTH_NOT_AUTHENTICATED);
+        assert_eq!(error.message, "Chưa đăng nhập");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
     }
 
     #[test]
     fn require_admin_user_rejects_non_admin_user() {
         let error =
             require_admin_user(Some(mock_user("receptionist"))).expect_err("non-admin must fail");
-        assert_eq!(error, "Không có quyền thực hiện. Yêu cầu quyền Admin.");
+        assert_eq!(error.code, codes::AUTH_FORBIDDEN);
+        assert_eq!(error.message, "Không có quyền thực hiện. Yêu cầu quyền Admin.");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
     }
 
     #[test]

--- a/mhm/src-tauri/src/commands/room_management.rs
+++ b/mhm/src-tauri/src/commands/room_management.rs
@@ -1,6 +1,8 @@
 use super::{emit_db_update, get_f64, require_admin, AppState};
+use crate::app_error::{codes, log_system_error, CommandError, CommandResult};
 use crate::app_identity;
 use crate::models::*;
+use serde_json::json;
 use sqlx::{Pool, Row, Sqlite};
 use tauri::State;
 
@@ -11,7 +13,7 @@ pub async fn update_room(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: UpdateRoomRequest,
-) -> Result<Room, String> {
+) -> CommandResult<Room> {
     require_admin(&state)?;
 
     let r = do_update_room(&state.db, req).await?;
@@ -20,7 +22,7 @@ pub async fn update_room(
     Ok(r)
 }
 
-async fn do_update_room(pool: &Pool<Sqlite>, req: UpdateRoomRequest) -> Result<Room, String> {
+async fn do_update_room(pool: &Pool<Sqlite>, req: UpdateRoomRequest) -> CommandResult<Room> {
     let UpdateRoomRequest {
         room_id,
         name,
@@ -32,7 +34,7 @@ async fn do_update_room(pool: &Pool<Sqlite>, req: UpdateRoomRequest) -> Result<R
         extra_person_fee,
     } = req;
 
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE rooms
          SET name = COALESCE(?, name),
              type = COALESCE(?, type),
@@ -53,11 +55,29 @@ async fn do_update_room(pool: &Pool<Sqlite>, req: UpdateRoomRequest) -> Result<R
     .bind(&room_id)
     .execute(pool)
     .await
-    .map_err(|e| e.to_string())?;
+    .map_err(|error| {
+        log_system_error(
+            "update_room",
+            error.to_string(),
+            json!({ "step": "update_room", "room_id": &room_id }),
+        )
+    })?;
+
+    if result.rows_affected() == 0 {
+        return Err(CommandError::user(codes::ROOM_NOT_FOUND, "Phòng không tồn tại"));
+    }
 
     let r = sqlx::query("SELECT id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status FROM rooms WHERE id = ?")
         .bind(&room_id)
-        .fetch_one(pool).await.map_err(|e| e.to_string())?;
+        .fetch_one(pool)
+        .await
+        .map_err(|error| {
+            log_system_error(
+                "update_room",
+                error.to_string(),
+                json!({ "step": "fetch_updated_room", "room_id": &room_id }),
+            )
+        })?;
 
     Ok(Room {
         id: r.get("id"),
@@ -79,44 +99,77 @@ pub async fn create_room(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: CreateRoomRequest,
-) -> Result<Room, String> {
+) -> CommandResult<Room> {
     require_admin(&state)?;
 
-    // Check ID doesn't already exist
+    let room = do_create_room(&state.db, req).await?;
+
+    emit_db_update(&app, "rooms");
+    Ok(room)
+}
+
+async fn do_create_room(pool: &Pool<Sqlite>, req: CreateRoomRequest) -> CommandResult<Room> {
+    let CreateRoomRequest {
+        id,
+        name,
+        room_type,
+        floor,
+        has_balcony,
+        base_price,
+        max_guests,
+        extra_person_fee,
+    } = req;
+
     let existing: Option<(String,)> = sqlx::query_as("SELECT id FROM rooms WHERE id = ?")
-        .bind(&req.id)
-        .fetch_optional(&state.db)
+        .bind(&id)
+        .fetch_optional(pool)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| {
+            log_system_error(
+                "create_room",
+                error.to_string(),
+                json!({ "step": "check_existing_room", "room_id": &id }),
+            )
+        })?;
     if existing.is_some() {
-        return Err(format!("Phòng '{}' đã tồn tại", req.id));
+        return Err(CommandError::user(codes::ROOM_ALREADY_EXISTS, "Phòng đã tồn tại"));
     }
 
     sqlx::query(
         "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'vacant')"
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'vacant')",
     )
-    .bind(&req.id)
-    .bind(&req.name)
-    .bind(&req.room_type)
-    .bind(req.floor)
-    .bind(req.has_balcony as i32)
-    .bind(req.base_price)
-    .bind(req.max_guests)
-    .bind(req.extra_person_fee)
-    .execute(&state.db).await.map_err(|e| e.to_string())?;
-
-    emit_db_update(&app, "rooms");
+    .bind(&id)
+    .bind(&name)
+    .bind(&room_type)
+    .bind(floor)
+    .bind(has_balcony as i32)
+    .bind(base_price)
+    .bind(max_guests)
+    .bind(extra_person_fee)
+    .execute(pool)
+    .await
+    .map_err(|error| {
+        if is_unique_constraint_error(&error) {
+            CommandError::user(codes::ROOM_ALREADY_EXISTS, "Phòng đã tồn tại")
+        } else {
+            log_system_error(
+                "create_room",
+                error.to_string(),
+                json!({ "step": "insert_room", "room_id": &id }),
+            )
+        }
+    })?;
 
     Ok(Room {
-        id: req.id,
-        name: req.name,
-        room_type: req.room_type,
-        floor: req.floor,
-        has_balcony: req.has_balcony,
-        base_price: req.base_price,
-        max_guests: req.max_guests,
-        extra_person_fee: req.extra_person_fee,
+        id,
+        name,
+        room_type,
+        floor,
+        has_balcony,
+        base_price,
+        max_guests,
+        extra_person_fee,
         status: "vacant".to_string(),
     })
 }
@@ -128,40 +181,71 @@ pub async fn delete_room(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     room_id: String,
-) -> Result<(), String> {
+) -> CommandResult<()> {
     require_admin(&state)?;
 
-    // Check room exists
+    do_delete_room(&state.db, room_id.clone()).await?;
+
+    emit_db_update(&app, "rooms");
+    Ok(())
+}
+
+async fn do_delete_room(pool: &Pool<Sqlite>, room_id: String) -> CommandResult<()> {
     let room_row = sqlx::query("SELECT status FROM rooms WHERE id = ?")
         .bind(&room_id)
-        .fetch_optional(&state.db)
+        .fetch_optional(pool)
         .await
-        .map_err(|e| e.to_string())?;
-    let room_row = room_row.ok_or(format!("Phòng '{}' không tồn tại", room_id))?;
+        .map_err(|error| {
+            log_system_error(
+                "delete_room",
+                error.to_string(),
+                json!({ "step": "fetch_room", "room_id": &room_id }),
+            )
+        })?;
+    let room_row = match room_row {
+        Some(row) => row,
+        None => return Err(CommandError::user(codes::ROOM_NOT_FOUND, "Phòng không tồn tại")),
+    };
     let status: String = room_row.get("status");
 
     if status == "occupied" {
-        return Err("Không thể xóa phòng đang có khách".to_string());
+        return Err(CommandError::user(
+            codes::ROOM_DELETE_OCCUPIED,
+            "Không thể xóa phòng đang có khách",
+        ));
     }
 
-    // Check no active bookings
     let active: (i64,) =
         sqlx::query_as("SELECT COUNT(*) FROM bookings WHERE room_id = ? AND status = 'active'")
             .bind(&room_id)
-            .fetch_one(&state.db)
+            .fetch_one(pool)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|error| {
+                log_system_error(
+                    "delete_room",
+                    error.to_string(),
+                    json!({ "step": "count_active_bookings", "room_id": &room_id }),
+                )
+            })?;
     if active.0 > 0 {
-        return Err("Không thể xóa phòng có booking đang hoạt động".to_string());
+        return Err(CommandError::user(
+            codes::ROOM_DELETE_ACTIVE_BOOKING,
+            "Không thể xóa phòng có booking đang hoạt động",
+        ));
     }
 
     sqlx::query("DELETE FROM rooms WHERE id = ?")
         .bind(&room_id)
-        .execute(&state.db)
+        .execute(pool)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| {
+            log_system_error(
+                "delete_room",
+                error.to_string(),
+                json!({ "step": "delete_room", "room_id": &room_id }),
+            )
+        })?;
 
-    emit_db_update(&app, "rooms");
     Ok(())
 }
 
@@ -193,31 +277,68 @@ pub async fn create_room_type(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: CreateRoomTypeRequest,
-) -> Result<RoomType, String> {
+) -> CommandResult<RoomType> {
     require_admin(&state)?;
 
-    let id = req.name.to_lowercase().replace(' ', "_");
+    let room_type = do_create_room_type(&state.db, req).await?;
+
+    emit_db_update(&app, "room_types");
+    Ok(room_type)
+}
+
+async fn do_create_room_type(
+    pool: &Pool<Sqlite>,
+    req: CreateRoomTypeRequest,
+) -> CommandResult<RoomType> {
+    let name = req.name;
+    let id = name.to_lowercase().replace(' ', "_");
     let now = chrono::Local::now().to_rfc3339();
+
+    let existing: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM room_types WHERE id = ? OR name = ?",
+    )
+    .bind(&id)
+    .bind(&name)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| {
+        log_system_error(
+            "create_room_type",
+            error.to_string(),
+            json!({ "step": "check_existing_room_type", "room_type_id": &id, "room_type_name": &name }),
+        )
+    })?;
+    if existing.is_some() {
+        return Err(CommandError::user(
+            codes::ROOM_TYPE_ALREADY_EXISTS,
+            "Loại phòng đã tồn tại",
+        ));
+    }
 
     sqlx::query("INSERT INTO room_types (id, name, created_at) VALUES (?, ?, ?)")
         .bind(&id)
-        .bind(&req.name)
+        .bind(&name)
         .bind(&now)
-        .execute(&state.db)
+        .execute(pool)
         .await
-        .map_err(|e| {
-            if e.to_string().contains("UNIQUE") {
-                format!("Loại phòng '{}' đã tồn tại", req.name)
+        .map_err(|error| {
+            if is_unique_constraint_error(&error) {
+                CommandError::user(
+                    codes::ROOM_TYPE_ALREADY_EXISTS,
+                    "Loại phòng đã tồn tại",
+                )
             } else {
-                e.to_string()
+                log_system_error(
+                    "create_room_type",
+                    error.to_string(),
+                    json!({ "step": "insert_room_type", "room_type_id": &id, "room_type_name": &name }),
+                )
             }
         })?;
 
-    emit_db_update(&app, "room_types");
-
     Ok(RoomType {
         id,
-        name: req.name,
+        name,
         created_at: now,
     })
 }
@@ -227,38 +348,73 @@ pub async fn delete_room_type(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     room_type_id: String,
-) -> Result<(), String> {
+) -> CommandResult<()> {
     require_admin(&state)?;
 
-    // Check no rooms using this type
+    do_delete_room_type(&state.db, room_type_id.clone()).await?;
+
+    emit_db_update(&app, "room_types");
+    Ok(())
+}
+
+async fn do_delete_room_type(pool: &Pool<Sqlite>, room_type_id: String) -> CommandResult<()> {
     let rt_row = sqlx::query("SELECT name FROM room_types WHERE id = ?")
         .bind(&room_type_id)
-        .fetch_optional(&state.db)
+        .fetch_optional(pool)
         .await
-        .map_err(|e| e.to_string())?;
-    let rt_row = rt_row.ok_or("Loại phòng không tồn tại".to_string())?;
+        .map_err(|error| {
+            log_system_error(
+                "delete_room_type",
+                error.to_string(),
+                json!({ "step": "fetch_room_type", "room_type_id": &room_type_id }),
+            )
+        })?;
+    let rt_row = match rt_row {
+        Some(row) => row,
+        None => return Err(CommandError::user(codes::ROOM_TYPE_NOT_FOUND, "Loại phòng không tồn tại")),
+    };
     let type_name: String = rt_row.get("name");
 
     let in_use: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM rooms WHERE type = ?")
         .bind(&type_name)
-        .fetch_one(&state.db)
+        .fetch_one(pool)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| {
+            log_system_error(
+                "delete_room_type",
+                error.to_string(),
+                json!({ "step": "count_rooms_by_type", "room_type_id": &room_type_id, "room_type_name": &type_name }),
+            )
+        })?;
     if in_use.0 > 0 {
-        return Err(format!(
-            "Không thể xóa: có {} phòng đang sử dụng loại '{}'",
-            in_use.0, type_name
+        return Err(CommandError::user(
+            codes::ROOM_TYPE_IN_USE,
+            "Không thể xóa loại phòng đang được sử dụng",
         ));
     }
 
     sqlx::query("DELETE FROM room_types WHERE id = ?")
         .bind(&room_type_id)
-        .execute(&state.db)
+        .execute(pool)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| {
+            log_system_error(
+                "delete_room_type",
+                error.to_string(),
+                json!({ "step": "delete_room_type", "room_type_id": &room_type_id }),
+            )
+        })?;
 
-    emit_db_update(&app, "room_types");
     Ok(())
+}
+
+fn is_unique_constraint_error(error: &sqlx::Error) -> bool {
+    matches!(
+        error,
+        sqlx::Error::Database(database_error)
+            if database_error.message().contains("UNIQUE constraint failed")
+                || database_error.message().contains("UNIQUE")
+    )
 }
 
 // ─── A5: Export CSV ───
@@ -320,8 +476,11 @@ pub async fn export_csv(state: State<'_, AppState>) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::do_update_room;
-    use crate::models::UpdateRoomRequest;
+    use super::{
+        do_create_room, do_create_room_type, do_delete_room, do_delete_room_type, do_update_room,
+    };
+    use crate::app_error::codes;
+    use crate::models::{CreateRoomRequest, CreateRoomTypeRequest, UpdateRoomRequest};
     use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite};
 
     async fn test_pool() -> Pool<Sqlite> {
@@ -348,10 +507,32 @@ mod tests {
         .await
         .expect("create rooms table");
 
+        sqlx::query(
+            "CREATE TABLE bookings (
+                id TEXT PRIMARY KEY,
+                room_id TEXT NOT NULL,
+                status TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create bookings table");
+
+        sqlx::query(
+            "CREATE TABLE room_types (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create room_types table");
+
         pool
     }
 
-    async fn seed_room(pool: &Pool<Sqlite>, room_id: &str) {
+    async fn seed_room(pool: &Pool<Sqlite>, room_id: &str, room_type: &str, status: &str) {
         sqlx::query(
             "INSERT INTO rooms (
                 id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status
@@ -359,22 +540,32 @@ mod tests {
         )
         .bind(room_id)
         .bind("Room 101")
-        .bind("standard")
+        .bind(room_type)
         .bind(1)
         .bind(1)
         .bind(300_000.0)
         .bind(2)
         .bind(100_000.0)
-        .bind("vacant")
+        .bind(status)
         .execute(pool)
         .await
         .expect("seed room");
     }
 
+    async fn seed_room_type(pool: &Pool<Sqlite>, id: &str, name: &str) {
+        sqlx::query("INSERT INTO room_types (id, name, created_at) VALUES (?, ?, ?)")
+            .bind(id)
+            .bind(name)
+            .bind("2026-04-22T00:00:00Z")
+            .execute(pool)
+            .await
+            .expect("seed room type");
+    }
+
     #[tokio::test]
     async fn update_room_leaves_unspecified_fields_unchanged() {
         let pool = test_pool().await;
-        seed_room(&pool, "R101").await;
+        seed_room(&pool, "R101", "standard", "vacant").await;
 
         let updated = do_update_room(
             &pool,
@@ -404,7 +595,7 @@ mod tests {
     #[tokio::test]
     async fn update_room_updates_multiple_fields_in_one_call() {
         let pool = test_pool().await;
-        seed_room(&pool, "R102").await;
+        seed_room(&pool, "R102", "standard", "vacant").await;
 
         let updated = do_update_room(
             &pool,
@@ -448,7 +639,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_room_returns_not_found_error_for_missing_room() {
+    async fn update_room_returns_room_not_found_error_for_missing_room() {
         let pool = test_pool().await;
 
         let error = do_update_room(
@@ -467,9 +658,109 @@ mod tests {
         .await
         .expect_err("missing room must return an error");
 
-        assert!(
-            error.contains("no rows returned"),
-            "expected fetch_one not-found error, got: {error}"
-        );
+        assert_eq!(error.code, codes::ROOM_NOT_FOUND);
+        assert_eq!(error.message, "Phòng không tồn tại");
+    }
+
+    #[tokio::test]
+    async fn create_room_returns_duplicate_room_error_for_taken_id() {
+        let pool = test_pool().await;
+        seed_room(&pool, "R201", "standard", "vacant").await;
+
+        let error = do_create_room(
+            &pool,
+            CreateRoomRequest {
+                id: "R201".to_string(),
+                name: "Suite 201".to_string(),
+                room_type: "standard".to_string(),
+                floor: 2,
+                has_balcony: false,
+                base_price: 500_000.0,
+                max_guests: 2,
+                extra_person_fee: 150_000.0,
+            },
+        )
+        .await
+        .expect_err("duplicate room id must fail");
+
+        assert_eq!(error.code, codes::ROOM_ALREADY_EXISTS);
+        assert_eq!(error.message, "Phòng đã tồn tại");
+    }
+
+    #[tokio::test]
+    async fn delete_room_returns_occupied_error_for_occupied_room() {
+        let pool = test_pool().await;
+        seed_room(&pool, "R301", "standard", "occupied").await;
+
+        let error = do_delete_room(&pool, "R301".to_string())
+            .await
+        .expect_err("occupied room must fail");
+
+        assert_eq!(error.code, codes::ROOM_DELETE_OCCUPIED);
+        assert_eq!(error.message, "Không thể xóa phòng đang có khách");
+    }
+
+    #[tokio::test]
+    async fn delete_room_returns_active_booking_error_for_room_with_booking() {
+        let pool = test_pool().await;
+        seed_room(&pool, "R302", "standard", "vacant").await;
+        sqlx::query("INSERT INTO bookings (id, room_id, status) VALUES (?, ?, ?)")
+            .bind("B302")
+            .bind("R302")
+            .bind("active")
+            .execute(&pool)
+            .await
+            .expect("seed active booking");
+
+        let error = do_delete_room(&pool, "R302".to_string())
+            .await
+        .expect_err("active booking must fail");
+
+        assert_eq!(error.code, codes::ROOM_DELETE_ACTIVE_BOOKING);
+        assert_eq!(error.message, "Không thể xóa phòng có booking đang hoạt động");
+    }
+
+    #[tokio::test]
+    async fn create_room_type_returns_duplicate_error_for_taken_name() {
+        let pool = test_pool().await;
+        seed_room_type(&pool, "standard", "Standard").await;
+
+        let error = do_create_room_type(
+            &pool,
+            CreateRoomTypeRequest {
+                name: "Standard".to_string(),
+            },
+        )
+        .await
+        .expect_err("duplicate room type must fail");
+
+        assert_eq!(error.code, codes::ROOM_TYPE_ALREADY_EXISTS);
+        assert_eq!(error.message, "Loại phòng đã tồn tại");
+    }
+
+    #[tokio::test]
+    async fn delete_room_type_returns_not_found_error_for_missing_type() {
+        let pool = test_pool().await;
+
+        let error = do_delete_room_type(&pool, "missing-type".to_string())
+            .await
+            .expect_err("missing room type must fail");
+
+        assert_eq!(error.code, codes::ROOM_TYPE_NOT_FOUND);
+        assert_eq!(error.message, "Loại phòng không tồn tại");
+    }
+
+    #[tokio::test]
+    async fn delete_room_type_returns_in_use_error_when_rooms_reference_it() {
+        let pool = test_pool().await;
+        seed_room_type(&pool, "standard", "Standard").await;
+        seed_room(&pool, "R401", "Standard", "vacant").await;
+
+        let error = do_delete_room_type(&pool, "standard".to_string())
+            .await
+        .expect_err("room type in use must fail");
+
+        assert_eq!(error.code, codes::ROOM_TYPE_IN_USE);
+        assert_eq!(error.message, "Không thể xóa loại phòng đang được sử dụng");
     }
 }

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -1,5 +1,12 @@
 use super::{emit_db_update, get_f64, get_user_id, AppState};
-use crate::{models::*, queries::booking::revenue_queries, services::booking::stay_lifecycle};
+use crate::{
+    app_error::{codes, log_system_error, CommandError, CommandResult},
+    domain::booking::BookingError,
+    models::*,
+    queries::booking::revenue_queries,
+    services::booking::stay_lifecycle,
+};
+use serde_json::{json, Value};
 use sqlx::{Pool, Row, Sqlite};
 use tauri::State;
 
@@ -50,15 +57,56 @@ pub async fn get_dashboard_stats(state: State<'_, AppState>) -> Result<Dashboard
 
 // ─── Check-in Command ───
 
+fn map_stay_error(command_name: &str, error: BookingError, context: Value) -> CommandError {
+    match error {
+        BookingError::NotFound(message) if message.starts_with("Không tìm thấy phòng ") => {
+            CommandError::user(codes::ROOM_NOT_FOUND, message)
+        }
+        BookingError::NotFound(message)
+            if message.starts_with("Không tìm thấy booking đang active ")
+                || message.starts_with("Không tìm thấy booking ") =>
+        {
+            CommandError::user(codes::BOOKING_NOT_FOUND, message)
+        }
+        BookingError::Validation(message) if message == "Phải có ít nhất 1 khách" => {
+            CommandError::user(codes::BOOKING_GUEST_REQUIRED, message)
+        }
+        BookingError::Validation(message) if message == "Number of nights must be greater than 0" => {
+            CommandError::user(codes::BOOKING_INVALID_NIGHTS, message)
+        }
+        BookingError::Validation(message)
+            if message == "Tổng quyết toán phải lớn hơn hoặc bằng 0" =>
+        {
+            CommandError::user(codes::BOOKING_INVALID_SETTLEMENT_TOTAL, message)
+        }
+        BookingError::Validation(message)
+            if message == "Overpaid booking requires refund handling before checkout" =>
+        {
+            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+        }
+        BookingError::Validation(message) | BookingError::Conflict(message) => {
+            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+        }
+        BookingError::NotFound(message)
+        | BookingError::Database(message)
+        | BookingError::DateTimeParse(message) => log_system_error(command_name, message, context),
+    }
+}
+
 #[tauri::command]
 pub async fn check_in(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: CheckInRequest,
-) -> Result<Booking, String> {
+) -> CommandResult<Booking> {
+    let error_context = json!({
+        "room_id": req.room_id.clone(),
+        "guest_count": req.guests.len(),
+        "nights": req.nights,
+    });
     let booking = stay_lifecycle::check_in(&state.db, req, get_user_id(&state))
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| map_stay_error("check_in", error, error_context))?;
 
     emit_db_update(&app, "rooms");
 
@@ -162,10 +210,15 @@ pub async fn check_out(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: CheckOutRequest,
-) -> Result<(), String> {
+) -> CommandResult<()> {
+    let error_context = json!({
+        "booking_id": req.booking_id.clone(),
+        "settlement_mode": req.settlement_mode,
+        "final_total": req.final_total,
+    });
     stay_lifecycle::check_out(&state.db, req)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| map_stay_error("check_out", error, error_context))?;
 
     emit_db_update(&app, "rooms");
 
@@ -402,4 +455,71 @@ pub async fn scan_image(path: String) -> Result<crate::ocr::CccdInfo, String> {
     let cccd = crate::ocr::parse_cccd(&lines);
 
     Ok(cccd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_stay_error;
+    use crate::app_error::{codes, AppErrorKind};
+    use crate::domain::booking::BookingError;
+    use serde_json::json;
+
+    #[test]
+    fn map_stay_error_maps_missing_room_to_room_not_found_contract() {
+        let error = map_stay_error(
+            "check_in",
+            BookingError::not_found("Không tìm thấy phòng R101"),
+            json!({ "room_id": "R101" }),
+        );
+
+        assert_eq!(error.code, codes::ROOM_NOT_FOUND);
+        assert_eq!(error.message, "Không tìm thấy phòng R101");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_stay_error_maps_guest_required_validation_to_shared_code() {
+        let error = map_stay_error(
+            "check_in",
+            BookingError::validation("Phải có ít nhất 1 khách"),
+            json!({ "room_id": "R101" }),
+        );
+
+        assert_eq!(error.code, codes::BOOKING_GUEST_REQUIRED);
+        assert_eq!(error.message, "Phải có ít nhất 1 khách");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_stay_error_maps_invalid_settlement_total_to_shared_code() {
+        let error = map_stay_error(
+            "check_out",
+            BookingError::validation("Tổng quyết toán phải lớn hơn hoặc bằng 0"),
+            json!({ "booking_id": "booking-1" }),
+        );
+
+        assert_eq!(error.code, codes::BOOKING_INVALID_SETTLEMENT_TOTAL);
+        assert_eq!(error.message, "Tổng quyết toán phải lớn hơn hoặc bằng 0");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_stay_error_maps_invalid_checkout_state_to_shared_code() {
+        let error = map_stay_error(
+            "check_out",
+            BookingError::validation("Overpaid booking requires refund handling before checkout"),
+            json!({ "booking_id": "booking-1" }),
+        );
+
+        assert_eq!(error.code, codes::BOOKING_INVALID_STATE);
+        assert_eq!(
+            error.message,
+            "Overpaid booking requires refund handling before checkout"
+        );
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
 }

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use log::{error, info};
 use tauri::Manager;
 
+pub mod app_error;
 pub mod app_identity;
 mod backup;
 mod commands;
@@ -15,6 +16,7 @@ mod queries;
 mod repositories;
 mod runtime_config;
 mod services;
+pub mod support_log;
 mod watcher;
 
 use commands::AppState;

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -100,6 +100,17 @@ fn write_smoke_ready_file() -> Result<(), String> {
 
     std::fs::write(path, payload.to_string()).map_err(|error| error.to_string())
 }
+
+fn updater_enabled_from_env(debug_build: bool, env_enabled: bool) -> bool {
+    !debug_build || env_enabled
+}
+
+fn updater_enabled() -> bool {
+    updater_enabled_from_env(
+        cfg!(debug_assertions),
+        runtime_config::env_flag("CAPYINN_ENABLE_UPDATER"),
+    )
+}
 /// Run the Tauri GUI application with MCP Gateway
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -119,9 +130,13 @@ pub fn run() {
         .setup(|app| {
             #[cfg(desktop)]
             {
-                app.handle()
-                    .plugin(tauri_plugin_updater::Builder::new().build())
-                    .expect("failed to register updater plugin");
+                if updater_enabled() {
+                    app.handle()
+                        .plugin(tauri_plugin_updater::Builder::new().build())
+                        .expect("failed to register updater plugin");
+                } else {
+                    info!("Updater plugin disabled for this build");
+                }
             }
 
             let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
@@ -324,4 +339,24 @@ async fn gateway_get_status(
         "port": port,
         "has_api_keys": has_keys,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::updater_enabled_from_env;
+
+    #[test]
+    fn updater_stays_disabled_for_plain_dev_runs() {
+        assert!(!updater_enabled_from_env(true, false));
+    }
+
+    #[test]
+    fn updater_can_be_enabled_for_dev_smoke_runs() {
+        assert!(updater_enabled_from_env(true, true));
+    }
+
+    #[test]
+    fn updater_stays_enabled_outside_dev_even_without_env_flag() {
+        assert!(updater_enabled_from_env(false, false));
+    }
 }

--- a/mhm/src-tauri/src/support_log.rs
+++ b/mhm/src-tauri/src/support_log.rs
@@ -1,0 +1,218 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::app_error::AppErrorKind;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupportErrorRecord {
+    pub timestamp: String,
+    pub support_id: String,
+    pub command: String,
+    pub code: String,
+    pub kind: AppErrorKind,
+    pub root_cause: String,
+    pub context: Value,
+}
+
+impl SupportErrorRecord {
+    pub fn new(
+        command: impl Into<String>,
+        code: impl Into<String>,
+        root_cause: impl Into<String>,
+        support_id: impl Into<String>,
+        context: Value,
+    ) -> Self {
+        Self {
+            timestamp: Utc::now().to_rfc3339(),
+            support_id: support_id.into(),
+            command: command.into(),
+            code: code.into(),
+            kind: AppErrorKind::System,
+            root_cause: root_cause.into(),
+            context,
+        }
+    }
+}
+
+fn append_mutex() -> &'static Mutex<()> {
+    static APPEND_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    APPEND_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+pub fn support_log_path(runtime_root: &Path) -> PathBuf {
+    runtime_root
+        .join("diagnostics")
+        .join("support-errors.jsonl")
+}
+
+pub fn append_support_error_record(
+    runtime_root: &Path,
+    record: &SupportErrorRecord,
+) -> Result<(), String> {
+    let _guard = append_mutex().lock().map_err(|error| error.to_string())?;
+    let path = support_log_path(runtime_root);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+
+    let line = serde_json::to_string(record).map_err(|error| error.to_string())?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|error| error.to_string())?;
+
+    file.write_all(line.as_bytes())
+        .and_then(|_| file.write_all(b"\n"))
+        .map_err(|error| error.to_string())?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn test_runtime_root(test_name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "capyinn-support-log-{}-{}",
+            test_name,
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    #[test]
+    fn support_log_path_stays_under_diagnostics() {
+        let root = PathBuf::from("/tmp/capyinn-runtime-root");
+        assert_eq!(
+            support_log_path(&root),
+            root.join("diagnostics").join("support-errors.jsonl")
+        );
+    }
+
+    #[test]
+    fn append_support_error_record_appends_json_lines_without_interleaving() {
+        let runtime_root = test_runtime_root("append");
+        let _ = fs::remove_dir_all(&runtime_root);
+
+        let first = SupportErrorRecord::new(
+            "login",
+            crate::app_error::codes::SYSTEM_INTERNAL_ERROR,
+            "database offline",
+            "SUP-AAAA0001",
+            json!({ "room_id": "R101" }),
+        );
+        let second = SupportErrorRecord::new(
+            "check_out",
+            crate::app_error::codes::SYSTEM_INTERNAL_ERROR,
+            "lock failed",
+            "SUP-BBBB0002",
+            json!({ "booking_id": "B202" }),
+        );
+
+        let barrier = Arc::new(Barrier::new(3));
+        let runtime_root_one = runtime_root.clone();
+        let runtime_root_two = runtime_root.clone();
+        let first_record = first.clone();
+        let second_record = second.clone();
+
+        let first_handle = {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                append_support_error_record(&runtime_root_one, &first_record)
+                    .expect("append first");
+            })
+        };
+
+        let second_handle = {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                append_support_error_record(&runtime_root_two, &second_record)
+                    .expect("append second");
+            })
+        };
+
+        barrier.wait();
+        first_handle.join().expect("first writer thread");
+        second_handle.join().expect("second writer thread");
+
+        let contents =
+            fs::read_to_string(support_log_path(&runtime_root)).expect("support log should exist");
+        let lines = contents.lines().collect::<Vec<_>>();
+
+        assert_eq!(lines.len(), 2);
+
+        let parsed = lines
+            .iter()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("json line"))
+            .collect::<Vec<_>>();
+
+        assert!(parsed
+            .iter()
+            .any(|line| line["support_id"] == "SUP-AAAA0001"));
+        assert!(parsed
+            .iter()
+            .any(|line| line["support_id"] == "SUP-BBBB0002"));
+        assert!(parsed
+            .iter()
+            .any(|line| line["context"]["room_id"] == "R101"));
+        assert!(parsed
+            .iter()
+            .any(|line| line["context"]["booking_id"] == "B202"));
+        assert!(parsed.iter().all(|line| line.get("room_id").is_none()));
+        assert!(parsed.iter().all(|line| line.get("booking_id").is_none()));
+    }
+
+    #[test]
+    fn append_support_error_record_keeps_conflicting_context_keys_nested() {
+        let runtime_root = test_runtime_root("conflict");
+        let _ = fs::remove_dir_all(&runtime_root);
+
+        let record = SupportErrorRecord::new(
+            "login",
+            crate::app_error::codes::SYSTEM_INTERNAL_ERROR,
+            "database offline",
+            "SUP-CCCC0003",
+            json!({
+                "code": "OVERRIDE",
+                "support_id": "SHADOW",
+                "timestamp": "2000-01-01T00:00:00Z",
+                "room_id": "R303"
+            }),
+        );
+
+        append_support_error_record(&runtime_root, &record).expect("append record");
+
+        let contents =
+            fs::read_to_string(support_log_path(&runtime_root)).expect("support log should exist");
+        let parsed: serde_json::Value = serde_json::from_str(contents.trim()).expect("json line");
+
+        assert_eq!(parsed["command"], "login");
+        assert_eq!(
+            parsed["code"],
+            crate::app_error::codes::SYSTEM_INTERNAL_ERROR
+        );
+        assert_eq!(parsed["support_id"], "SUP-CCCC0003");
+        assert_eq!(parsed["context"]["code"], "OVERRIDE");
+        assert_eq!(parsed["context"]["support_id"], "SHADOW");
+        assert_eq!(parsed["context"]["timestamp"], "2000-01-01T00:00:00Z");
+        assert_eq!(parsed["context"]["room_id"], "R303");
+        assert_ne!(parsed["support_id"], parsed["context"]["support_id"]);
+        assert_eq!(parsed.get("room_id"), None);
+
+        let _ = fs::remove_dir_all(&runtime_root);
+    }
+}

--- a/mhm/src/App.crashReporting.test.tsx
+++ b/mhm/src/App.crashReporting.test.tsx
@@ -9,6 +9,7 @@ import { clearMockResponses, setMockResponses } from "./__mocks__/tauri-core";
 import { resetEventMocks } from "./__mocks__/tauri-event";
 import { useAuthStore } from "./stores/useAuthStore";
 import { useHotelStore } from "./stores/useHotelStore";
+import { toast } from "sonner";
 
 vi.mock("./pages/Dashboard", () => ({ default: () => <div>Dashboard page</div> }));
 vi.mock("./pages/Rooms", () => ({ default: () => <div>Rooms page</div> }));
@@ -141,5 +142,56 @@ describe("App crash reporting flow", () => {
     expect(
       await screen.findByText("/Users/test/CapyInn/exports/crash-reports/bundle-1.json"),
     ).toBeInTheDocument();
+  });
+
+  it("lets the user dismiss the crash prompt even when local cleanup fails", async () => {
+    const user = userEvent.setup();
+
+    setMockResponses({
+      get_bootstrap_status: () => ({
+        setup_completed: true,
+        app_lock_enabled: false,
+        current_user: {
+          id: "owner",
+          name: "Owner",
+          role: "admin",
+          active: true,
+          created_at: "2026-04-20T00:00:00+07:00",
+        },
+      }),
+      get_crash_reporting_preference: () => false,
+      get_pending_crash_report: () => ({
+        bundle_id: "bundle-1",
+        crash_type: "rust_panic",
+        occurred_at: "2026-04-20T10:00:00+07:00",
+        app_version: "0.1.1",
+        environment: "production",
+        platform: "macos",
+        arch: "aarch64",
+        installation_id: "install-1",
+        message: "startup boom",
+        stacktrace: ["frame-a"],
+        module_hint: null,
+        attempt_count: 0,
+      }),
+      mark_crash_report_dismissed: () => {
+        throw new Error("disk still locked");
+      },
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Overview")).toBeInTheDocument());
+    expect(await screen.findByText("App encountered a serious error")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Don't send" }));
+
+    expect(invoke).toHaveBeenCalledWith("mark_crash_report_dismissed", {
+      bundle_id: "bundle-1",
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("App encountered a serious error")).not.toBeInTheDocument();
+    });
+    expect(toast.error).toHaveBeenCalled();
   });
 });

--- a/mhm/src/App.tsx
+++ b/mhm/src/App.tsx
@@ -380,14 +380,17 @@ export default function App() {
       return;
     }
 
+    const report = pendingCrashReport;
     setCrashPromptBusy(true);
     try {
       await invoke("mark_crash_report_dismissed", {
-        bundle_id: pendingCrashReport.bundle_id,
+        bundle_id: report.bundle_id,
       });
+    } catch {
+      toast.error("Không thể dọn crash report cục bộ. Prompt sẽ được ẩn cho phiên này.");
+    } finally {
       setPendingCrashReport(null);
       setCrashExportPath(null);
-    } finally {
       setCrashPromptBusy(false);
     }
   };

--- a/mhm/src/__mocks__/tauri-core.ts
+++ b/mhm/src/__mocks__/tauri-core.ts
@@ -90,7 +90,12 @@ export const invoke = vi.fn(async (command: string, args?: Record<string, unknow
     };
 
     if (command === "login") {
-        throw new Error("Invalid PIN");
+        throw {
+            code: "AUTH_INVALID_PIN",
+            message: "Mã PIN không đúng",
+            kind: "user",
+            support_id: null,
+        };
     }
 
     if (command in defaults) {
@@ -99,6 +104,5 @@ export const invoke = vi.fn(async (command: string, args?: Record<string, unknow
         return val;
     }
 
-    console.warn(`[tauri-mock] Unhandled invoke: "${command}" with args:`, args);
-    return undefined;
+    throw new Error(`[tauri-mock] Unhandled invoke: "${command}" with args: ${JSON.stringify(args ?? null)}`);
 });

--- a/mhm/src/components/CheckinSheet.tsx
+++ b/mhm/src/components/CheckinSheet.tsx
@@ -7,6 +7,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { Button } from "@/components/ui/button";
 import { FormField, FormFieldSelect } from "@/components/shared/FormField";
 import { useAvailability } from "@/hooks/useAvailability";
+import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtMoney } from "@/lib/format";
 import { createDeferredCleanup } from "@/lib/deferredCleanup";
@@ -168,7 +169,7 @@ export default function CheckinSheet({ preSelectedRoomId }: { preSelectedRoomId?
             closeAll();
             toast.success("Check-in thành công!");
         } catch (err) {
-            toast.error("Lỗi check-in: " + err);
+            toast.error("Lỗi check-in: " + formatAppError(err));
         }
         setSubmitting(false);
     };

--- a/mhm/src/components/GroupCheckinSheet.test.tsx
+++ b/mhm/src/components/GroupCheckinSheet.test.tsx
@@ -1,0 +1,110 @@
+import type {
+  ButtonHTMLAttributes,
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+  ReactNode,
+} from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAppErrorException,
+  formatAppError,
+  type AppError,
+} from "@/lib/appError";
+
+const autoAssignRooms = vi.hoisted(() => vi.fn());
+const groupCheckIn = vi.hoisted(() => vi.fn());
+const setGroupCheckinOpen = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/useHotelStore", () => ({
+  useHotelStore: () => ({
+    isGroupCheckinOpen: true,
+    setGroupCheckinOpen,
+    rooms: [
+      {
+        id: "R101",
+        name: "R101",
+        type: "standard",
+        room_type: "standard",
+        floor: 1,
+        has_balcony: false,
+        base_price: 500000,
+        max_guests: 2,
+        extra_person_fee: 0,
+        status: "vacant",
+      },
+    ],
+    groupCheckIn,
+    autoAssignRooms,
+    loading: false,
+  }),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: toastSuccess,
+  },
+}));
+
+import GroupCheckinSheet from "./GroupCheckinSheet";
+
+const autoAssignUserError: AppError = {
+  code: "GROUP_NOT_ENOUGH_VACANT_ROOMS",
+  message: "Chỉ có 1 phòng trống, cần 3 phòng",
+  kind: "user",
+  support_id: null,
+};
+
+describe("GroupCheckinSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    autoAssignRooms.mockRejectedValue(
+      createAppErrorException(autoAssignUserError),
+    );
+  });
+
+  it("keeps the sheet open and formats migrated auto-assign failures", async () => {
+    const user = userEvent.setup();
+    render(<GroupCheckinSheet />);
+
+    const textboxes = screen.getAllByRole("textbox");
+    await user.type(textboxes[0], "Test Group");
+    await user.type(textboxes[1], "Organizer");
+    await user.click(screen.getByRole("button", { name: /Tiếp theo/i }));
+    await user.click(screen.getByRole("button", { name: /Tự động chọn 3 phòng/i }));
+
+    expect(autoAssignRooms).toHaveBeenCalledWith(3, undefined);
+    expect(toastError).toHaveBeenCalledWith(formatAppError(autoAssignUserError));
+    expect(screen.getByText(/Bước 2\/4: Chọn phòng/i)).toBeInTheDocument();
+    expect(setGroupCheckinOpen).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/mhm/src/components/GroupCheckinSheet.tsx
+++ b/mhm/src/components/GroupCheckinSheet.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { FormField, FormFieldSelect } from "@/components/shared/FormField";
+import { formatAppError } from "@/lib/appError";
 import { fmtMoney } from "@/lib/format";
 import { toast } from "sonner";
 import { Sparkles, Hand, Check, ChevronLeft, ChevronRight, Users, Star, CalendarClock } from "lucide-react";
@@ -90,7 +91,7 @@ export default function GroupCheckinSheet() {
             if (ids.length > 0) setMasterRoomId(ids[0]);
             toast.success(`Đã chọn tự động ${ids.length} phòng`);
         } catch (err) {
-            toast.error(String(err));
+            toast.error(formatAppError(err));
         }
     };
 
@@ -127,7 +128,7 @@ export default function GroupCheckinSheet() {
             }
             setGroupCheckinOpen(false);
         } catch (err) {
-            toast.error(String(err));
+            toast.error(formatAppError(err));
         }
     };
 

--- a/mhm/src/components/RoomDetailPanel.tsx
+++ b/mhm/src/components/RoomDetailPanel.tsx
@@ -23,6 +23,7 @@ import StatusBadge from "@/components/shared/StatusBadge";
 import SlideDrawer from "@/components/shared/SlideDrawer";
 import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
+import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtDate, fmtDateShort, fmtMoney } from "@/lib/format";
 import { useHotelStore } from "@/stores/useHotelStore";
@@ -99,7 +100,7 @@ export default function RoomDetailPanel({
         handleClose();
       }
     } catch (err) {
-      toast.error("Lỗi check-out: " + err);
+      toast.error("Lỗi check-out: " + formatAppError(err));
     }
   };
 

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -23,6 +23,7 @@ import StatusBadge from "@/components/shared/StatusBadge";
 import SlideDrawer from "@/components/shared/SlideDrawer";
 import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
+import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtDateShort, fmtMoney } from "@/lib/format";
 import { useHotelStore } from "@/stores/useHotelStore";
@@ -112,7 +113,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
             toast.success("Check-out thành công!");
             handleClose();
         } catch (err) {
-            toast.error("Lỗi check-out: " + err);
+            toast.error("Lỗi check-out: " + formatAppError(err));
         }
     };
 

--- a/mhm/src/lib/appError.test.ts
+++ b/mhm/src/lib/appError.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+import { invoke } from "@tauri-apps/api/core";
+
+import errorCodes from "../../shared/error-codes.json";
+import { invokeCommand } from "./invokeCommand";
+import {
+  APP_ERROR_REGISTRY,
+  FALLBACK_SYSTEM_APP_ERROR,
+  formatAppError,
+  normalizeAppError,
+} from "./appError";
+
+describe("appError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes migrated user errors without changing the contract shape", () => {
+    const error = normalizeAppError({
+      code: "AUTH_INVALID_PIN",
+      message: "Mã PIN không đúng",
+      kind: "user",
+      support_id: null,
+    });
+
+    expect(error).toEqual({
+      code: "AUTH_INVALID_PIN",
+      message: "Mã PIN không đúng",
+      kind: "user",
+      support_id: null,
+    });
+  });
+
+  it("falls back to the generic system error for malformed payloads", () => {
+    expect(
+      normalizeAppError({
+        code: "AUTH_INVALID_PIN",
+        message: 123,
+        kind: "user",
+      }),
+    ).toEqual(FALLBACK_SYSTEM_APP_ERROR);
+  });
+
+  it("falls back to the generic system error for unknown codes", () => {
+    expect(
+      normalizeAppError({
+        code: "UNKNOWN_FRONTEND_CODE",
+        message: "Some message",
+        kind: "user",
+        support_id: null,
+      }),
+    ).toEqual(FALLBACK_SYSTEM_APP_ERROR);
+  });
+
+  it("formats system support ids alongside the generic message", () => {
+    expect(
+      formatAppError({
+        code: "SYSTEM_INTERNAL_ERROR",
+        message: "Có lỗi hệ thống, vui lòng thử lại",
+        kind: "system",
+        support_id: "SUP-ABCD1234",
+      }),
+    ).toBe("Có lỗi hệ thống, vui lòng thử lại (Mã hỗ trợ: SUP-ABCD1234)");
+  });
+
+  it("stays aligned with the shared error registry", () => {
+    expect(APP_ERROR_REGISTRY).toEqual(errorCodes);
+    expect(FALLBACK_SYSTEM_APP_ERROR.message).toBe(
+      errorCodes.find((entry) => entry.code === "SYSTEM_INTERNAL_ERROR")?.defaultMessage ??
+        "Có lỗi hệ thống, vui lòng thử lại",
+    );
+  });
+
+  it("rethrows structured auth errors as Error-like app errors", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce({
+      code: "AUTH_INVALID_PIN",
+      message: "Mã PIN không đúng",
+      kind: "user",
+      support_id: null,
+    });
+
+    const promise = invokeCommand("login", { req: { pin: "0000" } });
+
+    await expect(promise).rejects.toMatchObject({
+      name: "AppError",
+      code: "AUTH_INVALID_PIN",
+      message: "Mã PIN không đúng",
+      kind: "user",
+      support_id: null,
+    });
+
+    await promise.catch((error) => {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        name: "AppError",
+        code: "AUTH_INVALID_PIN",
+        message: "Mã PIN không đúng",
+        kind: "user",
+        support_id: null,
+      });
+      expect(error.cause).toEqual({
+        code: "AUTH_INVALID_PIN",
+        message: "Mã PIN không đúng",
+        kind: "user",
+        support_id: null,
+      });
+    });
+  });
+
+  it.each([
+    {
+      name: "unknown code",
+      payload: {
+        code: "UNKNOWN_FRONTEND_CODE",
+        message: "Some message",
+        kind: "user",
+        support_id: null,
+      },
+    },
+    {
+      name: "malformed payload",
+      payload: {
+        code: "AUTH_INVALID_PIN",
+        message: 123,
+        kind: "user",
+      },
+    },
+  ])("falls back to the generic system error for $name invoke payloads", async ({ payload }) => {
+    vi.mocked(invoke).mockRejectedValueOnce(payload);
+
+    const promise = invokeCommand("unknown_command");
+
+    await promise.catch((error) => {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        name: "AppError",
+        ...FALLBACK_SYSTEM_APP_ERROR,
+      });
+      expect(error.cause).toEqual(payload);
+    });
+  });
+});

--- a/mhm/src/lib/appError.ts
+++ b/mhm/src/lib/appError.ts
@@ -1,0 +1,138 @@
+import errorRegistry from "../../shared/error-codes.json";
+
+export type AppErrorKind = "user" | "system";
+
+export interface AppError {
+  code: string;
+  message: string;
+  kind: AppErrorKind;
+  support_id: string | null;
+}
+
+export interface AppErrorRegistryEntry {
+  code: string;
+  kind: AppErrorKind;
+  defaultMessage: string;
+}
+
+const LAST_RESORT_FALLBACK_ERROR_MESSAGE = "Có lỗi hệ thống, vui lòng thử lại";
+
+const registryEntries = errorRegistry as AppErrorRegistryEntry[];
+
+export const APP_ERROR_REGISTRY = Object.freeze(
+  registryEntries.map((entry) => ({ ...entry })),
+) as readonly AppErrorRegistryEntry[];
+
+export const APP_ERROR_CODE_MAP = Object.freeze(
+  APP_ERROR_REGISTRY.reduce(
+    (codes, entry) => {
+      codes[entry.code] = entry.code;
+      return codes;
+    },
+    {} as Record<string, string>,
+  ),
+);
+
+export const APP_ERROR_CODES = APP_ERROR_CODE_MAP;
+
+export const SYSTEM_INTERNAL_ERROR = "SYSTEM_INTERNAL_ERROR";
+
+const systemInternalErrorDefinition = APP_ERROR_REGISTRY.find(
+  (entry) => entry.code === SYSTEM_INTERNAL_ERROR,
+);
+
+const FALLBACK_ERROR_MESSAGE =
+  systemInternalErrorDefinition?.defaultMessage ?? LAST_RESORT_FALLBACK_ERROR_MESSAGE;
+
+export const FALLBACK_SYSTEM_APP_ERROR: AppError = Object.freeze({
+  code: SYSTEM_INTERNAL_ERROR,
+  message: FALLBACK_ERROR_MESSAGE,
+  kind: "system",
+  support_id: null,
+});
+
+const APP_ERROR_BY_CODE = Object.freeze(
+  APP_ERROR_REGISTRY.reduce(
+    (definitions, entry) => {
+      definitions[entry.code] = entry;
+      return definitions;
+    },
+    {} as Record<string, AppErrorRegistryEntry>,
+  ),
+);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isAppErrorKind(value: unknown): value is AppErrorKind {
+  return value === "user" || value === "system";
+}
+
+function isValidSupportId(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+export function getAppErrorDefinition(code: string): AppErrorRegistryEntry | undefined {
+  return APP_ERROR_BY_CODE[code];
+}
+
+export function isKnownAppErrorCode(code: string): boolean {
+  return Boolean(getAppErrorDefinition(code));
+}
+
+export function normalizeAppError(error: unknown): AppError {
+  if (!isRecord(error)) {
+    return FALLBACK_SYSTEM_APP_ERROR;
+  }
+
+  const { code, message, kind, support_id } = error;
+  if (
+    typeof code !== "string" ||
+    typeof message !== "string" ||
+    !isAppErrorKind(kind) ||
+    !isValidSupportId(support_id) ||
+    !isKnownAppErrorCode(code)
+  ) {
+    return FALLBACK_SYSTEM_APP_ERROR;
+  }
+
+  return {
+    code,
+    message,
+    kind,
+    support_id: support_id ?? null,
+  };
+}
+
+export function formatAppError(error: unknown): string {
+  const normalized = normalizeAppError(error);
+
+  if (normalized.kind === "user") {
+    return normalized.message;
+  }
+
+  if (normalized.support_id) {
+    return `${normalized.message} (Mã hỗ trợ: ${normalized.support_id})`;
+  }
+
+  return normalized.message;
+}
+
+export type NormalizedAppErrorException = Error & AppError & { cause?: unknown };
+
+export function createAppErrorException(
+  appError: AppError,
+  cause?: unknown,
+): NormalizedAppErrorException {
+  const error = new Error(appError.message) as NormalizedAppErrorException;
+  error.name = "AppError";
+  error.code = appError.code;
+  error.message = appError.message;
+  error.kind = appError.kind;
+  error.support_id = appError.support_id;
+  if (cause !== undefined) {
+    error.cause = cause;
+  }
+  return error;
+}

--- a/mhm/src/lib/invokeCommand.ts
+++ b/mhm/src/lib/invokeCommand.ts
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import { createAppErrorException, normalizeAppError } from "./appError";
+
+export async function invokeCommand<TResponse>(
+  command: string,
+  args?: Record<string, unknown>,
+): Promise<TResponse> {
+  try {
+    return await invoke<TResponse>(command, args);
+  } catch (error) {
+    throw createAppErrorException(normalizeAppError(error), error);
+  }
+}

--- a/mhm/src/pages/GroupManagement.tsx
+++ b/mhm/src/pages/GroupManagement.tsx
@@ -25,6 +25,16 @@ const STATUS_LABELS: Record<string, string> = {
     completed: "Completed",
 };
 
+function getLegacyErrorMessage(error: unknown): string {
+    if (typeof error === "string") {
+        return error;
+    }
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return "Có lỗi xảy ra";
+}
+
 export default function GroupManagement() {
     const { groups, fetchGroups, getGroupDetail, groupCheckout, addGroupService, removeGroupService, generateGroupInvoice } = useHotelStore();
     const [filter, setFilter] = useState<string>("");
@@ -86,7 +96,7 @@ export default function GroupManagement() {
             setSvcNote("");
             await refreshDetail();
         } catch (err) {
-            toast.error(String(err));
+            toast.error(getLegacyErrorMessage(err));
         }
     };
 
@@ -96,7 +106,7 @@ export default function GroupManagement() {
             toast.success("Đã xóa dịch vụ");
             await refreshDetail();
         } catch (err) {
-            toast.error(String(err));
+            toast.error(getLegacyErrorMessage(err));
         }
     };
 
@@ -122,7 +132,7 @@ export default function GroupManagement() {
             setInvoiceData(invoice);
             setInvoiceOpen(true);
         } catch (err) {
-            toast.error(String(err));
+            toast.error(getLegacyErrorMessage(err));
         }
     };
 

--- a/mhm/src/pages/GroupManagement.tsx
+++ b/mhm/src/pages/GroupManagement.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import EmptyState from "@/components/shared/EmptyState";
 import SlideDrawer from "@/components/shared/SlideDrawer";
+import { formatAppError } from "@/lib/appError";
 import { fmtMoney, fmtDateShort } from "@/lib/format";
 import { toast } from "sonner";
 import { Users, Plus, Trash2, FileText, LogOut, ChevronRight } from "lucide-react";
@@ -55,7 +56,7 @@ export default function GroupManagement() {
             const d = await getGroupDetail(groupId);
             setDetail(d);
         } catch (err) {
-            toast.error(String(err));
+            toast.error(formatAppError(err));
         }
         setLoadingDetail(false);
     };
@@ -110,7 +111,7 @@ export default function GroupManagement() {
             setCheckoutIds([]);
             await refreshDetail();
         } catch (err) {
-            toast.error(String(err));
+            toast.error(formatAppError(err));
         }
     };
 

--- a/mhm/src/pages/LoginScreen.tsx
+++ b/mhm/src/pages/LoginScreen.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { Delete, Lock } from "lucide-react";
 import AppLogo from "@/components/AppLogo";
+import { formatAppError } from "@/lib/appError";
 
 export default function LoginScreen() {
     const { login, loading, error, clearError } = useAuthStore();
@@ -73,7 +74,7 @@ export default function LoginScreen() {
                 {/* Error message */}
                 {error && (
                     <p className="text-sm text-red-500 font-medium -mt-4 animate-fade-up">
-                        Mã PIN không đúng
+                        {formatAppError(error)}
                     </p>
                 )}
 

--- a/mhm/src/pages/settings/UserManagement.tsx
+++ b/mhm/src/pages/settings/UserManagement.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { Shield } from "lucide-react";
 import { toast } from "sonner";
 
@@ -7,17 +6,40 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { formatAppError, normalizeAppError, type AppError } from "@/lib/appError";
+import { invokeCommand } from "@/lib/invokeCommand";
 import { type User } from "@/stores/useAuthStore";
 
 export default function UserManagement() {
   const [users, setUsers] = useState<User[]>([]);
+  const [loadError, setLoadError] = useState<AppError | null>(null);
   const [newName, setNewName] = useState("");
   const [newPin, setNewPin] = useState("");
   const [newRole, setNewRole] = useState("receptionist");
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
-    invoke<User[]>("list_users").then(setUsers).catch(() => {});
+    let active = true;
+
+    void (async () => {
+      try {
+        const loadedUsers = await invokeCommand<User[]>("list_users");
+        if (active) {
+          setUsers(loadedUsers);
+          setLoadError(null);
+        }
+      } catch (error) {
+        if (active) {
+          const appError = normalizeAppError(error);
+          setLoadError(appError);
+          toast.error(formatAppError(appError));
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
   }, []);
 
   const handleCreate = async () => {
@@ -28,7 +50,7 @@ export default function UserManagement() {
 
     setCreating(true);
     try {
-      const user = await invoke<User>("create_user", {
+      const user = await invokeCommand<User>("create_user", {
         req: { name: newName, pin: newPin, role: newRole },
       });
       setUsers((prev) => [...prev, user]);
@@ -37,7 +59,7 @@ export default function UserManagement() {
       setNewRole("receptionist");
       toast.success(`Đã tạo user "${user.name}"!`);
     } catch (error) {
-      toast.error(String(error) || "Lỗi tạo user");
+      toast.error(formatAppError(error));
     } finally {
       setCreating(false);
     }
@@ -52,6 +74,12 @@ export default function UserManagement() {
         </h3>
         <p className="text-sm text-brand-muted">Tạo tài khoản và phân quyền cho nhân viên (chỉ Admin)</p>
       </div>
+
+      {loadError && (
+        <div role="alert" className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {formatAppError(loadError)}
+        </div>
+      )}
 
       <div className="space-y-2">
         {users.map((user) => (

--- a/mhm/src/pages/settings/useRoomConfig.test.tsx
+++ b/mhm/src/pages/settings/useRoomConfig.test.tsx
@@ -1,0 +1,269 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  formatAppError,
+  type AppError,
+} from "@/lib/appError";
+
+const invokeCommand = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/invokeCommand", () => ({
+  invokeCommand,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: toastSuccess,
+  },
+}));
+
+import useRoomConfig from "./useRoomConfig";
+
+const duplicateRoomError: AppError = {
+  code: "ROOM_ALREADY_EXISTS",
+  message: "Phòng đã tồn tại",
+  kind: "user",
+  support_id: null,
+};
+
+const duplicateRoomTypeError: AppError = {
+  code: "ROOM_TYPE_ALREADY_EXISTS",
+  message: "Loại phòng đã tồn tại",
+  kind: "user",
+  support_id: null,
+};
+
+const roomDeleteActiveBookingError: AppError = {
+  code: "ROOM_DELETE_ACTIVE_BOOKING",
+  message: "Không thể xóa phòng có booking đang hoạt động",
+  kind: "user",
+  support_id: null,
+};
+
+const roomNotFoundError: AppError = {
+  code: "ROOM_NOT_FOUND",
+  message: "Phòng không tồn tại",
+  kind: "user",
+  support_id: null,
+};
+
+const roomTypeInUseError: AppError = {
+  code: "ROOM_TYPE_IN_USE",
+  message: "Không thể xóa loại phòng đang được sử dụng",
+  kind: "user",
+  support_id: null,
+};
+
+describe("useRoomConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeCommand.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "get_rooms":
+          return [];
+        case "get_room_types":
+          return [
+            { id: "standard", name: "Standard", created_at: "2026-04-22T00:00:00Z" },
+          ];
+        case "create_room_type":
+          throw duplicateRoomTypeError;
+        case "delete_room_type":
+          throw roomTypeInUseError;
+        case "create_room":
+          throw duplicateRoomError;
+        case "update_room":
+          throw roomNotFoundError;
+        case "delete_room":
+          throw roomDeleteActiveBookingError;
+        default:
+          throw new Error(`Unexpected command: ${command}`);
+      }
+    });
+  });
+
+  it("uses invokeCommand and shared formatting when adding a room type fails", async () => {
+    const { result } = renderHook(() => useRoomConfig());
+
+    await waitFor(() => expect(result.current.roomTypes).toHaveLength(1));
+
+    await act(async () => {
+      result.current.setNewTypeName("Deluxe");
+    });
+    await waitFor(() => expect(result.current.newTypeName).toBe("Deluxe"));
+
+    await act(async () => {
+      await result.current.handleAddType();
+    });
+
+    expect(invokeCommand).toHaveBeenCalledWith("create_room_type", {
+      req: { name: "Deluxe" },
+    });
+    expect(toastError).toHaveBeenCalledWith(formatAppError(duplicateRoomTypeError));
+  });
+
+  it("trims the room type name in the success toast", async () => {
+    invokeCommand.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "get_rooms":
+          return [];
+        case "get_room_types":
+          return [
+            { id: "standard", name: "Standard", created_at: "2026-04-22T00:00:00Z" },
+          ];
+        case "create_room_type":
+          return { id: "deluxe", name: "Deluxe", created_at: "2026-04-22T00:00:00Z" };
+        default:
+          throw new Error(`Unexpected command: ${command}`);
+      }
+    });
+
+    const { result } = renderHook(() => useRoomConfig());
+
+    await waitFor(() => expect(result.current.roomTypes).toHaveLength(1));
+
+    await act(async () => {
+      result.current.setNewTypeName("  Deluxe  ");
+    });
+    await waitFor(() => expect(result.current.newTypeName).toBe("  Deluxe  "));
+
+    await act(async () => {
+      await result.current.handleAddType();
+    });
+
+    expect(invokeCommand).toHaveBeenCalledWith("create_room_type", {
+      req: { name: "Deluxe" },
+    });
+    expect(toastSuccess).toHaveBeenCalledWith('Đã tạo loại phòng "Deluxe"');
+  });
+
+  it("uses invokeCommand and shared formatting when deleting a room type fails", async () => {
+    const { result } = renderHook(() => useRoomConfig());
+
+    await waitFor(() => expect(result.current.roomTypes).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleDeleteType("standard");
+    });
+
+    expect(invokeCommand).toHaveBeenCalledWith("delete_room_type", {
+      roomTypeId: "standard",
+    });
+    expect(toastError).toHaveBeenCalledWith(formatAppError(roomTypeInUseError));
+  });
+
+  it("keeps the room form open and formats the error when saving a room fails", async () => {
+    const { result } = renderHook(() => useRoomConfig());
+
+    await waitFor(() => expect(result.current.roomTypes).toHaveLength(1));
+
+    await act(async () => {
+      result.current.openAdd();
+      result.current.setForm({
+        id: "R501",
+        name: "Room 501",
+        room_type: "Standard",
+        floor: 5,
+        has_balcony: false,
+        base_price: 500000,
+        max_guests: 2,
+        extra_person_fee: 100000,
+      });
+    });
+
+    expect(result.current.showRoomForm).toBe(true);
+    await waitFor(() => expect(result.current.form.id).toBe("R501"));
+
+    await act(async () => {
+      await result.current.handleSaveRoom();
+    });
+
+    expect(invokeCommand).toHaveBeenCalledWith("create_room", {
+      req: {
+        id: "R501",
+        name: "Room 501",
+        room_type: "Standard",
+        floor: 5,
+        has_balcony: false,
+        base_price: 500000,
+        max_guests: 2,
+        extra_person_fee: 100000,
+      },
+    });
+    expect(result.current.showRoomForm).toBe(true);
+    expect(toastError).toHaveBeenCalledWith(formatAppError(duplicateRoomError));
+  });
+
+  it("keeps the room form open and formats the error when updating a room fails", async () => {
+    const { result } = renderHook(() => useRoomConfig());
+
+    await waitFor(() => expect(result.current.roomTypes).toHaveLength(1));
+
+    await act(async () => {
+      result.current.openEdit({
+        id: "R701",
+        name: "Room 701",
+        type: "Standard",
+        floor: 7,
+        has_balcony: true,
+        base_price: 700000,
+        max_guests: 3,
+        extra_person_fee: 150000,
+        status: "vacant",
+      });
+      result.current.setForm({
+        id: "R701",
+        name: "Room 701 Updated",
+        room_type: "Standard",
+        floor: 7,
+        has_balcony: true,
+        base_price: 750000,
+        max_guests: 3,
+        extra_person_fee: 150000,
+      });
+    });
+
+    expect(result.current.showRoomForm).toBe(true);
+    await waitFor(() => expect(result.current.form.name).toBe("Room 701 Updated"));
+
+    await act(async () => {
+      await result.current.handleSaveRoom();
+    });
+
+    expect(invokeCommand).toHaveBeenCalledWith("update_room", {
+      req: {
+        room_id: "R701",
+        name: "Room 701 Updated",
+        room_type: "Standard",
+        floor: 7,
+        has_balcony: true,
+        base_price: 750000,
+        max_guests: 3,
+        extra_person_fee: 150000,
+      },
+    });
+    expect(result.current.showRoomForm).toBe(true);
+    expect(toastError).toHaveBeenCalledWith(formatAppError(roomNotFoundError));
+  });
+
+  it("uses invokeCommand and shared formatting when deleting a room fails", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const { result } = renderHook(() => useRoomConfig());
+
+    await waitFor(() => expect(result.current.roomTypes).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleDeleteRoom("R601");
+    });
+
+    expect(invokeCommand).toHaveBeenCalledWith("delete_room", {
+      roomId: "R601",
+    });
+    expect(toastError).toHaveBeenCalledWith(formatAppError(roomDeleteActiveBookingError));
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/mhm/src/pages/settings/useRoomConfig.ts
+++ b/mhm/src/pages/settings/useRoomConfig.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import type { ConfigurableRoom, RoomTypeItem } from "@/types";
+import { formatAppError } from "@/lib/appError";
+import { invokeCommand } from "@/lib/invokeCommand";
 
 export interface RoomFormValues {
     id: string;
@@ -34,8 +35,8 @@ export default function useRoomConfig() {
     const [form, setForm] = useState<RoomFormValues>(EMPTY_FORM);
 
     const loadData = () => {
-        invoke<ConfigurableRoom[]>("get_rooms").then(setRooms).catch(() => { });
-        invoke<RoomTypeItem[]>("get_room_types").then(setRoomTypes).catch(() => { });
+        invokeCommand<ConfigurableRoom[]>("get_rooms").then(setRooms).catch(() => { });
+        invokeCommand<RoomTypeItem[]>("get_room_types").then(setRoomTypes).catch(() => { });
     };
 
     useEffect(loadData, []);
@@ -47,24 +48,25 @@ export default function useRoomConfig() {
     };
 
     const handleAddType = async () => {
-        if (!newTypeName.trim()) return;
+        const trimmedTypeName = newTypeName.trim();
+        if (!trimmedTypeName) return;
         try {
-            await invoke("create_room_type", { req: { name: newTypeName.trim() } });
-            toast.success(`Đã tạo loại phòng "${newTypeName}"`);
+            await invokeCommand("create_room_type", { req: { name: trimmedTypeName } });
+            toast.success(`Đã tạo loại phòng "${trimmedTypeName}"`);
             setNewTypeName("");
             loadData();
         } catch (error) {
-            toast.error(String(error));
+            toast.error(formatAppError(error));
         }
     };
 
     const handleDeleteType = async (roomTypeId: string) => {
         try {
-            await invoke("delete_room_type", { roomTypeId });
+            await invokeCommand("delete_room_type", { roomTypeId });
             toast.success("Đã xóa loại phòng");
             loadData();
         } catch (error) {
-            toast.error(String(error));
+            toast.error(formatAppError(error));
         }
     };
 
@@ -97,7 +99,7 @@ export default function useRoomConfig() {
 
         try {
             if (editingRoom) {
-                const updated = await invoke<ConfigurableRoom>("update_room", {
+                const updated = await invokeCommand<ConfigurableRoom>("update_room", {
                     req: {
                         room_id: editingRoom.id,
                         name: form.name,
@@ -112,7 +114,7 @@ export default function useRoomConfig() {
                 setRooms((prev) => prev.map((room) => (room.id === updated.id ? updated : room)));
                 toast.success("Đã cập nhật phòng!");
             } else {
-                const created = await invoke<ConfigurableRoom>("create_room", {
+                const created = await invokeCommand<ConfigurableRoom>("create_room", {
                     req: {
                         id: form.id,
                         name: form.name,
@@ -129,18 +131,18 @@ export default function useRoomConfig() {
             }
             resetForm();
         } catch (error) {
-            toast.error(String(error));
+            toast.error(formatAppError(error));
         }
     };
 
     const handleDeleteRoom = async (roomId: string) => {
         if (!confirm(`Xác nhận xóa phòng ${roomId}?`)) return;
         try {
-            await invoke("delete_room", { roomId });
+            await invokeCommand("delete_room", { roomId });
             setRooms((prev) => prev.filter((room) => room.id !== roomId));
             toast.success("Đã xóa phòng");
         } catch (error) {
-            toast.error(String(error));
+            toast.error(formatAppError(error));
         }
     };
 

--- a/mhm/src/stores/useAuthStore.ts
+++ b/mhm/src/stores/useAuthStore.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
 
+import { normalizeAppError, type AppError } from "@/lib/appError";
+import { invokeCommand } from "@/lib/invokeCommand";
+
 export interface User {
     id: string;
     name: string;
@@ -13,7 +16,7 @@ interface AuthStore {
     user: User | null;
     isAuthenticated: boolean;
     loading: boolean;
-    error: string | null;
+    error: AppError | null;
 
     login: (pin: string) => Promise<boolean>;
     logout: () => Promise<void>;
@@ -32,11 +35,11 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     login: async (pin: string) => {
         set({ loading: true, error: null });
         try {
-            const res = await invoke<{ user: User }>("login", { req: { pin } });
-            set({ user: res.user, isAuthenticated: true, loading: false });
+            const res = await invokeCommand<{ user: User }>("login", { req: { pin } });
+            set({ user: res.user, isAuthenticated: true, loading: false, error: null });
             return true;
-        } catch (err) {
-            set({ error: String(err), loading: false });
+        } catch (error) {
+            set({ error: normalizeAppError(error), loading: false });
             return false;
         }
     },
@@ -53,8 +56,12 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
             const user = await invoke<User | null>("get_current_user");
             if (user) {
                 set({ user, isAuthenticated: true });
+                return;
             }
-        } catch { /* ignore */ }
+            set({ user: null, isAuthenticated: false });
+        } catch {
+            set({ user: null, isAuthenticated: false });
+        }
     },
 
     clearError: () => set({ error: null }),

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "@/lib/invokeCommand";
 import type {
   CheckInGuestInput,
   DashboardStats,
@@ -100,7 +101,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     checkIn: async (roomId, guests, nights, paidAmount, source, notes) => {
       beginAction();
       try {
-        await invoke("check_in", {
+        await invokeCommand("check_in", {
           req: { room_id: roomId, guests, nights, source, notes, paid_amount: paidAmount },
         });
         await get().fetchRooms();
@@ -117,7 +118,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     checkOut: async (bookingId, settlementMode, finalTotal) => {
       beginAction();
       try {
-        await invoke("check_out", {
+        await invokeCommand("check_out", {
           req: {
             booking_id: bookingId,
             settlement_mode: settlementMode,
@@ -171,7 +172,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     groupCheckIn: async (req) => {
       beginAction();
       try {
-        await invoke("group_checkin", { req });
+        await invokeCommand("group_checkin", { req });
         await get().fetchRooms();
         await get().fetchStats();
         await get().fetchGroups();
@@ -187,7 +188,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     groupCheckout: async (req) => {
       beginAction();
       try {
-        await invoke("group_checkout", { req });
+        await invokeCommand("group_checkout", { req });
         await get().fetchRooms();
         await get().fetchStats();
         await get().fetchGroups();
@@ -205,7 +206,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     },
 
     getGroupDetail: async (groupId: string) => {
-      return invoke<GroupDetailResponse>("get_group_detail", { groupId });
+      return invokeCommand<GroupDetailResponse>("get_group_detail", { groupId });
     },
 
     addGroupService: async (req) => {
@@ -217,7 +218,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     },
 
     autoAssignRooms: async (roomCount: number, roomType?: string) => {
-      return invoke<AutoAssignResult>("auto_assign_rooms", {
+      return invokeCommand<AutoAssignResult>("auto_assign_rooms", {
         req: { room_count: roomCount, room_type: roomType || null },
       });
     },

--- a/mhm/tests/e2e/01-login.test.tsx
+++ b/mhm/tests/e2e/01-login.test.tsx
@@ -115,8 +115,15 @@ describe("01 — Login Screen", () => {
     });
 
     it("shows error message on wrong PIN", async () => {
+        const invalidPinError = {
+            code: "AUTH_INVALID_PIN",
+            message: "Mã PIN không đúng",
+            kind: "user" as const,
+            support_id: null,
+        };
+
         setMockResponse("login", () => {
-            throw new Error("Invalid PIN");
+            throw invalidPinError;
         });
 
         render(<LoginScreen />);
@@ -129,7 +136,8 @@ describe("01 — Login Screen", () => {
 
         // Error message should appear
         await waitFor(() => {
-            expect(screen.getByText(/Mã PIN không đúng/)).toBeInTheDocument();
+            expect(screen.getByText(invalidPinError.message)).toBeInTheDocument();
+            expect(useAuthStore.getState().error).toEqual(invalidPinError);
         });
     });
 

--- a/mhm/tests/e2e/03-checkin.test.tsx
+++ b/mhm/tests/e2e/03-checkin.test.tsx
@@ -103,7 +103,12 @@ describe("03 — Check-in Flow", () => {
 
     it("handles check-in error gracefully", async () => {
         setMockResponse("check_in", () => {
-            throw new Error("Room is already occupied");
+            throw {
+                code: "BOOKING_INVALID_STATE",
+                message: "Room is already occupied",
+                kind: "user",
+                support_id: null,
+            };
         });
 
         await expect(
@@ -112,7 +117,13 @@ describe("03 — Check-in Flow", () => {
                 [{ full_name: "Test", doc_number: "123456789012" }],
                 1
             )
-        ).rejects.toThrow("Room is already occupied");
+        ).rejects.toMatchObject({
+            name: "AppError",
+            code: "BOOKING_INVALID_STATE",
+            message: "Room is already occupied",
+            kind: "user",
+            support_id: null,
+        });
 
         // Store should not be in loading state after error
         expect(useHotelStore.getState().loading).toBe(false);

--- a/mhm/tests/e2e/05-checkout.test.tsx
+++ b/mhm/tests/e2e/05-checkout.test.tsx
@@ -55,12 +55,23 @@ describe("05 — Check-out Flow", () => {
 
     it("handles checkout error", async () => {
         setMockResponse("check_out", () => {
-            throw new Error("Booking not found");
+            throw {
+                code: "BOOKING_NOT_FOUND",
+                message: "Booking not found",
+                kind: "user",
+                support_id: null,
+            };
         });
 
         await expect(
             useHotelStore.getState().checkOut("nonexistent", "actual_nights", 500000)
-        ).rejects.toThrow("Booking not found");
+        ).rejects.toMatchObject({
+            name: "AppError",
+            code: "BOOKING_NOT_FOUND",
+            message: "Booking not found",
+            kind: "user",
+            support_id: null,
+        });
 
         expect(useHotelStore.getState().loading).toBe(false);
     });

--- a/mhm/tests/e2e/08-settings.test.tsx
+++ b/mhm/tests/e2e/08-settings.test.tsx
@@ -248,7 +248,30 @@ describe("08 — Settings", () => {
         await user.click(screen.getByText("Users"));
 
         await waitFor(() => {
-            expect(invoke).toHaveBeenCalledWith("list_users");
+            expect(invoke).toHaveBeenCalledWith("list_users", undefined);
+        });
+    });
+
+    it("shows a forbidden error when list_users is rejected", async () => {
+        const forbiddenError = {
+            code: "AUTH_FORBIDDEN",
+            message: "Không có quyền thực hiện. Yêu cầu quyền Admin.",
+            kind: "user" as const,
+            support_id: null,
+        };
+
+        setMockResponse("list_users", () => {
+            throw forbiddenError;
+        });
+
+        const user = userEvent.setup();
+        render(<Settings />);
+
+        await user.click(screen.getByText("Users"));
+
+        await waitFor(() => {
+            expect(invoke).toHaveBeenCalledWith("list_users", undefined);
+            expect(screen.getByRole("alert")).toHaveTextContent(forbiddenError.message);
         });
     });
 

--- a/mhm/tests/e2e/13-store-hardening.test.ts
+++ b/mhm/tests/e2e/13-store-hardening.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-core";
 import { useHotelStore } from "@/stores/useHotelStore";
+import { useAuthStore } from "@/stores/useAuthStore";
 import { createAllRooms, createBooking, createStats } from "../helpers/mock-data";
 
 function deferred<T>() {
@@ -32,6 +33,12 @@ describe("13 — Store Hardening", () => {
 
         setMockResponse("get_rooms", () => createAllRooms());
         setMockResponse("get_dashboard_stats", () => createStats());
+        useAuthStore.setState({
+            user: null,
+            isAuthenticated: false,
+            loading: false,
+            error: null,
+        });
     });
 
     it("keeps loading true while another booking action is still pending", async () => {
@@ -56,5 +63,49 @@ describe("13 — Store Hardening", () => {
         await checkInPromise;
 
         expect(useHotelStore.getState().loading).toBe(false);
+    });
+
+    it("clears stale auth state when session lookup returns null or throws", async () => {
+        useAuthStore.setState({
+            user: {
+                id: "u1",
+                name: "Admin",
+                role: "admin",
+                active: true,
+                created_at: "2026-01-01T00:00:00Z",
+            },
+            isAuthenticated: true,
+            loading: false,
+            error: null,
+        });
+
+        setMockResponse("get_current_user", () => null);
+
+        await useAuthStore.getState().checkSession();
+
+        expect(useAuthStore.getState().user).toBeNull();
+        expect(useAuthStore.getState().isAuthenticated).toBe(false);
+
+        useAuthStore.setState({
+            user: {
+                id: "u2",
+                name: "Admin 2",
+                role: "admin",
+                active: true,
+                created_at: "2026-01-01T00:00:00Z",
+            },
+            isAuthenticated: true,
+            loading: false,
+            error: null,
+        });
+
+        setMockResponse("get_current_user", () => {
+            throw new Error("boom");
+        });
+
+        await useAuthStore.getState().checkSession();
+
+        expect(useAuthStore.getState().user).toBeNull();
+        expect(useAuthStore.getState().isAuthenticated).toBe(false);
     });
 });


### PR DESCRIPTION
## What changed

This branch standardizes the FE/BE error contract across the Tauri command boundary and migrates the first wave of user-facing flows to the shared model.

It also includes two hardening fixes discovered during validation:
- skip updater plugin registration in plain dev builds unless `CAPYINN_ENABLE_UPDATER` is enabled, while keeping smoke verification on the updater path
- let users dismiss the crash-report prompt even if local bundle cleanup fails

## Why

Before this branch:
- backend commands returned inconsistent string errors
- frontend callers mixed raw `String(err)` handling with ad-hoc toast formatting
- local `tauri dev` could panic on updater startup because the checked-in config has no updater `pubkey`
- the crash prompt could become impossible to close if local dismiss cleanup failed

This branch gives the frontend one structured error shape to consume, makes the first rollout domains use it end-to-end, and removes two sharp edges found during verification.

## User and developer impact

- Auth, permission, room-management, and stay/group flows now return stable error codes plus display messages.
- Frontend migrated flows now route through shared `invokeCommand` / `appError` handling instead of raw string coercion.
- Quick verification includes the migrated UI/E2E slices.
- Plain local dev no longer crashes on updater plugin init.
- Crash recovery prompt is no longer a dead-end when dismiss cleanup fails.

## Root cause notes

- Updater panic root cause: Rust always registered the updater plugin on desktop, but the checked-in `tauri.conf.json` updater block had no `pubkey`; smoke masked this by injecting one into a generated config.
- Crash prompt trap root cause: `Don't send` only hid the prompt after `mark_crash_report_dismissed` succeeded, so any cleanup failure left the modal stuck.

## Validation

- `npm run verify:quick --prefix /Users/binhan/HotelManager/mhm`
- `npm run verify:full --prefix /Users/binhan/HotelManager/mhm`
- `cargo test --manifest-path /Users/binhan/HotelManager/mhm/src-tauri/Cargo.toml tests::updater_ -- --nocapture`
- Plain `tauri dev` booted successfully with the checked-in config after the updater gating fix
