### PR TITLE
[codex] Add in-app backup failure alert

### DIFF
--- a/mhm/src/App.backupStatus.test.tsx
+++ b/mhm/src/App.backupStatus.test.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes, HTMLAttributes } from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 
@@ -149,7 +149,9 @@ describe("App backup status integration", () => {
         message: "Ổ đĩa đầy",
       });
     });
-    expect(screen.getByText("Sao lưu thất bại")).toBeInTheDocument();
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("data-phase", "failed");
+    expect(within(status).getByText("Sao lưu thất bại")).toBeInTheDocument();
     expect(toast.error).toHaveBeenCalledWith("Ổ đĩa đầy");
 
     await act(async () => {
@@ -178,6 +180,154 @@ describe("App backup status integration", () => {
       vi.advanceTimersByTime(1000);
     });
     expect(screen.getByText("Đang sao lưu dữ liệu...")).toBeInTheDocument();
+  });
+
+  it("shows a persistent alert alongside the failed status indicator", async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-1",
+        state: "failed",
+        reason: "manual",
+        pending_jobs: 1,
+        message: "Ổ đĩa đầy",
+      });
+    });
+
+    const alert = screen.getByRole("alert", { name: "Sao lưu thất bại" });
+    expect(within(alert).getByText("Ổ đĩa đầy")).toBeInTheDocument();
+    expect(within(alert).getByText("Nguồn: Thủ công")).toBeInTheDocument();
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("data-phase", "failed");
+    expect(within(status).getByText("Sao lưu thất bại")).toBeInTheDocument();
+  });
+
+  it("uses fallback copy and source label for scheduled failures without a backend message", async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "scheduled-1",
+        state: "failed",
+        reason: "scheduled",
+        pending_jobs: 0,
+      });
+    });
+
+    const alert = screen.getByRole("alert", { name: "Sao lưu thất bại" });
+    expect(
+      within(alert).getByText(
+        "Không thể tạo bản sao lưu. Vui lòng kiểm tra dung lượng ổ đĩa hoặc thử lại.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(alert).getByText("Nguồn: Tự động")).toBeInTheDocument();
+  });
+
+  it("dismisses only the current failed job and reopens for a later failure", async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-1",
+        state: "failed",
+        reason: "manual",
+        pending_jobs: 1,
+        message: "Ổ đĩa đầy",
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Đóng cảnh báo sao lưu" }));
+    expect(screen.queryByRole("alert", { name: "Sao lưu thất bại" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-2",
+        state: "started",
+        reason: "scheduled",
+        pending_jobs: 1,
+      });
+    });
+    expect(screen.queryByRole("alert", { name: "Sao lưu thất bại" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-2",
+        state: "completed",
+        reason: "scheduled",
+        pending_jobs: 1,
+        path: "/tmp/job-2.db",
+      });
+    });
+    expect(screen.queryByRole("alert", { name: "Sao lưu thất bại" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-3",
+        state: "failed",
+        reason: "checkout",
+        pending_jobs: 0,
+        message: "Không thể ghi file",
+      });
+    });
+
+    const alert = screen.getByRole("alert", { name: "Sao lưu thất bại" });
+    expect(within(alert).getByText("Không thể ghi file")).toBeInTheDocument();
+    expect(within(alert).getByText("Nguồn: Trả phòng")).toBeInTheDocument();
+  });
+
+  it("keeps the alert while queued jobs remain and clears it after the queue drains", async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-1",
+        state: "failed",
+        reason: "manual",
+        pending_jobs: 2,
+        message: "Ổ đĩa đầy",
+      });
+    });
+    expect(screen.getByRole("alert", { name: "Sao lưu thất bại" })).toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-2",
+        state: "completed",
+        reason: "scheduled",
+        pending_jobs: 1,
+        path: "/tmp/job-2.db",
+      });
+    });
+    expect(screen.getByRole("alert", { name: "Sao lưu thất bại" })).toBeInTheDocument();
+
+    await act(async () => {
+      await emitTestEvent("backup-status", {
+        job_id: "job-3",
+        state: "completed",
+        reason: "scheduled",
+        pending_jobs: 0,
+        path: "/tmp/job-3.db",
+      });
+    });
+    expect(screen.queryByRole("alert", { name: "Sao lưu thất bại" })).not.toBeInTheDocument();
   });
 
   it("handles scheduled backup status events", async () => {

--- a/mhm/src/App.tsx
+++ b/mhm/src/App.tsx
@@ -20,6 +20,10 @@ import CrashReportPrompt from "./components/CrashReportPrompt";
 import AppUpdateBadge from "./components/AppUpdateBadge";
 import AppUpdateRestartModal from "./components/AppUpdateRestartModal";
 import { BackupStatusIndicator } from "./components/BackupStatusIndicator";
+import {
+  BackupFailureAlert,
+  type BackupFailureAlertState,
+} from "./components/BackupFailureAlert";
 import { Home, Calendar, BedDouble, Users, Sparkles, BarChart3, Settings as SettingsIcon, ChevronsLeft, ChevronsRight, LogOut, Moon, UsersRound } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -87,6 +91,10 @@ export default function App() {
   const [bootstrap, setBootstrap] = useState<BootstrapStatus | null>(null);
   const [bootstrapLoading, setBootstrapLoading] = useState(true);
   const [backupUi, setBackupUi] = useState<BackupUiState>(INITIAL_BACKUP_UI);
+  const [backupFailure, setBackupFailure] = useState<BackupFailureAlertState | null>(null);
+  const [dismissedBackupFailureJobId, setDismissedBackupFailureJobId] = useState<string | null>(
+    null,
+  );
   const [pendingCrashReport, setPendingCrashReport] = useState<CrashReportSummary | null>(null);
   const [crashPromptBusy, setCrashPromptBusy] = useState(false);
   const [crashExportPath, setCrashExportPath] = useState<string | null>(null);
@@ -173,6 +181,14 @@ export default function App() {
 
         if (payload.state === "failed") {
           toast.error(payload.message ?? "Sao lưu dữ liệu thất bại");
+          setDismissedBackupFailureJobId((current) =>
+            current === payload.job_id ? current : null,
+          );
+          setBackupFailure({
+            jobId: payload.job_id,
+            reason: payload.reason,
+            message: payload.message,
+          });
           setBackupUi({
             visible: true,
             phase: "failed",
@@ -192,6 +208,8 @@ export default function App() {
           return;
         }
 
+        setBackupFailure(null);
+        setDismissedBackupFailureJobId(null);
         setBackupUi({
           visible: true,
           phase: "saved",
@@ -411,6 +429,13 @@ export default function App() {
     }
   };
 
+  const visibleBackupFailure =
+    backupFailure && backupFailure.jobId !== dismissedBackupFailureJobId ? backupFailure : null;
+
+  const handleDismissBackupFailure = (jobId: string) => {
+    setDismissedBackupFailureJobId(jobId);
+  };
+
   return (
     <AppUpdateProvider value={appUpdate}>
       <div className="flex h-screen w-screen bg-brand-bg font-sans text-brand-text overflow-hidden select-none">
@@ -540,6 +565,15 @@ export default function App() {
             </Button>
           </div>
         </header>
+
+        {visibleBackupFailure && (
+          <div className="shrink-0 px-10 pb-4 pt-16">
+            <BackupFailureAlert
+              failure={visibleBackupFailure}
+              onDismiss={handleDismissBackupFailure}
+            />
+          </div>
+        )}
 
         {/* CONTENT AREA */}
         <div className="flex-1 overflow-y-auto px-10 pb-10">

--- a/mhm/src/components/BackupFailureAlert.test.tsx
+++ b/mhm/src/components/BackupFailureAlert.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackupFailureAlert } from "./BackupFailureAlert";
+
+describe("BackupFailureAlert", () => {
+  it("renders a distinct alert with title, backend message, and source label", () => {
+    render(
+      <BackupFailureAlert
+        failure={{ jobId: "job-1", reason: "manual", message: "Ổ đĩa đầy" }}
+        onDismiss={() => undefined}
+      />,
+    );
+
+    const alert = screen.getByRole("alert", { name: "Sao lưu thất bại" });
+    expect(within(alert).getByText("Sao lưu thất bại")).toBeInTheDocument();
+    expect(within(alert).getByText("Ổ đĩa đầy")).toBeInTheDocument();
+    expect(within(alert).getByText("Nguồn: Thủ công")).toBeInTheDocument();
+  });
+
+  it("uses the fallback message when the backend message is blank", () => {
+    render(
+      <BackupFailureAlert
+        failure={{ jobId: "job-1", reason: "scheduled", message: "   " }}
+        onDismiss={() => undefined}
+      />,
+    );
+
+    const alert = screen.getByRole("alert", { name: "Sao lưu thất bại" });
+    expect(within(alert).getByText("Sao lưu thất bại")).toBeInTheDocument();
+    expect(
+      within(alert).getByText(
+        "Không thể tạo bản sao lưu. Vui lòng kiểm tra dung lượng ổ đĩa hoặc thử lại.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(alert).getByText("Nguồn: Tự động")).toBeInTheDocument();
+  });
+
+  it("calls onDismiss with the failed job id", () => {
+    const onDismiss = vi.fn();
+
+    render(
+      <BackupFailureAlert
+        failure={{ jobId: "job-42", reason: "checkout", message: "Không thể ghi file" }}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const alert = screen.getByRole("alert", { name: "Sao lưu thất bại" });
+    expect(within(alert).getByText("Sao lưu thất bại")).toBeInTheDocument();
+    expect(within(alert).getByText("Nguồn: Trả phòng")).toBeInTheDocument();
+
+    fireEvent.click(within(alert).getByRole("button", { name: "Đóng cảnh báo sao lưu" }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("job-42");
+  });
+});

--- a/mhm/src/components/BackupFailureAlert.tsx
+++ b/mhm/src/components/BackupFailureAlert.tsx
@@ -1,0 +1,77 @@
+import { AlertTriangle, X } from "lucide-react";
+
+import type { BackupReason } from "@/types";
+import { cn } from "@/lib/utils";
+
+export const BACKUP_FAILURE_FALLBACK_MESSAGE =
+  "Không thể tạo bản sao lưu. Vui lòng kiểm tra dung lượng ổ đĩa hoặc thử lại.";
+
+const BACKUP_REASON_LABELS: Record<BackupReason, string> = {
+  settings: "Cài đặt",
+  checkout: "Trả phòng",
+  group_checkout: "Trả phòng nhóm",
+  night_audit: "Night audit",
+  app_exit: "Thoát ứng dụng",
+  manual: "Thủ công",
+  scheduled: "Tự động",
+};
+
+export type BackupFailureAlertState = {
+  jobId: string;
+  reason: BackupReason;
+  message?: string | null;
+};
+
+type BackupFailureAlertProps = {
+  failure: BackupFailureAlertState;
+  onDismiss: (jobId: string) => void;
+  className?: string;
+};
+
+function backupFailureMessage(message: string | null | undefined) {
+  const trimmed = message?.trim();
+  return trimmed ? trimmed : BACKUP_FAILURE_FALLBACK_MESSAGE;
+}
+
+export function BackupFailureAlert({ failure, onDismiss, className }: BackupFailureAlertProps) {
+  const titleId = `backup-failure-alert-title-${failure.jobId}`;
+  const messageId = `backup-failure-alert-message-${failure.jobId}`;
+  const sourceId = `backup-failure-alert-source-${failure.jobId}`;
+
+  return (
+    <div
+      role="alert"
+      aria-labelledby={titleId}
+      aria-describedby={`${messageId} ${sourceId}`}
+      className={cn(
+        "flex items-start gap-3 rounded-lg border border-rose-200 bg-white px-4 py-3 text-rose-800 shadow-soft",
+        className,
+      )}
+    >
+      <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-rose-50 text-rose-600">
+        <AlertTriangle aria-hidden="true" size={18} />
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p id={titleId} className="text-sm font-semibold">
+          Sao lưu thất bại
+        </p>
+        <p id={messageId} className="mt-1 text-sm text-rose-700">
+          {backupFailureMessage(failure.message)}
+        </p>
+        <p id={sourceId} className="mt-1 text-xs font-medium text-rose-500">
+          Nguồn: {BACKUP_REASON_LABELS[failure.reason]}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        aria-label="Đóng cảnh báo sao lưu"
+        onClick={() => onDismiss(failure.jobId)}
+        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-rose-500 transition-colors hover:bg-rose-50 hover:text-rose-700"
+      >
+        <X aria-hidden="true" size={16} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a persistent in-app backup failure alert that is separate from the existing floating backup status indicator.
- Show backend failure details, fallback copy, and Vietnamese source labels for backup reasons.
- Preserve queue-aware behavior: dismiss only the current failed job, keep the alert while jobs remain pending, and clear it after a successful queue drain.

## Validation
- `npm test -- BackupFailureAlert.test.tsx App.backupStatus.test.tsx`
- `npm run verify:quick`
- GitNexus `detect_changes` on staged changes: low risk, affected processes 0

Closes #40