### PR TITLE
[codex] fix dashboard activity and reservation dates

### DIFF
--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -455,9 +455,10 @@ mod tests {
             SET_CRASH_REPORTING_PREFERENCE_COMMAND,
         );
         let intent = serde_json::json!({ "enabled": true });
-        let now = ctx.issued_at.to_rfc3339();
+        let now = Utc::now();
+        let now_string = now.to_rfc3339();
         let lease_expires_at =
-            (ctx.issued_at + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
+            (now + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
 
         sqlx::query(
             "INSERT INTO command_idempotency (
@@ -484,9 +485,9 @@ mod tests {
         .bind("other-claim-token")
         .bind(0_i64)
         .bind(&lease_expires_at)
-        .bind(&now)
-        .bind(&now)
-        .bind(&now)
+        .bind(&now_string)
+        .bind(&now_string)
+        .bind(&now_string)
         .execute(&pool)
         .await
         .expect("seeds committed in-progress idempotency row");

--- a/mhm/src-tauri/tauri.conf.json
+++ b/mhm/src-tauri/tauri.conf.json
@@ -13,8 +13,9 @@
     "windows": [
       {
         "title": "CapyInn",
-        "width": 800,
-        "height": 600
+        "width": 1280,
+        "height": 800,
+        "maximized": true
       }
     ],
     "security": {

--- a/mhm/src/pages/Dashboard.tsx
+++ b/mhm/src/pages/Dashboard.tsx
@@ -16,7 +16,7 @@ import type { ActivityItem, BookingWithGuest, ChartDataPoint, ExpenseItem, RoomA
 const DAY_NAMES = ["CN", "T2", "T3", "T4", "T5", "T6", "T7"];
 
 export default function Dashboard() {
-  const { rooms, stats, fetchRooms, fetchStats, setTab } = useHotelStore();
+  const { rooms, stats, dashboardRefreshVersion, fetchRooms, fetchStats, setTab } = useHotelStore();
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [recentBookings, setRecentBookings] = useState<BookingWithGuest[]>([]);
   const [expenses, setExpenses] = useState<ExpenseItem[]>([]);
@@ -59,7 +59,7 @@ export default function Dashboard() {
         }, {});
         setExpenses(Object.entries(grouped).map(([category, amount]) => ({ category, amount })));
       }).catch(() => { });
-  }, []);
+  }, [dashboardRefreshVersion]);
 
   const maxExpense = Math.max(...expenses.map(e => e.amount), 1);
 

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -21,14 +21,34 @@ type BookingBar = BookingWithGuest & {
     isBooked: boolean;
 };
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfLocalDay(date: Date): Date {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function formatLocalDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}
+
+function differenceInCalendarDays(left: Date, right: Date): number {
+    const leftUtc = Date.UTC(left.getFullYear(), left.getMonth(), left.getDate());
+    const rightUtc = Date.UTC(right.getFullYear(), right.getMonth(), right.getDate());
+    return Math.round((leftUtc - rightUtc) / DAY_MS);
+}
+
 function getDateRange(offset: number) {
+    const today = startOfLocalDay(new Date());
     return Array.from({ length: 16 }, (_, i) => {
-        const d = new Date();
-        d.setDate(d.getDate() + i - 3 + offset);
+        const d = new Date(today);
+        d.setDate(today.getDate() + i - 3 + offset);
         return {
             day: d.toLocaleDateString("vi-VN", { weekday: "short" }).replace(".", ""),
             date: d.getDate(),
-            fullDate: d.toISOString().split("T")[0],
+            fullDate: formatLocalDate(d),
             isToday: i === 3 && offset === 0,
             dateObj: d,
         };
@@ -36,9 +56,13 @@ function getDateRange(offset: number) {
 }
 
 function parseDate(s: string): Date {
-    // Handle both ISO datetime and YYYY-MM-DD format
-    if (s.includes("T")) return new Date(s);
-    return new Date(s + "T12:00:00");
+    const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+    if (dateOnly) {
+        return new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]));
+    }
+
+    const parsed = new Date(s);
+    return Number.isNaN(parsed.getTime()) ? parsed : startOfLocalDay(parsed);
 }
 
 function getBookingBarColor(status: BookingStatus): string {
@@ -121,8 +145,8 @@ export default function Reservations() {
                 const checkOut = parseDate(b.scheduled_checkout || b.expected_checkout);
                 const startDay = DAYS[0].dateObj;
 
-                const startCol = Math.max(0, Math.floor((checkIn.getTime() - startDay.getTime()) / (1000 * 60 * 60 * 24)));
-                const endCol = Math.max(startCol + 1, Math.ceil((checkOut.getTime() - startDay.getTime()) / (1000 * 60 * 60 * 24)));
+                const startCol = Math.max(0, differenceInCalendarDays(checkIn, startDay));
+                const endCol = Math.max(startCol + 1, differenceInCalendarDays(checkOut, startDay));
                 const length = endCol - startCol;
 
                 if (startCol >= 16 || endCol <= 0) return [];

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -43,6 +43,7 @@ describe("useHotelStore monitoring context", () => {
     useHotelStore.setState({
       rooms: [],
       stats: null,
+      dashboardRefreshVersion: 0,
       roomDetail: null,
       activeTab: "dashboard",
       housekeepingTasks: [],

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -23,6 +23,7 @@ import type {
 interface HotelStore {
   rooms: Room[];
   stats: DashboardStats | null;
+  dashboardRefreshVersion: number;
   roomDetail: RoomWithBooking | null;
   activeTab: HotelTab;
   housekeepingTasks: HousekeepingTask[];
@@ -34,6 +35,7 @@ interface HotelStore {
 
   fetchRooms: () => Promise<void>;
   fetchStats: () => Promise<void>;
+  markDashboardDataChanged: () => void;
   setTab: (tab: HotelTab) => void;
   setCheckinOpen: (open: boolean, roomId?: string | null) => void;
   checkIn: (roomId: string, guests: CheckInGuestInput[], nights: number, paidAmount?: number, source?: string, notes?: string) => Promise<void>;
@@ -73,6 +75,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
   return {
     rooms: [],
     stats: null,
+    dashboardRefreshVersion: 0,
     roomDetail: null,
     activeTab: "dashboard",
     housekeepingTasks: [],
@@ -91,6 +94,11 @@ export const useHotelStore = create<HotelStore>((set, get) => {
       const stats = await invoke<DashboardStats>("get_dashboard_stats");
       set({ stats });
     },
+
+    markDashboardDataChanged: () =>
+      set((state) => ({
+        dashboardRefreshVersion: state.dashboardRefreshVersion + 1,
+      })),
 
     setTab: (tab) => set({ activeTab: tab }),
     setCheckinOpen: (open, roomId = null) =>
@@ -120,7 +128,10 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         );
         await get().fetchRooms();
         await get().fetchStats();
-        set({ activeTab: "dashboard" });
+        set((state) => ({
+          activeTab: "dashboard",
+          dashboardRefreshVersion: state.dashboardRefreshVersion + 1,
+        }));
       } catch (err) {
         console.error("check_in error:", err);
         throw err;
@@ -151,7 +162,10 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         );
         await get().fetchRooms();
         await get().fetchStats();
-        set({ activeTab: "dashboard" });
+        set((state) => ({
+          activeTab: "dashboard",
+          dashboardRefreshVersion: state.dashboardRefreshVersion + 1,
+        }));
       } catch (err) {
         console.error("check_out error:", err);
         throw err;
@@ -166,6 +180,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         await invoke("extend_stay", { bookingId });
         await get().fetchRooms();
         await get().fetchStats();
+        get().markDashboardDataChanged();
       } catch (err) {
         console.error("extend_stay error:", err);
         throw err;
@@ -201,6 +216,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         await get().fetchRooms();
         await get().fetchStats();
         await get().fetchGroups();
+        get().markDashboardDataChanged();
         set({ isGroupCheckinOpen: false });
       } catch (err) {
         console.error("group_checkin error:", err);
@@ -218,6 +234,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         await get().fetchRooms();
         await get().fetchStats();
         await get().fetchGroups();
+        get().markDashboardDataChanged();
       } catch (err) {
         console.error("group_checkout error:", err);
         throw err;

--- a/mhm/tests/e2e/02-dashboard.test.tsx
+++ b/mhm/tests/e2e/02-dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, waitFor } from "../helpers/render-app";
+import { act, render, screen, waitFor } from "../helpers/render-app";
 import userEvent from "@testing-library/user-event";
 import Dashboard from "@/pages/Dashboard";
 import { setMockResponse, clearMockResponses, invoke } from "@test-mocks/tauri-core";
@@ -17,6 +17,7 @@ describe("02 — Dashboard", () => {
         useHotelStore.setState({
             rooms: mockRooms,
             stats: mockStats,
+            dashboardRefreshVersion: 0,
             activeTab: "dashboard",
             roomDetail: null,
             housekeepingTasks: [],
@@ -132,5 +133,60 @@ describe("02 — Dashboard", () => {
         expect(screen.getByText("Ghi nhận lúc")).toBeInTheDocument();
         expect(screen.getByText("Điều hướng")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /mở phòng 2a/i })).toBeInTheDocument();
+    });
+
+    it("refreshes activity immediately after a successful check-in", async () => {
+        let activityCalls = 0;
+        setMockResponse("get_recent_activity", () => {
+            activityCalls += 1;
+            return activityCalls === 1
+                ? [
+                    {
+                        icon: "🔑",
+                        text: "Check-in phòng 2A — Nguyễn Văn A",
+                        time: "10:30",
+                        color: "green",
+                        kind: "check_in",
+                        room_id: "2A",
+                        guest_name: "Nguyễn Văn A",
+                        occurred_at: "2026-03-15T10:30:00",
+                        status_label: "Đã check-in",
+                    },
+                ]
+                : [
+                    {
+                        icon: "🔑",
+                        text: "Check-in phòng 1A — Trần Thị Mới",
+                        time: "15:40",
+                        color: "green",
+                        kind: "check_in",
+                        room_id: "1A",
+                        guest_name: "Trần Thị Mới",
+                        occurred_at: "2026-04-24T15:40:00+07:00",
+                        status_label: "Đã check-in",
+                    },
+                ];
+        });
+        setMockResponse("check_in", () => createBookingWithGuest({ room_id: "1A", guest_name: "Trần Thị Mới" }));
+
+        render(<Dashboard />);
+
+        expect(await screen.findByText("Check-in phòng 2A — Nguyễn Văn A")).toBeInTheDocument();
+
+        await act(async () => {
+            await useHotelStore.getState().checkIn(
+                "1A",
+                [{ full_name: "Trần Thị Mới", doc_number: "012345678901" }],
+                1,
+                400000,
+                "walk-in",
+                "",
+            );
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Check-in phòng 1A — Trần Thị Mới")).toBeInTheDocument();
+        });
+        expect(activityCalls).toBeGreaterThanOrEqual(2);
     });
 });

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, waitFor } from "../helpers/render-app";
 import userEvent from "@testing-library/user-event";
 import Reservations from "@/pages/Reservations";
@@ -61,6 +61,10 @@ describe("09 — Reservations", () => {
         })));
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it("loads and displays booking list", async () => {
         render(<Reservations />);
 
@@ -116,5 +120,28 @@ describe("09 — Reservations", () => {
 
         expect(screen.queryByText("Nguyễn Văn A")).not.toBeInTheDocument();
         expect(screen.queryByText("Lê Văn C")).not.toBeInTheDocument();
+    });
+
+    it("positions same-day check-ins on the local calendar day column", async () => {
+        vi.useFakeTimers({ toFake: ["Date"] });
+        vi.setSystemTime(new Date("2026-04-24T15:36:12+07:00"));
+        setMockResponse("get_all_bookings", () => [
+            createBookingWithGuest({
+                id: "same-day-checkin",
+                room_id: "2A",
+                guest_name: "Khách ngày 24",
+                status: "active",
+                check_in_at: "2026-04-24T08:00:00+07:00",
+                expected_checkout: "2026-04-25T08:00:00+07:00",
+            }),
+        ]);
+
+        render(<Reservations />);
+
+        const guestName = await screen.findByText("Khách ngày 24");
+        const bookingBar = guestName.closest(".absolute");
+
+        expect(bookingBar).toHaveStyle({ left: "240px" });
+        expect(bookingBar).not.toHaveStyle({ left: "160px" });
     });
 });


### PR DESCRIPTION
## Summary
- Refresh dashboard activity and related widgets immediately after successful booking state changes.
- Normalize reservations timeline date math to local calendar days so same-day check-ins render under the correct day.
- Open the Tauri desktop window maximized by default with a larger fallback size.
- Add regression coverage for activity refresh and April 24 same-day check-in placement.

## Root Cause
- Dashboard loaded recent activity only on mount, so check-in refreshed rooms/stats but not the activity feed.
- Reservations timeline used Date objects with current time and raw millisecond day differences, which could floor same-day check-ins into the previous column.
- The Tauri window config still used the small default 800x600 launch size.

## Validation
- `npm test -- tests/e2e/02-dashboard.test.tsx tests/e2e/09-reservations.test.tsx src/stores/useHotelStore.test.ts`
- `npm run build`
- `npm run tauri -- info`
- `npm test` passed earlier after the booking/date fix; after the window config commit, one full-suite onboarding test timed out under parallel load, then `npm test -- tests/e2e/00-onboarding.test.tsx` passed.
- `git diff --check`
- GitNexus `detect_changes` reported low risk with no affected processes.