### PR TITLE
[codex] Add correlation IDs for stay, group, and audit flows

### DIFF
--- a/docs/superpowers/specs/2026-04-22-correlation-id-booking-checkin-audit-design.md
+++ b/docs/superpowers/specs/2026-04-22-correlation-id-booking-checkin-audit-design.md
@@ -1,0 +1,404 @@
+# CapyInn Correlation ID For Booking, Check-In, Checkout, And Audit Design
+
+## Summary
+
+CapyInn will add one action-scoped correlation ID to the selected stay and audit flows under issue `#30`.
+
+For this release, the scope is intentionally limited to:
+
+- `check_in`
+- `check_out`
+- `group_checkin`
+- `group_checkout`
+- `run_night_audit`
+
+Each time the operator runs one of those actions, the frontend will create a short correlation ID such as `COR-8F3A1C7D`, send it with the command, and keep that same ID attached to the failed action if the command rejects.
+
+The backend will log the same ID on command start, command success, and command failure so developers can trace one operator action across the relevant log lines. The frontend will show the correlation ID when that action fails so support can ask for one visible reference even for ordinary business-rule errors.
+
+This design deliberately keeps the FE/BE error contract from PR `#50` stable. `support_id` remains the system-error support code. Correlation ID is a separate action-tracking value and is not persisted to database records in this release.
+
+## Goals
+
+- Give every selected operator action one visible tracking ID from the moment the command is sent.
+- Make backend logs for the selected flows easy to search by one shared ID.
+- Show one tracking ID in the UI when an action fails, including user-facing business errors that do not produce `support_id`.
+- Reuse the shared command-error foundation from PR `#50` instead of creating a second error system.
+- Bring `run_night_audit` onto the same shared command-error path as the already migrated stay and group flows.
+
+## Non-Goals
+
+- No schema migration and no new database columns for correlation IDs.
+- No persistence of correlation IDs into `bookings`, `booking_groups`, `audit_logs`, or any other business record.
+- No full-app rollout across every Tauri command in this release.
+- No new diagnostics screen or UI for searching correlation IDs.
+- No replacement of `support_id`; it remains the identifier for system-error support lookup.
+- No global Tauri command middleware layer. This release applies explicit instrumentation only to the selected commands.
+
+## Current Baseline
+
+PR `#50` already created a stable FE/BE error contract around:
+
+- `code`
+- `message`
+- `kind`
+- `support_id`
+
+That rollout already covers the main stay and group command paths used by:
+
+- [useHotelStore.ts](/Users/binhan/HotelManager/mhm/src/stores/useHotelStore.ts)
+- [rooms.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/rooms.rs)
+- [groups.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/groups.rs)
+
+However, the current code still has three gaps relative to issue `#30`:
+
+- there is no action-scoped ID shared between frontend and backend for `check_in`, `check_out`, `group_checkin`, or `group_checkout`
+- backend system-error logs can include `support_id`, but there is no single ID that also covers user-facing business errors
+- [audit.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/audit.rs) and [NightAudit.tsx](/Users/binhan/HotelManager/mhm/src/pages/NightAudit.tsx) still use raw string-error handling instead of the shared command wrapper from PR `#50`
+
+This means support can get stuck in two common cases:
+
+- the operator sees a business error such as invalid state or missing booking and has no stable tracking value to report
+- backend logs for one failed action must be pieced together from timestamps and message text instead of one action ID
+
+## Chosen Approach
+
+CapyInn will add a frontend-generated correlation ID for the selected flows and thread it through the command call explicitly.
+
+The chosen approach has five parts:
+
+1. The frontend generates one correlation ID per selected action attempt.
+2. The shared command wrapper sends that ID with the Tauri command.
+3. The shared command wrapper re-attaches that same ID to the local thrown error object if the command fails.
+4. The selected backend commands log that ID on start, success, and failure.
+5. The selected frontend screens and stores show that ID in error text for failed actions.
+
+This is the preferred approach because it guarantees the UI and backend refer to the same action even if the backend returns a malformed or legacy error payload. The frontend created the ID before the call, so it never loses that reference.
+
+## Rejected Alternatives
+
+### Reuse `support_id` As The Only Tracking Value
+
+Rejected because `support_id` is intentionally tied to system errors in PR `#50`.
+
+If CapyInn reused `support_id` as the only tracking value here, one of two bad outcomes would follow:
+
+- ordinary user-facing business errors would still have no visible tracking ID
+- or `support_id` would have to change meaning and start appearing on non-system errors, which would blur the contract just standardized in PR `#50`
+
+### Let The Backend Generate Correlation IDs On Its Own
+
+Rejected because the current app has no single backend wrapper around all Tauri commands where this can be added cleanly for only the selected flows.
+
+Frontend would still need extra work to display the ID on failure, and malformed backend errors would still risk losing the action reference before the UI could show it.
+
+### Persist Correlation IDs Into Booking Or Audit Records
+
+Rejected for this release because it expands the scope too far:
+
+- schema or storage questions appear immediately
+- historical-data semantics become part of the design
+- the issue asks first for observability, not for durable business reporting
+
+This release only needs action-level tracing, not long-term record attribution.
+
+## Correlation ID Model
+
+### Purpose
+
+Correlation ID is the identifier for one operator action attempt.
+
+Examples:
+
+- one click on `Check-in`
+- one click on `Check-out`
+- one click on `Group Check-in`
+- one click on `Group Checkout`
+- one click on `Run Night Audit`
+
+If the operator retries after a failure, that retry must receive a new correlation ID. The ID belongs to an action attempt, not to a booking or audit entity.
+
+### Format
+
+For this release, the frontend will generate IDs in this format:
+
+- prefix: `COR-`
+- suffix: 8 uppercase hexadecimal characters
+
+Example:
+
+- `COR-8F3A1C7D`
+
+The value only needs to be short, human-readable, and collision-resistant enough for local support and log lookup. This is not a security token.
+
+### Source Of Truth
+
+The frontend is the source of truth for correlation ID generation in this release.
+
+Rules:
+
+- create the ID immediately before sending the selected command
+- pass it through the command call as `correlationId`
+- if the command rejects, keep the same ID attached to the local thrown error object
+- do not regenerate the ID during error formatting
+
+## Relationship To `support_id`
+
+Correlation ID and `support_id` serve different purposes and must both remain clear.
+
+`support_id`:
+
+- exists only for `system` errors in the PR `#50` contract
+- is created by backend error handling
+- is the support reference for an unexpected system failure
+
+Correlation ID:
+
+- exists for every selected action attempt, whether the error is `user` or `system`
+- is created by the frontend before the command is sent
+- is the action reference for log tracing and user-visible error follow-up
+
+In a failed system error case, the UI may show both values:
+
+- one `support_id` for the system failure
+- one correlation ID for the action attempt
+
+This is acceptable because the two IDs answer different questions:
+
+- `support_id`: which internal system failure record is this
+- correlation ID: which operator action are we talking about
+
+## Scope
+
+### Included Commands
+
+This release applies only to:
+
+- `check_in`
+- `check_out`
+- `group_checkin`
+- `group_checkout`
+- `run_night_audit`
+
+### Included Frontend Call Sites
+
+This release applies only to the frontend paths that either send those commands or render their failure toasts:
+
+- [useHotelStore.ts](/Users/binhan/HotelManager/mhm/src/stores/useHotelStore.ts) for stay and group command dispatch
+- [CheckinSheet.tsx](/Users/binhan/HotelManager/mhm/src/components/CheckinSheet.tsx) for `check_in` failure display
+- [RoomDetailPanel.tsx](/Users/binhan/HotelManager/mhm/src/components/RoomDetailPanel.tsx) for `check_out` failure display
+- [RoomDrawer.tsx](/Users/binhan/HotelManager/mhm/src/components/RoomDrawer.tsx) for `check_out` failure display
+- [GroupCheckinSheet.tsx](/Users/binhan/HotelManager/mhm/src/components/GroupCheckinSheet.tsx) for `group_checkin` failure display
+- [GroupManagement.tsx](/Users/binhan/HotelManager/mhm/src/pages/GroupManagement.tsx) for `group_checkout` failure display
+- [NightAudit.tsx](/Users/binhan/HotelManager/mhm/src/pages/NightAudit.tsx) for `run_night_audit` dispatch and failure display
+
+### Excluded For Now
+
+This release does not yet cover:
+
+- reservation create/modify/cancel flows
+- extend-stay
+- read-only fetch commands
+- settings, auth, room management, diagnostics, or export commands outside the selected scope
+
+## Frontend Design
+
+### Shared Correlation Helper
+
+Frontend should add one small helper module, for example:
+
+- [correlationId.ts](/Users/binhan/HotelManager/mhm/src/lib/correlationId.ts)
+
+Responsibility:
+
+- generate a new correlation ID
+- hide format details from screens and stores
+
+The helper should use browser/runtime crypto rather than ad hoc `Math.random()` string building.
+
+### Shared Command Wrapper
+
+[invokeCommand.ts](/Users/binhan/HotelManager/mhm/src/lib/invokeCommand.ts) should be extended rather than bypassed.
+
+Required behavior:
+
+- keep the existing first two parameters unchanged: `invokeCommand(command, args?)`
+- add an optional third parameter for tracked calls only:
+  `invokeCommand(command, args?, options?: { correlationId?: string })`
+- when present, merge `correlationId` into the outgoing command args for the selected commands
+- if the command fails, normalize the backend error exactly as PR `#50` already does
+- then attach the correlation ID to the thrown local error object before rethrowing
+
+This keeps the serialized backend error contract stable while still letting the frontend carry extra local context.
+
+The wrapper must not repurpose the second parameter or force unrelated callers onto a new shape. This release only opts selected tracked commands into the third-parameter options object.
+
+### Local Error Shape
+
+[appError.ts](/Users/binhan/HotelManager/mhm/src/lib/appError.ts) should keep the shared FE/BE contract unchanged for normalized backend payloads.
+
+However, the local thrown exception type may be extended with one frontend-only optional field:
+
+- `correlation_id`
+
+Rules:
+
+- do not require backend payloads to contain `correlation_id`
+- do not add `correlation_id` to `normalizeAppError()` validation for backend payloads
+- allow the local wrapper-created exception object to carry `correlation_id`
+
+This distinction keeps the transport contract stable and makes the correlation ID an application-level wrapper feature.
+
+### Error Formatting
+
+Frontend should add one focused helper for the selected flows, for example:
+
+- `formatTrackedAppError(error: unknown): string`
+
+Expected behavior:
+
+- preserve the existing output of `formatAppError(error)`
+- append `Mã theo dõi: COR-XXXXXXX` when the local error object carries `correlation_id`
+- if both `support_id` and `correlation_id` exist, show both without dropping either
+
+The selected flows should use this tracked formatter instead of hand-building error strings.
+
+### UI Rules
+
+Success case:
+
+- do not show the correlation ID on successful check-in, checkout, group flow completion, or audit completion
+
+Failure case:
+
+- show the existing error message
+- add the correlation ID on a new line
+- keep the formatting compact enough for toast usage
+
+This keeps the feature useful without adding noise to normal operator work.
+
+## Backend Design
+
+### Command Signatures
+
+The selected commands should accept `correlation_id: String` as an additional argument:
+
+- [rooms.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/rooms.rs): `check_in`, `check_out`
+- [groups.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/groups.rs): `group_checkin`, `group_checkout`
+- [audit.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/audit.rs): `run_night_audit`
+
+No service-layer or repository-layer signature changes are required unless they make logging materially cleaner. The ID may remain command-boundary context in this release.
+
+### Logging Rules
+
+Each selected command should emit log lines with the correlation ID at:
+
+- start
+- success
+- failure
+
+The minimum logging payload should include:
+
+- command name
+- correlation ID
+- relevant entity hints already available at the command boundary, such as `room_id`, `booking_id`, `group_id`, `audit_date`, or booking count
+
+Failure handling rules:
+
+- for `system` errors, include `correlation_id` inside the structured context passed to `log_system_error(...)`
+- for `user` errors, emit a warn-level or info-level log line that still includes `correlation_id`
+
+This ensures log search works for both expected and unexpected failures.
+
+### Audit Migration
+
+[audit.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/audit.rs) should be migrated to the shared command-error pattern introduced in PR `#50`.
+
+Required changes:
+
+- `run_night_audit` should stop returning raw `Result<_, String>`
+- admin checks should use the existing shared command-error path
+- booking and query failures should be mapped into `CommandError` using the same style already used in `rooms.rs` and `groups.rs`
+- backend logging for audit should include correlation ID on start, success, and failure
+
+Read-only `get_audit_logs` may remain outside this migration unless implementation work proves a direct dependency.
+
+### Audit Error Codes
+
+Because `normalizeAppError()` only accepts codes from the shared registry, this release must add explicit audit user-error codes instead of relying on free-form strings.
+
+Required new registry entries:
+
+- `AUDIT_INVALID_DATE`
+- `AUDIT_ALREADY_RUN`
+
+Expected user-facing meanings:
+
+- `AUDIT_INVALID_DATE`:
+  the provided audit date cannot be parsed or is not acceptable input
+- `AUDIT_ALREADY_RUN`:
+  the requested date has already been audited
+
+Mapping rules for `run_night_audit`:
+
+- invalid date parsing or equivalent audit-date validation failure:
+  `AUDIT_INVALID_DATE`
+- duplicate audit attempt for the same date:
+  `AUDIT_ALREADY_RUN`
+- database, transaction, or query failures:
+  `SYSTEM_INTERNAL_ERROR`
+
+This keeps audit aligned with the shared PR `#50` contract and avoids forcing audit-specific business failures into misleading booking error codes.
+
+## Data And Persistence Rules
+
+This release does not store correlation IDs in business data.
+
+Explicit rules:
+
+- do not add columns to `bookings`
+- do not add columns to `booking_groups`
+- do not add columns to `audit_logs`
+- do not write correlation IDs into `pricing_snapshot`
+- do not treat correlation IDs as historical reporting fields
+
+The only persistence side effect allowed in this release is indirect:
+
+- correlation ID may appear inside support error logs or command logs
+
+## Testing Strategy
+
+### Frontend Tests
+
+Frontend should add or update tests that cover:
+
+- correlation ID generation format
+- `invokeCommand(...)` attaching correlation ID to the thrown local error object
+- tracked error formatting showing correlation ID without breaking existing `support_id` formatting
+- `NightAudit.tsx` switching to the shared tracked-command path
+
+If store-level tests are easier than component-level tests for the stay and group flows, that is acceptable. The important outcome is that selected actions pass a correlation ID and failed actions surface it.
+
+### Rust Tests
+
+Rust tests should cover:
+
+- selected command failure paths include `correlation_id` in the structured failure context used for system-error logging
+- migrated audit error mapping now returns the shared `CommandError` contract instead of raw free-form strings
+- user-error mapping remains stable for stay and group flows after the extra parameter is added
+
+Where direct log capture is awkward, helper-level tests that assert the generated error context includes `correlation_id` are acceptable.
+
+### Verification
+
+Run the smallest existing verification path that still exercises the changed surface area, including:
+
+- frontend unit tests touched by the wrapper and formatter changes
+- Rust tests for the selected commands and helpers
+- quick verification covering check-in, checkout, group flow, and night audit if those slices already exist in the repo's current suite
+
+## Rollout Notes
+
+This design intentionally adds correlation IDs only where issue `#30` asked first and where PR `#50` already laid shared groundwork.
+
+If this release works well, the next wave can reuse the same pattern for reservation commands and other operator actions. That future expansion should be a separate design or implementation-plan decision, not an implicit requirement in this release.

