### PR TITLE
[codex] Add reusable write command executor

### DIFF
--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -5,7 +5,8 @@ use crate::{
 use chrono::{DateTime, FixedOffset, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite};
+use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, Transaction};
+use std::{future::Future, pin::Pin};
 
 pub const SET_CRASH_REPORTING_PREFERENCE_COMMAND: &str = "settings.set_crash_reporting_preference";
 const CLAIM_LEASE_SECONDS: i64 = 30;
@@ -36,6 +37,340 @@ pub struct WriteCommandContext {
 pub struct IdempotentCommandResult<T> {
     pub response: T,
     pub replayed: bool,
+}
+
+pub type LockKeyDeriver = fn(&serde_json::Value) -> CommandResult<Vec<String>>;
+
+pub type WriteCommandServiceFuture<'tx> =
+    Pin<Box<dyn Future<Output = CommandResult<serde_json::Value>> + Send + 'tx>>;
+
+#[derive(Debug, Clone)]
+pub struct WriteCommandRequest {
+    pub intent: serde_json::Value,
+    pub primary_aggregate_key: Option<String>,
+    pub lock_key_deriver: LockKeyDeriver,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandStatus {
+    InProgress,
+    Completed,
+    FailedRetryable,
+    FailedTerminal,
+}
+
+impl CommandStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::FailedRetryable => "failed_retryable",
+            Self::FailedTerminal => "failed_terminal",
+        }
+    }
+
+    fn from_str(value: &str) -> CommandResult<Self> {
+        match value {
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            "failed_retryable" => Ok(Self::FailedRetryable),
+            "failed_terminal" => Ok(Self::FailedTerminal),
+            _ => Err(system_error(format!(
+                "unknown idempotency command status: {value}"
+            ))),
+        }
+    }
+}
+
+impl WriteCommandRequest {
+    pub fn new(intent: serde_json::Value) -> Self {
+        Self {
+            intent,
+            primary_aggregate_key: None,
+            lock_key_deriver: default_lock_key_deriver,
+        }
+    }
+
+    pub fn with_primary_aggregate_key(mut self, primary_aggregate_key: impl Into<String>) -> Self {
+        self.primary_aggregate_key = Some(primary_aggregate_key.into());
+        self
+    }
+
+    pub fn with_lock_key_deriver(mut self, lock_key_deriver: LockKeyDeriver) -> Self {
+        self.lock_key_deriver = lock_key_deriver;
+        self
+    }
+}
+
+pub fn default_lock_key_deriver(_intent: &serde_json::Value) -> CommandResult<Vec<String>> {
+    Ok(Vec::new())
+}
+
+pub struct WriteCommandExecutor {
+    pool: Pool<Sqlite>,
+}
+
+enum ClaimOutcome {
+    Claimed { claim_token: String },
+    Replayed(IdempotentCommandResult<serde_json::Value>),
+}
+
+struct PreparedWriteCommandRequest {
+    request_hash: String,
+    intent_json: String,
+    lock_keys_json: String,
+    primary_aggregate_key: Option<String>,
+}
+
+impl WriteCommandExecutor {
+    pub fn new(pool: Pool<Sqlite>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn execute<F>(
+        &self,
+        ctx: &WriteCommandContext,
+        request: WriteCommandRequest,
+        service: F,
+    ) -> CommandResult<IdempotentCommandResult<serde_json::Value>>
+    where
+        F: for<'tx> FnOnce(&'tx mut Transaction<'_, Sqlite>) -> WriteCommandServiceFuture<'tx>,
+    {
+        let prepared = prepare_write_command_request(request)?;
+        let claim = self.claim_or_reclaim(ctx, &prepared).await?;
+
+        match claim {
+            ClaimOutcome::Claimed { claim_token } => {
+                self.run_claimed(ctx, &claim_token, service).await
+            }
+            ClaimOutcome::Replayed(result) => Ok(result),
+        }
+    }
+
+    async fn claim_or_reclaim(
+        &self,
+        ctx: &WriteCommandContext,
+        prepared: &PreparedWriteCommandRequest,
+    ) -> CommandResult<ClaimOutcome> {
+        let now = Utc::now();
+        let now_string = now.to_rfc3339();
+        let lease_expires_at = (now + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
+        let claim_token = uuid::Uuid::new_v4().to_string();
+
+        if let Some(row) = fetch_existing_claim(&self.pool, ctx).await? {
+            if existing_claim_is_reclaimable(&row, &prepared.request_hash, now)? {
+                if reclaim_claim(
+                    &self.pool,
+                    ctx,
+                    prepared,
+                    &claim_token,
+                    &now_string,
+                    &lease_expires_at,
+                )
+                .await?
+                {
+                    return Ok(ClaimOutcome::Claimed { claim_token });
+                }
+
+                return resolve_existing_claim(&self.pool, ctx, &prepared.request_hash).await;
+            }
+
+            return resolve_existing_claim_row(ctx, &prepared.request_hash, row)
+                .map(ClaimOutcome::Replayed);
+        }
+
+        let mut claim_tx = self.pool.begin().await.map_err(system_error)?;
+        let claim_result = sqlx::query(
+            "INSERT OR IGNORE INTO command_idempotency (
+                idempotency_key,
+                command_name,
+                request_hash,
+                intent_json,
+                primary_aggregate_key,
+                lock_keys_json,
+                status,
+                claim_token,
+                response_json,
+                error_code,
+                error_json,
+                retryable,
+                lease_expires_at,
+                created_at,
+                updated_at,
+                completed_at,
+                last_attempt_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&ctx.idempotency_key)
+        .bind(&ctx.command_name)
+        .bind(&prepared.request_hash)
+        .bind(&prepared.intent_json)
+        .bind(&prepared.primary_aggregate_key)
+        .bind(&prepared.lock_keys_json)
+        .bind(CommandStatus::InProgress.as_str())
+        .bind(&claim_token)
+        .bind(Option::<String>::None)
+        .bind(Option::<String>::None)
+        .bind(Option::<String>::None)
+        .bind(0_i64)
+        .bind(&lease_expires_at)
+        .bind(&now_string)
+        .bind(&now_string)
+        .bind(Option::<String>::None)
+        .bind(&now_string)
+        .execute(&mut *claim_tx)
+        .await
+        .map_err(system_error)?;
+
+        claim_tx.commit().await.map_err(system_error)?;
+
+        if claim_result.rows_affected() != 1 {
+            return resolve_existing_claim(&self.pool, ctx, &prepared.request_hash).await;
+        }
+
+        Ok(ClaimOutcome::Claimed { claim_token })
+    }
+
+    async fn run_claimed<F>(
+        &self,
+        ctx: &WriteCommandContext,
+        claim_token: &str,
+        service: F,
+    ) -> CommandResult<IdempotentCommandResult<serde_json::Value>>
+    where
+        F: for<'tx> FnOnce(&'tx mut Transaction<'_, Sqlite>) -> WriteCommandServiceFuture<'tx>,
+    {
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(system_error)?;
+
+        let response = match service(&mut tx).await {
+            Ok(response) => response,
+            Err(mut error) => {
+                tx.rollback().await.map_err(system_error)?;
+                error.request_id = Some(ctx.request_id.clone());
+                self.finalize_failure(ctx, claim_token, &error).await?;
+                return Err(error);
+            }
+        };
+
+        let response_json = stable_json_string(&response)?;
+        let completed_at = chrono::Utc::now().to_rfc3339();
+        let completion_result = sqlx::query(
+            "UPDATE command_idempotency
+             SET status = ?,
+                 response_json = ?,
+                 error_code = NULL,
+                 error_json = NULL,
+                 retryable = 0,
+                 lease_expires_at = NULL,
+                 updated_at = ?,
+                 completed_at = ?
+             WHERE command_name = ?
+               AND idempotency_key = ?
+               AND status = ?
+               AND claim_token = ?",
+        )
+        .bind(CommandStatus::Completed.as_str())
+        .bind(&response_json)
+        .bind(&completed_at)
+        .bind(&completed_at)
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .bind(CommandStatus::InProgress.as_str())
+        .bind(claim_token)
+        .execute(&mut *tx)
+        .await;
+
+        let completion_result = match completion_result {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = tx.rollback().await;
+                return Err(system_error(error).with_request_id(ctx.request_id.clone()));
+            }
+        };
+
+        if completion_result.rows_affected() != 1 {
+            tx.rollback().await.map_err(system_error)?;
+            return Err(CommandError::system(
+                codes::SYSTEM_INTERNAL_ERROR,
+                "Failed to complete claimed idempotency row",
+            )
+            .with_request_id(ctx.request_id.clone()));
+        }
+
+        tx.commit().await.map_err(system_error)?;
+
+        Ok(IdempotentCommandResult {
+            response,
+            replayed: false,
+        })
+    }
+
+    async fn finalize_failure(
+        &self,
+        ctx: &WriteCommandContext,
+        claim_token: &str,
+        error: &CommandError,
+    ) -> CommandResult<()> {
+        let status = if error.retryable {
+            CommandStatus::FailedRetryable
+        } else {
+            CommandStatus::FailedTerminal
+        };
+        let retryable = if error.retryable { 1_i64 } else { 0_i64 };
+        let error_json = serde_json::to_string(error).map_err(system_error)?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let completed_at = if status == CommandStatus::FailedTerminal {
+            Some(now.clone())
+        } else {
+            None
+        };
+
+        let mut tx = self.pool.begin().await.map_err(system_error)?;
+        let result = sqlx::query(
+            "UPDATE command_idempotency
+             SET status = ?,
+                 response_json = NULL,
+                 error_code = ?,
+                 error_json = ?,
+                 retryable = ?,
+                 lease_expires_at = NULL,
+                 updated_at = ?,
+                 completed_at = ?
+             WHERE command_name = ?
+               AND idempotency_key = ?
+               AND status = ?
+               AND claim_token = ?",
+        )
+        .bind(status.as_str())
+        .bind(&error.code)
+        .bind(&error_json)
+        .bind(retryable)
+        .bind(&now)
+        .bind(&completed_at)
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .bind(CommandStatus::InProgress.as_str())
+        .bind(claim_token)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
+
+        if result.rows_affected() != 1 {
+            tx.rollback().await.map_err(system_error)?;
+            return Err(CommandError::system(
+                codes::SYSTEM_INTERNAL_ERROR,
+                "Failed to record failed idempotency row",
+            )
+            .with_request_id(ctx.request_id.clone()));
+        }
+
+        tx.commit().await.map_err(system_error)
+    }
 }
 
 impl WriteCommandContext {
@@ -78,182 +413,73 @@ pub async fn set_crash_reporting_preference_idempotent(
     enabled: bool,
 ) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
     let intent = serde_json::json!({ "enabled": enabled });
-    let intent_json = stable_json_string(&intent)?;
-    let request_hash = stable_request_hash(&intent)?;
-    let now = Utc::now();
-    let now_string = now.to_rfc3339();
-    let lease_expires_at = (now + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
-    let response = serde_json::json!({ "ok": true });
-    let response_json = stable_json_string(&response)?;
-    let claim_token = uuid::Uuid::new_v4().to_string();
-
-    if let Some(row) = fetch_existing_claim(pool, ctx).await? {
-        if existing_claim_is_reclaimable(&row, &request_hash, now)? {
-            if reclaim_expired_claim(
-                pool,
-                ctx,
-                &request_hash,
-                &intent_json,
-                &claim_token,
-                &now_string,
-                &lease_expires_at,
-            )
-            .await?
-            {
-                return complete_claimed_crash_reporting_preference(
-                    pool,
-                    ctx,
-                    enabled,
-                    &claim_token,
-                    response,
-                    &response_json,
+    WriteCommandExecutor::new(pool.clone())
+        .execute(ctx, WriteCommandRequest::new(intent), move |tx| {
+            Box::pin(async move {
+                settings_store::save_setting_tx(
+                    tx,
+                    "send_crash_reports",
+                    if enabled { "true" } else { "false" },
                 )
-                .await;
-            }
+                .await
+                .map_err(system_error)?;
 
-            return resolve_existing_claim(pool, ctx, &request_hash).await;
-        }
-        return resolve_existing_claim_row(ctx, &request_hash, row);
-    }
-
-    let mut claim_tx = pool.begin().await.map_err(system_error)?;
-    let claim_result = sqlx::query(
-        "INSERT OR IGNORE INTO command_idempotency (
-            idempotency_key,
-            command_name,
-            request_hash,
-            intent_json,
-            primary_aggregate_key,
-            lock_keys_json,
-            status,
-            claim_token,
-            response_json,
-            error_code,
-            retryable,
-            lease_expires_at,
-            created_at,
-            updated_at,
-            completed_at,
-            last_attempt_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )
-    .bind(&ctx.idempotency_key)
-    .bind(&ctx.command_name)
-    .bind(&request_hash)
-    .bind(&intent_json)
-    .bind(Option::<String>::None)
-    .bind("[]")
-    .bind("in_progress")
-    .bind(&claim_token)
-    .bind(Option::<String>::None)
-    .bind(Option::<String>::None)
-    .bind(0_i64)
-    .bind(&lease_expires_at)
-    .bind(&now_string)
-    .bind(&now_string)
-    .bind(Option::<String>::None)
-    .bind(&now_string)
-    .execute(&mut *claim_tx)
-    .await
-    .map_err(system_error)?;
-
-    claim_tx.commit().await.map_err(system_error)?;
-
-    if claim_result.rows_affected() != 1 {
-        return resolve_existing_claim(pool, ctx, &request_hash).await;
-    }
-
-    complete_claimed_crash_reporting_preference(
-        pool,
-        ctx,
-        enabled,
-        &claim_token,
-        response,
-        &response_json,
-    )
-    .await
-}
-
-async fn complete_claimed_crash_reporting_preference(
-    pool: &Pool<Sqlite>,
-    ctx: &WriteCommandContext,
-    enabled: bool,
-    claim_token: &str,
-    response: serde_json::Value,
-    response_json: &str,
-) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
-    let mut tx = pool.begin().await.map_err(system_error)?;
-
-    settings_store::save_setting_tx(
-        &mut tx,
-        "send_crash_reports",
-        if enabled { "true" } else { "false" },
-    )
-    .await
-    .map_err(system_error)?;
-
-    let completed_at = chrono::Utc::now().to_rfc3339();
-    let completion_result = sqlx::query(
-        "UPDATE command_idempotency
-         SET status = 'completed',
-             response_json = ?,
-             lease_expires_at = NULL,
-             updated_at = ?,
-             completed_at = ?
-         WHERE command_name = ? AND idempotency_key = ? AND claim_token = ?",
-    )
-    .bind(response_json)
-    .bind(&completed_at)
-    .bind(&completed_at)
-    .bind(&ctx.command_name)
-    .bind(&ctx.idempotency_key)
-    .bind(claim_token)
-    .execute(&mut *tx)
-    .await
-    .map_err(system_error)?;
-
-    if completion_result.rows_affected() != 1 {
-        return Err(CommandError::system(
-            codes::SYSTEM_INTERNAL_ERROR,
-            "Failed to complete claimed idempotency row",
-        ));
-    }
-
-    tx.commit().await.map_err(system_error)?;
-
-    Ok(IdempotentCommandResult {
-        response,
-        replayed: false,
-    })
+                Ok(serde_json::json!({ "ok": true }))
+            })
+        })
+        .await
 }
 
 fn stable_json_string(value: &serde_json::Value) -> CommandResult<String> {
     serde_json::to_string(value).map_err(system_error)
 }
 
+#[cfg(test)]
 fn stable_request_hash(intent: &serde_json::Value) -> CommandResult<String> {
     let intent_json = stable_json_string(intent)?;
+    stable_request_hash_from_json(&intent_json)
+}
+
+fn stable_request_hash_from_json(intent_json: &str) -> CommandResult<String> {
     let digest = Sha256::digest(intent_json.as_bytes());
     Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn prepare_write_command_request(
+    request: WriteCommandRequest,
+) -> CommandResult<PreparedWriteCommandRequest> {
+    let mut lock_keys = (request.lock_key_deriver)(&request.intent)?;
+    lock_keys.sort();
+    lock_keys.dedup();
+
+    let lock_keys_json = stable_json_string(&serde_json::json!(lock_keys))?;
+    let intent_json = stable_json_string(&request.intent)?;
+    let request_hash = stable_request_hash_from_json(&intent_json)?;
+
+    Ok(PreparedWriteCommandRequest {
+        request_hash,
+        intent_json,
+        lock_keys_json,
+        primary_aggregate_key: request.primary_aggregate_key,
+    })
 }
 
 async fn resolve_existing_claim(
     pool: &Pool<Sqlite>,
     ctx: &WriteCommandContext,
     request_hash: &str,
-) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+) -> CommandResult<ClaimOutcome> {
     let row = fetch_existing_claim(pool, ctx)
         .await?
         .ok_or_else(|| system_error("Idempotency claim was not inserted and no row exists"))?;
 
-    resolve_existing_claim_row(ctx, request_hash, row)
+    resolve_existing_claim_row(ctx, request_hash, row).map(ClaimOutcome::Replayed)
 }
 
-async fn reclaim_expired_claim(
+async fn reclaim_claim(
     pool: &Pool<Sqlite>,
     ctx: &WriteCommandContext,
-    request_hash: &str,
-    intent_json: &str,
+    prepared: &PreparedWriteCommandRequest,
     claim_token: &str,
     now: &str,
     lease_expires_at: &str,
@@ -263,10 +489,13 @@ async fn reclaim_expired_claim(
         "UPDATE command_idempotency
          SET request_hash = ?,
              intent_json = ?,
+             primary_aggregate_key = ?,
+             lock_keys_json = ?,
              status = 'in_progress',
              claim_token = ?,
              response_json = NULL,
              error_code = NULL,
+             error_json = NULL,
              retryable = 0,
              lease_expires_at = ?,
              updated_at = ?,
@@ -275,18 +504,25 @@ async fn reclaim_expired_claim(
          WHERE command_name = ?
            AND idempotency_key = ?
            AND request_hash = ?
-           AND status = 'in_progress'
-           AND (lease_expires_at IS NULL OR lease_expires_at <= ?)",
+           AND (
+                status = 'failed_retryable'
+                OR (
+                    status = 'in_progress'
+                    AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
+                )
+           )",
     )
-    .bind(request_hash)
-    .bind(intent_json)
+    .bind(&prepared.request_hash)
+    .bind(&prepared.intent_json)
+    .bind(&prepared.primary_aggregate_key)
+    .bind(&prepared.lock_keys_json)
     .bind(claim_token)
     .bind(lease_expires_at)
     .bind(now)
     .bind(now)
     .bind(&ctx.command_name)
     .bind(&ctx.idempotency_key)
-    .bind(request_hash)
+    .bind(&prepared.request_hash)
     .bind(now)
     .execute(&mut *tx)
     .await
@@ -302,7 +538,7 @@ async fn fetch_existing_claim(
     ctx: &WriteCommandContext,
 ) -> CommandResult<Option<SqliteRow>> {
     sqlx::query(
-        "SELECT request_hash, status, response_json, lease_expires_at
+        "SELECT request_hash, status, response_json, error_json, lease_expires_at
          FROM command_idempotency
          WHERE command_name = ? AND idempotency_key = ?",
     )
@@ -323,9 +559,11 @@ fn existing_claim_is_reclaimable(
         return Ok(false);
     }
 
-    let status: String = row.get("status");
-    if status != "in_progress" {
-        return Ok(false);
+    let status = CommandStatus::from_str(row.get::<String, _>("status").as_str())?;
+    match status {
+        CommandStatus::FailedRetryable => return Ok(true),
+        CommandStatus::InProgress => {}
+        CommandStatus::Completed | CommandStatus::FailedTerminal => return Ok(false),
     }
 
     let lease_expires_at: Option<String> = row.try_get("lease_expires_at").map_err(system_error)?;
@@ -354,24 +592,36 @@ fn resolve_existing_claim_row(
         .with_request_id(ctx.request_id.clone()));
     }
 
-    let status: String = row.get("status");
-    if status == "completed" {
-        let raw_response = row
-            .try_get::<Option<String>, _>("response_json")
-            .map_err(system_error)?
-            .ok_or_else(|| system_error("completed idempotency row is missing response_json"))?;
-        let response = serde_json::from_str(&raw_response).map_err(system_error)?;
-        return Ok(IdempotentCommandResult {
-            response,
-            replayed: true,
-        });
+    let status = CommandStatus::from_str(row.get::<String, _>("status").as_str())?;
+    match status {
+        CommandStatus::Completed => {
+            let raw_response = row
+                .try_get::<Option<String>, _>("response_json")
+                .map_err(system_error)?
+                .ok_or_else(|| {
+                    system_error("completed idempotency row is missing response_json")
+                })?;
+            let response = serde_json::from_str(&raw_response).map_err(system_error)?;
+            Ok(IdempotentCommandResult {
+                response,
+                replayed: true,
+            })
+        }
+        CommandStatus::FailedTerminal => {
+            let raw_error = row
+                .try_get::<Option<String>, _>("error_json")
+                .map_err(system_error)?
+                .ok_or_else(|| system_error("terminal idempotency row is missing error_json"))?;
+            let mut error: CommandError = serde_json::from_str(&raw_error).map_err(system_error)?;
+            error.request_id = Some(ctx.request_id.clone());
+            Err(error)
+        }
+        CommandStatus::InProgress | CommandStatus::FailedRetryable => Err(CommandError::user(
+            codes::CONFLICT_DUPLICATE_IN_FLIGHT,
+            "A command with this idempotency key is already in progress",
+        )
+        .with_request_id(ctx.request_id.clone())),
     }
-
-    Err(CommandError::user(
-        codes::CONFLICT_DUPLICATE_IN_FLIGHT,
-        "A command with this idempotency key is already in progress",
-    )
-    .with_request_id(ctx.request_id.clone()))
 }
 
 fn system_error(error: impl std::fmt::Display) -> CommandError {
@@ -457,8 +707,7 @@ mod tests {
         let intent = serde_json::json!({ "enabled": true });
         let now = Utc::now();
         let now_string = now.to_rfc3339();
-        let lease_expires_at =
-            (now + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
+        let lease_expires_at = (now + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
 
         sqlx::query(
             "INSERT INTO command_idempotency (
@@ -575,5 +824,218 @@ mod tests {
                 .await
                 .expect("reads crash reporting setting");
         assert_eq!(setting, "true");
+    }
+
+    #[tokio::test]
+    async fn write_command_executor_terminal_failure_returns_cached_error_without_rerun() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-terminal-failure",
+            "idem-terminal-failure",
+            "test.terminal_failure",
+        );
+        let request = WriteCommandRequest::new(serde_json::json!({ "case": "terminal" }));
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let first_attempts = attempts.clone();
+        let first_error = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request.clone(), move |_tx| {
+                let attempts = first_attempts.clone();
+                Box::pin(async move {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Err(CommandError::user(
+                        codes::AUTH_FORBIDDEN,
+                        "terminal failure",
+                    ))
+                })
+            })
+            .await
+            .expect_err("first terminal failure is returned");
+
+        let second_attempts = attempts.clone();
+        let second_error = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request, move |_tx| {
+                let attempts = second_attempts.clone();
+                Box::pin(async move {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(serde_json::json!({ "unexpected": true }))
+                })
+            })
+            .await
+            .expect_err("terminal failure is replayed");
+
+        assert_eq!(first_error.code, codes::AUTH_FORBIDDEN);
+        assert_eq!(
+            first_error.request_id.as_deref(),
+            Some(ctx.request_id.as_str())
+        );
+        assert_eq!(second_error.code, codes::AUTH_FORBIDDEN);
+        assert_eq!(second_error.message, "terminal failure");
+        assert_eq!(
+            second_error.request_id.as_deref(),
+            Some(ctx.request_id.as_str())
+        );
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let row = sqlx::query(
+            "SELECT status, error_code, error_json, retryable, lease_expires_at, completed_at
+             FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads failed row");
+
+        assert_eq!(row.get::<String, _>("status"), "failed_terminal");
+        assert_eq!(
+            row.get::<Option<String>, _>("error_code"),
+            Some(codes::AUTH_FORBIDDEN.to_string())
+        );
+        assert_eq!(row.get::<i64, _>("retryable"), 0);
+        assert_eq!(row.get::<Option<String>, _>("lease_expires_at"), None);
+        assert!(row.get::<Option<String>, _>("completed_at").is_some());
+        assert!(row
+            .get::<Option<String>, _>("error_json")
+            .expect("error_json is stored")
+            .contains("terminal failure"));
+    }
+
+    #[tokio::test]
+    async fn write_command_executor_retryable_failure_reclaims_and_reruns() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-retryable-failure",
+            "idem-retryable-failure",
+            "test.retryable_failure",
+        );
+        let request = WriteCommandRequest::new(serde_json::json!({ "case": "retryable" }));
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let first_attempts = attempts.clone();
+        let first_error = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request.clone(), move |_tx| {
+                let attempts = first_attempts.clone();
+                Box::pin(async move {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Err(
+                        CommandError::system(codes::DB_LOCKED_RETRYABLE, "database locked")
+                            .retryable(true),
+                    )
+                })
+            })
+            .await
+            .expect_err("first retryable failure is returned");
+
+        assert_eq!(first_error.code, codes::DB_LOCKED_RETRYABLE);
+        assert!(first_error.retryable);
+
+        let failed_row = sqlx::query(
+            "SELECT status, completed_at
+             FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads failed retryable row");
+
+        assert_eq!(failed_row.get::<String, _>("status"), "failed_retryable");
+        assert_eq!(failed_row.get::<Option<String>, _>("completed_at"), None);
+
+        let second_attempts = attempts.clone();
+        let second = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request, move |_tx| {
+                let attempts = second_attempts.clone();
+                Box::pin(async move {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(serde_json::json!({ "ok": true }))
+                })
+            })
+            .await
+            .expect("retryable failure is reclaimed and rerun");
+
+        assert_eq!(second.response, serde_json::json!({ "ok": true }));
+        assert!(!second.replayed);
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+
+        let row = sqlx::query(
+            "SELECT status, retryable, error_json, lease_expires_at
+             FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads completed row");
+
+        assert_eq!(row.get::<String, _>("status"), "completed");
+        assert_eq!(row.get::<i64, _>("retryable"), 0);
+        assert_eq!(row.get::<Option<String>, _>("error_json"), None);
+        assert_eq!(row.get::<Option<String>, _>("lease_expires_at"), None);
+    }
+
+    #[tokio::test]
+    async fn write_command_executor_stale_claimant_finalize_rolls_back_business_tx() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-stale-claimant",
+            "idem-stale-claimant",
+            "test.stale_claimant",
+        );
+        let request = WriteCommandRequest::new(serde_json::json!({ "case": "stale" }));
+        let command_name = ctx.command_name.clone();
+        let idempotency_key = ctx.idempotency_key.clone();
+
+        let error = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request, |tx| {
+                Box::pin(async move {
+                    settings_store::save_setting_tx(tx, "send_crash_reports", "true")
+                        .await
+                        .map_err(system_error)?;
+
+                    sqlx::query(
+                        "UPDATE command_idempotency
+                         SET claim_token = 'stale-claim-token'
+                         WHERE command_name = ? AND idempotency_key = ?",
+                    )
+                    .bind(&command_name)
+                    .bind(&idempotency_key)
+                    .execute(&mut **tx)
+                    .await
+                    .map_err(system_error)?;
+
+                    Ok(serde_json::json!({ "ok": true }))
+                })
+            })
+            .await
+            .expect_err("stale claimant cannot finalize");
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert_eq!(error.request_id.as_deref(), Some(ctx.request_id.as_str()));
+
+        let setting: Option<String> =
+            sqlx::query_scalar("SELECT value FROM settings WHERE key = 'send_crash_reports'")
+                .fetch_optional(&pool)
+                .await
+                .expect("reads crash reporting setting");
+        assert_eq!(setting, None);
+
+        let row = sqlx::query(
+            "SELECT status, response_json
+             FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads idempotency row after rollback");
+
+        assert_eq!(row.get::<String, _>("status"), "in_progress");
+        assert_eq!(row.get::<Option<String>, _>("response_json"), None);
     }
 }

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -341,8 +341,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
             "ALTER TABLE transactions ADD COLUMN payment_method TEXT DEFAULT 'cash'",
         )
         .await?;
-        execute_compat_alter(&mut tx, "ALTER TABLE transactions ADD COLUMN created_by TEXT")
-            .await?;
+        execute_compat_alter(
+            &mut tx,
+            "ALTER TABLE transactions ADD COLUMN created_by TEXT",
+        )
+        .await?;
 
         // Add created_by to bookings
         execute_compat_alter(&mut tx, "ALTER TABLE bookings ADD COLUMN created_by TEXT").await?;
@@ -393,8 +396,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         .await?;
 
         // Add pricing_snapshot to bookings (JSON)
-        execute_compat_alter(&mut tx, "ALTER TABLE bookings ADD COLUMN pricing_snapshot TEXT")
-            .await?;
+        execute_compat_alter(
+            &mut tx,
+            "ALTER TABLE bookings ADD COLUMN pricing_snapshot TEXT",
+        )
+        .await?;
 
         // Add pricing_type to bookings
         execute_compat_alter(
@@ -448,8 +454,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         .await?;
 
         // Add is_audited flag to bookings
-        execute_compat_alter(&mut tx, "ALTER TABLE bookings ADD COLUMN is_audited INTEGER DEFAULT 0")
-            .await?;
+        execute_compat_alter(
+            &mut tx,
+            "ALTER TABLE bookings ADD COLUMN is_audited INTEGER DEFAULT 0",
+        )
+        .await?;
 
         set_schema_version(&mut tx, 4).await?;
         tx.commit().await?;
@@ -662,8 +671,8 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
 
         // Indexes
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_bookings_group ON bookings(group_id)")
-        .execute(&mut *tx)
-        .await?;
+            .execute(&mut *tx)
+            .await?;
         sqlx::query(
             "CREATE INDEX IF NOT EXISTS idx_group_services_group ON group_services(group_id)",
         )
@@ -720,6 +729,20 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         .await?;
 
         set_schema_version(&mut tx, 10).await?;
+        tx.commit().await?;
+    }
+
+    // ── V11: Command terminal error replay payload ──
+    if current < 11 {
+        let mut tx = pool.begin().await?;
+
+        execute_compat_alter(
+            &mut tx,
+            "ALTER TABLE command_idempotency ADD COLUMN error_json TEXT",
+        )
+        .await?;
+
+        set_schema_version(&mut tx, 11).await?;
         tx.commit().await?;
     }
 
@@ -801,6 +824,17 @@ mod tests {
         tx.commit().await.expect("commits tx");
     }
 
+    async fn command_idempotency_error_json_column_count(pool: &SqlitePool) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*)
+             FROM pragma_table_info('command_idempotency')
+             WHERE name = 'error_json'",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("checks command_idempotency error_json column")
+    }
+
     #[tokio::test]
     async fn migrations_run_to_latest_schema_version() {
         let pool = SqlitePool::connect("sqlite::memory:")
@@ -815,7 +849,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 10);
+        assert_eq!(version, 11);
     }
 
     #[tokio::test]
