### PR TITLE
[codex] Concurrency guard foundation

### DIFF
--- a/mhm/shared/error-codes.json
+++ b/mhm/shared/error-codes.json
@@ -140,6 +140,11 @@
     "defaultMessage": "Lệnh đang được xử lý."
   },
   {
+    "code": "CONFLICT_INVALID_STATE_TRANSITION",
+    "kind": "user",
+    "defaultMessage": "Dữ liệu đã thay đổi, vui lòng tải lại trước khi thao tác."
+  },
+  {
     "code": "SYSTEM_INTERNAL_ERROR",
     "kind": "system",
     "defaultMessage": "Có lỗi hệ thống, vui lòng thử lại"

--- a/mhm/src-tauri/src/aggregate_locks.rs
+++ b/mhm/src-tauri/src/aggregate_locks.rs
@@ -152,10 +152,28 @@ mod tests {
     #[tokio::test]
     async fn unrelated_keys_do_not_wait_for_each_other() {
         let manager = AggregateLockManager::default();
-        let _first = manager.acquire(["room:R1"]).await.expect("first lock");
-        let second = manager.acquire(["room:R2"]).await.expect("second lock");
+        let first = manager.acquire(["room:R1"]).await.expect("first lock");
+        let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
 
-        assert_eq!(second.keys(), &["room:R2".to_string()]);
+        let second_manager = manager.clone();
+        let second = tokio::spawn(async move {
+            let second_guard = second_manager.acquire(["room:R2"]).await.expect("second lock");
+            acquired_tx
+                .send(second_guard.keys().to_vec())
+                .expect("main task waits for acquired signal");
+            release_rx.await.expect("release signal received");
+            drop(second_guard);
+        });
+
+        assert_eq!(
+            acquired_rx.await.expect("second key acquired"),
+            vec!["room:R2".to_string()]
+        );
+
+        drop(first);
+        release_tx.send(()).expect("second task waits for release");
+        second.await.expect("second task joins");
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/aggregate_locks.rs
+++ b/mhm/src-tauri/src/aggregate_locks.rs
@@ -1,0 +1,170 @@
+use crate::app_error::{codes, CommandError, CommandResult};
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+#[derive(Clone, Default)]
+pub struct AggregateLockManager {
+    inner: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+}
+
+pub struct AggregateLockGuard {
+    keys: Vec<String>,
+    _guards: Vec<OwnedMutexGuard<()>>,
+}
+
+impl AggregateLockGuard {
+    pub fn keys(&self) -> &[String] {
+        &self.keys
+    }
+}
+
+pub fn room_key(room_id: &str) -> CommandResult<String> {
+    aggregate_key("room", room_id)
+}
+
+pub fn booking_key(booking_id: &str) -> CommandResult<String> {
+    aggregate_key("booking", booking_id)
+}
+
+pub fn folio_key(booking_id: &str) -> CommandResult<String> {
+    aggregate_key("folio", booking_id)
+}
+
+pub fn group_key(group_id: &str) -> CommandResult<String> {
+    aggregate_key("group", group_id)
+}
+
+fn aggregate_key(prefix: &str, id: &str) -> CommandResult<String> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return Err(CommandError::user(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            "Missing aggregate lock key",
+        ));
+    }
+    Ok(format!("{prefix}:{trimmed}"))
+}
+
+pub fn canonicalize_lock_keys<I, S>(keys: I) -> CommandResult<Vec<String>>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut keys = keys
+        .into_iter()
+        .map(Into::into)
+        .map(|key| key.trim().to_string())
+        .collect::<Vec<_>>();
+
+    if keys.is_empty() || keys.iter().any(|key| key.is_empty()) {
+        return Err(CommandError::user(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            "Missing aggregate lock key",
+        ));
+    }
+
+    keys.sort();
+    keys.dedup();
+    Ok(keys)
+}
+
+impl AggregateLockManager {
+    pub async fn acquire<I, S>(&self, keys: I) -> CommandResult<AggregateLockGuard>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let keys = canonicalize_lock_keys(keys)?;
+        let locks = {
+            let mut map = self.inner.lock().await;
+            keys.iter()
+                .map(|key| {
+                    map.entry(key.clone())
+                        .or_insert_with(|| Arc::new(Mutex::new(())))
+                        .clone()
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut guards = Vec::with_capacity(locks.len());
+        for lock in locks {
+            guards.push(lock.lock_owned().await);
+        }
+
+        Ok(AggregateLockGuard {
+            keys,
+            _guards: guards,
+        })
+    }
+}
+
+static GLOBAL_MANAGER: OnceLock<AggregateLockManager> = OnceLock::new();
+
+pub fn global_manager() -> &'static AggregateLockManager {
+    GLOBAL_MANAGER.get_or_init(AggregateLockManager::default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn canonicalize_lock_keys_sorts_and_deduplicates() {
+        let keys = canonicalize_lock_keys(vec![
+            "room:R2".to_string(),
+            "booking:B1".to_string(),
+            "room:R2".to_string(),
+            "room:R1".to_string(),
+        ])
+        .expect("keys canonicalize");
+
+        assert_eq!(keys, vec!["booking:B1", "room:R1", "room:R2"]);
+    }
+
+    #[tokio::test]
+    async fn canonicalize_lock_keys_rejects_empty_input() {
+        let err = canonicalize_lock_keys(Vec::<String>::new()).expect_err("empty keys reject");
+
+        assert_eq!(err.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+        assert_eq!(err.message, "Missing aggregate lock key");
+    }
+
+    #[tokio::test]
+    async fn same_key_waits_for_first_guard_to_drop() {
+        let manager = AggregateLockManager::default();
+        let first = manager.acquire(["room:R1"]).await.expect("first lock");
+
+        let second_manager = manager.clone();
+        let second = tokio::spawn(async move {
+            second_manager.acquire(["room:R1"]).await.expect("second lock")
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!second.is_finished());
+
+        drop(first);
+        let _second_guard = second.await.expect("second task joins");
+    }
+
+    #[tokio::test]
+    async fn unrelated_keys_do_not_wait_for_each_other() {
+        let manager = AggregateLockManager::default();
+        let _first = manager.acquire(["room:R1"]).await.expect("first lock");
+        let second = manager.acquire(["room:R2"]).await.expect("second lock");
+
+        assert_eq!(second.keys(), &["room:R2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn reversed_multi_key_inputs_are_canonicalized() {
+        let first = canonicalize_lock_keys(vec!["room:R2".to_string(), "room:R1".to_string()])
+            .expect("first order");
+        let second = canonicalize_lock_keys(vec!["room:R1".to_string(), "room:R2".to_string()])
+            .expect("second order");
+
+        assert_eq!(first, second);
+    }
+}

--- a/mhm/src-tauri/src/app_error.rs
+++ b/mhm/src-tauri/src/app_error.rs
@@ -36,6 +36,9 @@ pub mod codes {
     pub const CONFLICT_ROOM_UNAVAILABLE: &str = "CONFLICT_ROOM_UNAVAILABLE";
     pub const CONFLICT_IDEMPOTENCY_HASH_MISMATCH: &str = "CONFLICT_IDEMPOTENCY_HASH_MISMATCH";
     pub const CONFLICT_DUPLICATE_IN_FLIGHT: &str = "CONFLICT_DUPLICATE_IN_FLIGHT";
+    pub const CONFLICT_INVALID_STATE_TRANSITION: &str = "CONFLICT_INVALID_STATE_TRANSITION";
+    pub const CONFLICT_INVALID_STATE_TRANSITION_DEFAULT_MESSAGE: &str =
+        "Dữ liệu đã thay đổi, vui lòng tải lại trước khi thao tác.";
     pub const COMMAND_LEDGER_ROW_NOT_FOUND: &str = "COMMAND_LEDGER_ROW_NOT_FOUND";
     pub const SYSTEM_INTERNAL_ERROR: &str = "SYSTEM_INTERNAL_ERROR";
 
@@ -68,6 +71,7 @@ pub mod codes {
         CONFLICT_ROOM_UNAVAILABLE,
         CONFLICT_IDEMPOTENCY_HASH_MISMATCH,
         CONFLICT_DUPLICATE_IN_FLIGHT,
+        CONFLICT_INVALID_STATE_TRANSITION,
         COMMAND_LEDGER_ROW_NOT_FOUND,
         SYSTEM_INTERNAL_ERROR,
     ];
@@ -384,6 +388,34 @@ mod tests {
     }
 
     #[test]
+    fn invalid_state_transition_conflict_code_is_registered_with_default_message() {
+        #[derive(Deserialize)]
+        struct RegistryEntry {
+            code: String,
+            kind: AppErrorKind,
+            #[serde(rename = "defaultMessage")]
+            default_message: String,
+        }
+
+        let registry_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../shared/error-codes.json");
+        let registry: Vec<RegistryEntry> =
+            serde_json::from_str(&fs::read_to_string(&registry_path).expect("read registry"))
+                .expect("parse registry");
+        let entry = registry
+            .iter()
+            .find(|entry| entry.code == codes::CONFLICT_INVALID_STATE_TRANSITION)
+            .expect("invalid state transition code is registered");
+
+        assert!(codes::ALL.contains(&codes::CONFLICT_INVALID_STATE_TRANSITION));
+        assert_eq!(entry.kind, AppErrorKind::User);
+        assert_eq!(
+            entry.default_message,
+            codes::CONFLICT_INVALID_STATE_TRANSITION_DEFAULT_MESSAGE
+        );
+    }
+
+    #[test]
     fn registry_matches_the_exported_code_constants() {
         #[derive(Deserialize)]
         struct RegistryEntry {
@@ -538,6 +570,11 @@ mod tests {
                 codes::CONFLICT_DUPLICATE_IN_FLIGHT,
                 AppErrorKind::User,
                 "Lệnh đang được xử lý.",
+            ),
+            (
+                codes::CONFLICT_INVALID_STATE_TRANSITION,
+                AppErrorKind::User,
+                codes::CONFLICT_INVALID_STATE_TRANSITION_DEFAULT_MESSAGE,
             ),
             (
                 codes::SYSTEM_INTERNAL_ERROR,

--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -489,6 +489,39 @@ impl WriteCommandExecutor {
         }
     }
 
+    pub async fn execute_with_pre_transaction_guard<F, G, GFut, Guard>(
+        &self,
+        ctx: &WriteCommandContext,
+        request: WriteCommandRequest,
+        before_transaction: G,
+        service: F,
+    ) -> CommandResult<IdempotentCommandResult<serde_json::Value>>
+    where
+        F: for<'tx> FnOnce(&'tx mut Transaction<'_, Sqlite>) -> WriteCommandServiceFuture<'tx>,
+        G: FnOnce() -> GFut,
+        GFut: Future<Output = CommandResult<Guard>> + Send,
+        Guard: Send,
+    {
+        let prepared = prepare_write_command_request(request)?;
+        let claim = self.claim_or_reclaim(ctx, &prepared).await?;
+
+        match claim {
+            ClaimOutcome::Claimed { claim_token } => {
+                let _guard = match before_transaction().await {
+                    Ok(guard) => guard,
+                    Err(mut error) => {
+                        error.request_id = Some(ctx.request_id.clone());
+                        self.finalize_failure(ctx, &claim_token, &error).await?;
+                        return Err(error);
+                    }
+                };
+                self.run_claimed(ctx, &claim_token, &prepared, service)
+                    .await
+            }
+            ClaimOutcome::Replayed(result) => Ok(result),
+        }
+    }
+
     pub async fn execute_atomic<F>(
         &self,
         ctx: &WriteCommandContext,

--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -70,6 +70,16 @@ fn map_known_group_error_code(
         ));
     }
 
+    if message.contains(codes::CONFLICT_INVALID_STATE_TRANSITION) {
+        return Some(map_group_user_error(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            command_name,
+            effective_correlation_id,
+            message.to_string(),
+            context,
+        ));
+    }
+
     match classify_db_error_code(message) {
         Some(codes::DB_LOCKED_RETRYABLE) => Some(
             CommandError::system(codes::DB_LOCKED_RETRYABLE, message.to_string()).retryable(true),
@@ -773,6 +783,24 @@ mod tests {
 
         assert_eq!(error.code, codes::CONFLICT_ROOM_UNAVAILABLE);
         assert!(error.message.contains("lịch trùng"));
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn map_group_error_maps_invalid_state_transition_to_shared_conflict_code() {
+        let effective_correlation_id = frontend_correlation_id();
+        let error = map_group_error(
+            "group_checkout",
+            &effective_correlation_id,
+            BookingError::conflict(
+                "CONFLICT_INVALID_STATE_TRANSITION: booking is no longer active",
+            ),
+            json!({ "group_id": "group-1" }),
+        );
+
+        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+        assert!(error.message.contains("CONFLICT_INVALID_STATE_TRANSITION"));
         assert_eq!(error.kind, AppErrorKind::User);
         assert!(error.support_id.is_none());
     }

--- a/mhm/src-tauri/src/commands/reservations.rs
+++ b/mhm/src-tauri/src/commands/reservations.rs
@@ -161,6 +161,19 @@ fn map_known_reservation_error_code(
         ));
     }
 
+    if message.contains(codes::CONFLICT_INVALID_STATE_TRANSITION) {
+        return Some((
+            map_create_reservation_user_error(
+                codes::CONFLICT_INVALID_STATE_TRANSITION,
+                command_name,
+                effective_correlation_id,
+                message,
+                context,
+            ),
+            Some(DbErrorGroup::Constraint),
+        ));
+    }
+
     match classify_db_error_code(message) {
         Some(codes::DB_LOCKED_RETRYABLE) => Some((
             CommandError::system(codes::DB_LOCKED_RETRYABLE, message.to_string()).retryable(true),
@@ -850,6 +863,24 @@ mod tests {
 
         assert_eq!(error.code, codes::CONFLICT_ROOM_UNAVAILABLE);
         assert!(error.message.contains("is booked on"));
+        assert_eq!(error.kind, AppErrorKind::User);
+        assert!(error.support_id.is_none());
+        assert_eq!(db_error_group, Some(DbErrorGroup::Constraint));
+    }
+
+    #[test]
+    fn map_create_reservation_error_maps_invalid_state_transition_to_shared_conflict_code() {
+        let (error, db_error_group) = map_create_reservation_error(
+            "modify_reservation",
+            &frontend_correlation_id(),
+            BookingError::conflict(
+                "CONFLICT_INVALID_STATE_TRANSITION: booking is no longer active",
+            ),
+            json!({ "booking_id": "B101" }),
+        );
+
+        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+        assert!(error.message.contains("CONFLICT_INVALID_STATE_TRANSITION"));
         assert_eq!(error.kind, AppErrorKind::User);
         assert!(error.support_id.is_none());
         assert_eq!(db_error_group, Some(DbErrorGroup::Constraint));

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -572,6 +572,14 @@ pub async fn update_housekeeping(
     new_status: String,
     note: Option<String>,
 ) -> Result<(), String> {
+    if new_status == "clean" {
+        complete_housekeeping_clean_to_vacant(&state.db, &task_id, note.as_deref())
+            .await
+            .map_err(|error| format!("{}: {}", error.code, error.message))?;
+        emit_db_update(&app, "housekeeping");
+        return Ok(());
+    }
+
     let now = chrono::Local::now();
 
     let cleaned_at = if new_status == "clean" {
@@ -591,22 +599,114 @@ pub async fn update_housekeeping(
     .await
     .map_err(|e| e.to_string())?;
 
-    // If clean, update room to vacant
-    if new_status == "clean" {
-        let room_id: (String,) = sqlx::query_as("SELECT room_id FROM housekeeping WHERE id = ?")
-            .bind(&task_id)
-            .fetch_one(&state.db)
-            .await
-            .map_err(|e| e.to_string())?;
+    emit_db_update(&app, "housekeeping");
 
-        sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = ?")
-            .bind(&room_id.0)
-            .execute(&state.db)
-            .await
-            .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+async fn complete_housekeeping_clean_to_vacant(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    note: Option<&str>,
+) -> CommandResult<()> {
+    let room_id: String = sqlx::query_scalar("SELECT room_id FROM housekeeping WHERE id = ?")
+        .bind(task_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|error| {
+            log_system_error(
+                "update_housekeeping",
+                error.to_string(),
+                json!({
+                    "task_id": task_id,
+                    "step": "lookup_room",
+                }),
+            )
+        })?;
+
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::room_key(&room_id)?])
+        .await?;
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        log_system_error(
+            "update_housekeeping",
+            error.to_string(),
+            json!({
+                "task_id": task_id,
+                "room_id": room_id,
+                "step": "begin",
+            }),
+        )
+    })?;
+
+    let cleaned_at = chrono::Local::now().to_rfc3339();
+    let housekeeping_result = sqlx::query(
+        "UPDATE housekeeping
+         SET status = 'clean', note = COALESCE(?, note), cleaned_at = ?
+         WHERE id = ? AND status = 'cleaning'",
+    )
+    .bind(note)
+    .bind(&cleaned_at)
+    .bind(task_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|error| {
+        log_system_error(
+            "update_housekeeping",
+            error.to_string(),
+            json!({
+                "task_id": task_id,
+                "room_id": room_id,
+                "step": "update_housekeeping",
+            }),
+        )
+    })?;
+
+    if housekeeping_result.rows_affected() != 1 {
+        let _ = tx.rollback().await;
+        return Err(CommandError::user(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            "Housekeeping task is no longer cleaning",
+        ));
     }
 
-    emit_db_update(&app, "housekeeping");
+    let room_result =
+        sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = ? AND status = 'cleaning'")
+            .bind(&room_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|error| {
+                log_system_error(
+                    "update_housekeeping",
+                    error.to_string(),
+                    json!({
+                        "task_id": task_id,
+                        "room_id": room_id,
+                        "step": "update_room",
+                    }),
+                )
+            })?;
+
+    if room_result.rows_affected() != 1 {
+        let _ = tx.rollback().await;
+        return Err(CommandError::user(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            "Room is no longer waiting for cleaning completion",
+        ));
+    }
+
+    tx.commit().await.map_err(|error| {
+        log_system_error(
+            "update_housekeeping",
+            error.to_string(),
+            json!({
+                "task_id": task_id,
+                "room_id": room_id,
+                "step": "commit",
+            }),
+        )
+    })?;
 
     Ok(())
 }
@@ -743,7 +843,10 @@ pub async fn scan_image(path: String) -> Result<crate::ocr::CccdInfo, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{check_in_failure_context, check_out_failure_context, map_stay_error};
+    use super::{
+        check_in_failure_context, check_out_failure_context,
+        complete_housekeeping_clean_to_vacant, map_stay_error,
+    };
     use crate::app_error::{
         codes, record_command_failure_with_db_group, AppErrorKind, CorrelationIdSource,
         EffectiveCorrelationId,
@@ -754,7 +857,20 @@ mod tests {
         CheckInRequest, CheckOutRequest, CheckoutSettlementMode, CreateGuestRequest,
     };
     use serde_json::json;
+    use sqlx::{sqlite::SqlitePoolOptions, Row};
     use std::fs;
+
+    async fn migrated_pool() -> sqlx::Pool<sqlx::Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
 
     fn frontend_correlation_id() -> EffectiveCorrelationId {
         EffectiveCorrelationId {
@@ -778,6 +894,58 @@ mod tests {
             Some(value) => std::env::set_var("CAPYINN_RUNTIME_ROOT", value),
             None => std::env::remove_var("CAPYINN_RUNTIME_ROOT"),
         }
+    }
+
+    #[tokio::test]
+    async fn housekeeping_clean_does_not_mark_occupied_room_vacant() {
+        let pool = migrated_pool().await;
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("R-HK")
+        .bind("Housekeeping Guard")
+        .bind("standard")
+        .bind(1)
+        .bind(0)
+        .bind(100000.0)
+        .bind(2)
+        .bind(0.0)
+        .bind("occupied")
+        .execute(&pool)
+        .await
+        .expect("insert occupied room");
+        sqlx::query(
+            "INSERT INTO housekeeping (id, room_id, status, note, triggered_at, cleaned_at, created_at)
+             VALUES (?, ?, ?, ?, datetime('now'), NULL, datetime('now'))",
+        )
+        .bind("HK1")
+        .bind("R-HK")
+        .bind("cleaning")
+        .bind("started")
+        .execute(&pool)
+        .await
+        .expect("insert housekeeping task");
+
+        let error = complete_housekeeping_clean_to_vacant(&pool, "HK1", None)
+            .await
+            .expect_err("occupied room should reject clean-to-vacant");
+
+        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+
+        let room = sqlx::query("SELECT status FROM rooms WHERE id = ?")
+            .bind("R-HK")
+            .fetch_one(&pool)
+            .await
+            .expect("room status");
+        assert_eq!(room.get::<String, _>("status"), "occupied");
+
+        let housekeeping = sqlx::query("SELECT status FROM housekeeping WHERE id = ?")
+            .bind("HK1")
+            .fetch_one(&pool)
+            .await
+            .expect("housekeeping status");
+        assert_eq!(housekeeping.get::<String, _>("status"), "cleaning");
     }
 
     #[test]

--- a/mhm/src-tauri/src/gateway/policy.rs
+++ b/mhm/src-tauri/src/gateway/policy.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use crate::app_error::codes;
 use crate::runtime_config;
+use crate::write_manifest::LockDeriverId;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -21,15 +22,12 @@ pub struct WriteToolMeta {
     pub description: &'static str,
 }
 
-const RESERVATION_WRITE_LOCK_DERIVER_PLACEHOLDER: &str =
-    "reservation_write_lock_deriver_placeholder";
-
 pub const CREATE_RESERVATION_META: WriteToolMeta = WriteToolMeta {
     command_name: "create_reservation",
     risk_level: RiskLevel::High,
     requires_approval: true,
     requires_idempotency_key: true,
-    lock_deriver: RESERVATION_WRITE_LOCK_DERIVER_PLACEHOLDER,
+    lock_deriver: LockDeriverId::RoomFromRequest.policy_name(),
     description: "Creates a reservation booking row and reserves room calendar dates.",
 };
 
@@ -38,7 +36,7 @@ pub const CANCEL_RESERVATION_META: WriteToolMeta = WriteToolMeta {
     risk_level: RiskLevel::High,
     requires_approval: true,
     requires_idempotency_key: true,
-    lock_deriver: RESERVATION_WRITE_LOCK_DERIVER_PLACEHOLDER,
+    lock_deriver: LockDeriverId::ReservationBookingAndRoom.policy_name(),
     description: "Cancels an existing booked reservation.",
 };
 
@@ -47,7 +45,7 @@ pub const MODIFY_RESERVATION_META: WriteToolMeta = WriteToolMeta {
     risk_level: RiskLevel::High,
     requires_approval: true,
     requires_idempotency_key: true,
-    lock_deriver: RESERVATION_WRITE_LOCK_DERIVER_PLACEHOLDER,
+    lock_deriver: LockDeriverId::ReservationBookingAndRoom.policy_name(),
     description: "Changes an existing booked reservation's scheduled dates.",
 };
 
@@ -124,6 +122,21 @@ mod tests {
             assert!(meta.requires_approval);
             assert!(meta.requires_idempotency_key);
             assert!(!meta.lock_deriver.is_empty());
+        }
+    }
+
+    #[test]
+    fn write_tool_manifest_lock_derivers_match_write_manifest() {
+        for meta in WRITE_TOOL_MANIFEST {
+            let write_meta = crate::write_manifest::meta_for(meta.command_name)
+                .expect("gateway write tool must exist in write manifest");
+
+            assert_eq!(
+                meta.lock_deriver,
+                write_meta.lock_deriver.policy_name(),
+                "lock deriver mismatch for {}",
+                meta.command_name
+            );
         }
     }
 }

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use tauri::Manager;
 
 pub mod app_error;
 pub mod app_identity;
+pub mod aggregate_locks;
 mod backup;
 mod command_failure_log;
 pub mod command_idempotency;

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod runtime_config;
 mod services;
 pub mod support_log;
 mod watcher;
+pub mod write_manifest;
 
 use commands::AppState;
 use std::sync::{Arc, Mutex, Once};

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -18,7 +18,10 @@ use crate::{
 use super::{
     billing_service::{record_charge_tx, record_payment_tx, record_payment_with_origin_tx},
     guest_service::{create_group_guest_manifest, link_booking_guests},
-    support::{begin_immediate_tx, insert_room_calendar_rows},
+    support::{
+        begin_immediate_tx, ensure_one_row_affected, ensure_rows_affected,
+        insert_room_calendar_rows, invalid_state_transition,
+    },
 };
 
 const GROUP_ACTIVE: &str = "active";
@@ -184,6 +187,15 @@ pub async fn group_checkin_idempotent(
     let req_for_service = req;
     let user_id_for_service = user_id;
     let origin_idempotency_key = ctx.idempotency_key.clone();
+
+    let lock_keys = req_for_service
+        .room_ids
+        .iter()
+        .map(|room_id| crate::aggregate_locks::room_key(room_id))
+        .collect::<CommandResult<Vec<_>>>()?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire(lock_keys)
+        .await?;
 
     WriteCommandExecutor::new(pool.clone())
         .execute_atomic(ctx, request, move |tx| {
@@ -440,11 +452,13 @@ async fn group_checkin_tx(
         .await?;
 
         if !is_reservation {
-            sqlx::query("UPDATE rooms SET status = ? WHERE id = ?")
+            let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status = ?")
                 .bind(status::room::OCCUPIED)
                 .bind(room_id)
+                .bind(status::room::VACANT)
                 .execute(&mut **tx)
                 .await?;
+            ensure_one_row_affected(result, format!("room {room_id} is no longer vacant"))?;
         }
     }
 
@@ -467,21 +481,25 @@ pub async fn group_checkout(pool: &Pool<Sqlite>, req: GroupCheckoutRequest) -> B
     }
 
     let now = Local::now().to_rfc3339();
-    let mut tx = begin_immediate_tx(pool).await?;
+    let mut unique_booking_ids = Vec::new();
+    let mut seen_booking_ids = std::collections::HashSet::new();
+    for id in &req.booking_ids {
+        if seen_booking_ids.insert(id.clone()) {
+            unique_booking_ids.push(id.clone());
+        }
+    }
 
     let mut query_builder: sqlx::QueryBuilder<Sqlite> =
-        sqlx::QueryBuilder::new("SELECT id, room_id FROM bookings WHERE status = ");
-    query_builder.push_bind(status::booking::ACTIVE);
-    query_builder.push(" AND group_id = ");
+        sqlx::QueryBuilder::new("SELECT id, room_id FROM bookings WHERE group_id = ");
     query_builder.push_bind(&req.group_id);
     query_builder.push(" AND id IN (");
     let mut separated = query_builder.separated(", ");
-    for id in &req.booking_ids {
+    for id in &unique_booking_ids {
         separated.push_bind(id);
     }
     separated.push_unseparated(")");
 
-    let rows = query_builder.build().fetch_all(&mut *tx).await?;
+    let rows = query_builder.build().fetch_all(pool).await?;
     let mut booking_room_map = std::collections::HashMap::new();
     for row in rows {
         let id: String = row.get("id");
@@ -498,29 +516,104 @@ pub async fn group_checkout(pool: &Pool<Sqlite>, req: GroupCheckoutRequest) -> B
         }
     }
 
-    let room_ids: Vec<String> = booking_room_map.values().cloned().collect();
+    let mut room_ids = Vec::new();
+    let mut seen_room_ids = std::collections::HashSet::new();
+    for booking_id in &unique_booking_ids {
+        if let Some(room_id) = booking_room_map.get(booking_id) {
+            if seen_room_ids.insert(room_id.clone()) {
+                room_ids.push(room_id.clone());
+            }
+        }
+    }
+
+    let mut lock_keys = vec![crate::aggregate_locks::group_key(&req.group_id)
+        .map_err(|error| BookingError::validation(error.message))?];
+    for booking_id in &unique_booking_ids {
+        lock_keys.push(
+            crate::aggregate_locks::booking_key(booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        );
+    }
+    for room_id in &room_ids {
+        lock_keys.push(
+            crate::aggregate_locks::room_key(room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        );
+    }
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire(lock_keys)
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+
+    let mut query_builder: sqlx::QueryBuilder<Sqlite> =
+        sqlx::QueryBuilder::new("SELECT id, room_id FROM bookings WHERE group_id = ");
+    query_builder.push_bind(&req.group_id);
+    query_builder.push(" AND id IN (");
+    let mut separated = query_builder.separated(", ");
+    for id in &unique_booking_ids {
+        separated.push_bind(id);
+    }
+    separated.push_unseparated(")");
+
+    let rows = query_builder.build().fetch_all(&mut *tx).await?;
+    let mut current_booking_room_map = std::collections::HashMap::new();
+    for row in rows {
+        let id: String = row.get("id");
+        let room_id: String = row.get("room_id");
+        current_booking_room_map.insert(id, room_id);
+    }
+    ensure_group_checkout_room_map_still_locked(
+        &req.group_id,
+        &unique_booking_ids,
+        &booking_room_map,
+        &current_booking_room_map,
+    )?;
 
     let mut qb = sqlx::QueryBuilder::new("UPDATE bookings SET status = ");
     qb.push_bind(status::booking::CHECKED_OUT);
     qb.push(", actual_checkout = ");
     qb.push_bind(&now);
-    qb.push(" WHERE id IN (");
+    qb.push(" WHERE group_id = ");
+    qb.push_bind(&req.group_id);
+    qb.push(" AND status = ");
+    qb.push_bind(status::booking::ACTIVE);
+    qb.push(" AND id IN (");
     let mut sep = qb.separated(", ");
-    for id in &req.booking_ids {
+    for id in &unique_booking_ids {
         sep.push_bind(id);
     }
     sep.push_unseparated(")");
-    qb.build().execute(&mut *tx).await?;
+    let result = qb.build().execute(&mut *tx).await?;
+    ensure_rows_affected(
+        result,
+        unique_booking_ids.len() as u64,
+        format!(
+            "one or more bookings in group {} are no longer active",
+            req.group_id
+        ),
+    )?;
 
     let mut qb = sqlx::QueryBuilder::new("UPDATE rooms SET status = ");
     qb.push_bind(status::room::CLEANING);
-    qb.push(" WHERE id IN (");
+    qb.push(" WHERE status = ");
+    qb.push_bind(status::room::OCCUPIED);
+    qb.push(" AND id IN (");
     let mut sep = qb.separated(", ");
     for rid in &room_ids {
         sep.push_bind(rid);
     }
     sep.push_unseparated(")");
-    qb.build().execute(&mut *tx).await?;
+    let result = qb.build().execute(&mut *tx).await?;
+    ensure_rows_affected(
+        result,
+        room_ids.len() as u64,
+        format!(
+            "one or more rooms in group {} are no longer occupied",
+            req.group_id
+        ),
+    )?;
 
     let mut qb = sqlx::QueryBuilder::new(
         "INSERT INTO housekeeping (id, room_id, status, triggered_at, created_at) ",
@@ -536,13 +629,13 @@ pub async fn group_checkout(pool: &Pool<Sqlite>, req: GroupCheckoutRequest) -> B
 
     let mut qb = sqlx::QueryBuilder::new("DELETE FROM room_calendar WHERE booking_id IN (");
     let mut sep = qb.separated(", ");
-    for id in &req.booking_ids {
+    for id in &unique_booking_ids {
         sep.push_bind(id);
     }
     sep.push_unseparated(")");
     qb.build().execute(&mut *tx).await?;
 
-    maybe_reassign_master_booking(&mut tx, &req.group_id, &req.booking_ids).await?;
+    maybe_reassign_master_booking(&mut tx, &req.group_id, &unique_booking_ids).await?;
 
     let remaining_active: (i64,) =
         sqlx::query_as("SELECT COUNT(*) FROM bookings WHERE group_id = ? AND status = ?")
@@ -584,6 +677,23 @@ pub async fn group_checkout(pool: &Pool<Sqlite>, req: GroupCheckoutRequest) -> B
     }
 
     tx.commit().await.map_err(BookingError::from)?;
+    Ok(())
+}
+
+pub(crate) fn ensure_group_checkout_room_map_still_locked(
+    group_id: &str,
+    booking_ids: &[String],
+    locked_booking_room_map: &std::collections::HashMap<String, String>,
+    current_booking_room_map: &std::collections::HashMap<String, String>,
+) -> BookingResult<()> {
+    for booking_id in booking_ids {
+        if current_booking_room_map.get(booking_id) != locked_booking_room_map.get(booking_id) {
+            return Err(invalid_state_transition(format!(
+                "one or more bookings in group {group_id} changed rooms before checkout"
+            )));
+        }
+    }
+
     Ok(())
 }
 

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -44,6 +44,9 @@ fn map_group_checkin_command_error(error: BookingError) -> CommandError {
             CommandError::user(codes::ROOM_NOT_FOUND, message)
         }
         BookingError::Validation(message) | BookingError::Conflict(message) => {
+            if message.contains(codes::CONFLICT_INVALID_STATE_TRANSITION) {
+                return CommandError::user(codes::CONFLICT_INVALID_STATE_TRANSITION, message);
+            }
             if is_room_unavailable_conflict_message(&message) {
                 return CommandError::user(codes::CONFLICT_ROOM_UNAVAILABLE, message);
             }
@@ -111,6 +114,25 @@ fn build_group_checkin_hash_payload(req: &GroupCheckinRequest) -> serde_json::Va
         "notes": req.notes.clone(),
         "paid_minor_units": paid_minor_units,
     })
+}
+
+fn group_checkin_lock_keys_from_payload(
+    hash_payload: &serde_json::Value,
+) -> CommandResult<Vec<String>> {
+    let room_ids = hash_payload
+        .get("room_ids")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| system_error("group check-in lock payload missing room_ids"))?;
+
+    room_ids
+        .iter()
+        .map(|value| {
+            let room_id = value
+                .as_str()
+                .ok_or_else(|| system_error("group check-in lock room id must be a string"))?;
+            crate::aggregate_locks::room_key(room_id)
+        })
+        .collect()
 }
 
 fn build_group_checkin_payment_origins(
@@ -181,47 +203,49 @@ pub async fn group_checkin_idempotent(
     ])?;
     let summary =
         CommandLedgerSummary::new("Group check-in")?.with_business_date(effective_checkin_date)?;
+    let runtime_lock_keys = group_checkin_lock_keys_from_payload(&hash_payload)?;
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_lock_key_deriver(group_checkin_lock_keys_from_payload)
         .with_success_summary(CommandLedgerResultSummary::success("Group checked in")?);
 
     let req_for_service = req;
     let user_id_for_service = user_id;
     let origin_idempotency_key = ctx.idempotency_key.clone();
 
-    let lock_keys = req_for_service
-        .room_ids
-        .iter()
-        .map(|room_id| crate::aggregate_locks::room_key(room_id))
-        .collect::<CommandResult<Vec<_>>>()?;
-    let _lock_guard = crate::aggregate_locks::global_manager()
-        .acquire(lock_keys)
-        .await?;
-
     WriteCommandExecutor::new(pool.clone())
-        .execute_atomic(ctx, request, move |tx| {
-            Box::pin(async move {
-                let payment_origins = if req_for_service.paid_amount.unwrap_or(0.0) > 0.0 {
-                    Some(build_group_checkin_payment_origins(
-                        &origin_idempotency_key,
-                        &req_for_service.room_ids,
-                    )?)
-                } else {
-                    None
-                };
-                let group_id = group_checkin_tx(
-                    tx,
-                    user_id_for_service.as_deref(),
-                    &req_for_service,
-                    payment_origins.as_ref(),
-                )
-                .await
-                .map_err(map_group_checkin_command_error)?;
-                let group = fetch_group_tx(tx, &group_id)
+        .execute_with_pre_transaction_guard(
+            ctx,
+            request,
+            move || async move {
+                crate::aggregate_locks::global_manager()
+                    .acquire(runtime_lock_keys)
+                    .await
+            },
+            move |tx| {
+                Box::pin(async move {
+                    let payment_origins = if req_for_service.paid_amount.unwrap_or(0.0) > 0.0 {
+                        Some(build_group_checkin_payment_origins(
+                            &origin_idempotency_key,
+                            &req_for_service.room_ids,
+                        )?)
+                    } else {
+                        None
+                    };
+                    let group_id = group_checkin_tx(
+                        tx,
+                        user_id_for_service.as_deref(),
+                        &req_for_service,
+                        payment_origins.as_ref(),
+                    )
                     .await
                     .map_err(map_group_checkin_command_error)?;
-                serde_json::to_value(&group).map_err(system_error)
-            })
-        })
+                    let group = fetch_group_tx(tx, &group_id)
+                        .await
+                        .map_err(map_group_checkin_command_error)?;
+                    serde_json::to_value(&group).map_err(system_error)
+                })
+            },
+        )
         .await
 }
 
@@ -896,4 +920,19 @@ async fn fetch_group(pool: &Pool<Sqlite>, group_id: &str) -> BookingResult<Booki
 fn parse_date(value: &str) -> BookingResult<NaiveDate> {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
         .map_err(|error| BookingError::datetime_parse(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_group_checkin_command_error_maps_invalid_state_transition_code() {
+        let error = map_group_checkin_command_error(BookingError::conflict(format!(
+            "{}: room R101 is no longer vacant",
+            codes::CONFLICT_INVALID_STATE_TRANSITION
+        )));
+
+        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+    }
 }

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -21,7 +21,10 @@ use super::{
         record_deposit_with_origin_tx,
     },
     guest_service::{create_reservation_guest_manifest, link_booking_guests},
-    support::{begin_immediate_tx, fetch_booking, insert_room_calendar_rows, read_f64_strict},
+    support::{
+        begin_immediate_tx, ensure_one_row_affected, fetch_booking, insert_room_calendar_rows,
+        invalid_state_transition, lookup_booking_room_id, read_f64_strict,
+    },
 };
 
 fn mark_write_db_error(error: BookingError) -> BookingError {
@@ -322,6 +325,17 @@ pub async fn create_reservation_idempotent(
 }
 
 pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<()> {
+    let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key(booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            crate::aggregate_locks::room_key(&locked_room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
     let mut tx = begin_immediate_tx(pool).await?;
 
     let booking = sqlx::query(
@@ -337,21 +351,31 @@ pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Bookin
         .ok_or_else(|| BookingError::not_found(format!("Booking not found: {}", booking_id)))?;
 
     let status: String = booking.get("status");
-    if status != status::booking::BOOKED {
-        return Err(BookingError::conflict(format!(
-            "Can only cancel reservations in 'booked' status (current: {})",
-            status
+    let room_id: String = booking.get("room_id");
+    if room_id != locked_room_id {
+        return Err(invalid_state_transition(format!(
+            "reservation {booking_id} changed rooms before cancellation"
         )));
     }
 
-    let room_id: String = booking.get("room_id");
+    if status != status::booking::BOOKED {
+        return Err(invalid_state_transition(format!(
+            "reservation {booking_id} is no longer booked"
+        )));
+    }
+
     let deposit_amount: f64 = booking.get("deposit_amount");
 
-    sqlx::query("UPDATE bookings SET status = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE bookings SET status = ? WHERE id = ? AND status = ?")
         .bind(status::booking::CANCELLED)
         .bind(booking_id)
+        .bind(status::booking::BOOKED)
         .execute(&mut *tx)
         .await?;
+    ensure_one_row_affected(
+        result,
+        format!("reservation {booking_id} is no longer booked"),
+    )?;
 
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ? AND status = ?")
         .bind(booking_id)
@@ -395,8 +419,24 @@ pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Bookin
 }
 
 pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
+    let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key(booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            crate::aggregate_locks::room_key(&locked_room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
     let mut tx = begin_immediate_tx(pool).await?;
     let reservation = load_booked_reservation(&mut tx, booking_id).await?;
+    if reservation.room_id != locked_room_id {
+        return Err(invalid_state_transition(format!(
+            "reservation {booking_id} changed rooms before confirmation"
+        )));
+    }
     reject_no_show_confirmation(&mut tx, booking_id).await?;
 
     let now = Local::now();
@@ -434,10 +474,10 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
     )
     .await?;
 
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE bookings
          SET status = ?, check_in_at = ?, expected_checkout = ?, nights = ?, total_price = ?, paid_amount = ?
-         WHERE id = ?",
+         WHERE id = ? AND status = ?",
     )
     .bind(status::booking::ACTIVE)
     .bind(&check_in_at)
@@ -446,14 +486,28 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
     .bind(pricing.total)
     .bind(reservation.paid_amount)
     .bind(booking_id)
+    .bind(status::booking::BOOKED)
     .execute(&mut *tx)
     .await?;
+    ensure_one_row_affected(
+        result,
+        format!("reservation {booking_id} is no longer booked"),
+    )?;
 
-    sqlx::query("UPDATE rooms SET status = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status IN (?, ?)")
         .bind(status::room::OCCUPIED)
         .bind(&reservation.room_id)
+        .bind(status::room::VACANT)
+        .bind(status::room::BOOKED)
         .execute(&mut *tx)
         .await?;
+    ensure_one_row_affected(
+        result,
+        format!(
+            "room {} is no longer available for confirmation",
+            reservation.room_id
+        ),
+    )?;
 
     record_charge_tx(
         &mut tx,
@@ -485,8 +539,25 @@ pub async fn modify_reservation(
         req.new_nights,
     )? as i64;
 
+    let locked_room_id = lookup_booking_room_id(pool, &req.booking_id).await?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key(&req.booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            crate::aggregate_locks::room_key(&locked_room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
     let mut tx = begin_immediate_tx(pool).await?;
     let reservation = load_booked_reservation(&mut tx, &req.booking_id).await?;
+    if reservation.room_id != locked_room_id {
+        return Err(invalid_state_transition(format!(
+            "reservation {} changed rooms before modification",
+            req.booking_id
+        )));
+    }
 
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ? AND status = ?")
         .bind(&req.booking_id)
@@ -520,10 +591,10 @@ pub async fn modify_reservation(
     )
     .await?;
 
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE bookings
          SET check_in_at = ?, expected_checkout = ?, scheduled_checkin = ?, scheduled_checkout = ?, nights = ?, total_price = ?
-         WHERE id = ?",
+         WHERE id = ? AND status = ? AND room_id = ?",
     )
     .bind(&req.new_check_in_date)
     .bind(&req.new_check_out_date)
@@ -532,8 +603,14 @@ pub async fn modify_reservation(
     .bind(derived_nights)
     .bind(pricing.total)
     .bind(&req.booking_id)
+    .bind(status::booking::BOOKED)
+    .bind(&locked_room_id)
     .execute(&mut *tx)
     .await?;
+    ensure_one_row_affected(
+        result,
+        format!("reservation {} is no longer booked", req.booking_id),
+    )?;
 
     insert_booked_calendar_rows(
         &mut tx,
@@ -624,9 +701,8 @@ async fn load_booked_reservation(
         row.ok_or_else(|| BookingError::not_found(format!("Booking not found: {}", booking_id)))?;
     let booking_status: String = row.get("status");
     if booking_status != status::booking::BOOKED {
-        return Err(BookingError::conflict(format!(
-            "Can only operate on reservations in 'booked' status (current: {})",
-            booking_status
+        return Err(invalid_state_transition(format!(
+            "reservation {booking_id} is no longer booked"
         )));
     }
 

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -13,7 +13,8 @@ use super::{
     billing_service::{record_charge_tx, record_payment_tx},
     guest_service::{create_guest_manifest, link_booking_guests},
     support::{
-        begin_immediate_tx, begin_tx, fetch_booking, insert_room_calendar_rows,
+        begin_immediate_tx, begin_tx, ensure_one_row_affected, fetch_booking,
+        insert_room_calendar_rows, invalid_state_transition, lookup_booking_room_id,
         map_room_calendar_insert_error, parse_booking_datetime, read_f64_or_zero,
     },
 };
@@ -25,12 +26,30 @@ fn mark_write_db_error(error: BookingError) -> BookingError {
     }
 }
 
+fn ensure_locked_room_matches_booking(
+    locked_room_id: &str,
+    current_room_id: &str,
+    message: impl AsRef<str>,
+) -> BookingResult<()> {
+    if locked_room_id == current_room_id {
+        Ok(())
+    } else {
+        Err(invalid_state_transition(message))
+    }
+}
+
 pub async fn check_in(
     pool: &Pool<Sqlite>,
     req: CheckInRequest,
     user_id: Option<String>,
 ) -> BookingResult<Booking> {
     validate_check_in_request(&req)?;
+
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::room_key(&req.room_id)
+            .map_err(|error| BookingError::validation(error.message))?])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
 
     let now = Local::now();
     let check_in_at = now.to_rfc3339();
@@ -157,13 +176,15 @@ pub async fn check_in(
     .await
     .map_err(mark_write_db_error)?;
 
-    sqlx::query("UPDATE rooms SET status = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status = ?")
         .bind(status::room::OCCUPIED)
         .bind(&req.room_id)
+        .bind(status::room::VACANT)
         .execute(&mut *tx)
         .await
         .map_err(BookingError::from)
         .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(result, format!("room {} is no longer vacant", req.room_id))?;
 
     tx.commit()
         .await
@@ -401,6 +422,17 @@ pub async fn check_out_at(
         ));
     }
 
+    let room_id = lookup_booking_room_id(pool, &req.booking_id).await?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key(&req.booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            crate::aggregate_locks::room_key(&room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
     let mut tx = begin_immediate_tx(pool)
         .await
         .map_err(mark_write_db_error)?;
@@ -409,6 +441,11 @@ pub async fn check_out_at(
         settlement_mode: req.settlement_mode,
     };
     let settlement = preview_checkout_settlement_tx(&mut tx, &preview_req, now).await?;
+    ensure_locked_room_matches_booking(
+        &room_id,
+        &settlement.room_id,
+        format!("booking {} changed rooms before checkout", req.booking_id),
+    )?;
     let actual_checkout = now.to_rfc3339();
 
     if settlement.already_paid > req.final_total {
@@ -455,10 +492,10 @@ pub async fn check_out_at(
         manual_override,
     );
 
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE bookings
          SET status = ?, actual_checkout = ?, nights = ?, total_price = ?, pricing_snapshot = ?
-         WHERE id = ?",
+         WHERE id = ? AND status = ?",
     )
         .bind(status::booking::CHECKED_OUT)
         .bind(&actual_checkout)
@@ -466,18 +503,28 @@ pub async fn check_out_at(
         .bind(req.final_total)
         .bind(pricing_snapshot)
         .bind(&req.booking_id)
+        .bind(status::booking::ACTIVE)
         .execute(&mut *tx)
         .await
         .map_err(BookingError::from)
         .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(
+        result,
+        format!("booking {} is no longer active", req.booking_id),
+    )?;
 
-    sqlx::query("UPDATE rooms SET status = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status = ?")
         .bind(status::room::CLEANING)
         .bind(&settlement.room_id)
+        .bind(status::room::OCCUPIED)
         .execute(&mut *tx)
         .await
         .map_err(BookingError::from)
         .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(
+        result,
+        format!("room {} is no longer occupied", settlement.room_id),
+    )?;
 
     sqlx::query(
         "INSERT INTO housekeeping (id, room_id, status, triggered_at, created_at)
@@ -508,6 +555,17 @@ pub async fn check_out_at(
 }
 
 pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
+    let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key(booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            crate::aggregate_locks::room_key(&locked_room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
     let mut tx = begin_immediate_tx(pool).await?;
 
     let booking = sqlx::query(
@@ -524,6 +582,11 @@ pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult
     })?;
 
     let room_id: String = booking.get("room_id");
+    ensure_locked_room_matches_booking(
+        &locked_room_id,
+        &room_id,
+        format!("booking {booking_id} changed rooms before extend-stay"),
+    )?;
     let current_nights: i32 = booking.get("nights");
     let current_total = read_f64_or_zero(&booking, "total_price");
     let old_expected_checkout: String = booking.get("expected_checkout");
@@ -575,15 +638,23 @@ pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult
     let new_total = current_total + incremental_pricing.total;
     let new_checkout = new_expected.to_rfc3339();
 
-    sqlx::query(
-        "UPDATE bookings SET nights = ?, total_price = ?, expected_checkout = ? WHERE id = ?",
+    let result = sqlx::query(
+        "UPDATE bookings
+         SET nights = ?, total_price = ?, expected_checkout = ?
+         WHERE id = ? AND status = ? AND expected_checkout = ?",
     )
     .bind(current_nights + 1)
     .bind(new_total)
     .bind(&new_checkout)
     .bind(booking_id)
+    .bind(status::booking::ACTIVE)
+    .bind(&old_expected_checkout)
     .execute(&mut *tx)
     .await?;
+    ensure_one_row_affected(
+        result,
+        format!("booking {booking_id} changed before extend-stay"),
+    )?;
 
     sqlx::query(
         "INSERT INTO room_calendar (room_id, date, booking_id, status)
@@ -652,7 +723,7 @@ async fn insert_occupied_calendar_rows(
 
 #[cfg(test)]
 mod tests {
-    use super::mark_write_db_error;
+    use super::{ensure_locked_room_matches_booking, mark_write_db_error};
     use crate::domain::booking::BookingError;
 
     #[test]
@@ -664,6 +735,19 @@ mod tests {
         assert_eq!(
             mark_write_db_error(BookingError::not_found("Booking not found: booking-1")),
             BookingError::not_found("Booking not found: booking-1")
+        );
+    }
+
+    #[test]
+    fn ensure_locked_room_matches_booking_rejects_stale_room_lock() {
+        let result = ensure_locked_room_matches_booking(
+            "room-old",
+            "room-new",
+            "booking booking-1 changed rooms before checkout",
+        );
+
+        assert!(
+            matches!(result, Err(BookingError::Conflict(message)) if message.contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION) && message.contains("booking booking-1 changed rooms before checkout"))
         );
     }
 }

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -322,11 +322,10 @@ async fn preview_checkout_settlement_tx(
 ) -> BookingResult<CheckoutSettlementComputation> {
     let booking = sqlx::query(
         "SELECT room_id, check_in_at, nights, total_price, paid_amount,
-                COALESCE(pricing_type, 'nightly') AS pricing_type
-         FROM bookings WHERE id = ? AND status = ?",
+                COALESCE(pricing_type, 'nightly') AS pricing_type, status
+         FROM bookings WHERE id = ?",
     )
     .bind(&req.booking_id)
-    .bind(status::booking::ACTIVE)
     .fetch_optional(&mut **tx)
     .await?
     .ok_or_else(|| {
@@ -335,6 +334,14 @@ async fn preview_checkout_settlement_tx(
             req.booking_id
         ))
     })?;
+
+    let booking_status: String = booking.get("status");
+    if booking_status != status::booking::ACTIVE {
+        return Err(invalid_state_transition(format!(
+            "booking {} is no longer active",
+            req.booking_id
+        )));
+    }
 
     let room_id: String = booking.get("room_id");
     let check_in_at: String = booking.get("check_in_at");

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -16,6 +16,48 @@ pub async fn begin_immediate_tx<'a>(
         .map_err(BookingError::from)
 }
 
+pub fn invalid_state_transition(message: impl AsRef<str>) -> BookingError {
+    BookingError::conflict(format!(
+        "{}: {}",
+        crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION,
+        message.as_ref()
+    ))
+}
+
+pub fn ensure_one_row_affected(
+    result: sqlx::sqlite::SqliteQueryResult,
+    message: impl AsRef<str>,
+) -> BookingResult<()> {
+    if result.rows_affected() == 1 {
+        Ok(())
+    } else {
+        Err(invalid_state_transition(message))
+    }
+}
+
+pub fn ensure_rows_affected(
+    result: sqlx::sqlite::SqliteQueryResult,
+    expected: u64,
+    message: impl AsRef<str>,
+) -> BookingResult<()> {
+    if result.rows_affected() == expected {
+        Ok(())
+    } else {
+        Err(invalid_state_transition(message))
+    }
+}
+
+pub async fn lookup_booking_room_id(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+) -> BookingResult<String> {
+    sqlx::query_scalar::<_, String>("SELECT room_id FROM bookings WHERE id = ?")
+        .bind(booking_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {}", booking_id)))
+}
+
 pub fn rfc3339_now() -> String {
     Local::now().to_rfc3339()
 }
@@ -124,8 +166,16 @@ pub fn read_f64_strict(row: &SqliteRow, column: &str) -> f64 {
 
 #[cfg(test)]
 pub mod tests {
-    use super::begin_immediate_tx;
+    use super::{begin_immediate_tx, invalid_state_transition};
     use sqlx::{sqlite::SqlitePoolOptions, Row};
+
+    #[test]
+    fn invalid_state_transition_error_includes_shared_code() {
+        let error = invalid_state_transition("booking is no longer active");
+        assert!(error
+            .to_string()
+            .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+    }
 
     #[tokio::test]
     async fn begin_immediate_tx_starts_transaction_that_can_write() {

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -1121,6 +1121,22 @@ async fn group_checkin_rejects_duplicate_room_ids() {
 }
 
 #[tokio::test]
+async fn group_checkin_lock_keys_are_stable_for_room_order() {
+    let left = crate::aggregate_locks::canonicalize_lock_keys(vec![
+        crate::aggregate_locks::room_key("R2").unwrap(),
+        crate::aggregate_locks::room_key("R1").unwrap(),
+    ])
+    .unwrap();
+    let right = crate::aggregate_locks::canonicalize_lock_keys(vec![
+        crate::aggregate_locks::room_key("R1").unwrap(),
+        crate::aggregate_locks::room_key("R2").unwrap(),
+    ])
+    .unwrap();
+
+    assert_eq!(left, right);
+}
+
+#[tokio::test]
 async fn group_checkin_idempotent_normalizes_room_order_and_assigns_payment_ordinals() {
     let pool = test_pool().await;
     seed_room(&pool, "GI601").await.unwrap();
@@ -1504,6 +1520,78 @@ async fn group_checkout_clears_master_flag_when_group_completes() {
         .await
         .unwrap();
     assert_eq!(booking_row.get::<i64, _>("is_master_room"), 0);
+}
+
+#[tokio::test]
+async fn group_checkout_rejects_stale_selected_booking() {
+    let pool = test_pool().await;
+    seed_room(&pool, "G501").await.unwrap();
+    seed_room(&pool, "G502").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 250_000.0)
+        .await
+        .unwrap();
+
+    let group = group_lifecycle::group_checkin(
+        &pool,
+        Some("seed-user".to_string()),
+        minimal_group_checkin_request(&["G501", "G502"]),
+    )
+    .await
+    .unwrap();
+
+    let booking_ids: Vec<String> =
+        sqlx::query_scalar("SELECT id FROM bookings WHERE group_id = ? ORDER BY room_id")
+            .bind(&group.id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    sqlx::query("UPDATE bookings SET status = 'checked_out' WHERE id = ?")
+        .bind(&booking_ids[0])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = group_lifecycle::group_checkout(
+        &pool,
+        GroupCheckoutRequest {
+            group_id: group.id.clone(),
+            booking_ids,
+            final_paid: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+}
+
+#[test]
+fn group_checkout_locked_room_map_rejects_changed_room_mapping() {
+    let locked = std::collections::HashMap::from([
+        ("booking-1".to_string(), "room-old".to_string()),
+        ("booking-2".to_string(), "room-stable".to_string()),
+    ]);
+    let current = std::collections::HashMap::from([
+        ("booking-1".to_string(), "room-new".to_string()),
+        ("booking-2".to_string(), "room-stable".to_string()),
+    ]);
+
+    let error = group_lifecycle::ensure_group_checkout_room_map_still_locked(
+        "group-1",
+        &["booking-1".to_string(), "booking-2".to_string()],
+        &locked,
+        &current,
+    )
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+    assert!(error
+        .to_string()
+        .contains("one or more bookings in group group-1 changed rooms before checkout"));
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -344,6 +344,32 @@ pub async fn test_pool() -> Pool<Sqlite> {
     pool
 }
 
+async fn shared_file_test_pools(label: &str) -> (Pool<Sqlite>, Pool<Sqlite>, std::path::PathBuf) {
+    let db_path = std::env::temp_dir().join(format!(
+        "capyinn-{label}-{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let database_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    let pool_a = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("failed to open first sqlite file test pool");
+
+    crate::db::run_migrations(&pool_a)
+        .await
+        .expect("failed to run migrations for shared file test pool");
+
+    let pool_b = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("failed to open second sqlite file test pool");
+
+    (pool_a, pool_b, db_path)
+}
+
 pub async fn seed_room(pool: &Pool<Sqlite>, room_id: &str) -> BookingResult<()> {
     sqlx::query(
         "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
@@ -2901,6 +2927,40 @@ async fn check_in_rolls_back_when_room_status_changes_before_guarded_room_update
         .await
         .unwrap();
     assert_eq!(booking_count, 0);
+}
+
+#[tokio::test]
+async fn checkout_fails_when_second_pool_checked_out_booking_first() {
+    let (pool_a, pool_b, db_path) = shared_file_test_pools("second-pool-checkout").await;
+    seed_room(&pool_a, "R-2POOL").await.unwrap();
+    seed_active_booking(&pool_a, "B-2POOL", "R-2POOL")
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'checked_out' WHERE id = ?")
+        .bind("B-2POOL")
+        .execute(&pool_b)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::check_out(
+        &pool_a,
+        CheckOutRequest {
+            booking_id: "B-2POOL".to_string(),
+            settlement_mode: CheckoutSettlementMode::BookedNights,
+            final_total: 100_000.0,
+        },
+    )
+    .await
+    .expect_err("checkout should reject stale booking state");
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+
+    pool_a.close().await;
+    pool_b.close().await;
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -1213,6 +1213,88 @@ async fn group_checkin_idempotent_normalizes_room_order_and_assigns_payment_ordi
     assert_eq!(rows[0].get::<i64, _>("origin_transaction_ordinal"), 0);
     assert_eq!(rows[1].get::<String, _>("room_id"), "GI602");
     assert_eq!(rows[1].get::<i64, _>("origin_transaction_ordinal"), 1);
+
+    let lock_keys_json: String = sqlx::query_scalar(
+        "SELECT lock_keys_json
+         FROM command_idempotency
+         WHERE idempotency_key = ?",
+    )
+    .bind("idem-group-checkin-1")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(lock_keys_json, r#"["room:GI601","room:GI602"]"#);
+}
+
+#[tokio::test]
+async fn group_checkin_duplicate_in_flight_does_not_wait_for_room_lock() {
+    let pool = test_pool().await;
+    seed_room(&pool, "GI650").await.unwrap();
+    seed_room(&pool, "GI651").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 250_000.0)
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-group-idem-inflight",
+        "idem-group-checkin-inflight",
+        "group_checkin",
+    );
+    let held_room_lock = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::room_key("GI650").unwrap()])
+        .await
+        .unwrap();
+
+    let first_pool = pool.clone();
+    let first_ctx = ctx.clone();
+    let first = tokio::spawn(async move {
+        group_lifecycle::group_checkin_idempotent(
+            &first_pool,
+            Some("seed-user".to_string()),
+            &first_ctx,
+            rich_group_checkin_request(&["GI650", "GI651"], "GI650", Some(100_000.0)),
+        )
+        .await
+    });
+
+    let mut claim_seen = false;
+    for _ in 0..50 {
+        let in_progress_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)
+             FROM command_idempotency
+             WHERE idempotency_key = ? AND status = 'in_progress'",
+        )
+        .bind("idem-group-checkin-inflight")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        if in_progress_count == 1 {
+            claim_seen = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(claim_seen, "first command should claim before waiting for room lock");
+
+    let duplicate = tokio::time::timeout(
+        std::time::Duration::from_millis(200),
+        group_lifecycle::group_checkin_idempotent(
+            &pool,
+            Some("seed-user".to_string()),
+            &ctx,
+            rich_group_checkin_request(&["GI650", "GI651"], "GI650", Some(100_000.0)),
+        ),
+    )
+    .await
+    .expect("duplicate should return without waiting for room lock")
+    .expect_err("duplicate in-flight command should conflict");
+
+    assert_eq!(
+        duplicate.code,
+        crate::app_error::codes::CONFLICT_DUPLICATE_IN_FLIGHT
+    );
+
+    drop(held_room_lock);
+    first.await.unwrap().expect("first command completes");
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -2316,6 +2316,29 @@ async fn cancel_reservation_releases_calendar_and_keeps_fee_record() {
 }
 
 #[tokio::test]
+async fn cancel_reservation_returns_invalid_state_when_booking_is_not_booked() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-CAS-CANCEL").await.unwrap();
+    seed_booked_reservation(&pool, "B-CAS-CANCEL", "R-CAS-CANCEL")
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'active' WHERE id = ?")
+        .bind("B-CAS-CANCEL")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = reservation_lifecycle::cancel_reservation(&pool, "B-CAS-CANCEL")
+        .await
+        .expect_err("stale reservation should fail");
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+}
+
+#[tokio::test]
 async fn do_create_reservation_returns_service_booking_and_leaves_room_vacant() {
     let pool = test_pool().await;
     seed_room(&pool, "R162").await.unwrap();
@@ -2516,6 +2539,29 @@ async fn confirm_reservation_rejects_no_show_calendar_rows() {
 }
 
 #[tokio::test]
+async fn confirm_reservation_returns_invalid_state_when_booking_is_not_booked() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-CAS-CONFIRM").await.unwrap();
+    seed_booked_reservation(&pool, "B-CAS-CONFIRM", "R-CAS-CONFIRM")
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'cancelled' WHERE id = ?")
+        .bind("B-CAS-CONFIRM")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = reservation_lifecycle::confirm_reservation(&pool, "B-CAS-CONFIRM")
+        .await
+        .expect_err("stale reservation should fail");
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+}
+
+#[tokio::test]
 async fn confirm_reservation_late_arrival_persists_effective_checkout() {
     let pool = test_pool().await;
     seed_room(&pool, "R165A").await.unwrap();
@@ -2708,6 +2754,37 @@ async fn modify_reservation_rejects_inconsistent_nights_input() {
         error,
         crate::domain::booking::BookingError::Validation(_)
     ));
+}
+
+#[tokio::test]
+async fn modify_reservation_returns_invalid_state_when_booking_is_not_booked() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-CAS-MOD").await.unwrap();
+    seed_booked_reservation(&pool, "B-CAS-MOD", "R-CAS-MOD")
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'cancelled' WHERE id = ?")
+        .bind("B-CAS-MOD")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = reservation_lifecycle::modify_reservation(
+        &pool,
+        crate::models::ModifyReservationRequest {
+            booking_id: "B-CAS-MOD".to_string(),
+            new_check_in_date: "2026-04-24".to_string(),
+            new_check_out_date: "2026-04-26".to_string(),
+            new_nights: 2,
+        },
+    )
+    .await
+    .expect_err("stale reservation should fail");
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -2703,6 +2703,42 @@ async fn check_in_posts_charge_and_marks_room_occupied() {
 }
 
 #[tokio::test]
+async fn check_in_rolls_back_when_room_status_changes_before_guarded_room_update() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-CAS-CHECKIN").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 100_000.0)
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "CREATE TRIGGER occupy_room_after_booking_insert
+         AFTER INSERT ON bookings
+         WHEN NEW.room_id = 'R-CAS-CHECKIN'
+         BEGIN
+           UPDATE rooms SET status = 'occupied' WHERE id = NEW.room_id;
+         END",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let error = stay_lifecycle::check_in(&pool, minimal_checkin_request("R-CAS-CHECKIN"), None)
+        .await
+        .expect_err("guarded room update should catch stale state");
+
+    assert!(error
+        .to_string()
+        .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+
+    let booking_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+        .bind("R-CAS-CHECKIN")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(booking_count, 0);
+}
+
+#[tokio::test]
 async fn check_out_settles_same_day_actual_nights_to_minimum_one_night() {
     let pool = test_pool().await;
     seed_room(&pool, "R410").await.unwrap();

--- a/mhm/src-tauri/src/write_manifest.rs
+++ b/mhm/src-tauri/src/write_manifest.rs
@@ -1,0 +1,141 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockDeriverId {
+    RoomFromRequest,
+    BookingAndRoomFromBooking,
+    GroupCheckinRooms,
+    GroupCheckoutBookingsAndRooms,
+    ReservationBookingAndRoom,
+    HousekeepingTaskRoom,
+    FolioBooking,
+    PaymentBooking,
+}
+
+impl LockDeriverId {
+    pub const fn policy_name(self) -> &'static str {
+        match self {
+            Self::RoomFromRequest => "room_from_request",
+            Self::BookingAndRoomFromBooking => "booking_and_room_from_booking",
+            Self::GroupCheckinRooms => "group_checkin_rooms",
+            Self::GroupCheckoutBookingsAndRooms => "group_checkout_bookings_and_rooms",
+            Self::ReservationBookingAndRoom => "reservation_booking_and_room",
+            Self::HousekeepingTaskRoom => "housekeeping_task_room",
+            Self::FolioBooking => "folio_booking",
+            Self::PaymentBooking => "payment_booking",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteCommandMeta {
+    pub command_name: &'static str,
+    pub lock_deriver: LockDeriverId,
+    pub enforced_in_foundation: bool,
+}
+
+pub const WRITE_COMMAND_MANIFEST: &[WriteCommandMeta] = &[
+    WriteCommandMeta {
+        command_name: "check_in",
+        lock_deriver: LockDeriverId::RoomFromRequest,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "check_out",
+        lock_deriver: LockDeriverId::BookingAndRoomFromBooking,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "extend_stay",
+        lock_deriver: LockDeriverId::BookingAndRoomFromBooking,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "group_checkin",
+        lock_deriver: LockDeriverId::GroupCheckinRooms,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "group_checkout",
+        lock_deriver: LockDeriverId::GroupCheckoutBookingsAndRooms,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "confirm_reservation",
+        lock_deriver: LockDeriverId::ReservationBookingAndRoom,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "cancel_reservation",
+        lock_deriver: LockDeriverId::ReservationBookingAndRoom,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "modify_reservation",
+        lock_deriver: LockDeriverId::ReservationBookingAndRoom,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "update_housekeeping",
+        lock_deriver: LockDeriverId::HousekeepingTaskRoom,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
+        command_name: "create_reservation",
+        lock_deriver: LockDeriverId::RoomFromRequest,
+        enforced_in_foundation: false,
+    },
+    WriteCommandMeta {
+        command_name: "add_folio_line",
+        lock_deriver: LockDeriverId::FolioBooking,
+        enforced_in_foundation: false,
+    },
+    WriteCommandMeta {
+        command_name: "record_payment",
+        lock_deriver: LockDeriverId::PaymentBooking,
+        enforced_in_foundation: false,
+    },
+];
+
+pub fn meta_for(command_name: &str) -> Option<&'static WriteCommandMeta> {
+    WRITE_COMMAND_MANIFEST
+        .iter()
+        .find(|meta| meta.command_name == command_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_manifest_declares_required_lock_derivers() {
+        let command_names = WRITE_COMMAND_MANIFEST
+            .iter()
+            .map(|meta| meta.command_name)
+            .collect::<std::collections::BTreeSet<_>>();
+
+        for expected in [
+            "check_in",
+            "check_out",
+            "extend_stay",
+            "group_checkin",
+            "group_checkout",
+            "confirm_reservation",
+            "cancel_reservation",
+            "modify_reservation",
+            "update_housekeeping",
+            "create_reservation",
+            "add_folio_line",
+            "record_payment",
+        ] {
+            assert!(command_names.contains(expected), "missing {expected}");
+        }
+    }
+
+    #[test]
+    fn metadata_only_commands_are_not_runtime_enforced() {
+        let folio = meta_for("add_folio_line").expect("folio meta exists");
+        let payment = meta_for("record_payment").expect("payment meta exists");
+
+        assert!(!folio.enforced_in_foundation);
+        assert!(!payment.enforced_in_foundation);
+    }
+}


### PR DESCRIPTION
## Summary
- Add aggregate lock manager, shared lock-key derivation metadata, and a stable invalid-state conflict code.
- Enforce aggregate locks and guarded state updates on the hot stay, group, reservation, and housekeeping flows covered by #71/#72/#73.
- Preserve group check-in idempotency ordering while recording derived lock keys in the command ledger.

## Verification
- `npx gitnexus analyze`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml` twice: 369 passed each run
- `cargo check --manifest-path mhm/src-tauri/Cargo.toml` twice
- `cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets -- -D warnings` twice
- GitNexus compare against `main`: critical blast radius expected for shared lock/state guard foundation

## Notes
- This does not migrate reservation/stay/folio/payment commands through `WriteCommandExecutor`; that remains #69/#70 scope.