--- a/docs/superpowers/specs/2026-04-22-correlation-id-booking-checkin-audit-design.md
+++ b/docs/superpowers/specs/2026-04-22-correlation-id-booking-checkin-audit-design.md
@@ -131,9 +131,19 @@ Example:
 
 The value only needs to be short, human-readable, and collision-resistant enough for local support and log lookup. This is not a security token.
 
+Backend must treat incoming correlation IDs as untrusted input.
+
+Rules:
+
+- accept only values that exactly match `^COR-[0-9A-F]{8}$`
+- never log an invalid raw value verbatim
+- never allow correlation ID parsing or validation failure to fail the business action by itself
+
+If the frontend sends a missing or invalid value, backend must replace it with a backend-generated fallback ID in the same format and continue the command.
+
 ### Source Of Truth
 
-The frontend is the source of truth for correlation ID generation in this release.
+The frontend is the source of truth for correlation ID generation in normal operation for this release.
 
 Rules:
 
@@ -141,6 +151,8 @@ Rules:
 - pass it through the command call as `correlationId`
 - if the command rejects, keep the same ID attached to the local thrown error object
 - do not regenerate the ID during error formatting
+
+Backend fallback generation exists only as a defensive path for partial rollout, malformed input, or caller bugs. It is not the intended steady-state path.
 
 ## Relationship To `support_id`
 
@@ -225,7 +237,7 @@ Required behavior:
 - keep the existing first two parameters unchanged: `invokeCommand(command, args?)`
 - add an optional third parameter for tracked calls only:
   `invokeCommand(command, args?, options?: { correlationId?: string })`
-- when present, merge `correlationId` into the outgoing command args for the selected commands
+- when `options.correlationId` is present, merge `correlationId` into the outgoing command args
 - if the command fails, normalize the backend error exactly as PR `#50` already does
 - then attach the correlation ID to the thrown local error object before rethrowing
 
@@ -249,19 +261,25 @@ Rules:
 
 This distinction keeps the transport contract stable and makes the correlation ID an application-level wrapper feature.
 
+Implementation direction:
+
+- extend `createAppErrorException(...)` with an optional local-extras parameter, for example:
+  `createAppErrorException(appError, cause?, extras?: { correlation_id?: string })`
+- have `invokeCommand(...)` pass the correlation ID through that helper instead of mutating the thrown object afterward
+
+This keeps the TypeScript error shape centralized in one place and avoids silent type drift between the helper and the wrapper.
+
 ### Error Formatting
 
-Frontend should add one focused helper for the selected flows, for example:
-
-- `formatTrackedAppError(error: unknown): string`
+Frontend should extend the existing `formatAppError(error)` helper rather than introduce a second formatter.
 
 Expected behavior:
 
-- preserve the existing output of `formatAppError(error)`
-- append `Mã theo dõi: COR-XXXXXXX` when the local error object carries `correlation_id`
+- preserve the existing `formatAppError(error)` output for callers that have no correlation ID
+- append `Mã theo dõi: COR-XXXXXXXX` when the local error object carries `correlation_id`
 - if both `support_id` and `correlation_id` exist, show both without dropping either
 
-The selected flows should use this tracked formatter instead of hand-building error strings.
+The selected flows should keep calling `formatAppError(error)` after that helper learns how to render the optional local `correlation_id`.
 
 ### UI Rules
 
@@ -281,13 +299,24 @@ This keeps the feature useful without adding noise to normal operator work.
 
 ### Command Signatures
 
-The selected commands should accept `correlation_id: String` as an additional argument:
+The selected commands should accept `correlation_id: Option<String>` as an additional argument:
 
 - [rooms.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/rooms.rs): `check_in`, `check_out`
 - [groups.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/groups.rs): `group_checkin`, `group_checkout`
 - [audit.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/commands/audit.rs): `run_night_audit`
 
 No service-layer or repository-layer signature changes are required unless they make logging materially cleaner. The ID may remain command-boundary context in this release.
+
+At the command boundary, each selected command should normalize that optional input into one safe effective correlation ID before any log line is emitted.
+
+Normalization rules:
+
+- if the input matches `^COR-[0-9A-F]{8}$`, keep it
+- if the input is missing, generate a backend fallback ID and emit a warn-level log that the tracked command arrived without a frontend ID
+- if the input is present but invalid, generate a backend fallback ID and emit a warn-level log that the frontend ID failed validation
+- warning logs for missing or invalid IDs must not print the raw invalid value verbatim; logging the reason plus sanitized metadata such as length is sufficient
+
+This prevents Tauri argument deserialization failures from turning into a hidden rollout hazard and closes the log-injection risk from untrusted correlation ID input.
 
 ### Logging Rules
 
@@ -330,13 +359,13 @@ Because `normalizeAppError()` only accepts codes from the shared registry, this 
 Required new registry entries:
 
 - `AUDIT_INVALID_DATE`
-- `AUDIT_ALREADY_RUN`
+- `AUDIT_DATE_ALREADY_RUN`
 
 Expected user-facing meanings:
 
 - `AUDIT_INVALID_DATE`:
   the provided audit date cannot be parsed or is not acceptable input
-- `AUDIT_ALREADY_RUN`:
+- `AUDIT_DATE_ALREADY_RUN`:
   the requested date has already been audited
 
 Mapping rules for `run_night_audit`:
@@ -344,7 +373,7 @@ Mapping rules for `run_night_audit`:
 - invalid date parsing or equivalent audit-date validation failure:
   `AUDIT_INVALID_DATE`
 - duplicate audit attempt for the same date:
-  `AUDIT_ALREADY_RUN`
+  `AUDIT_DATE_ALREADY_RUN`
 - database, transaction, or query failures:
   `SYSTEM_INTERNAL_ERROR`
 
@@ -374,7 +403,9 @@ Frontend should add or update tests that cover:
 
 - correlation ID generation format
 - `invokeCommand(...)` attaching correlation ID to the thrown local error object
-- tracked error formatting showing correlation ID without breaking existing `support_id` formatting
+- `invokeCommand(...)` preserving the existing call shape for callers that omit the third parameter
+- `createAppErrorException(...)` carrying optional `correlation_id` through its typed exception shape
+- `formatAppError(...)` showing correlation ID without breaking existing `support_id` formatting
 - `NightAudit.tsx` switching to the shared tracked-command path
 
 If store-level tests are easier than component-level tests for the stay and group flows, that is acceptable. The important outcome is that selected actions pass a correlation ID and failed actions surface it.
@@ -383,11 +414,13 @@ If store-level tests are easier than component-level tests for the stay and grou
 
 Rust tests should cover:
 
+- correlation ID normalization accepting valid IDs and replacing missing or invalid input with a safe fallback
 - selected command failure paths include `correlation_id` in the structured failure context used for system-error logging
