### PR TITLE
Build backup scheduler

### DIFF
--- a/mhm/src-tauri/src/backup/mod.rs
+++ b/mhm/src-tauri/src/backup/mod.rs
@@ -11,6 +11,7 @@ pub use coordinator::{drain_and_backup_on_exit, request_backup, BackupCoordinato
 pub(crate) use events::emit_backup_status;
 pub use events::BackupStatusPayload;
 pub use runner::run_backup_once;
+pub use scheduler::{start_backup_scheduler, BackupSchedulerHandle};
 #[allow(unused_imports)]
 pub use storage::{build_backup_filename, is_managed_backup_file, prune_old_backups};
 #[allow(unused_imports)]

--- a/mhm/src-tauri/src/backup/mod.rs
+++ b/mhm/src-tauri/src/backup/mod.rs
@@ -1,6 +1,7 @@
 mod coordinator;
 mod events;
 mod runner;
+mod scheduler;
 mod storage;
 #[cfg(test)]
 mod test_support;

--- a/mhm/src-tauri/src/backup/scheduler.rs
+++ b/mhm/src-tauri/src/backup/scheduler.rs
@@ -1,0 +1,225 @@
+use super::{storage::latest_backup_timestamp_for_reason, BackupError, BackupReason};
+use chrono::{Duration as ChronoDuration, NaiveDateTime, Utc};
+use std::{path::Path, time::Duration};
+
+#[allow(dead_code)]
+const SCHEDULED_BACKUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+#[allow(dead_code)]
+fn scheduled_backup_interval_chrono() -> ChronoDuration {
+    ChronoDuration::from_std(SCHEDULED_BACKUP_INTERVAL)
+        .expect("scheduled backup interval must fit in chrono duration")
+}
+
+#[allow(dead_code)]
+fn scheduler_now() -> NaiveDateTime {
+    Utc::now().naive_utc()
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum StartupCatchUpError<ScanError, RequestError> {
+    Scan(ScanError),
+    Request(RequestError),
+}
+
+#[allow(dead_code)]
+pub(crate) fn should_run_startup_catch_up(
+    latest_scheduled: Option<NaiveDateTime>,
+    now: NaiveDateTime,
+) -> bool {
+    match latest_scheduled {
+        Some(timestamp) => now - timestamp > scheduled_backup_interval_chrono(),
+        None => true,
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn latest_scheduled_backup_timestamp(
+    backup_dir: &Path,
+) -> Result<Option<NaiveDateTime>, BackupError> {
+    latest_backup_timestamp_for_reason(backup_dir, BackupReason::Scheduled)
+}
+
+#[allow(dead_code)]
+pub(crate) async fn run_startup_catch_up_with<
+    Scan,
+    Request,
+    RequestFuture,
+    ScanError,
+    RequestError,
+>(
+    scan_latest: Scan,
+    request_backup: Request,
+    now: NaiveDateTime,
+) -> Result<(), StartupCatchUpError<ScanError, RequestError>>
+where
+    Scan: FnOnce() -> Result<Option<NaiveDateTime>, ScanError>,
+    Request: FnOnce() -> RequestFuture,
+    RequestFuture: std::future::Future<Output = Result<(), RequestError>>,
+{
+    let latest_scheduled = scan_latest().map_err(StartupCatchUpError::Scan)?;
+    if should_run_startup_catch_up(latest_scheduled, now) {
+        request_backup()
+            .await
+            .map_err(StartupCatchUpError::Request)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::{
+        build_backup_filename,
+        test_support::{backup_file_name, make_temp_dir},
+        BackupReason,
+    };
+    use chrono::{NaiveDate, NaiveDateTime};
+    use std::fs;
+
+    fn fixed_time(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+    ) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(hour, minute, second)
+            .unwrap()
+    }
+
+    #[test]
+    fn startup_catch_up_runs_when_no_scheduled_backup_exists() {
+        assert!(should_run_startup_catch_up(
+            None,
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        ));
+    }
+
+    #[test]
+    fn startup_catch_up_runs_when_latest_scheduled_backup_is_older_than_one_hour() {
+        assert!(should_run_startup_catch_up(
+            Some(fixed_time(2026, 4, 25, 8, 59, 59)),
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        ));
+    }
+
+    #[test]
+    fn startup_catch_up_skips_when_latest_scheduled_backup_is_within_one_hour() {
+        assert!(!should_run_startup_catch_up(
+            Some(fixed_time(2026, 4, 25, 9, 0, 0)),
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        ));
+        assert!(!should_run_startup_catch_up(
+            Some(fixed_time(2026, 4, 25, 9, 30, 0)),
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        ));
+    }
+
+    #[test]
+    fn latest_scheduled_backup_timestamp_uses_storage_parser() {
+        let temp = make_temp_dir("scheduler-latest");
+        let backup_dir = temp.join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+
+        let scheduled = fixed_time(2026, 4, 25, 9, 0, 0);
+        let manual = fixed_time(2026, 4, 25, 10, 0, 0);
+        let scheduled_path =
+            backup_dir.join(build_backup_filename(BackupReason::Scheduled, scheduled));
+        let manual_path = backup_dir.join(build_backup_filename(BackupReason::Manual, manual));
+
+        fs::write(&scheduled_path, b"db").unwrap();
+        fs::write(&manual_path, b"db").unwrap();
+
+        let latest = latest_scheduled_backup_timestamp(&backup_dir).unwrap();
+
+        assert_eq!(
+            backup_file_name(&scheduled_path),
+            "capyinn_backup_scheduled_20260425_090000.db"
+        );
+        assert_eq!(latest, Some(scheduled));
+    }
+
+    #[tokio::test]
+    async fn startup_catch_up_requests_backup_when_due() {
+        let requested = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let requested_for_call = requested.clone();
+
+        run_startup_catch_up_with(
+            || Ok::<Option<NaiveDateTime>, BackupError>(None),
+            move || async move {
+                requested_for_call.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok::<(), BackupError>(())
+            },
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        )
+        .await
+        .unwrap();
+
+        assert!(requested.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn startup_catch_up_skips_backup_when_recent() {
+        let requested = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let requested_for_call = requested.clone();
+
+        run_startup_catch_up_with(
+            || Ok::<Option<NaiveDateTime>, BackupError>(Some(fixed_time(2026, 4, 25, 9, 30, 0))),
+            move || async move {
+                requested_for_call.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok::<(), BackupError>(())
+            },
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        )
+        .await
+        .unwrap();
+
+        assert!(!requested.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn startup_catch_up_returns_scan_errors_without_requesting_backup() {
+        let requested = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let requested_for_call = requested.clone();
+        let temp = make_temp_dir("scheduler-scan-error");
+        let backup_dir = temp.join("backups");
+        fs::write(&backup_dir, b"not a directory").unwrap();
+
+        let result = run_startup_catch_up_with(
+            || latest_scheduled_backup_timestamp(&backup_dir),
+            move || async move {
+                requested_for_call.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok::<(), BackupError>(())
+            },
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        )
+        .await;
+
+        assert!(matches!(result, Err(StartupCatchUpError::Scan(_))));
+        assert!(!requested.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn startup_catch_up_returns_request_errors() {
+        let requested = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let requested_for_call = requested.clone();
+
+        let result = run_startup_catch_up_with(
+            || Ok::<Option<NaiveDateTime>, BackupError>(None),
+            move || async move {
+                requested_for_call.store(true, std::sync::atomic::Ordering::SeqCst);
+                Err(BackupError::Io(std::io::Error::other("request failed")))
+            },
+            fixed_time(2026, 4, 25, 10, 0, 0),
+        )
+        .await;
+
+        assert!(matches!(result, Err(StartupCatchUpError::Request(_))));
+        assert!(requested.load(std::sync::atomic::Ordering::SeqCst));
+    }
+}

--- a/mhm/src-tauri/src/backup/scheduler.rs
+++ b/mhm/src-tauri/src/backup/scheduler.rs
@@ -1,29 +1,72 @@
-use super::{storage::latest_backup_timestamp_for_reason, BackupError, BackupReason};
+use super::{
+    log_backup_request_error, request_backup, storage::latest_backup_timestamp_for_reason,
+    BackupError, BackupReason, BackupRequestError,
+};
 use chrono::{Duration as ChronoDuration, NaiveDateTime, Utc};
-use std::{path::Path, time::Duration};
+use log::{error, info, warn};
+use std::{future::Future, path::Path, sync::Mutex, time::Duration};
+use tauri::AppHandle;
+use tokio::sync::oneshot;
 
-#[allow(dead_code)]
 const SCHEDULED_BACKUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
-#[allow(dead_code)]
 fn scheduled_backup_interval_chrono() -> ChronoDuration {
     ChronoDuration::from_std(SCHEDULED_BACKUP_INTERVAL)
         .expect("scheduled backup interval must fit in chrono duration")
 }
 
-#[allow(dead_code)]
 fn scheduler_now() -> NaiveDateTime {
     Utc::now().naive_utc()
 }
 
-#[allow(dead_code)]
+pub struct BackupSchedulerHandle {
+    task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl BackupSchedulerHandle {
+    pub(crate) fn new(
+        task: tauri::async_runtime::JoinHandle<()>,
+        shutdown_tx: oneshot::Sender<()>,
+    ) -> Self {
+        Self {
+            task: Mutex::new(Some(task)),
+            shutdown_tx: Mutex::new(Some(shutdown_tx)),
+        }
+    }
+
+    pub fn shutdown(&self) {
+        let shutdown_tx = self
+            .shutdown_tx
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take());
+
+        if let Some(shutdown_tx) = shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
+
+        // Do not abort: the task may be inside BackupCoordinator. Dropping the
+        // join handle detaches it so any active backup can finish and drain.
+        let _task = self.task.lock().ok().and_then(|mut guard| guard.take());
+    }
+}
+
+pub fn start_backup_scheduler(app: AppHandle) -> BackupSchedulerHandle {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let task = tauri::async_runtime::spawn(async move {
+        run_backup_scheduler(app, shutdown_rx).await;
+    });
+
+    BackupSchedulerHandle::new(task, shutdown_tx)
+}
+
 #[derive(Debug)]
 pub(crate) enum StartupCatchUpError<ScanError, RequestError> {
     Scan(ScanError),
     Request(RequestError),
 }
 
-#[allow(dead_code)]
 pub(crate) fn should_run_startup_catch_up(
     latest_scheduled: Option<NaiveDateTime>,
     now: NaiveDateTime,
@@ -34,14 +77,12 @@ pub(crate) fn should_run_startup_catch_up(
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn latest_scheduled_backup_timestamp(
     backup_dir: &Path,
 ) -> Result<Option<NaiveDateTime>, BackupError> {
     latest_backup_timestamp_for_reason(backup_dir, BackupReason::Scheduled)
 }
 
-#[allow(dead_code)]
 pub(crate) async fn run_startup_catch_up_with<
     Scan,
     Request,
@@ -65,6 +106,74 @@ where
             .map_err(StartupCatchUpError::Request)?;
     }
     Ok(())
+}
+
+async fn run_backup_scheduler(app: AppHandle, shutdown_rx: oneshot::Receiver<()>) {
+    run_startup_catch_up(&app).await;
+    run_interval_loop_with(
+        || request_scheduled_backup(&app, "scheduled backup interval"),
+        shutdown_rx,
+        SCHEDULED_BACKUP_INTERVAL,
+    )
+    .await;
+}
+
+async fn run_interval_loop_with<Request, RequestFuture>(
+    mut request_backup: Request,
+    mut shutdown_rx: oneshot::Receiver<()>,
+    interval: Duration,
+) where
+    Request: FnMut() -> RequestFuture,
+    RequestFuture: Future<Output = Result<(), BackupRequestError>>,
+{
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut shutdown_rx => {
+                break;
+            }
+            _ = tokio::time::sleep(interval) => {
+                let _ = request_backup().await;
+            }
+        }
+    }
+}
+
+async fn run_startup_catch_up(app: &AppHandle) {
+    let Some(runtime_root) = crate::app_identity::runtime_root_opt() else {
+        warn!("scheduled backup startup catch-up skipped: cannot find home directory");
+        return;
+    };
+
+    let backup_dir = runtime_root.join("backups");
+    match run_startup_catch_up_with(
+        || latest_scheduled_backup_timestamp(&backup_dir),
+        || request_scheduled_backup(app, "scheduled backup startup catch-up"),
+        scheduler_now(),
+    )
+    .await
+    {
+        Ok(()) => {
+            info!("scheduled backup startup catch-up completed");
+        }
+        Err(StartupCatchUpError::Scan(error)) => {
+            error!("scheduled backup startup catch-up scan failed: {error}");
+        }
+        Err(StartupCatchUpError::Request(_)) => {}
+    }
+}
+
+async fn request_scheduled_backup(
+    app: &AppHandle,
+    context: &str,
+) -> Result<(), BackupRequestError> {
+    request_backup(app, BackupReason::Scheduled)
+        .await
+        .map(|_| ())
+        .map_err(|error| {
+            log_backup_request_error(context, &error);
+            error
+        })
 }
 
 #[cfg(test)]
@@ -221,5 +330,80 @@ mod tests {
 
         assert!(matches!(result, Err(StartupCatchUpError::Request(_))));
         assert!(requested.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn scheduler_shutdown_is_idempotent() {
+        let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+        let handle = BackupSchedulerHandle::new(
+            tauri::async_runtime::spawn(async {
+                std::future::pending::<()>().await;
+            }),
+            shutdown_tx,
+        );
+
+        handle.shutdown();
+        handle.shutdown();
+    }
+
+    #[tokio::test]
+    async fn scheduler_shutdown_does_not_abort_in_flight_task() {
+        let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+        let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let completed_for_task = completed.clone();
+        let handle = BackupSchedulerHandle::new(
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                completed_for_task.store(true, std::sync::atomic::Ordering::SeqCst);
+            }),
+            shutdown_tx,
+        );
+
+        handle.shutdown();
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        assert!(completed.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn scheduler_interval_shutdown_waits_for_in_flight_request() {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let request_started = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release_request = std::sync::Arc::new(tokio::sync::Notify::new());
+        let request_completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let request_started_for_loop = request_started.clone();
+        let release_request_for_loop = release_request.clone();
+        let request_completed_for_loop = request_completed.clone();
+        let scheduler_task = tokio::spawn(async move {
+            run_interval_loop_with(
+                move || {
+                    let request_started = request_started_for_loop.clone();
+                    let release_request = release_request_for_loop.clone();
+                    let request_completed = request_completed_for_loop.clone();
+                    async move {
+                        request_started.notify_one();
+                        release_request.notified().await;
+                        request_completed.store(true, std::sync::atomic::Ordering::SeqCst);
+                        Ok::<(), BackupRequestError>(())
+                    }
+                },
+                shutdown_rx,
+                Duration::from_millis(1),
+            )
+            .await;
+        });
+
+        request_started.notified().await;
+        let _ = shutdown_tx.send(());
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert!(!scheduler_task.is_finished());
+        assert!(!request_completed.load(std::sync::atomic::Ordering::SeqCst));
+
+        release_request.notify_one();
+        scheduler_task.await.unwrap();
+
+        assert!(request_completed.load(std::sync::atomic::Ordering::SeqCst));
     }
 }

--- a/mhm/src-tauri/src/backup/scheduler.rs
+++ b/mhm/src-tauri/src/backup/scheduler.rs
@@ -16,7 +16,9 @@ fn scheduled_backup_interval_chrono() -> ChronoDuration {
 }
 
 fn scheduler_now() -> NaiveDateTime {
-    Utc::now().naive_utc()
+    crate::runtime_config::test_now()
+        .map(|value| value.naive_local())
+        .unwrap_or_else(|| Utc::now().naive_utc())
 }
 
 pub struct BackupSchedulerHandle {
@@ -169,11 +171,10 @@ async fn request_scheduled_backup(
 ) -> Result<(), BackupRequestError> {
     request_backup(app, BackupReason::Scheduled)
         .await
-        .map(|_| ())
-        .map_err(|error| {
-            log_backup_request_error(context, &error);
-            error
+        .inspect_err(|error| {
+            log_backup_request_error(context, error);
         })
+        .map(|_| ())
 }
 
 #[cfg(test)]
@@ -251,6 +252,17 @@ mod tests {
             "capyinn_backup_scheduled_20260425_090000.db"
         );
         assert_eq!(latest, Some(scheduled));
+    }
+
+    #[test]
+    fn scheduler_now_uses_frozen_backup_clock_when_present() {
+        let _guard = crate::runtime_config::env_lock().lock().unwrap();
+
+        std::env::set_var("CAPYINN_TEST_NOW", "2026-04-21T09:15:00+07:00");
+        let timestamp = scheduler_now();
+        std::env::remove_var("CAPYINN_TEST_NOW");
+
+        assert_eq!(timestamp, fixed_time(2026, 4, 21, 9, 15, 0));
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/backup/storage.rs
+++ b/mhm/src-tauri/src/backup/storage.rs
@@ -26,7 +26,8 @@ impl BackupRetentionGroup {
             | BackupReason::Checkout
             | BackupReason::GroupCheckout
             | BackupReason::NightAudit
-            | BackupReason::AppExit => Self::Automatic,
+            | BackupReason::AppExit
+            | BackupReason::Scheduled => Self::Automatic,
         }
     }
 
@@ -247,6 +248,7 @@ fn parse_backup_reason(reason: &str) -> Option<BackupReason> {
         "night_audit" => Some(BackupReason::NightAudit),
         "app_exit" => Some(BackupReason::AppExit),
         "manual" => Some(BackupReason::Manual),
+        "scheduled" => Some(BackupReason::Scheduled),
         _ => None,
     }
 }
@@ -321,9 +323,13 @@ mod tests {
         assert_eq!(BackupReason::NightAudit.as_str(), "night_audit");
         assert_eq!(BackupReason::AppExit.as_str(), "app_exit");
         assert_eq!(BackupReason::Manual.as_str(), "manual");
+        assert_eq!(BackupReason::Scheduled.as_str(), "scheduled");
 
         assert!(is_managed_backup_file(
             "capyinn_backup_settings_20260418_231500.db"
+        ));
+        assert!(is_managed_backup_file(
+            "capyinn_backup_scheduled_20260418_231500.db"
         ));
         assert!(is_managed_backup_file(
             "capyinn_backup_app_exit_20260419_000102.db"
@@ -459,6 +465,39 @@ mod tests {
         assert_eq!(
             sorted_backup_file_names(&outcome.removed_files),
             sorted_backup_file_names(&[older_manual, older_auto])
+        );
+        assert!(outcome.error.is_none());
+    }
+
+    #[test]
+    fn prune_old_backups_treats_scheduled_as_automatic() {
+        let temp = make_temp_dir("backup-scheduled-retention");
+        let backup_dir = temp.join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+
+        let now = fixed_time(2026, 4, 25, 8, 0, 0);
+        let scheduled_at_boundary = write_backup_at(
+            &backup_dir,
+            BackupReason::Scheduled,
+            now - Duration::days(7),
+        );
+        let scheduled_expired = write_backup_at(
+            &backup_dir,
+            BackupReason::Scheduled,
+            now - Duration::days(8),
+        );
+        let manual_recent =
+            write_backup_at(&backup_dir, BackupReason::Manual, now - Duration::days(1));
+
+        let outcome = prune_old_backups(&backup_dir, now);
+
+        assert_eq!(
+            sorted_backup_file_names(&outcome.kept_files),
+            sorted_backup_file_names(&[scheduled_at_boundary, manual_recent])
+        );
+        assert_eq!(
+            sorted_backup_file_names(&outcome.removed_files),
+            sorted_backup_file_names(&[scheduled_expired])
         );
         assert!(outcome.error.is_none());
     }

--- a/mhm/src-tauri/src/backup/storage.rs
+++ b/mhm/src-tauri/src/backup/storage.rs
@@ -61,6 +61,43 @@ pub fn is_managed_backup_file(name: &str) -> bool {
     parse_backup_filename(name).is_some()
 }
 
+#[allow(dead_code)]
+pub(crate) fn latest_backup_timestamp_for_reason(
+    backup_dir: &Path,
+    reason: BackupReason,
+) -> Result<Option<NaiveDateTime>, BackupError> {
+    let entries = match fs::read_dir(backup_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let mut latest: Option<(NaiveDateTime, u64, String)> = None;
+
+    for entry in entries {
+        let entry = entry?;
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        let Some(metadata) = parse_backup_filename(&file_name) else {
+            continue;
+        };
+
+        if metadata.reason != reason {
+            continue;
+        }
+
+        let candidate = (metadata.timestamp, metadata.collision_index, file_name);
+        let should_replace = match &latest {
+            Some(current) => candidate > *current,
+            None => true,
+        };
+
+        if should_replace {
+            latest = Some(candidate);
+        }
+    }
+
+    Ok(latest.map(|(timestamp, _, _)| timestamp))
+}
+
 pub(crate) struct BackupReservation {
     pub(crate) final_path: PathBuf,
     pub(crate) temp_path: PathBuf,
@@ -350,6 +387,64 @@ mod tests {
             "capyinn_backup_checkout_20260418_231500-abc.db"
         ));
         assert!(!is_managed_backup_file("notes.db"));
+    }
+
+    #[test]
+    fn latest_backup_timestamp_for_reason_finds_newest_matching_reason() {
+        let temp = make_temp_dir("backup-latest-reason");
+        let backup_dir = temp.join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+
+        let older_scheduled = fixed_time(2026, 4, 25, 7, 0, 0);
+        let newest_scheduled = fixed_time(2026, 4, 25, 9, 0, 0);
+        let newer_manual = fixed_time(2026, 4, 25, 10, 0, 0);
+
+        write_backup_at(&backup_dir, BackupReason::Scheduled, older_scheduled);
+        write_backup_at(&backup_dir, BackupReason::Scheduled, newest_scheduled);
+        write_backup_at(&backup_dir, BackupReason::Manual, newer_manual);
+        write_named_backup(&backup_dir, "notes.db");
+
+        let latest =
+            latest_backup_timestamp_for_reason(&backup_dir, BackupReason::Scheduled).unwrap();
+
+        assert_eq!(latest, Some(newest_scheduled));
+    }
+
+    #[test]
+    fn latest_backup_timestamp_for_reason_uses_collision_suffix_for_same_second() {
+        let temp = make_temp_dir("backup-latest-collision");
+        let backup_dir = temp.join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+
+        write_named_backup(&backup_dir, "capyinn_backup_scheduled_20260425_090000.db");
+        write_named_backup(&backup_dir, "capyinn_backup_scheduled_20260425_090000-1.db");
+
+        let latest =
+            latest_backup_timestamp_for_reason(&backup_dir, BackupReason::Scheduled).unwrap();
+
+        assert_eq!(latest, Some(fixed_time(2026, 4, 25, 9, 0, 0)));
+    }
+
+    #[test]
+    fn latest_backup_timestamp_for_reason_returns_none_for_missing_directory() {
+        let temp = make_temp_dir("backup-latest-missing");
+        let backup_dir = temp.join("missing-backups");
+
+        let latest =
+            latest_backup_timestamp_for_reason(&backup_dir, BackupReason::Scheduled).unwrap();
+
+        assert_eq!(latest, None);
+    }
+
+    #[test]
+    fn latest_backup_timestamp_for_reason_returns_read_errors() {
+        let temp = make_temp_dir("backup-latest-read-error");
+        let backup_dir = temp.join("backups");
+        fs::write(&backup_dir, b"not a directory").unwrap();
+
+        let result = latest_backup_timestamp_for_reason(&backup_dir, BackupReason::Scheduled);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/mhm/src-tauri/src/backup/types.rs
+++ b/mhm/src-tauri/src/backup/types.rs
@@ -8,6 +8,7 @@ pub enum BackupReason {
     NightAudit,
     AppExit,
     Manual,
+    Scheduled,
 }
 
 impl BackupReason {
@@ -19,6 +20,7 @@ impl BackupReason {
             Self::NightAudit => "night_audit",
             Self::AppExit => "app_exit",
             Self::Manual => "manual",
+            Self::Scheduled => "scheduled",
         }
     }
 }
@@ -131,6 +133,7 @@ mod tests {
         assert_eq!(BackupReason::NightAudit.as_str(), "night_audit");
         assert_eq!(BackupReason::AppExit.as_str(), "app_exit");
         assert_eq!(BackupReason::Manual.as_str(), "manual");
+        assert_eq!(BackupReason::Scheduled.as_str(), "scheduled");
     }
 
     #[test]

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -182,6 +182,7 @@ pub fn run() {
                 current_user: Arc::new(Mutex::new(None)),
             });
             app.manage(backup::BackupCoordinator::new());
+            app.manage(backup::start_backup_scheduler(app.handle().clone()));
             app.manage(GatewayRuntimeState::new(rt, gateway_runtime));
 
             let _ = std::fs::create_dir_all(app_identity::models_dir());
@@ -305,6 +306,9 @@ pub fn run() {
             {
                 return;
             }
+            app_handle
+                .state::<backup::BackupSchedulerHandle>()
+                .shutdown();
             let handle = app_handle.clone();
             tauri::async_runtime::spawn(async move {
                 if let Err(error) = backup::drain_and_backup_on_exit(&handle).await {

--- a/mhm/src/App.backupStatus.test.tsx
+++ b/mhm/src/App.backupStatus.test.tsx
@@ -179,4 +179,34 @@ describe("App backup status integration", () => {
     });
     expect(screen.getByText("Đang sao lưu dữ liệu...")).toBeInTheDocument();
   });
+
+  it("handles scheduled backup status events", async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "scheduled-1",
+        state: "started",
+        reason: "scheduled",
+        pending_jobs: 1,
+      });
+    });
+    expect(screen.getByText("Đang sao lưu dữ liệu...")).toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "scheduled-1",
+        state: "completed",
+        reason: "scheduled",
+        pending_jobs: 0,
+        path: "/tmp/scheduled-1.db",
+      });
+    });
+    expect(screen.getByText("Đã sao lưu")).toBeInTheDocument();
+  });
 });

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -240,7 +240,8 @@ export type BackupReason =
   | "group_checkout"
   | "night_audit"
   | "app_exit"
-  | "manual";
+  | "manual"
+  | "scheduled";
 
 export type BackupStatusState = "started" | "completed" | "failed";
 


### PR DESCRIPTION
## Summary
- add scheduled backup reason and reuse retention parsing for scheduled snapshots
- add hourly backend scheduler with startup catch-up and graceful shutdown during app exit
- cover scheduled backup status events in frontend tests

## Verification
- cargo test --manifest-path mhm/src-tauri/Cargo.toml backup:: -- --nocapture
- cargo test --manifest-path mhm/src-tauri/Cargo.toml updater_enabled -- --nocapture
- cargo check --manifest-path mhm/src-tauri/Cargo.toml
- cd mhm && npm test -- src/App.backupStatus.test.tsx src/pages/settings/DataSection.test.tsx