@@ -837,5 +871,70 @@ mod tests {
         .get("count");
 
         assert_eq!(table_count, 1);
+    }
+
+    #[tokio::test]
+    async fn migration_v11_adds_command_error_json_on_fresh_migration() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+
+        run_migrations(&pool).await.expect("runs migrations");
+
+        assert_eq!(command_idempotency_error_json_column_count(&pool).await, 1);
+    }
+
+    #[tokio::test]
+    async fn migration_v11_upgrades_existing_v10_command_idempotency_table() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+
+        get_schema_version(&pool)
+            .await
+            .expect("bootstraps schema version state");
+
+        sqlx::query(
+            "CREATE TABLE command_idempotency (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                idempotency_key TEXT NOT NULL,
+                command_name TEXT NOT NULL,
+                request_hash TEXT NOT NULL,
+                intent_json TEXT NOT NULL,
+                primary_aggregate_key TEXT,
+                lock_keys_json TEXT NOT NULL,
+                status TEXT NOT NULL,
+                claim_token TEXT NOT NULL,
+                response_json TEXT,
+                error_code TEXT,
+                retryable INTEGER NOT NULL DEFAULT 0,
+                lease_expires_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                completed_at TEXT,
+                last_attempt_at TEXT,
+                UNIQUE(command_name, idempotency_key)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("creates v10 command_idempotency table");
+
+        sqlx::query("UPDATE schema_version SET version = 10")
+            .execute(&pool)
+            .await
+            .expect("sets schema version to v10");
+
+        run_migrations(&pool).await.expect("runs migrations");
+
+        assert_eq!(command_idempotency_error_json_column_count(&pool).await, 1);
+
+        let version: i32 = sqlx::query("SELECT version FROM schema_version LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .expect("reads final schema version")
+            .get("version");
+
+        assert_eq!(version, 11);
     }
 }


### PR DESCRIPTION
## Summary
- Add reusable `WriteCommandExecutor` with request preparation, stable intent hashing, lock-key derivation scaffolding, claim/reclaim handling, and fenced finalize behavior.
- Move crash reporting preference writes onto the executor without expanding #65 beyond the agreed scope.
- Add V11 migration for `command_idempotency.error_json`, including fresh migration and existing-v10 upgrade coverage.
- Add executor regression coverage for exact retry, duplicate in-flight, hash mismatch, expired reclaim, terminal/retryable failures, and stale claimant rollback.

## Validation
- `npm run verify:full`
- `npm run build`
- `cargo test`
- `cargo check`
- `rustfmt --edition 2021 --check mhm/src-tauri/src/command_idempotency.rs mhm/src-tauri/src/db.rs`
- `git diff --check`
- GitNexus `detect_changes`: HIGH because `run_migrations` is shared by startup/gateway flows; changed files are limited to `command_idempotency.rs` and `db.rs`.

## Notes
- Full `cargo fmt --check` still reports pre-existing unrelated formatting diffs outside this PR; the touched Rust files pass `rustfmt --check`.
- The #65 spec/plan docs are gitignored and intentionally not included in this PR.