+- selected command start and success log payloads include the effective correlation ID
 - migrated audit error mapping now returns the shared `CommandError` contract instead of raw free-form strings
 - user-error mapping remains stable for stay and group flows after the extra parameter is added
 
-Where direct log capture is awkward, helper-level tests that assert the generated error context includes `correlation_id` are acceptable.
+Where direct log capture is awkward, extract a small helper for log payload construction or correlation ID normalization and unit-test that helper for start, success, and failure cases.
 
 ### Verification
 
@@ -400,5 +433,7 @@ Run the smallest existing verification path that still exercises the changed sur
 ## Rollout Notes
 
 This design intentionally adds correlation IDs only where issue `#30` asked first and where PR `#50` already laid shared groundwork.
+
+Audit migration also changes audit command failures from raw string errors to the shared FE/BE contract. That means admin rejection and audit validation failures in `run_night_audit` will become structured user errors with stable codes instead of free-form strings.
 
 If this release works well, the next wave can reuse the same pattern for reservation commands and other operator actions. That future expansion should be a separate design or implementation-plan decision, not an implicit requirement in this release.

--- a/mhm/scripts/verify/quick.mjs
+++ b/mhm/scripts/verify/quick.mjs
@@ -8,9 +8,11 @@ await run(
   [
     "test",
     "--",
+    "src/lib/correlationId.test.ts",
     "src/lib/appError.test.ts",
     "src/pages/settings/useRoomConfig.test.tsx",
     "src/components/GroupCheckinSheet.test.tsx",
+    "src/pages/GroupManagement.test.tsx",
     "src/pages/NightAudit.test.tsx",
     "src/App.updateFlow.test.tsx",
     "src/hooks/useAppUpdateController.test.tsx",
@@ -19,6 +21,7 @@ await run(
     "tests/e2e/05-checkout.test.tsx",
     "tests/e2e/08-settings.test.tsx",
     "tests/e2e/11-night-audit.test.tsx",
+    "tests/e2e/13-store-hardening.test.ts",
   ],
   { cwd },
 );

--- a/mhm/scripts/verify/quick.mjs
+++ b/mhm/scripts/verify/quick.mjs
@@ -11,12 +11,14 @@ await run(
     "src/lib/appError.test.ts",
     "src/pages/settings/useRoomConfig.test.tsx",
     "src/components/GroupCheckinSheet.test.tsx",
+    "src/pages/NightAudit.test.tsx",
     "src/App.updateFlow.test.tsx",
     "src/hooks/useAppUpdateController.test.tsx",
     "tests/e2e/01-login.test.tsx",
     "tests/e2e/03-checkin.test.tsx",
     "tests/e2e/05-checkout.test.tsx",
     "tests/e2e/08-settings.test.tsx",
+    "tests/e2e/11-night-audit.test.tsx",
   ],
   { cwd },
 );
@@ -32,6 +34,13 @@ await run(
   "command-helper-tests",
   "cargo",
   ["test", "--manifest-path", "src-tauri/Cargo.toml", "commands::tests::", "--", "--nocapture"],
+  { cwd },
+);
+
+await run(
+  "audit-command-tests",
+  "cargo",
+  ["test", "--manifest-path", "src-tauri/Cargo.toml", "commands::audit::tests::", "--", "--nocapture"],
   { cwd },
 );
 

