### PR TITLE
[codex] Skip non-file restore drill backup entries

### DIFF
--- a/mhm/src-tauri/src/restore_drill.rs
+++ b/mhm/src-tauri/src/restore_drill.rs
@@ -273,6 +273,13 @@ fn select_newest_managed_backup(runtime_root: &Path) -> Result<ManagedBackup, St
     for entry in entries {
         let entry =
             entry.map_err(|error| format!("cannot read backup directory entry: {error}"))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("cannot inspect backup directory entry: {error}"))?;
+        if !file_type.is_file() {
+            continue;
+        }
+
         let file_name = entry.file_name().to_string_lossy().into_owned();
         let Some(metadata) = parse_managed_backup_file_name(&file_name) else {
             continue;
@@ -669,9 +676,7 @@ fn render_report(
 }
 
 fn escape_markdown_table(value: &str) -> String {
-    value
-        .replace(['\n', '\r'], " ")
-        .replace('|', "\\|")
+    value.replace(['\n', '\r'], " ").replace('|', "\\|")
 }
 
 fn pass_check(name: impl Into<String>, detail: impl Into<String>) -> RestoreDrillCheck {
@@ -831,6 +836,26 @@ mod tests {
         )
         .unwrap();
         fs::write(backup_dir.join("notes.db"), b"ignore").unwrap();
+
+        let selected = select_newest_managed_backup(temp.path()).unwrap();
+
+        assert_eq!(
+            selected.path.file_name().unwrap().to_string_lossy(),
+            "capyinn_backup_scheduled_20260426_110000.db"
+        );
+    }
+
+    #[test]
+    fn select_newest_managed_backup_ignores_managed_name_directories() {
+        let temp = make_temp_dir("restore-drill-select-directory");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        fs::write(
+            backup_dir.join("capyinn_backup_scheduled_20260426_110000.db"),
+            b"real backup",
+        )
+        .unwrap();
+        fs::create_dir(backup_dir.join("capyinn_backup_scheduled_20260426_120000.db")).unwrap();
 
         let selected = select_newest_managed_backup(temp.path()).unwrap();
 


### PR DESCRIPTION
## Summary
- Address the unresolved Codex review thread from #93: https://github.com/chuanman2707/CapyInn/pull/93#discussion_r3142855680
- Skip non-file directory entries before managed backup name parsing/ranking.
- Add a regression test where a managed-name directory is newer than a valid backup file.

## Validation
- `cargo test restore_drill` — 8 passed.
- `cargo clippy --all-targets -- -D warnings` — passed.
- `rustfmt --edition 2021 --check mhm/src-tauri/src/restore_drill.rs` — passed.

## Notes
- GitNexus reports critical scope because `select_newest_managed_backup` feeds all restore-drill flows, but the actual change is limited to skipping non-file entries inside the restore-drill module.