--- a/mhm/shared/error-codes.json
+++ b/mhm/shared/error-codes.json
@@ -95,6 +95,16 @@
     "defaultMessage": "Tổng quyết toán phải lớn hơn hoặc bằng 0"
   },
   {
+    "code": "AUDIT_INVALID_DATE",
+    "kind": "user",
+    "defaultMessage": "Ngày kiểm toán không hợp lệ"
+  },
+  {
+    "code": "AUDIT_DATE_ALREADY_RUN",
+    "kind": "user",
+    "defaultMessage": "Ngày kiểm toán này đã được chạy"
+  },
+  {
     "code": "SYSTEM_INTERNAL_ERROR",
     "kind": "system",
     "defaultMessage": "Có lỗi hệ thống, vui lòng thử lại"

--- a/mhm/src-tauri/src/app_error.rs
+++ b/mhm/src-tauri/src/app_error.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Map;
 use serde_json::Value;
 
 use crate::app_identity;
@@ -24,6 +25,8 @@ pub mod codes {
     pub const BOOKING_GUEST_REQUIRED: &str = "BOOKING_GUEST_REQUIRED";
     pub const BOOKING_INVALID_NIGHTS: &str = "BOOKING_INVALID_NIGHTS";
     pub const BOOKING_INVALID_SETTLEMENT_TOTAL: &str = "BOOKING_INVALID_SETTLEMENT_TOTAL";
+    pub const AUDIT_INVALID_DATE: &str = "AUDIT_INVALID_DATE";
+    pub const AUDIT_DATE_ALREADY_RUN: &str = "AUDIT_DATE_ALREADY_RUN";
     pub const SYSTEM_INTERNAL_ERROR: &str = "SYSTEM_INTERNAL_ERROR";
 
     pub const ALL: &[&str] = &[
@@ -46,6 +49,8 @@ pub mod codes {
         BOOKING_GUEST_REQUIRED,
         BOOKING_INVALID_NIGHTS,
         BOOKING_INVALID_SETTLEMENT_TOTAL,
+        AUDIT_INVALID_DATE,
+        AUDIT_DATE_ALREADY_RUN,
         SYSTEM_INTERNAL_ERROR,
     ];
 }
@@ -68,6 +73,20 @@ pub struct CommandError {
 }
 
 pub type CommandResult<T> = Result<T, CommandError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorrelationIdSource {
+    Frontend,
+    MissingFallback,
+    InvalidFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveCorrelationId {
+    pub value: String,
+    pub source: CorrelationIdSource,
+    pub rejected_length: Option<usize>,
+}
 
 fn ensure_registered_code(code: &'static str) -> &'static str {
     assert!(
@@ -116,6 +135,61 @@ impl CommandError {
 pub fn generate_support_id() -> String {
     let raw = uuid::Uuid::new_v4().simple().to_string();
     format!("SUP-{}", raw[..8].to_ascii_uppercase())
+}
+
+pub fn generate_correlation_id() -> String {
+    let raw = uuid::Uuid::new_v4().simple().to_string();
+    format!("COR-{}", raw[..8].to_ascii_uppercase())
+}
+
+fn is_valid_correlation_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 12
+        && &bytes[..4] == b"COR-"
+        && bytes[4..]
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'A'..=b'F'))
+}
+
+pub fn normalize_correlation_id(input: Option<String>) -> EffectiveCorrelationId {
+    match input {
+        Some(value) if is_valid_correlation_id(&value) => EffectiveCorrelationId {
+            value,
+            source: CorrelationIdSource::Frontend,
+            rejected_length: None,
+        },
+        Some(value) => EffectiveCorrelationId {
+            value: generate_correlation_id(),
+            source: CorrelationIdSource::InvalidFallback,
+            rejected_length: Some(value.len()),
+        },
+        None => EffectiveCorrelationId {
+            value: generate_correlation_id(),
+            source: CorrelationIdSource::MissingFallback,
+            rejected_length: None,
+        },
+    }
+}
+
+pub fn correlation_context(correlation_id: &str, context: Value) -> Value {
+    match context {
+        Value::Object(mut object) => {
+            object.insert(
+                "correlation_id".to_string(),
+                Value::String(correlation_id.to_string()),
+            );
+            Value::Object(object)
+        }
+        other => {
+            let mut object = Map::new();
+            object.insert(
+                "correlation_id".to_string(),
+                Value::String(correlation_id.to_string()),
+            );
+            object.insert("context".to_string(), other);
+            Value::Object(object)
+        }
+    }
 }
 
 pub fn log_system_error(
@@ -327,6 +401,16 @@ mod tests {
                 "Tổng quyết toán phải lớn hơn hoặc bằng 0",
             ),
             (
+                codes::AUDIT_INVALID_DATE,
+                AppErrorKind::User,
+                "Ngày kiểm toán không hợp lệ",
+            ),
+            (
+                codes::AUDIT_DATE_ALREADY_RUN,
+                AppErrorKind::User,
+                "Ngày kiểm toán này đã được chạy",
+            ),
+            (
                 codes::SYSTEM_INTERNAL_ERROR,
                 AppErrorKind::System,
                 GENERIC_SYSTEM_ERROR_MESSAGE,
@@ -380,5 +464,57 @@ mod tests {
         assert_eq!(parsed["support_id"], support_id);
 
         let _ = fs::remove_dir_all(&runtime_root);
+    }
+
+    #[test]
+    fn normalize_correlation_id_preserves_valid_frontend_value() {
+        let effective = normalize_correlation_id(Some("COR-1A2B3C4D".to_string()));
+
+        assert_eq!(effective.value, "COR-1A2B3C4D");
+        assert_eq!(effective.source, CorrelationIdSource::Frontend);
+        assert_eq!(effective.rejected_length, None);
+    }
+
+    #[test]
+    fn normalize_correlation_id_generates_fallback_for_missing_value() {
+        let effective = normalize_correlation_id(None);
+
+        assert_eq!(effective.source, CorrelationIdSource::MissingFallback);
+        assert_eq!(effective.rejected_length, None);
+        assert_eq!(effective.value.len(), 12);
+        assert!(effective.value.starts_with("COR-"));
+        assert!(effective.value[4..]
+            .chars()
+            .all(|character: char| character.is_ascii_digit() || matches!(character, 'A'..='F')));
+    }
+
+    #[test]
+    fn normalize_correlation_id_replaces_invalid_input_without_echoing_it() {
+        let raw_input = "not-a-real-correlation-id";
+        let effective = normalize_correlation_id(Some(raw_input.to_string()));
+
+        assert_eq!(effective.source, CorrelationIdSource::InvalidFallback);
+        assert_eq!(effective.rejected_length, Some(raw_input.len()));
+        assert_eq!(effective.value.len(), 12);
+        assert!(effective.value.starts_with("COR-"));
+        assert_ne!(effective.value, raw_input);
+        assert!(!effective.value.contains(raw_input));
+    }
+
+    #[test]
+    fn correlation_context_merges_correlation_id_without_dropping_existing_fields() {
+        let merged = correlation_context(
+            "COR-1A2B3C4D",
+            json!({ "room_id": "R101", "booking_id": "B202" }),
+        );
+
+        assert_eq!(
+            merged,
+            json!({
+                "correlation_id": "COR-1A2B3C4D",
+                "room_id": "R101",
+                "booking_id": "B202",
+            })
+        );
     }
 }

--- a/mhm/src-tauri/src/commands/audit.rs
+++ b/mhm/src-tauri/src/commands/audit.rs
@@ -1,11 +1,104 @@
 use super::{emit_db_update, require_admin, AppState};
 use crate::app_identity;
-use crate::{queries::booking::audit_queries, services::booking::audit_service};
+use crate::{
+    app_error::{
+        codes, correlation_context, log_system_error, normalize_correlation_id, CommandError,
+        CommandResult, EffectiveCorrelationId,
+    },
+    domain::booking::BookingError,
+    queries::booking::audit_queries,
+    services::booking::audit_service,
+};
+use serde_json::{json, Value};
 use tauri::State;
 
 // ═══════════════════════════════════════════════
 // Phase 4: Night Audit Commands
 // ═══════════════════════════════════════════════
+
+fn log_user_audit_error(
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    message: &str,
+    context: &Value,
+) {
+    let context_json = serde_json::to_string(&correlation_context(
+        &effective_correlation_id.value,
+        context.clone(),
+    ))
+    .unwrap_or_else(|_| "{}".to_string());
+
+    log::warn!(
+        "user error {} correlation_id={} source={:?}: {} | context={}",
+        command_name,
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        message,
+        context_json
+    );
+}
+
+fn map_audit_user_error(
+    code: &'static str,
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    message: String,
+    context: &Value,
+) -> CommandError {
+    log_user_audit_error(
+        command_name,
+        effective_correlation_id,
+        message.as_str(),
+        context,
+    );
+    CommandError::user(code, message)
+}
+
+fn map_audit_error(
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    error: BookingError,
+    context: Value,
+) -> CommandError {
+    match error {
+        BookingError::Validation(message) if message == "Ngày audit không hợp lệ" => {
+            map_audit_user_error(
+                codes::AUDIT_INVALID_DATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
+        }
+        BookingError::Validation(message) | BookingError::Conflict(message)
+            if message.starts_with("Đã audit ngày ") =>
+        {
+            map_audit_user_error(
+                codes::AUDIT_DATE_ALREADY_RUN,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
+        }
+        BookingError::Validation(message) | BookingError::Conflict(message) => {
+            map_audit_user_error(
+                codes::AUDIT_INVALID_DATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
+        }
+        BookingError::NotFound(message)
+        | BookingError::Database(message)
+        | BookingError::DateTimeParse(message) => log_system_error(
+            command_name,
+            message,
+            correlation_context(&effective_correlation_id.value, context),
+        ),
+    }
+}
 
 #[tauri::command]
 pub async fn run_night_audit(
@@ -13,11 +106,43 @@ pub async fn run_night_audit(
     app: tauri::AppHandle,
     audit_date: String,
     notes: Option<String>,
-) -> Result<crate::models::AuditLog, String> {
+    correlation_id: Option<String>,
+) -> CommandResult<crate::models::AuditLog> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let notes_present = notes
+        .as_ref()
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false);
+    let error_context = json!({
+        "audit_date": audit_date.clone(),
+        "notes_present": notes_present,
+    });
+    log::info!(
+        "run_night_audit start correlation_id={} source={:?} audit_date={} notes_present={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        audit_date,
+        notes_present
+    );
     let user = require_admin(&state)?;
     let log = audit_service::run_night_audit(&state.db, &audit_date, notes, &user.id)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            map_audit_error(
+                "run_night_audit",
+                &effective_correlation_id,
+                error,
+                error_context,
+            )
+        })?;
+
+    log::info!(
+        "run_night_audit success correlation_id={} source={:?} audit_log_id={} audit_date={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        log.id,
+        log.audit_date
+    );
 
     emit_db_update(&app, "audit");
 
@@ -111,4 +236,66 @@ pub async fn export_bookings_csv(
     std::fs::write(&file_path, &csv).map_err(|e| e.to_string())?;
 
     Ok(file_path.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_audit_error;
+    use crate::app_error::{
+        codes, AppErrorKind, CorrelationIdSource, EffectiveCorrelationId,
+    };
+    use crate::domain::booking::BookingError;
+    use serde_json::json;
+
+    fn frontend_correlation_id() -> EffectiveCorrelationId {
+        EffectiveCorrelationId {
+            value: "COR-1A2B3C4D".to_string(),
+            source: CorrelationIdSource::Frontend,
+            rejected_length: None,
+        }
+    }
+
+    #[test]
+    fn map_audit_error_maps_invalid_date_to_shared_code() {
+        let error = map_audit_error(
+            "run_night_audit",
+            &frontend_correlation_id(),
+            BookingError::validation("Ngày audit không hợp lệ"),
+            json!({ "audit_date": "2026-02-30" }),
+        );
+
+        assert_eq!(error.code, codes::AUDIT_INVALID_DATE);
+        assert_eq!(error.message, "Ngày audit không hợp lệ");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_audit_error_maps_duplicate_audit_to_shared_code() {
+        let error = map_audit_error(
+            "run_night_audit",
+            &frontend_correlation_id(),
+            BookingError::validation("Đã audit ngày 2026-04-20 rồi!"),
+            json!({ "audit_date": "2026-04-20" }),
+        );
+
+        assert_eq!(error.code, codes::AUDIT_DATE_ALREADY_RUN);
+        assert_eq!(error.message, "Đã audit ngày 2026-04-20 rồi!");
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_audit_error_keeps_system_failures_in_system_contract() {
+        let error = map_audit_error(
+            "run_night_audit",
+            &frontend_correlation_id(),
+            BookingError::database("disk I/O failure"),
+            json!({ "audit_date": "2026-04-20" }),
+        );
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert_eq!(error.kind, AppErrorKind::System);
+        assert!(error.support_id.is_some());
+    }
 }

--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -707,6 +707,21 @@ mod tests {
     }
 
     #[test]
+    fn map_group_error_keeps_system_failures_in_system_contract() {
+        let effective_correlation_id = frontend_correlation_id();
+        let error = map_group_error(
+            "group_checkout",
+            &effective_correlation_id,
+            BookingError::database("disk I/O failure"),
+            json!({ "group_id": "group-1" }),
+        );
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert_eq!(error.kind, AppErrorKind::System);
+        assert!(error.support_id.is_some());
+    }
+
+    #[test]
     fn map_auto_assign_error_maps_invalid_room_count_to_shared_code() {
         let error = map_auto_assign_error(
             "auto_assign_rooms",

--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -1,6 +1,9 @@
 use super::{emit_db_update, get_f64, get_user_id, AppState};
 use crate::{
-    app_error::{codes, log_system_error, CommandError, CommandResult},
+    app_error::{
+        codes, correlation_context, log_system_error, normalize_correlation_id, CommandError,
+        CommandResult, EffectiveCorrelationId,
+    },
     domain::booking::BookingError,
     models::*,
 };
@@ -11,36 +14,125 @@ use tauri::State;
 
 // ─── Group Booking Commands ───
 
-fn map_group_error(command_name: &str, error: BookingError, context: Value) -> CommandError {
+fn log_group_user_error(
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    message: &str,
+    context: &Value,
+) {
+    let context_json = serde_json::to_string(&correlation_context(
+        &effective_correlation_id.value,
+        context.clone(),
+    ))
+    .unwrap_or_else(|_| "{}".to_string());
+
+    log::warn!(
+        "user error {} correlation_id={} source={:?}: {} | context={}",
+        command_name,
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        message,
+        context_json
+    );
+}
+
+fn map_group_user_error(
+    code: &'static str,
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    message: String,
+    context: &Value,
+) -> CommandError {
+    log_group_user_error(
+        command_name,
+        effective_correlation_id,
+        message.as_str(),
+        context,
+    );
+    CommandError::user(code, message)
+}
+
+fn map_group_error(
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    error: BookingError,
+    context: Value,
+) -> CommandError {
     match error {
         BookingError::Validation(message) if message == "Phải chọn ít nhất 1 phòng để checkout" => {
-            CommandError::user(codes::GROUP_CHECKOUT_SELECTION_REQUIRED, message)
+            map_group_user_error(
+                codes::GROUP_CHECKOUT_SELECTION_REQUIRED,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message)
             if message == "Phải chọn ít nhất 1 phòng" || message == "Số phòng phải > 0" =>
         {
-            CommandError::user(codes::GROUP_INVALID_ROOM_COUNT, message)
+            map_group_user_error(
+                codes::GROUP_INVALID_ROOM_COUNT,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message) if message == "Số đêm phải > 0" => {
-            CommandError::user(codes::BOOKING_INVALID_NIGHTS, message)
+            map_group_user_error(
+                codes::BOOKING_INVALID_NIGHTS,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::NotFound(message) if message.starts_with("Phòng ") => {
-            CommandError::user(codes::ROOM_NOT_FOUND, message)
+            map_group_user_error(
+                codes::ROOM_NOT_FOUND,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::NotFound(message) if message.starts_with("Không tìm thấy group ") => {
-            CommandError::user(codes::GROUP_NOT_FOUND, message)
+            map_group_user_error(
+                codes::GROUP_NOT_FOUND,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::NotFound(message)
             if message.starts_with("Booking ") && message.contains("không tìm thấy") =>
         {
-            CommandError::user(codes::BOOKING_NOT_FOUND, message)
+            map_group_user_error(
+                codes::BOOKING_NOT_FOUND,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message) | BookingError::Conflict(message) => {
-            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+            map_group_user_error(
+                codes::BOOKING_INVALID_STATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::NotFound(message)
         | BookingError::Database(message)
-        | BookingError::DateTimeParse(message) => log_system_error(command_name, message, context),
+        | BookingError::DateTimeParse(message) => log_system_error(
+            command_name,
+            message,
+            correlation_context(&effective_correlation_id.value, context),
+        ),
     }
 }
 
@@ -74,16 +166,35 @@ pub async fn group_checkin(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: GroupCheckinRequest,
+    correlation_id: Option<String>,
 ) -> CommandResult<BookingGroup> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
     let error_context = json!({
         "group_name": req.group_name.clone(),
         "room_count": req.room_ids.len(),
         "nights": req.nights,
         "master_room_id": req.master_room_id.clone(),
     });
+    log::info!(
+        "group_checkin start correlation_id={} source={:?} group_name={} room_count={} nights={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        req.group_name,
+        req.room_ids.len(),
+        req.nights
+    );
     let group = group_lifecycle::group_checkin(&state.db, get_user_id(&state), req)
         .await
-        .map_err(|error| map_group_error("group_checkin", error, error_context))?;
+        .map_err(|error| {
+            map_group_error("group_checkin", &effective_correlation_id, error, error_context)
+        })?;
+    log::info!(
+        "group_checkin success correlation_id={} source={:?} group_id={} total_rooms={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        group.id,
+        group.total_rooms
+    );
     emit_db_update(&app, "rooms");
     emit_db_update(&app, "groups");
     Ok(group)
@@ -95,15 +206,36 @@ pub async fn group_checkout(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: GroupCheckoutRequest,
+    correlation_id: Option<String>,
 ) -> CommandResult<()> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let group_id = req.group_id.clone();
+    let booking_count = req.booking_ids.len();
     let error_context = json!({
-        "group_id": req.group_id.clone(),
-        "booking_count": req.booking_ids.len(),
+        "group_id": group_id,
+        "booking_count": booking_count,
         "final_paid": req.final_paid,
     });
+    log::info!(
+        "group_checkout start correlation_id={} source={:?} group_id={} booking_count={} final_paid={:?}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        req.group_id,
+        req.booking_ids.len(),
+        req.final_paid
+    );
     group_lifecycle::group_checkout(&state.db, req)
         .await
-        .map_err(|error| map_group_error("group_checkout", error, error_context))?;
+        .map_err(|error| {
+            map_group_error("group_checkout", &effective_correlation_id, error, error_context)
+        })?;
+    log::info!(
+        "group_checkout success correlation_id={} source={:?} group_id={} booking_count={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        group_id,
+        booking_count
+    );
     emit_db_update(&app, "rooms");
     emit_db_update(&app, "groups");
 
@@ -512,14 +644,26 @@ pub async fn generate_group_invoice(
 #[cfg(test)]
 mod tests {
     use super::{map_auto_assign_error, map_group_detail_error, map_group_error};
-    use crate::app_error::{codes, AppErrorKind};
+    use crate::app_error::{
+        codes, AppErrorKind, CorrelationIdSource, EffectiveCorrelationId,
+    };
     use crate::domain::booking::BookingError;
     use serde_json::json;
 
+    fn frontend_correlation_id() -> EffectiveCorrelationId {
+        EffectiveCorrelationId {
+            value: "COR-1A2B3C4D".to_string(),
+            source: CorrelationIdSource::Frontend,
+            rejected_length: None,
+        }
+    }
+
     #[test]
     fn map_group_error_maps_missing_group_to_shared_contract() {
+        let effective_correlation_id = frontend_correlation_id();
         let error = map_group_error(
             "group_checkin",
+            &effective_correlation_id,
             BookingError::not_found("Không tìm thấy group group-1"),
             json!({ "group_id": "group-1" }),
         );
@@ -532,8 +676,10 @@ mod tests {
 
     #[test]
     fn map_group_error_maps_checkout_selection_required_to_shared_code() {
+        let effective_correlation_id = frontend_correlation_id();
         let error = map_group_error(
             "group_checkout",
+            &effective_correlation_id,
             BookingError::validation("Phải chọn ít nhất 1 phòng để checkout"),
             json!({ "group_id": "group-1" }),
         );
@@ -546,8 +692,10 @@ mod tests {
 
     #[test]
     fn map_group_error_maps_invalid_room_count_to_shared_code() {
+        let effective_correlation_id = frontend_correlation_id();
         let error = map_group_error(
             "group_checkin",
+            &effective_correlation_id,
             BookingError::validation("Phải chọn ít nhất 1 phòng"),
             json!({ "group_id": "group-1" }),
         );

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -1,6 +1,9 @@
 use super::{emit_db_update, get_f64, get_user_id, AppState};
 use crate::{
-    app_error::{codes, log_system_error, CommandError, CommandResult},
+    app_error::{
+        codes, correlation_context, log_system_error, normalize_correlation_id, CommandError,
+        CommandResult, EffectiveCorrelationId,
+    },
     domain::booking::BookingError,
     models::*,
     queries::booking::revenue_queries,
@@ -57,39 +60,128 @@ pub async fn get_dashboard_stats(state: State<'_, AppState>) -> Result<Dashboard
 
 // ─── Check-in Command ───
 
-fn map_stay_error(command_name: &str, error: BookingError, context: Value) -> CommandError {
+fn log_user_stay_error(
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    message: &str,
+    context: &Value,
+) {
+    let context_json = serde_json::to_string(&correlation_context(
+        &effective_correlation_id.value,
+        context.clone(),
+    ))
+    .unwrap_or_else(|_| "{}".to_string());
+
+    log::warn!(
+        "user error {} correlation_id={} source={:?}: {} | context={}",
+        command_name,
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        message,
+        context_json
+    );
+}
+
+fn map_stay_user_error(
+    code: &'static str,
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    message: String,
+    context: &Value,
+) -> CommandError {
+    log_user_stay_error(
+        command_name,
+        effective_correlation_id,
+        message.as_str(),
+        context,
+    );
+    CommandError::user(code, message)
+}
+
+fn map_stay_error(
+    command_name: &str,
+    effective_correlation_id: &EffectiveCorrelationId,
+    error: BookingError,
+    context: Value,
+) -> CommandError {
     match error {
         BookingError::NotFound(message) if message.starts_with("Không tìm thấy phòng ") => {
-            CommandError::user(codes::ROOM_NOT_FOUND, message)
+            map_stay_user_error(
+                codes::ROOM_NOT_FOUND,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::NotFound(message)
             if message.starts_with("Không tìm thấy booking đang active ")
                 || message.starts_with("Không tìm thấy booking ") =>
         {
-            CommandError::user(codes::BOOKING_NOT_FOUND, message)
+            map_stay_user_error(
+                codes::BOOKING_NOT_FOUND,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message) if message == "Phải có ít nhất 1 khách" => {
-            CommandError::user(codes::BOOKING_GUEST_REQUIRED, message)
+            map_stay_user_error(
+                codes::BOOKING_GUEST_REQUIRED,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message) if message == "Number of nights must be greater than 0" => {
-            CommandError::user(codes::BOOKING_INVALID_NIGHTS, message)
+            map_stay_user_error(
+                codes::BOOKING_INVALID_NIGHTS,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message)
             if message == "Tổng quyết toán phải lớn hơn hoặc bằng 0" =>
         {
-            CommandError::user(codes::BOOKING_INVALID_SETTLEMENT_TOTAL, message)
+            map_stay_user_error(
+                codes::BOOKING_INVALID_SETTLEMENT_TOTAL,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message)
             if message == "Overpaid booking requires refund handling before checkout" =>
         {
-            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+            map_stay_user_error(
+                codes::BOOKING_INVALID_STATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::Validation(message) | BookingError::Conflict(message) => {
-            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+            map_stay_user_error(
+                codes::BOOKING_INVALID_STATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            )
         }
         BookingError::NotFound(message)
         | BookingError::Database(message)
-        | BookingError::DateTimeParse(message) => log_system_error(command_name, message, context),
+        | BookingError::DateTimeParse(message) => log_system_error(
+            command_name,
+            message,
+            correlation_context(&effective_correlation_id.value, context),
+        ),
     }
 }
 
@@ -98,15 +190,35 @@ pub async fn check_in(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: CheckInRequest,
+    correlation_id: Option<String>,
 ) -> CommandResult<Booking> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
     let error_context = json!({
         "room_id": req.room_id.clone(),
         "guest_count": req.guests.len(),
         "nights": req.nights,
     });
+    log::info!(
+        "check_in start correlation_id={} source={:?} room_id={} guest_count={} nights={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        req.room_id,
+        req.guests.len(),
+        req.nights
+    );
     let booking = stay_lifecycle::check_in(&state.db, req, get_user_id(&state))
         .await
-        .map_err(|error| map_stay_error("check_in", error, error_context))?;
+        .map_err(|error| {
+            map_stay_error("check_in", &effective_correlation_id, error, error_context)
+        })?;
+
+    log::info!(
+        "check_in success correlation_id={} source={:?} booking_id={} room_id={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        booking.id,
+        booking.room_id
+    );
 
     emit_db_update(&app, "rooms");
 
@@ -210,15 +322,33 @@ pub async fn check_out(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: CheckOutRequest,
+    correlation_id: Option<String>,
 ) -> CommandResult<()> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
     let error_context = json!({
         "booking_id": req.booking_id.clone(),
         "settlement_mode": req.settlement_mode,
         "final_total": req.final_total,
     });
+    log::info!(
+        "check_out start correlation_id={} source={:?} booking_id={} settlement_mode={:?} final_total={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        req.booking_id,
+        req.settlement_mode,
+        req.final_total
+    );
     stay_lifecycle::check_out(&state.db, req)
         .await
-        .map_err(|error| map_stay_error("check_out", error, error_context))?;
+        .map_err(|error| {
+            map_stay_error("check_out", &effective_correlation_id, error, error_context)
+        })?;
+
+    log::info!(
+        "check_out success correlation_id={} source={:?}",
+        effective_correlation_id.value,
+        effective_correlation_id.source
+    );
 
     emit_db_update(&app, "rooms");
 
@@ -460,14 +590,23 @@ pub async fn scan_image(path: String) -> Result<crate::ocr::CccdInfo, String> {
 #[cfg(test)]
 mod tests {
     use super::map_stay_error;
-    use crate::app_error::{codes, AppErrorKind};
+    use crate::app_error::{codes, AppErrorKind, CorrelationIdSource, EffectiveCorrelationId};
     use crate::domain::booking::BookingError;
     use serde_json::json;
+
+    fn frontend_correlation_id() -> EffectiveCorrelationId {
+        EffectiveCorrelationId {
+            value: "COR-1A2B3C4D".to_string(),
+            source: CorrelationIdSource::Frontend,
+            rejected_length: None,
+        }
+    }
 
     #[test]
     fn map_stay_error_maps_missing_room_to_room_not_found_contract() {
         let error = map_stay_error(
             "check_in",
+            &frontend_correlation_id(),
             BookingError::not_found("Không tìm thấy phòng R101"),
             json!({ "room_id": "R101" }),
         );
@@ -482,6 +621,7 @@ mod tests {
     fn map_stay_error_maps_guest_required_validation_to_shared_code() {
         let error = map_stay_error(
             "check_in",
+            &frontend_correlation_id(),
             BookingError::validation("Phải có ít nhất 1 khách"),
             json!({ "room_id": "R101" }),
         );
@@ -496,6 +636,7 @@ mod tests {
     fn map_stay_error_maps_invalid_settlement_total_to_shared_code() {
         let error = map_stay_error(
             "check_out",
+            &frontend_correlation_id(),
             BookingError::validation("Tổng quyết toán phải lớn hơn hoặc bằng 0"),
             json!({ "booking_id": "booking-1" }),
         );
@@ -510,6 +651,7 @@ mod tests {
     fn map_stay_error_maps_invalid_checkout_state_to_shared_code() {
         let error = map_stay_error(
             "check_out",
+            &frontend_correlation_id(),
             BookingError::validation("Overpaid booking requires refund handling before checkout"),
             json!({ "booking_id": "booking-1" }),
         );
@@ -521,5 +663,19 @@ mod tests {
         );
         assert_eq!(error.kind, AppErrorKind::User);
         assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_stay_error_keeps_system_errors_in_system_contract() {
+        let error = map_stay_error(
+            "check_out",
+            &frontend_correlation_id(),
+            BookingError::database("disk I/O failure"),
+            json!({ "booking_id": "booking-1" }),
+        );
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert_eq!(error.kind, AppErrorKind::System);
+        assert!(error.support_id.is_some());
     }
 }

--- a/mhm/src-tauri/src/services/booking/audit_service.rs
+++ b/mhm/src-tauri/src/services/booking/audit_service.rs
@@ -18,7 +18,7 @@ pub async fn run_night_audit(
     created_by: &str,
 ) -> BookingResult<AuditLog> {
     NaiveDate::parse_from_str(audit_date, "%Y-%m-%d")
-        .map_err(|error| BookingError::validation(error.to_string()))?;
+        .map_err(|_| BookingError::validation("Ngày audit không hợp lệ"))?;
 
     if night_audit_repository::find_audit_log_id(pool, audit_date)
         .await?

--- a/mhm/src/components/GroupCheckinSheet.test.tsx
+++ b/mhm/src/components/GroupCheckinSheet.test.tsx
@@ -84,12 +84,20 @@ const autoAssignUserError: AppError = {
   support_id: null,
 };
 
+const groupCheckInUserError: AppError = {
+  code: "BOOKING_INVALID_STATE",
+  message: "Master guest information is required",
+  kind: "user",
+  support_id: null,
+};
+
 describe("GroupCheckinSheet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     autoAssignRooms.mockRejectedValue(
       createAppErrorException(autoAssignUserError),
     );
+    groupCheckIn.mockResolvedValue(undefined);
   });
 
   it("keeps the sheet open and formats migrated auto-assign failures", async () => {
@@ -105,6 +113,58 @@ describe("GroupCheckinSheet", () => {
     expect(autoAssignRooms).toHaveBeenCalledWith(3, undefined);
     expect(toastError).toHaveBeenCalledWith(formatAppError(autoAssignUserError));
     expect(screen.getByText(/Bước 2\/4: Chọn phòng/i)).toBeInTheDocument();
+    expect(setGroupCheckinOpen).not.toHaveBeenCalledWith(false);
+  });
+
+  it("surfaces correlation IDs when group check-in fails", async () => {
+    const correlationId = "COR-1A2B3C4D";
+    const user = userEvent.setup();
+
+    autoAssignRooms.mockResolvedValue({
+      assignments: [
+        {
+          room: {
+            id: "R101",
+            name: "R101",
+            type: "standard",
+            room_type: "standard",
+            floor: 1,
+            has_balcony: false,
+            base_price: 500000,
+            max_guests: 2,
+            extra_person_fee: 0,
+            status: "vacant",
+          },
+          floor: 1,
+        },
+      ],
+    });
+    groupCheckIn.mockRejectedValue(
+      createAppErrorException(groupCheckInUserError, undefined, {
+        correlation_id: correlationId,
+      }),
+    );
+
+    render(<GroupCheckinSheet />);
+
+    const textboxes = screen.getAllByRole("textbox");
+    await user.type(textboxes[0], "Test Group");
+    await user.type(textboxes[1], "Organizer");
+    await user.click(screen.getByRole("button", { name: /Tiếp theo/i }));
+    await user.click(screen.getByRole("button", { name: /Tự động chọn 3 phòng/i }));
+    await user.click(screen.getByRole("button", { name: /Tiếp theo/i }));
+    await user.click(screen.getByRole("button", { name: /Tiếp theo/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Hoàn tất Group Check-in/i }),
+    );
+
+    expect(groupCheckIn).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith(
+      formatAppError({
+        ...groupCheckInUserError,
+        correlation_id: correlationId,
+      }),
+    );
     expect(setGroupCheckinOpen).not.toHaveBeenCalledWith(false);
   });
 });

--- a/mhm/src/lib/appError.test.ts
+++ b/mhm/src/lib/appError.test.ts
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 import errorCodes from "../../shared/error-codes.json";
 import { invokeCommand } from "./invokeCommand";
+import { createAppErrorException } from "./appError";
 import {
   APP_ERROR_REGISTRY,
   FALLBACK_SYSTEM_APP_ERROR,
@@ -55,14 +56,30 @@ describe("appError", () => {
   });
 
   it("formats system support ids alongside the generic message", () => {
-    expect(
-      formatAppError({
+    const error = createAppErrorException(
+      {
         code: "SYSTEM_INTERNAL_ERROR",
         message: "Có lỗi hệ thống, vui lòng thử lại",
         kind: "system",
         support_id: "SUP-ABCD1234",
-      }),
-    ).toBe("Có lỗi hệ thống, vui lòng thử lại (Mã hỗ trợ: SUP-ABCD1234)");
+      },
+      undefined,
+      {
+        correlation_id: "COR-8F3A1C7D",
+      },
+    );
+
+    expect(formatAppError(error)).toBe(
+      "Có lỗi hệ thống, vui lòng thử lại (Mã hỗ trợ: SUP-ABCD1234)\nMã theo dõi: COR-8F3A1C7D",
+    );
+  });
+
+  it("does not change invoke payloads when no correlation options are provided", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce("ok");
+
+    await invokeCommand("login", { req: { pin: "0000" } });
+
+    expect(invoke).toHaveBeenCalledWith("login", { req: { pin: "0000" } });
   });
 
   it("stays aligned with the shared error registry", () => {
@@ -81,7 +98,14 @@ describe("appError", () => {
       support_id: null,
     });
 
-    const promise = invokeCommand("login", { req: { pin: "0000" } });
+    const promise = invokeCommand("login", { req: { pin: "0000" } }, {
+      correlationId: "COR-8F3A1C7D",
+    });
+
+    expect(invoke).toHaveBeenCalledWith("login", {
+      req: { pin: "0000" },
+      correlationId: "COR-8F3A1C7D",
+    });
 
     await expect(promise).rejects.toMatchObject({
       name: "AppError",
@@ -89,6 +113,7 @@ describe("appError", () => {
       message: "Mã PIN không đúng",
       kind: "user",
       support_id: null,
+      correlation_id: "COR-8F3A1C7D",
     });
 
     await promise.catch((error) => {
@@ -99,6 +124,7 @@ describe("appError", () => {
         message: "Mã PIN không đúng",
         kind: "user",
         support_id: null,
+        correlation_id: "COR-8F3A1C7D",
       });
       expect(error.cause).toEqual({
         code: "AUTH_INVALID_PIN",

--- a/mhm/src/lib/appError.ts
+++ b/mhm/src/lib/appError.ts
@@ -105,25 +105,38 @@ export function normalizeAppError(error: unknown): AppError {
   };
 }
 
+function getLocalCorrelationId(error: unknown): string | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const { correlation_id } = error;
+  return typeof correlation_id === "string" ? correlation_id : null;
+}
+
 export function formatAppError(error: unknown): string {
   const normalized = normalizeAppError(error);
+  const localCorrelationId = getLocalCorrelationId(error);
+  const trackingLine = localCorrelationId ? `\nMã theo dõi: ${localCorrelationId}` : "";
 
   if (normalized.kind === "user") {
-    return normalized.message;
+    return `${normalized.message}${trackingLine}`;
   }
 
   if (normalized.support_id) {
-    return `${normalized.message} (Mã hỗ trợ: ${normalized.support_id})`;
+    return `${normalized.message} (Mã hỗ trợ: ${normalized.support_id})${trackingLine}`;
   }
 
-  return normalized.message;
+  return `${normalized.message}${trackingLine}`;
 }
 
-export type NormalizedAppErrorException = Error & AppError & { cause?: unknown };
+export type NormalizedAppErrorException = Error &
+  AppError & { correlation_id?: string | null; cause?: unknown };
 
 export function createAppErrorException(
   appError: AppError,
   cause?: unknown,
+  options?: { correlation_id?: string | null },
 ): NormalizedAppErrorException {
   const error = new Error(appError.message) as NormalizedAppErrorException;
   error.name = "AppError";
@@ -131,6 +144,9 @@ export function createAppErrorException(
   error.message = appError.message;
   error.kind = appError.kind;
   error.support_id = appError.support_id;
+  if (options?.correlation_id !== undefined) {
+    error.correlation_id = options.correlation_id;
+  }
   if (cause !== undefined) {
     error.cause = cause;
   }

--- a/mhm/src/lib/correlationId.test.ts
+++ b/mhm/src/lib/correlationId.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCorrelationId } from "./correlationId";
+
+describe("correlationId", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates COR-prefixed uppercase hexadecimal ids from crypto randomness", () => {
+    const getRandomValues = vi.fn((array: Uint8Array) => {
+      array.set([0x8f, 0x3a, 0x1c, 0x7d]);
+      return array;
+    });
+
+    vi.stubGlobal("crypto", {
+      getRandomValues,
+    });
+
+    expect(createCorrelationId()).toBe("COR-8F3A1C7D");
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mhm/src/lib/correlationId.ts
+++ b/mhm/src/lib/correlationId.ts
@@ -1,0 +1,8 @@
+export function createCorrelationId(): string {
+  const bytes = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(bytes);
+
+  return `COR-${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .toUpperCase()}`;
+}

--- a/mhm/src/lib/invokeCommand.ts
+++ b/mhm/src/lib/invokeCommand.ts
@@ -5,10 +5,18 @@ import { createAppErrorException, normalizeAppError } from "./appError";
 export async function invokeCommand<TResponse>(
   command: string,
   args?: Record<string, unknown>,
+  options?: { correlationId?: string },
 ): Promise<TResponse> {
   try {
-    return await invoke<TResponse>(command, args);
+    const payload =
+      options?.correlationId === undefined
+        ? args
+        : { ...(args ?? {}), correlationId: options.correlationId };
+
+    return await invoke<TResponse>(command, payload);
   } catch (error) {
-    throw createAppErrorException(normalizeAppError(error), error);
+    throw createAppErrorException(normalizeAppError(error), error, {
+      correlation_id: options?.correlationId,
+    });
   }
 }

--- a/mhm/src/pages/GroupManagement.test.tsx
+++ b/mhm/src/pages/GroupManagement.test.tsx
@@ -1,0 +1,193 @@
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  ReactNode,
+} from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAppErrorException,
+  formatAppError,
+  type AppError,
+} from "@/lib/appError";
+
+const fetchGroups = vi.hoisted(() => vi.fn());
+const getGroupDetail = vi.hoisted(() => vi.fn());
+const groupCheckout = vi.hoisted(() => vi.fn());
+const addGroupService = vi.hoisted(() => vi.fn());
+const removeGroupService = vi.hoisted(() => vi.fn());
+const generateGroupInvoice = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/useHotelStore", () => ({
+  useHotelStore: () => ({
+    groups: [
+      {
+        id: "group-1",
+        group_name: "Đoàn A",
+        organizer_name: "Trưởng đoàn",
+        organizer_phone: "0123456789",
+        total_rooms: 1,
+        status: "active",
+        created_at: "2026-04-22T00:00:00Z",
+      },
+    ],
+    fetchGroups,
+    getGroupDetail,
+    groupCheckout,
+    addGroupService,
+    removeGroupService,
+    generateGroupInvoice,
+  }),
+}));
+
+vi.mock("@/components/ui/table", () => ({
+  Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,
+  TableBody: ({ children }: { children: ReactNode }) => <tbody>{children}</tbody>,
+  TableCell: ({ children, ...props }: HTMLAttributes<HTMLTableCellElement>) => (
+    <td {...props}>{children}</td>
+  ),
+  TableHead: ({ children, ...props }: HTMLAttributes<HTMLTableCellElement>) => (
+    <th {...props}>{children}</th>
+  ),
+  TableHeader: ({ children }: { children: ReactNode }) => <thead>{children}</thead>,
+  TableRow: ({ children, ...props }: HTMLAttributes<HTMLTableRowElement>) => (
+    <tr {...props}>{children}</tr>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/shared/EmptyState", () => ({
+  default: ({ message }: { message: string }) => <div>{message}</div>,
+}));
+
+vi.mock("@/components/shared/SlideDrawer", () => ({
+  default: ({
+    children,
+    open,
+  }: {
+    children: ReactNode;
+    open: boolean;
+  }) => (open ? <div>{children}</div> : null),
+}));
+
+vi.mock("@/components/InvoiceDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: toastSuccess,
+  },
+}));
+
+import GroupManagement from "./GroupManagement";
+
+const checkoutUserError: AppError = {
+  code: "BOOKING_INVALID_STATE",
+  message: "Không thể checkout booking đã đóng",
+  kind: "user",
+  support_id: null,
+};
+
+describe("GroupManagement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchGroups.mockResolvedValue(undefined);
+    getGroupDetail.mockResolvedValue({
+      group: {
+        id: "group-1",
+        group_name: "Đoàn A",
+        organizer_name: "Trưởng đoàn",
+        organizer_phone: "0123456789",
+        total_rooms: 1,
+        status: "active",
+        created_at: "2026-04-22T00:00:00Z",
+      },
+      bookings: [
+        {
+          id: "booking-1",
+          room_id: "R101",
+          room_name: "R101",
+          guest_name: "Nguyễn Văn A",
+          check_in_at: "2026-04-22T00:00:00Z",
+          expected_checkout: "2026-04-23T00:00:00Z",
+          actual_checkout: null,
+          nights: 1,
+          total_price: 500000,
+          paid_amount: 0,
+          status: "active",
+          source: "walk-in",
+          booking_type: "group",
+          deposit_amount: null,
+          scheduled_checkin: null,
+          scheduled_checkout: null,
+          guest_phone: null,
+        },
+      ],
+      services: [],
+      total_room_cost: 500000,
+      total_service_cost: 0,
+      grand_total: 500000,
+      paid_amount: 0,
+    });
+    addGroupService.mockResolvedValue(undefined);
+    removeGroupService.mockResolvedValue(undefined);
+    generateGroupInvoice.mockResolvedValue(undefined);
+    groupCheckout.mockResolvedValue(undefined);
+  });
+
+  it("surfaces correlation IDs when group checkout fails", async () => {
+    const correlationId = "COR-5E6F7A8B";
+    const user = userEvent.setup();
+
+    groupCheckout.mockRejectedValue(
+      createAppErrorException(checkoutUserError, undefined, {
+        correlation_id: correlationId,
+      }),
+    );
+
+    render(<GroupManagement />);
+
+    await user.click(screen.getByText("Đoàn A"));
+
+    const checkbox = await screen.findByRole("checkbox");
+    await user.click(checkbox);
+    await user.click(
+      await screen.findByRole("button", { name: /Checkout 1 phòng/i }),
+    );
+
+    await waitFor(() => {
+      expect(groupCheckout).toHaveBeenCalledWith({
+        group_id: "group-1",
+        booking_ids: ["booking-1"],
+      });
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      formatAppError({
+        ...checkoutUserError,
+        correlation_id: correlationId,
+      }),
+    );
+  });
+});

--- a/mhm/src/pages/NightAudit.test.tsx
+++ b/mhm/src/pages/NightAudit.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAppErrorException,
+  formatAppError,
+  type AppError,
+} from "@/lib/appError";
+import { useAuthStore } from "@/stores/useAuthStore";
+
+const invoke = vi.hoisted(() => vi.fn());
+const invokeCommand = vi.hoisted(() => vi.fn());
+const createCorrelationId = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+}));
+
+vi.mock("@/lib/invokeCommand", () => ({
+  invokeCommand,
+}));
+
+vi.mock("@/lib/correlationId", () => ({
+  createCorrelationId,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: toastSuccess,
+  },
+}));
+
+import NightAudit from "./NightAudit";
+
+const auditRunError: AppError = {
+  code: "AUDIT_DATE_ALREADY_RUN",
+  message: "Đã audit ngày 2026-04-20 rồi!",
+  kind: "user",
+  support_id: null,
+};
+
+describe("NightAudit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invoke.mockResolvedValue([]);
+    invokeCommand.mockResolvedValue({
+      id: "audit-1",
+      audit_date: "2026-04-20",
+      total_revenue: 1200000,
+      room_revenue: 800000,
+      folio_revenue: 400000,
+      total_expenses: 200000,
+      occupancy_pct: 30,
+      rooms_sold: 3,
+      total_rooms: 10,
+      notes: "Đã kiểm tra kho",
+      created_at: "2026-04-20T23:59:59+07:00",
+    });
+    createCorrelationId.mockReturnValue("COR-5E6F7A8B");
+    useAuthStore.setState({
+      user: { id: "u1", name: "Admin", role: "admin", active: true, created_at: "" },
+      isAuthenticated: true,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("uses invokeCommand with a generated correlation ID when running night audit", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<NightAudit />);
+    const dateInput = container.querySelector('input[type="date"]');
+
+    expect(dateInput).not.toBeNull();
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("get_audit_logs");
+    });
+
+    fireEvent.change(dateInput!, { target: { value: "2026-04-20" } });
+    await user.type(
+      screen.getByPlaceholderText("VD: Đã kiểm tra kho..."),
+      "Đã kiểm tra kho",
+    );
+    await user.click(screen.getByRole("button", { name: /chạy audit/i }));
+
+    expect(createCorrelationId).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(invokeCommand).toHaveBeenCalledWith(
+        "run_night_audit",
+        {
+          auditDate: "2026-04-20",
+          notes: "Đã kiểm tra kho",
+        },
+        { correlationId: "COR-5E6F7A8B" },
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Night Audit ngày 2026-04-20 hoàn tất!",
+    );
+  });
+
+  it("formats invokeCommand failures with the correlation ID", async () => {
+    const user = userEvent.setup();
+    const error = createAppErrorException(auditRunError, undefined, {
+      correlation_id: "COR-5E6F7A8B",
+    });
+    invokeCommand.mockRejectedValue(error);
+
+    render(<NightAudit />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("get_audit_logs");
+    });
+
+    await user.click(screen.getByRole("button", { name: /chạy audit/i }));
+
+    await waitFor(() => {
+      expect(invokeCommand).toHaveBeenCalledWith(
+        "run_night_audit",
+        expect.objectContaining({
+          notes: null,
+        }),
+        { correlationId: "COR-5E6F7A8B" },
+      );
+    });
+    expect(toastError).toHaveBeenCalledWith(formatAppError(error));
+  });
+});

--- a/mhm/src/pages/NightAudit.tsx
+++ b/mhm/src/pages/NightAudit.tsx
@@ -4,6 +4,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
+import { createCorrelationId } from "@/lib/correlationId";
+import { formatAppError } from "@/lib/appError";
+import { invokeCommand } from "@/lib/invokeCommand";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { Moon, TrendingUp, Home, DollarSign, AlertCircle } from "lucide-react";
 import { fmtMoney } from "@/lib/format";
@@ -30,15 +33,16 @@ export default function NightAudit() {
         }
         setRunning(true);
         try {
-            const result = await invoke<AuditLog>("run_night_audit", {
+            const correlationId = createCorrelationId();
+            const result = await invokeCommand<AuditLog>("run_night_audit", {
                 auditDate,
                 notes: notes || null,
-            });
+            }, { correlationId });
             toast.success(`Night Audit ngày ${auditDate} hoàn tất!`);
             setLogs((prev) => [result, ...prev]);
             setNotes("");
         } catch (e: any) {
-            toast.error(e?.toString?.() || "Lỗi chạy Night Audit");
+            toast.error(formatAppError(e));
         } finally {
             setRunning(false);
         }

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -101,8 +101,8 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     checkIn: async (roomId, guests, nights, paidAmount, source, notes) => {
       beginAction();
-      const correlationId = createCorrelationId();
       try {
+        const correlationId = createCorrelationId();
         await invokeCommand("check_in", {
           req: { room_id: roomId, guests, nights, source, notes, paid_amount: paidAmount },
         }, { correlationId });
@@ -119,8 +119,8 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     checkOut: async (bookingId, settlementMode, finalTotal) => {
       beginAction();
-      const correlationId = createCorrelationId();
       try {
+        const correlationId = createCorrelationId();
         await invokeCommand("check_out", {
           req: {
             booking_id: bookingId,
@@ -174,8 +174,8 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     groupCheckIn: async (req) => {
       beginAction();
-      const correlationId = createCorrelationId();
       try {
+        const correlationId = createCorrelationId();
         await invokeCommand("group_checkin", { req }, { correlationId });
         await get().fetchRooms();
         await get().fetchStats();
@@ -191,8 +191,8 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     groupCheckout: async (req) => {
       beginAction();
-      const correlationId = createCorrelationId();
       try {
+        const correlationId = createCorrelationId();
         await invokeCommand("group_checkout", { req }, { correlationId });
         await get().fetchRooms();
         await get().fetchStats();

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
+import { createCorrelationId } from "@/lib/correlationId";
 import { invokeCommand } from "@/lib/invokeCommand";
 import type {
   CheckInGuestInput,
@@ -100,10 +101,11 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     checkIn: async (roomId, guests, nights, paidAmount, source, notes) => {
       beginAction();
+      const correlationId = createCorrelationId();
       try {
         await invokeCommand("check_in", {
           req: { room_id: roomId, guests, nights, source, notes, paid_amount: paidAmount },
-        });
+        }, { correlationId });
         await get().fetchRooms();
         await get().fetchStats();
         set({ activeTab: "dashboard" });
@@ -117,6 +119,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     checkOut: async (bookingId, settlementMode, finalTotal) => {
       beginAction();
+      const correlationId = createCorrelationId();
       try {
         await invokeCommand("check_out", {
           req: {
@@ -124,7 +127,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
             settlement_mode: settlementMode,
             final_total: finalTotal,
           },
-        });
+        }, { correlationId });
         await get().fetchRooms();
         await get().fetchStats();
         set({ activeTab: "dashboard" });

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -174,8 +174,9 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     groupCheckIn: async (req) => {
       beginAction();
+      const correlationId = createCorrelationId();
       try {
-        await invokeCommand("group_checkin", { req });
+        await invokeCommand("group_checkin", { req }, { correlationId });
         await get().fetchRooms();
         await get().fetchStats();
         await get().fetchGroups();
@@ -190,8 +191,9 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
     groupCheckout: async (req) => {
       beginAction();
+      const correlationId = createCorrelationId();
       try {
-        await invokeCommand("group_checkout", { req });
+        await invokeCommand("group_checkout", { req }, { correlationId });
         await get().fetchRooms();
         await get().fetchStats();
         await get().fetchGroups();

--- a/mhm/tests/e2e/03-checkin.test.tsx
+++ b/mhm/tests/e2e/03-checkin.test.tsx
@@ -89,7 +89,10 @@ describe("03 — Check-in Flow", () => {
             ""
         );
 
-        expect(invoke).toHaveBeenCalledWith("check_in", {
+        const checkInCall = invoke.mock.calls.find(([command]) => command === "check_in");
+        expect(checkInCall).toBeDefined();
+
+        expect(checkInCall?.[1]).toMatchObject({
             req: {
                 room_id: "1A",
                 guests: [{ full_name: "Nguyễn Văn A", doc_number: "012345678901" }],
@@ -98,6 +101,7 @@ describe("03 — Check-in Flow", () => {
                 notes: "",
                 paid_amount: 400000,
             },
+            correlationId: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
         });
     });
 
@@ -111,18 +115,27 @@ describe("03 — Check-in Flow", () => {
             };
         });
 
-        await expect(
-            useHotelStore.getState().checkIn(
-                "2A", // already occupied
-                [{ full_name: "Test", doc_number: "123456789012" }],
-                1
-            )
-        ).rejects.toMatchObject({
+        const promise = useHotelStore.getState().checkIn(
+            "2A", // already occupied
+            [{ full_name: "Test", doc_number: "123456789012" }],
+            1
+        );
+
+        await expect(promise).rejects.toMatchObject({
             name: "AppError",
             code: "BOOKING_INVALID_STATE",
             message: "Room is already occupied",
             kind: "user",
             support_id: null,
+            correlation_id: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
+        });
+
+        const checkInCall = invoke.mock.calls.find(([command]) => command === "check_in");
+        const correlationId = checkInCall?.[1]?.correlationId;
+        expect(correlationId).toMatch(/^COR-[0-9A-F]{8}$/);
+
+        await promise.catch((error) => {
+            expect(error.correlation_id).toBe(correlationId);
         });
 
         // Store should not be in loading state after error

--- a/mhm/tests/e2e/05-checkout.test.tsx
+++ b/mhm/tests/e2e/05-checkout.test.tsx
@@ -29,8 +29,12 @@ describe("05 — Check-out Flow", () => {
 
         await useHotelStore.getState().checkOut("booking-1", "hourly", 400000);
 
-        expect(invoke).toHaveBeenCalledWith("check_out", {
+        const checkOutCall = invoke.mock.calls.find(([command]) => command === "check_out");
+        expect(checkOutCall).toBeDefined();
+
+        expect(checkOutCall?.[1]).toMatchObject({
             req: { booking_id: "booking-1", settlement_mode: "hourly", final_total: 400000 },
+            correlationId: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
         });
     });
 
@@ -63,14 +67,25 @@ describe("05 — Check-out Flow", () => {
             };
         });
 
-        await expect(
-            useHotelStore.getState().checkOut("nonexistent", "actual_nights", 500000)
-        ).rejects.toMatchObject({
+        const promise = useHotelStore
+            .getState()
+            .checkOut("nonexistent", "actual_nights", 500000);
+
+        await expect(promise).rejects.toMatchObject({
             name: "AppError",
             code: "BOOKING_NOT_FOUND",
             message: "Booking not found",
             kind: "user",
             support_id: null,
+            correlation_id: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
+        });
+
+        const checkOutCall = invoke.mock.calls.find(([command]) => command === "check_out");
+        const correlationId = checkOutCall?.[1]?.correlationId;
+        expect(correlationId).toMatch(/^COR-[0-9A-F]{8}$/);
+
+        await promise.catch((error) => {
+            expect(error.correlation_id).toBe(correlationId);
         });
 
         expect(useHotelStore.getState().loading).toBe(false);
@@ -81,8 +96,10 @@ describe("05 — Check-out Flow", () => {
 
         await useHotelStore.getState().checkOut("booking-1", "booked_nights", 2500000);
 
-        expect(invoke).toHaveBeenCalledWith("check_out", {
+        const checkOutCall = invoke.mock.calls.find(([command]) => command === "check_out");
+        expect(checkOutCall?.[1]).toMatchObject({
             req: { booking_id: "booking-1", settlement_mode: "booked_nights", final_total: 2500000 },
+            correlationId: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
         });
     });
 });

--- a/mhm/tests/e2e/11-night-audit.test.tsx
+++ b/mhm/tests/e2e/11-night-audit.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, waitFor } from "../helpers/render-app";
+import { fireEvent, render, screen, waitFor } from "../helpers/render-app";
+import userEvent from "@testing-library/user-event";
 import NightAudit from "@/pages/NightAudit";
 import { setMockResponse, clearMockResponses, invoke } from "@test-mocks/tauri-core";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -40,10 +41,10 @@ describe("11 — Night Audit", () => {
         });
     });
 
-    it("run_night_audit sends correct command", async () => {
-        setMockResponse("run_night_audit", () => ({
+    it("run_night_audit sends correlation-aware command through the page", async () => {
+        setMockResponse("run_night_audit", (args) => ({
             id: "audit-1",
-            audit_date: "2026-03-15",
+            audit_date: String(args?.auditDate),
             total_revenue: 1200000,
             room_revenue: 800000,
             folio_revenue: 400000,
@@ -51,21 +52,30 @@ describe("11 — Night Audit", () => {
             occupancy_pct: 30,
             rooms_sold: 3,
             total_rooms: 10,
-            notes: null,
+            notes: args?.notes ?? null,
             created_at: "2026-03-15T23:59:59+07:00",
         }));
+        const user = userEvent.setup();
+        const { container } = render(<NightAudit />);
+        const dateInput = container.querySelector('input[type="date"]');
 
-        // Call directly through invoke
-        const result = await invoke("run_night_audit", {
+        expect(dateInput).not.toBeNull();
+
+        fireEvent.change(dateInput!, { target: { value: "2026-03-15" } });
+        await user.type(screen.getByPlaceholderText("VD: Đã kiểm tra kho..."), "Ca đêm");
+        await user.click(screen.getByRole("button", { name: /chạy audit/i }));
+
+        const auditCall = invoke.mock.calls.find(([command]) => command === "run_night_audit");
+        expect(auditCall).toBeDefined();
+        expect(auditCall?.[1]).toMatchObject({
             auditDate: "2026-03-15",
-            notes: null,
+            notes: "Ca đêm",
+            correlationId: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
         });
 
-        expect(invoke).toHaveBeenCalledWith("run_night_audit", {
-            auditDate: "2026-03-15",
-            notes: null,
+        await waitFor(() => {
+            expect(screen.getByText("Ca đêm")).toBeInTheDocument();
         });
-        expect(result).toHaveProperty("total_rooms", 10);
     });
 
     it("handles audit logs display", async () => {

--- a/mhm/tests/e2e/13-store-hardening.test.ts
+++ b/mhm/tests/e2e/13-store-hardening.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-core";
 import { useHotelStore } from "@/stores/useHotelStore";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -15,6 +15,8 @@ function deferred<T>() {
 }
 
 describe("13 — Store Hardening", () => {
+    const originalCrypto = globalThis.crypto;
+
     beforeEach(() => {
         clearMockResponses();
         invoke.mockClear();
@@ -40,6 +42,13 @@ describe("13 — Store Hardening", () => {
             loading: false,
             error: null,
         });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        if (originalCrypto) {
+            vi.stubGlobal("crypto", originalCrypto);
+        }
     });
 
     it("keeps loading true while another booking action is still pending", async () => {
@@ -191,5 +200,52 @@ describe("13 — Store Hardening", () => {
         await promise.catch((error) => {
             expect(error.correlation_id).toBe(correlationId);
         });
+    });
+
+    it.each([
+        [
+            "checkIn",
+            () =>
+                useHotelStore.getState().checkIn(
+                    "1A",
+                    [{ full_name: "Nguyễn Văn A", doc_number: "012345678901" }],
+                    1
+                ),
+        ],
+        [
+            "checkOut",
+            () => useHotelStore.getState().checkOut("booking-1", "actual_nights", 500000),
+        ],
+        [
+            "groupCheckIn",
+            () =>
+                useHotelStore.getState().groupCheckIn({
+                    group_name: "Đoàn A",
+                    organizer_name: "Trưởng đoàn",
+                    room_ids: ["1A"],
+                    master_room_id: "1A",
+                    guests_per_room: {},
+                    nights: 1,
+                    source: "walk-in",
+                }),
+        ],
+        [
+            "groupCheckout",
+            () =>
+                useHotelStore.getState().groupCheckout({
+                    group_id: "group-1",
+                    booking_ids: ["booking-1"],
+                }),
+        ],
+    ])("%s clears loading when correlation ID generation throws", async (_actionName, runAction) => {
+        vi.stubGlobal("crypto", {
+            getRandomValues: () => {
+                throw new Error("crypto unavailable");
+            },
+        });
+
+        await expect(runAction()).rejects.toThrow("crypto unavailable");
+        expect(useHotelStore.getState().loading).toBe(false);
+        expect(invoke).not.toHaveBeenCalled();
     });
 });

--- a/mhm/tests/e2e/13-store-hardening.test.ts
+++ b/mhm/tests/e2e/13-store-hardening.test.ts
@@ -33,6 +33,7 @@ describe("13 — Store Hardening", () => {
 
         setMockResponse("get_rooms", () => createAllRooms());
         setMockResponse("get_dashboard_stats", () => createStats());
+        setMockResponse("get_all_groups", () => []);
         useAuthStore.setState({
             user: null,
             isAuthenticated: false,
@@ -107,5 +108,88 @@ describe("13 — Store Hardening", () => {
 
         expect(useAuthStore.getState().user).toBeNull();
         expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    });
+
+    it("sends a correlation ID for group check-in and preserves it on rejection", async () => {
+        const req = {
+            group_name: "Đoàn A",
+            organizer_name: "Trưởng đoàn",
+            room_ids: ["1A"],
+            master_room_id: "1A",
+            guests_per_room: {},
+            nights: 1,
+            source: "walk-in",
+        };
+
+        setMockResponse("group_checkin", () => {
+            throw {
+                code: "BOOKING_INVALID_STATE",
+                message: "Master guest information is required",
+                kind: "user",
+                support_id: null,
+            };
+        });
+
+        const promise = useHotelStore.getState().groupCheckIn(req);
+
+        await expect(promise).rejects.toMatchObject({
+            name: "AppError",
+            code: "BOOKING_INVALID_STATE",
+            message: "Master guest information is required",
+            kind: "user",
+            support_id: null,
+            correlation_id: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
+        });
+
+        const groupCheckInCall = invoke.mock.calls.find(([command]) => command === "group_checkin");
+        const correlationId = groupCheckInCall?.[1]?.correlationId;
+
+        expect(groupCheckInCall?.[1]).toMatchObject({
+            req,
+            correlationId: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
+        });
+
+        await promise.catch((error) => {
+            expect(error.correlation_id).toBe(correlationId);
+        });
+    });
+
+    it("sends a correlation ID for group checkout and preserves it on rejection", async () => {
+        const req = {
+            group_id: "group-1",
+            booking_ids: ["booking-1"],
+        };
+
+        setMockResponse("group_checkout", () => {
+            throw {
+                code: "BOOKING_INVALID_STATE",
+                message: "Không thể checkout booking đã đóng",
+                kind: "user",
+                support_id: null,
+            };
+        });
+
+        const promise = useHotelStore.getState().groupCheckout(req);
+
+        await expect(promise).rejects.toMatchObject({
+            name: "AppError",
+            code: "BOOKING_INVALID_STATE",
+            message: "Không thể checkout booking đã đóng",
+            kind: "user",
+            support_id: null,
+            correlation_id: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
+        });
+
+        const groupCheckoutCall = invoke.mock.calls.find(([command]) => command === "group_checkout");
+        const correlationId = groupCheckoutCall?.[1]?.correlationId;
+
+        expect(groupCheckoutCall?.[1]).toMatchObject({
+            req,
+            correlationId: expect.stringMatching(/^COR-[0-9A-F]{8}$/),
+        });
+
+        await promise.catch((error) => {
+            expect(error.correlation_id).toBe(correlationId);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- add shared frontend and backend correlation ID helpers without changing the existing FE/BE app-error contract
- wire correlation IDs through stay, group, and night-audit commands so failures surface the same tracking ID in the UI and backend logs
- expand regression coverage and quick verification for the new tracked flows

## Test Plan
- [x] npm test
- [x] cargo test --manifest-path mhm/src-tauri/Cargo.toml
- [x] npm run verify:quick
- [x] cargo check --manifest-path mhm/src-tauri/Cargo.toml

Refs #30