### PR TITLE
[codex] implement reservation command idempotency

### DIFF
--- a/docs/superpowers/specs/2026-04-29-reservation-lifecycle-command-executor-design.md
+++ b/docs/superpowers/specs/2026-04-29-reservation-lifecycle-command-executor-design.md
@@ -62,7 +62,7 @@ Each reservation write receives a `WriteCommandContext` containing:
 - actor metadata
 - timestamp and request context metadata already supported by the command ledger
 
-UI commands use human actor context. MCP gateway commands use hidden gateway-created command context with an AI-agent or integration actor type as appropriate. The LLM must not see or supply idempotency keys as ordinary business tool arguments.
+UI commands use human actor context. MCP gateway reservation writes use hidden gateway-created command context with `ActorType::AiAgent`. The LLM must not see or supply idempotency keys as ordinary business tool arguments.
 
 ## UI Behavior
 
@@ -88,7 +88,7 @@ The UI treats same-key replay as a normal success. It may still refresh rooms/bo
 
 Reservation write tool schemas must not expose `idempotency_key`.
 
-The gateway creates hidden idempotency keys per tool call. If the gateway retries the same tool-call request, it reuses the same hidden key. If the LLM asks for a new tool call, the gateway generates a new key and normal business validation runs.
+The gateway creates hidden idempotency keys per tool call. The key is derived from gateway instance/session identity, command name, MCP request id, and the canonical tool-argument hash. If the gateway retries the same tool-call request with the same canonical arguments, it reuses the same hidden key. If the LLM asks for a new tool call, or a client reuses a JSON-RPC request id with different arguments, the gateway generates a different hidden key and normal business validation runs.
 
 Gateway reservation writes must return structured JSON success/error envelopes instead of raw string-only `Error: ...` values. This keeps policy, idempotency, conflict, and validation results machine-readable.
 
@@ -137,7 +137,9 @@ Confirm payload includes:
 
 The app currently stores and models VND amounts in several places as floating-point values. Full conversion to integer VND storage and models is issue #102.
 
-#69 must not expand into full money migration. It must also avoid introducing new float-based idempotency behavior. For reservation command hashing and ledger intent, any reservation deposit is canonicalized to integer VND units before hashing. For example, a `deposit_amount` representing `500000` VND is hashed as integer `500000`, not as `500000.0`.
+#69 must not expand into full money migration. It must also avoid introducing new float-based idempotency behavior. For reservation command hashing and safe ledger intent, any reservation deposit is canonicalized to integer VND units before hashing. For example, a `deposit_amount` representing `500000` VND is hashed as integer `500000`, not as `500000.0`.
+
+Command ledger safe fields must not contain raw booking UUIDs, guest identifiers, phone numbers, or other values rejected by the existing safe-field sanitizer. Exact booking and room ids belong in the canonical hash payload, primary aggregate key, and lock key metadata, not in sanitized ledger summary fields. Ledger summaries can use safe facts such as command schema, date fields, booleans, and small integer VND amounts.
 
 ## Idempotency Result Contract
 
@@ -202,20 +204,27 @@ The current room id may require a pre-transaction lookup before acquiring the ru
 
 Lock keys are sorted and deduplicated by existing lock/executor conventions.
 
+For modify, cancel, and confirm, the idempotency row must be claimed before the room lookup. The booking id is available from the canonical payload and can be recorded immediately as `booking:{booking_id}`. After the claimed command resolves the current room id, the executor path must acquire the combined booking and room runtime locks and refresh the command row lock metadata to include `room:{current_room_id}` before the business transaction runs. If the booking lookup fails, the failure is finalized as a terminal command error so same-key replay returns the stored not-found result.
+
+Create already knows `room_id` from the canonical payload. It must acquire the real runtime room lock, not only persist lock metadata.
+
 ## Business Transaction Rules
 
 Each reservation command runs as one business mutation:
 
-1. validate command payload
-2. derive and acquire stable locks
-3. claim or replay the idempotency row
-4. open `BEGIN IMMEDIATE`
-5. revalidate booking, room, and state inside the transaction
-6. mutate booking, calendar, and any ledger/folio side effects
-7. write response snapshot and finalize the command row
-8. commit, or roll back all business and command-finalize writes together
+1. validate command payload and build the canonical request hash
+2. claim or replay the idempotency row before fallible business lookups
+3. resolve and acquire stable runtime locks
+4. refresh command lock metadata when post-claim lookup discovers additional lock keys
+5. open `BEGIN IMMEDIATE`
+6. revalidate booking, room, and state inside the transaction
+7. mutate booking, calendar, and any ledger/folio side effects
+8. write response snapshot and finalize the command row
+9. commit, or roll back all business and command-finalize writes together
 
 Where the executor path can make command claim, business mutation, and finalize atomic in one transaction, use that atomic path.
+
+#69 is not production-complete under the durable outbox rule until the later outbox roadmap work (#76 through #82) is implemented. This issue must not add direct external side effects inside business mutations; existing UI refresh events remain adapter-level notifications after command success.
 
 ## Calendar Conflict Semantics
 
@@ -296,7 +305,7 @@ Primary tests:
 - `mhm/src-tauri/src/commands/reservations.rs` unit tests
 - `mhm/src-tauri/src/gateway/tools.rs` tests
 - `mhm/src/components/ReservationSheet.test.tsx`
-- reservation page/UI tests as needed for confirm/cancel wiring
+- reservation page/UI tests for confirm and cancel wiring
 
 ## Test Plan
 
@@ -308,7 +317,7 @@ Backend idempotency tests:
 - confirm exact retry does not write an extra room charge and does not recalculate by retry date
 - same key with changed payload returns `CONFLICT_IDEMPOTENCY_HASH_MISMATCH`
 - duplicate in-flight returns `CONFLICT_DUPLICATE_IN_FLIGHT`
-- retryable DB lock failure can be reclaimed when appropriate
+- retryable DB lock failure can be reclaimed with the same key after the failed command row becomes reclaimable
 
 Conflict and state tests:
 

--- a/docs/superpowers/specs/2026-04-29-reservation-lifecycle-command-executor-design.md
+++ b/docs/superpowers/specs/2026-04-29-reservation-lifecycle-command-executor-design.md
@@ -1,0 +1,383 @@
+# Reservation Lifecycle Through WriteCommandExecutor
+
+## Status
+
+Approved design for issue #69.
+
+This spec covers routing single-reservation create, modify, cancel, and confirm writes through the durable command boundary. It is part of the #64 M2.5 durable command boundary roadmap.
+
+## Context
+
+The current codebase already has the command foundation:
+
+- #65 built `WriteCommandExecutor`.
+- #66 promoted `command_idempotency` into a command ledger.
+- #67 added origin idempotency keys for ledger and folio side effects.
+- #71, #72, and #73 added aggregate locks, manifest lock metadata, and state-transition guards.
+
+Reservation create is already partially idempotent through `create_reservation_idempotent`. Reservation modify, cancel, and confirm still have direct production paths from Tauri into reservation lifecycle services. The MCP gateway currently exposes reservation create, modify, and cancel write tools; those gateway writes also bypass the idempotent reservation service boundary.
+
+Issue #69 finishes the reservation slice by making all single-reservation writes use the same service-level idempotent command boundary.
+
+## Goals
+
+- Route reservation create, modify, cancel, and confirm through `WriteCommandExecutor`.
+- Make UI/Tauri and MCP gateway writes share the same idempotent service functions.
+- Keep calendar conflict behavior strict and structured.
+- Prevent repeated reservation commands from duplicating booking, calendar, folio, or ledger effects.
+- Return `CONFLICT_IDEMPOTENCY_HASH_MISMATCH` for same key with different payload.
+- Keep UI flows working without asking humans to type or understand idempotency keys.
+- Keep LLM-facing MCP schemas free of idempotency internals.
+
+## Non-Goals
+
+- Full money schema/model conversion is out of scope. It is tracked by #102.
+- Group reservation is out of scope for #69.
+- Stay, group, folio, and payment command rollout is out of scope. It remains #70.
+- Command recovery queue and operator inspection actions remain #68.
+- Supervised high-risk MCP rollout remains #74.
+- Durable outbox work remains #76 through #82.
+- The modify flow will not gain room, guest, or deposit editing in this issue.
+
+## Chosen Approach
+
+Use service-level idempotent reservation lifecycle functions shared by UI/Tauri and MCP gateway:
+
+- `create_reservation_idempotent`
+- `modify_reservation_idempotent`
+- `cancel_reservation_idempotent`
+- `confirm_reservation_idempotent`
+
+Tauri command handlers and MCP gateway write tools must call these idempotent functions for production writes. Existing non-idempotent service functions may remain for focused internal tests or as private transaction helpers, but they must not remain the production write path for #69 flows.
+
+This is narrower than a full command-envelope rebuild and broader than a thin Tauri-only wrapper. It satisfies the PMS rule that UI, bots, agents, and integrations all cross the same explicit command boundary.
+
+## Command Context
+
+Each reservation write receives a `WriteCommandContext` containing:
+
+- request id or correlation id
+- idempotency key
+- command name
+- actor metadata
+- timestamp and request context metadata already supported by the command ledger
+
+UI commands use human actor context. MCP gateway commands use hidden gateway-created command context with an AI-agent or integration actor type as appropriate. The LLM must not see or supply idempotency keys as ordinary business tool arguments.
+
+## UI Behavior
+
+Add a shared frontend helper for write commands, conceptually `invokeWriteCommand`.
+
+The helper:
+
+- generates an idempotency key for each submit attempt
+- attaches the key to the Tauri command args
+- preserves existing correlation-id and monitoring behavior
+- normalizes structured command errors through the existing app-error path
+
+Reservation UI callers use this helper for:
+
+- `create_reservation`
+- `modify_reservation`
+- `cancel_reservation`
+- `confirm_reservation`
+
+The UI treats same-key replay as a normal success. It may still refresh rooms/bookings after success so the screen reflects current read-model state. Button disabled/loading states remain useful for ergonomics but must not be required for correctness.
+
+## MCP Gateway Behavior
+
+Reservation write tool schemas must not expose `idempotency_key`.
+
+The gateway creates hidden idempotency keys per tool call. If the gateway retries the same tool-call request, it reuses the same hidden key. If the LLM asks for a new tool call, the gateway generates a new key and normal business validation runs.
+
+Gateway reservation writes must return structured JSON success/error envelopes instead of raw string-only `Error: ...` values. This keeps policy, idempotency, conflict, and validation results machine-readable.
+
+## Canonical Payloads
+
+Each command uses a versioned canonical payload schema:
+
+- `reservation.create.v1`
+- `reservation.modify.v1`
+- `reservation.cancel.v1`
+- `reservation.confirm.v1`
+
+Canonical payloads contain only business input that defines the command. They do not include idempotency key, request id, correlation id, actor, timestamp, or UI monitoring context.
+
+Create payload includes:
+
+- room id
+- guest name
+- optional guest document number
+- optional guest phone
+- check-in date
+- check-out date
+- nights
+- source
+- notes
+- deposit value canonicalized as integer VND units
+
+Modify payload includes:
+
+- booking id
+- new check-in date
+- new check-out date
+- new nights
+
+Cancel payload includes:
+
+- booking id
+
+Confirm payload includes:
+
+- booking id
+
+`confirm_reservation` intentionally does not include the current date in the payload. A replay of the same completed command returns the stored command result snapshot, not a recalculation against a later date.
+
+## Money Handling In #69
+
+The app currently stores and models VND amounts in several places as floating-point values. Full conversion to integer VND storage and models is issue #102.
+
+#69 must not expand into full money migration. It must also avoid introducing new float-based idempotency behavior. For reservation command hashing and ledger intent, any reservation deposit is canonicalized to integer VND units before hashing. For example, a `deposit_amount` representing `500000` VND is hashed as integer `500000`, not as `500000.0`.
+
+## Idempotency Result Contract
+
+Completed exact retry:
+
+- Same command name, same idempotency key, same canonical payload hash.
+- The executor returns the `response_json` snapshot stored in the command row.
+- It does not query the booking or room tables again during replay.
+
+Hash mismatch:
+
+- Same command name and idempotency key but different canonical payload hash.
+- Return `CONFLICT_IDEMPOTENCY_HASH_MISMATCH`.
+
+Duplicate in-flight:
+
+- Same command name, same idempotency key, same payload hash, still in progress.
+- Return `CONFLICT_DUPLICATE_IN_FLIGHT`.
+
+Retryable system failure:
+
+- Retryable system errors such as retryable DB lock failures are recorded as retryable and may be reclaimed with the same key.
+
+Terminal user failure:
+
+- Calendar conflicts, invalid state transitions, not-found user errors, and validation failures are terminal command results.
+- A same-key replay returns the stored terminal error rather than re-running the mutation.
+
+The response snapshot is the command result, not the current read-model state. UI and gateway callers can query read APIs after success if they need current state.
+
+## Response Shapes
+
+Create returns a `Booking` snapshot.
+
+Modify returns a `Booking` snapshot.
+
+Confirm returns a `Booking` snapshot.
+
+Cancel returns a structured success snapshot:
+
+```json
+{
+  "ok": true,
+  "booking_id": "..."
+}
+```
+
+This avoids ambiguous unit responses and gives cancel replays a concrete stored response.
+
+## Locking
+
+Create reservation derives:
+
+- `room:{room_id}`
+
+Modify, cancel, and confirm derive:
+
+- `booking:{booking_id}`
+- `room:{current_room_id}`
+
+The current room id may require a pre-transaction lookup before acquiring the runtime lock. Because that lookup can go stale, the service must re-read and revalidate the booking room inside the transaction before mutating.
+
+Lock keys are sorted and deduplicated by existing lock/executor conventions.
+
+## Business Transaction Rules
+
+Each reservation command runs as one business mutation:
+
+1. validate command payload
+2. derive and acquire stable locks
+3. claim or replay the idempotency row
+4. open `BEGIN IMMEDIATE`
+5. revalidate booking, room, and state inside the transaction
+6. mutate booking, calendar, and any ledger/folio side effects
+7. write response snapshot and finalize the command row
+8. commit, or roll back all business and command-finalize writes together
+
+Where the executor path can make command claim, business mutation, and finalize atomic in one transaction, use that atomic path.
+
+## Calendar Conflict Semantics
+
+Create:
+
+- checks `room_calendar` for the requested range before insert
+- inserts booked calendar rows only after the range is clear
+- relies on the `room_calendar` uniqueness constraint as the final safety net
+
+Modify:
+
+- only works for a booked reservation
+- deletes only this booking's booked calendar rows inside the transaction
+- checks the new range against remaining room calendar rows
+- inserts the new booked range only after the range is clear
+
+Conflict errors map to `CONFLICT_ROOM_UNAVAILABLE` with a structured `CommandError`.
+
+## State Transition Semantics
+
+Cancel:
+
+- allowed only from `booked` to `cancelled`
+- deletes this reservation's booked calendar rows
+- records cancellation fee behavior once, if applicable
+- exact replay does not write another cancellation fee
+
+Confirm:
+
+- allowed only from `booked` to `active`
+- rejects no-show calendar state
+- converts booked calendar rows into occupied rows for the effective stay
+- records room charge once
+- exact replay does not reprice or write another charge
+
+Modify:
+
+- allowed only while booking status is `booked`
+- does not change room, guest, or deposit
+- exact replay returns the original modify result snapshot
+
+Stale state transitions return `CONFLICT_INVALID_STATE_TRANSITION`.
+
+## Error Classification
+
+Reservation command errors use the existing structured app error registry:
+
+- `CONFLICT_ROOM_UNAVAILABLE` for calendar conflicts
+- `CONFLICT_INVALID_STATE_TRANSITION` for stale booking/room state
+- `CONFLICT_IDEMPOTENCY_HASH_MISMATCH` for key reuse with different payload
+- `CONFLICT_DUPLICATE_IN_FLIGHT` for duplicate in-flight attempts
+- `IDEMPOTENCY_KEY_REQUIRED` for missing UI/Tauri idempotency keys
+- `DB_LOCKED_RETRYABLE` for retryable lock contention
+- existing not-found and validation codes where already mapped
+
+System errors must keep correlation/request id behavior and failure logging.
+
+## Implementation Surface
+
+Primary backend files:
+
+- `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs`
+- `mhm/src-tauri/src/commands/reservations.rs`
+- `mhm/src-tauri/src/gateway/tools.rs`
+- `mhm/src-tauri/src/gateway/models.rs`
+- `mhm/src-tauri/src/gateway/policy.rs`
+- `mhm/src-tauri/src/command_idempotency.rs` only if small helper additions are needed
+
+Primary frontend files:
+
+- `mhm/src/lib/invokeCommand.ts`
+- `mhm/src/components/ReservationSheet.tsx`
+- `mhm/src/pages/Reservations.tsx`
+
+Primary tests:
+
+- `mhm/src-tauri/src/services/booking/tests.rs`
+- `mhm/src-tauri/src/commands/reservations.rs` unit tests
+- `mhm/src-tauri/src/gateway/tools.rs` tests
+- `mhm/src/components/ReservationSheet.test.tsx`
+- reservation page/UI tests as needed for confirm/cancel wiring
+
+## Test Plan
+
+Backend idempotency tests:
+
+- create exact retry does not duplicate booking, calendar rows, or deposit transaction
+- modify exact retry does not rewrite extra calendar effects and returns stored snapshot
+- cancel exact retry does not write an extra cancellation fee
+- confirm exact retry does not write an extra room charge and does not recalculate by retry date
+- same key with changed payload returns `CONFLICT_IDEMPOTENCY_HASH_MISMATCH`
+- duplicate in-flight returns `CONFLICT_DUPLICATE_IN_FLIGHT`
+- retryable DB lock failure can be reclaimed when appropriate
+
+Conflict and state tests:
+
+- create calendar conflict returns `CONFLICT_ROOM_UNAVAILABLE`
+- modify calendar conflict returns `CONFLICT_ROOM_UNAVAILABLE`
+- conflict replay returns the stored terminal error
+- cancel non-booked reservation returns `CONFLICT_INVALID_STATE_TRANSITION`
+- modify non-booked reservation returns `CONFLICT_INVALID_STATE_TRANSITION`
+- confirm non-booked reservation returns `CONFLICT_INVALID_STATE_TRANSITION`
+- no-show confirmation remains rejected
+
+UI tests:
+
+- create uses the shared write-command helper
+- modify uses the shared write-command helper
+- cancel uses the shared write-command helper
+- confirm uses the shared write-command helper
+- UI does not expose or require human-entered idempotency keys
+
+Gateway tests:
+
+- reservation write schemas do not expose idempotency key
+- create, modify, and cancel route through idempotent service functions
+- confirm is not added as a new MCP tool in #69 unless a confirm tool already exists by implementation time
+- gateway exact retry uses stored snapshot behavior
+- gateway errors are structured JSON envelopes
+
+## Acceptance Criteria Mapping
+
+Reservation writes use canonical request hashing and idempotency keys:
+
+- All four single-reservation writes build versioned canonical payloads and use `WriteCommandExecutor`.
+
+Calendar conflict behavior remains strict and structured:
+
+- Create and modify preserve strict calendar checks and map conflicts to `CONFLICT_ROOM_UNAVAILABLE`.
+
+Repeating the same reservation command does not duplicate effects:
+
+- Exact retry returns command snapshot and does not re-run booking, calendar, folio, or ledger writes.
+
+Same key with different payload returns hash mismatch:
+
+- Executor returns `CONFLICT_IDEMPOTENCY_HASH_MISMATCH`.
+
+UI flows continue to work without asking humans to type idempotency keys:
+
+- Shared UI helper creates and passes idempotency keys automatically.
+
+## Rollout Order
+
+1. Add failing backend tests for modify/cancel/confirm idempotency.
+2. Introduce idempotent service functions and structured cancel response.
+3. Route Tauri reservation commands through the idempotent service functions.
+4. Add shared frontend write-command helper and update reservation UI callers.
+5. Route MCP reservation writes through the idempotent service functions with hidden gateway keys.
+6. Add conflict, hash mismatch, duplicate in-flight, and replay tests.
+7. Run GitNexus change detection before any commit.
+
+## Open Decisions Closed During Brainstorming
+
+- Same-key completed replay behaves as normal success in UI.
+- Replay returns stored command response snapshot, not current DB state.
+- UI and MCP gateway are both in #69 scope.
+- UI uses a shared write-command helper.
+- `confirm_reservation` replay does not recalculate by retry date.
+- Calendar conflict is a terminal command result.
+- Group reservation is excluded from #69.
+- Money schema/model migration is #102, not #69.
+- Gateway creates hidden idempotency keys; the LLM does not see them.
+- Modify remains limited to date and night changes.
+- Retryable system errors can reclaim; user conflicts and invalid states are terminal.

--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -345,6 +345,25 @@ pub type LockKeyDeriver = fn(&serde_json::Value) -> CommandResult<Vec<String>>;
 pub type WriteCommandServiceFuture<'tx> =
     Pin<Box<dyn Future<Output = CommandResult<serde_json::Value>> + Send + 'tx>>;
 
+#[derive(Debug)]
+pub struct ResolvedWriteCommandGuard<T> {
+    pub guard: T,
+    pub lock_keys: Vec<String>,
+}
+
+impl<T> ResolvedWriteCommandGuard<T> {
+    pub fn new<I, S>(guard: T, lock_keys: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            guard,
+            lock_keys: lock_keys.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct WriteCommandRequest {
     hash_payload: serde_json::Value,
@@ -533,6 +552,57 @@ impl WriteCommandExecutor {
         }
     }
 
+    pub async fn execute_with_resolved_guard<F, G, GFut, Guard>(
+        &self,
+        ctx: &WriteCommandContext,
+        request: WriteCommandRequest,
+        before_transaction: G,
+        service: F,
+    ) -> CommandResult<IdempotentCommandResult<serde_json::Value>>
+    where
+        F: for<'tx> FnOnce(
+            &'tx mut Transaction<'_, Sqlite>,
+            Guard,
+        ) -> WriteCommandServiceFuture<'tx>,
+        G: FnOnce() -> GFut,
+        GFut: Future<Output = CommandResult<ResolvedWriteCommandGuard<Guard>>> + Send,
+        Guard: Send,
+    {
+        let prepared = prepare_write_command_request(request)?;
+        let claim = self.claim_or_reclaim(ctx, &prepared).await?;
+
+        match claim {
+            ClaimOutcome::Claimed { claim_token } => {
+                let resolved = match self
+                    .await_pre_transaction_guard(ctx, &claim_token, before_transaction())
+                    .await
+                {
+                    Ok(guard) => guard,
+                    Err(mut error) => {
+                        error.request_id = Some(ctx.request_id.clone());
+                        self.finalize_failure(ctx, &claim_token, &error).await?;
+                        return Err(error);
+                    }
+                };
+
+                if let Err(mut error) = self
+                    .refresh_claim_lock_keys(ctx, &claim_token, resolved.lock_keys)
+                    .await
+                {
+                    error.request_id = Some(ctx.request_id.clone());
+                    self.finalize_failure(ctx, &claim_token, &error).await?;
+                    return Err(error);
+                }
+
+                self.run_claimed(ctx, &claim_token, &prepared, move |tx| {
+                    service(tx, resolved.guard)
+                })
+                .await
+            }
+            ClaimOutcome::Replayed(result) => Ok(result),
+        }
+    }
+
     async fn await_pre_transaction_guard<GFut, Guard>(
         &self,
         ctx: &WriteCommandContext,
@@ -556,6 +626,65 @@ impl WriteCommandExecutor {
                     self.refresh_claim_lease(ctx, claim_token).await?;
                 }
             }
+        }
+    }
+
+    async fn refresh_claim_lock_keys<I, S>(
+        &self,
+        ctx: &WriteCommandContext,
+        claim_token: &str,
+        lock_keys: I,
+    ) -> CommandResult<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut lock_keys = lock_keys
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<String>>();
+        lock_keys.sort();
+        lock_keys.dedup();
+        if lock_keys.is_empty() {
+            return Err(system_error("Resolved idempotency lock keys are required"));
+        }
+        let lock_keys_json = stable_json_string(&serde_json::json!(lock_keys))?;
+        let now = Utc::now().to_rfc3339();
+        let result = sqlx::query(
+            "UPDATE command_idempotency
+             SET lock_keys_json = ?,
+                 updated_at = ?
+             WHERE command_name = ?
+               AND idempotency_key = ?
+               AND status = ?
+               AND claim_token = ?",
+        )
+        .bind(&lock_keys_json)
+        .bind(&now)
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .bind(CommandStatus::InProgress.as_str())
+        .bind(claim_token)
+        .execute(&self.pool)
+        .await
+        .map_err(|error| {
+            let message = error.to_string();
+            if crate::db_error_monitoring::classify_db_error_code(&message)
+                == Some(codes::DB_LOCKED_RETRYABLE)
+            {
+                return CommandError::system(codes::DB_LOCKED_RETRYABLE, message).retryable(true);
+            }
+            system_error(message)
+        })?;
+
+        if result.rows_affected() == 1 {
+            Ok(())
+        } else {
+            Err(CommandError::system(
+                codes::SYSTEM_INTERNAL_ERROR,
+                "Failed to refresh claimed idempotency lock keys",
+            )
+            .with_request_id(ctx.request_id.clone()))
         }
     }
 
@@ -1143,8 +1272,7 @@ fn stable_json_string(value: &serde_json::Value) -> CommandResult<String> {
     serde_json::to_string(&canonicalize_json_value(value.clone())).map_err(system_error)
 }
 
-#[cfg(test)]
-fn stable_request_hash(intent: &serde_json::Value) -> CommandResult<String> {
+pub(crate) fn stable_request_hash(intent: &serde_json::Value) -> CommandResult<String> {
     let intent_json = stable_json_string(intent)?;
     stable_request_hash_from_json(&intent_json)
 }
@@ -2047,6 +2175,252 @@ mod tests {
 
         assert_eq!(result.response, serde_json::json!({ "ok": true }));
         assert!(!result.replayed);
+    }
+
+    #[tokio::test]
+    async fn execute_with_resolved_guard_finalizes_guard_error_as_terminal() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-resolved-guard-error",
+            "idem-resolved-guard-error",
+            "test.resolved_guard_error",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "resolved-guard-error" }),
+            "Resolved guard error",
+        )
+        .expect("request builds");
+        let guard_attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let first_attempts = guard_attempts.clone();
+        let first_error = WriteCommandExecutor::new(pool.clone())
+            .execute_with_resolved_guard(
+                &ctx,
+                request.clone(),
+                move || {
+                    let first_attempts = first_attempts.clone();
+                    async move {
+                        first_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        Err(CommandError::user(codes::AUTH_FORBIDDEN, "guard denied"))
+                    }
+                },
+                |_tx, _guard: ()| {
+                    Box::pin(async move { Ok(serde_json::json!({ "unexpected": true })) })
+                },
+            )
+            .await
+            .expect_err("guard error should fail command");
+
+        let second_attempts = guard_attempts.clone();
+        let replay_error = WriteCommandExecutor::new(pool.clone())
+            .execute_with_resolved_guard(
+                &ctx,
+                request,
+                move || {
+                    let second_attempts = second_attempts.clone();
+                    async move {
+                        second_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        Ok(ResolvedWriteCommandGuard::new((), vec!["lock:unexpected"]))
+                    }
+                },
+                |_tx, _guard: ()| {
+                    Box::pin(async move { Ok(serde_json::json!({ "unexpected": true })) })
+                },
+            )
+            .await
+            .expect_err("terminal guard error should replay");
+
+        assert_eq!(first_error.code, codes::AUTH_FORBIDDEN);
+        assert_eq!(replay_error.code, codes::AUTH_FORBIDDEN);
+        assert_eq!(guard_attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads command status");
+        assert_eq!(status, "failed_terminal");
+    }
+
+    #[tokio::test]
+    async fn execute_with_resolved_guard_finalizes_retryable_guard_error_as_reclaimable() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-resolved-guard-retryable",
+            "idem-resolved-guard-retryable",
+            "test.resolved_guard_retryable",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "resolved-guard-retryable" }),
+            "Resolved guard retryable",
+        )
+        .expect("request builds");
+
+        let error = WriteCommandExecutor::new(pool.clone())
+            .execute_with_resolved_guard(
+                &ctx,
+                request.clone(),
+                || async {
+                    Err::<ResolvedWriteCommandGuard<()>, _>(
+                        CommandError::system(codes::DB_LOCKED_RETRYABLE, "database is locked")
+                            .retryable(true),
+                    )
+                },
+                |_tx, _guard: ()| {
+                    Box::pin(async move { Ok(serde_json::json!({ "unexpected": true })) })
+                },
+            )
+            .await
+            .expect_err("retryable guard error should fail first attempt");
+
+        assert_eq!(error.code, codes::DB_LOCKED_RETRYABLE);
+        assert!(error.retryable);
+
+        let row = sqlx::query(
+            "SELECT status, retryable FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads command row");
+
+        assert_eq!(row.get::<String, _>("status"), "failed_retryable");
+        assert_eq!(row.get::<i64, _>("retryable"), 1);
+
+        let result = WriteCommandExecutor::new(pool.clone())
+            .execute_with_resolved_guard(
+                &ctx,
+                request,
+                || async { Ok(ResolvedWriteCommandGuard::new((), vec!["booking:B1"])) },
+                |_tx, _guard: ()| Box::pin(async move { Ok(serde_json::json!({ "ok": true })) }),
+            )
+            .await
+            .expect("retryable guard error can be reclaimed");
+
+        assert!(!result.replayed);
+        assert_eq!(result.response, serde_json::json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn execute_with_resolved_guard_lock_key_refresh_failure_finalizes_claim() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-resolved-lock-refresh-fail",
+            "idem-resolved-lock-refresh-fail",
+            "test.resolved_lock_refresh_fail",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "resolved-lock-refresh-fail" }),
+            "Resolved lock refresh fail",
+        )
+        .expect("request builds");
+
+        let error = WriteCommandExecutor::new(pool.clone())
+            .execute_with_resolved_guard(
+                &ctx,
+                request,
+                || async { Ok(ResolvedWriteCommandGuard::new((), Vec::<String>::new())) },
+                |_tx, _guard: ()| {
+                    Box::pin(async move { Ok(serde_json::json!({ "unexpected": true })) })
+                },
+            )
+            .await
+            .expect_err("empty resolved lock keys should fail after claim");
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads command status");
+
+        assert_ne!(status, "in_progress");
+    }
+
+    #[tokio::test]
+    async fn execute_with_resolved_guard_refreshes_lock_keys_before_transaction() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-resolved-locks",
+            "idem-resolved-locks",
+            "test.resolved_locks",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "resolved-locks" }),
+            "Resolved locks",
+        )
+        .expect("request builds");
+        let command_name = ctx.command_name.clone();
+        let idempotency_key = ctx.idempotency_key.clone();
+
+        let result = WriteCommandExecutor::new(pool.clone())
+            .execute_with_resolved_guard(
+                &ctx,
+                request,
+                || async {
+                    Ok(ResolvedWriteCommandGuard::new(
+                        "guard-payload".to_string(),
+                        vec!["room:R1", "booking:B1", "room:R1"],
+                    ))
+                },
+                move |tx, guard| {
+                    Box::pin(async move {
+                        let lock_keys_json: String = sqlx::query_scalar(
+                            "SELECT lock_keys_json FROM command_idempotency
+                             WHERE command_name = ? AND idempotency_key = ?",
+                        )
+                        .bind(&command_name)
+                        .bind(&idempotency_key)
+                        .fetch_one(&mut **tx)
+                        .await
+                        .map_err(system_error)?;
+
+                        Ok(serde_json::json!({
+                            "guard": guard,
+                            "lock_keys_json": lock_keys_json,
+                        }))
+                    })
+                },
+            )
+            .await
+            .expect("command succeeds");
+
+        assert_eq!(result.response["guard"], "guard-payload");
+        assert_eq!(
+            result.response["lock_keys_json"],
+            "[\"booking:B1\",\"room:R1\"]"
+        );
+        assert!(!result.replayed);
+    }
+
+    #[test]
+    fn stable_request_hash_matches_executor_request_hash() {
+        let payload = serde_json::json!({
+            "schema": "test.hash.v1",
+            "nested": {
+                "b": 2,
+                "a": 1
+            }
+        });
+        let request = WriteCommandRequest::new_low_risk(payload.clone(), "Hash match")
+            .expect("request builds");
+        let prepared = prepare_write_command_request(request).expect("request prepares");
+
+        assert_eq!(
+            stable_request_hash(&payload).expect("payload hashes"),
+            prepared.request_hash
+        );
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -593,7 +593,14 @@ impl WriteCommandExecutor {
             Ok(Ok(result)) => result,
             Ok(Err(error)) if lease_refresh_error_is_transient(&error) => return Ok(()),
             Ok(Err(error)) => return Err(system_error(error)),
-            Err(_) => return Ok(()),
+            Err(_) => {
+                return Err(CommandError::system(
+                    codes::SYSTEM_INTERNAL_ERROR,
+                    "Timed out refreshing claimed idempotency lease",
+                )
+                .retryable(true)
+                .with_request_id(ctx.request_id.clone()))
+            }
         };
 
         if result.rows_affected() == 1 {
@@ -1351,14 +1358,14 @@ mod tests {
     use crate::app_error::codes;
     use sqlx::sqlite::SqlitePoolOptions;
 
-    async fn test_pool() -> Pool<Sqlite> {
+    async fn test_pool_with_max_connections(max_connections: u32) -> Pool<Sqlite> {
         let database_url = format!(
             "sqlite://file:{}?mode=memory&cache=shared",
             uuid::Uuid::new_v4()
         );
 
         let pool = SqlitePoolOptions::new()
-            .max_connections(5)
+            .max_connections(max_connections)
             .connect(&database_url)
             .await
             .expect("failed to open sqlite test pool");
@@ -1368,6 +1375,10 @@ mod tests {
             .expect("failed to run migrations");
 
         pool
+    }
+
+    async fn test_pool() -> Pool<Sqlite> {
+        test_pool_with_max_connections(5).await
     }
 
     #[test]
@@ -2039,7 +2050,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_claim_lease_ignores_transient_database_lock() {
+    async fn refresh_claim_lease_write_lock_timeout_fails_claim() {
         let pool = test_pool().await;
         let ctx = WriteCommandContext::for_internal_test(
             "test-request-refresh-lock",
@@ -2053,8 +2064,8 @@ mod tests {
         .expect("request builds");
         let prepared = prepare_write_command_request(request).expect("prepares request");
         let now = Utc::now().to_rfc3339();
-        let lease_expires_at = (Utc::now() + chrono::Duration::seconds(CLAIM_LEASE_SECONDS))
-            .to_rfc3339();
+        let lease_expires_at =
+            (Utc::now() + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
         let claim_token = "refresh-lock-claim-token";
 
         sqlx::query(
@@ -2094,14 +2105,88 @@ mod tests {
             .await
             .expect("holds a write lock");
 
-        let result = tokio::time::timeout(
+        let error = tokio::time::timeout(
             std::time::Duration::from_secs(3),
             WriteCommandExecutor::new(pool.clone()).refresh_claim_lease(&ctx, claim_token),
         )
         .await
-        .expect("refresh returns without waiting for the blocking writer");
+        .expect("refresh returns without waiting past the refresh timeout")
+        .expect_err("refresh timeout must fail the claim");
 
-        result.expect("transient lock should not fail the command");
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert!(error.retryable);
+        assert_eq!(error.request_id.as_deref(), Some(ctx.request_id.as_str()));
+        assert_eq!(
+            error.message,
+            "Timed out refreshing claimed idempotency lease"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_claim_lease_timeout_fails_claim() {
+        let pool = test_pool_with_max_connections(1).await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-refresh-timeout",
+            "idem-refresh-timeout",
+            "test.refresh_timeout",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "refresh-timeout" }),
+            "Refresh timeout",
+        )
+        .expect("request builds");
+        let prepared = prepare_write_command_request(request).expect("prepares request");
+        let now = Utc::now().to_rfc3339();
+        let lease_expires_at =
+            (Utc::now() + chrono::Duration::seconds(CLAIM_LEASE_SECONDS)).to_rfc3339();
+        let claim_token = "refresh-timeout-claim-token";
+
+        sqlx::query(
+            "INSERT INTO command_idempotency (
+                idempotency_key,
+                command_name,
+                request_hash,
+                intent_json,
+                lock_keys_json,
+                status,
+                claim_token,
+                retryable,
+                lease_expires_at,
+                created_at,
+                updated_at,
+                last_attempt_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&ctx.idempotency_key)
+        .bind(&ctx.command_name)
+        .bind(&prepared.request_hash)
+        .bind(&prepared.intent_json)
+        .bind(&prepared.lock_keys_json)
+        .bind(CommandStatus::InProgress.as_str())
+        .bind(claim_token)
+        .bind(0_i64)
+        .bind(&lease_expires_at)
+        .bind(&now)
+        .bind(&now)
+        .bind(&now)
+        .execute(&pool)
+        .await
+        .expect("seeds in-progress claim");
+
+        let _held_connection = pool.acquire().await.expect("holds the only connection");
+
+        let error = WriteCommandExecutor::new(pool.clone())
+            .refresh_claim_lease(&ctx, claim_token)
+            .await
+            .expect_err("refresh timeout must fail the claim");
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert!(error.retryable);
+        assert_eq!(error.request_id.as_deref(), Some(ctx.request_id.as_str()));
+        assert_eq!(
+            error.message,
+            "Timed out refreshing claimed idempotency lease"
+        );
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/commands/reservations.rs
+++ b/mhm/src-tauri/src/commands/reservations.rs
@@ -1,5 +1,5 @@
 use super::{emit_db_update, get_f64, get_user, AppState};
-use crate::services::booking::reservation_lifecycle;
+use crate::services::booking::reservation_lifecycle::{self, ReservationCancelResponse};
 use crate::{
     app_error::{
         codes, correlation_context, log_system_error, normalize_correlation_id,
@@ -11,7 +11,7 @@ use crate::{
         classify_db_error_code, classify_db_failure, inject_db_error_group,
         is_room_unavailable_conflict_message, DbErrorGroup, MonitoredDbFailure,
     },
-    domain::booking::{BookingError, BookingResult},
+    domain::booking::BookingError,
     models::*,
 };
 use serde_json::{json, Value};
@@ -92,9 +92,18 @@ pub async fn check_availability(
 pub async fn do_create_reservation(
     pool: &Pool<Sqlite>,
     app_handle: Option<&tauri::AppHandle>,
+    ctx: &WriteCommandContext,
     req: CreateReservationRequest,
-) -> BookingResult<Booking> {
-    let booking = reservation_lifecycle::create_reservation(pool, req).await?;
+) -> CommandResult<Booking> {
+    let create_result =
+        reservation_lifecycle::create_reservation_idempotent(pool, ctx, req).await?;
+    let booking: Booking = serde_json::from_value(create_result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid create_reservation idempotent response: {error}"),
+        )
+        .with_request_id(ctx.request_id.clone())
+    })?;
 
     if let Some(app) = app_handle {
         emit_db_update(app, "rooms");
@@ -433,33 +442,15 @@ pub async fn create_reservation(
         );
     })?;
 
-    let create_result = reservation_lifecycle::create_reservation_idempotent(
-        &state.db,
-        &write_command_context,
-        req,
-    )
-    .await
-    .inspect_err(|command_error| {
-        record_create_reservation_command_failure(
-            &effective_correlation_id,
-            command_error,
-            error_context.clone(),
-        );
-    })?;
-
-    let booking: Booking = serde_json::from_value(create_result.response).map_err(|error| {
-        let command_error = CommandError::system(
-            codes::SYSTEM_INTERNAL_ERROR,
-            format!("Invalid create_reservation idempotent response: {error}"),
-        )
-        .with_request_id(effective_correlation_id.value.clone());
-        record_create_reservation_command_failure(
-            &effective_correlation_id,
-            &command_error,
-            error_context.clone(),
-        );
-        command_error
-    })?;
+    let booking = do_create_reservation(&state.db, Some(&app), &write_command_context, req)
+        .await
+        .inspect_err(|command_error| {
+            record_create_reservation_command_failure(
+                &effective_correlation_id,
+                command_error,
+                error_context.clone(),
+            );
+        })?;
 
     log::info!(
         "create_reservation success correlation_id={} source={:?} booking_id={} room_id={}",
@@ -468,8 +459,6 @@ pub async fn create_reservation(
         booking.id,
         booking.room_id
     );
-
-    emit_db_update(&app, "rooms");
 
     Ok(booking)
 }
@@ -481,11 +470,70 @@ pub async fn confirm_reservation(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     booking_id: String,
-) -> Result<Booking, String> {
-    get_user(&state).ok_or_else(|| "Chưa đăng nhập".to_string())?;
-    let booking = reservation_lifecycle::confirm_reservation(&state.db, &booking_id)
-        .await
-        .map_err(|error| error.to_string())?;
+    idempotency_key: String,
+    correlation_id: Option<String>,
+) -> CommandResult<Booking> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let error_context = reservation_booking_failure_context(&booking_id);
+
+    if get_user(&state).is_none() {
+        let command_error = CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập");
+        record_command_failure(
+            "confirm_reservation",
+            &command_error,
+            &effective_correlation_id.value,
+            error_context,
+        );
+        return Err(command_error);
+    }
+
+    let write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "confirm_reservation",
+    )
+    .inspect_err(|command_error| {
+        record_command_failure_with_db_group(
+            "confirm_reservation",
+            command_error,
+            &effective_correlation_id.value,
+            map_create_reservation_command_error_db_group(command_error),
+            error_context.clone(),
+        );
+    })?;
+
+    let confirm_result = reservation_lifecycle::confirm_reservation_idempotent(
+        &state.db,
+        &write_command_context,
+        &booking_id,
+    )
+    .await
+    .inspect_err(|command_error| {
+        record_command_failure_with_db_group(
+            "confirm_reservation",
+            command_error,
+            &effective_correlation_id.value,
+            map_create_reservation_command_error_db_group(command_error),
+            error_context.clone(),
+        );
+    })?;
+
+    let booking: Booking = serde_json::from_value(confirm_result.response).map_err(|error| {
+        let command_error = CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid confirm_reservation idempotent response: {error}"),
+        )
+        .with_request_id(effective_correlation_id.value.clone());
+        record_command_failure_with_db_group(
+            "confirm_reservation",
+            &command_error,
+            &effective_correlation_id.value,
+            map_create_reservation_command_error_db_group(&command_error),
+            error_context.clone(),
+        );
+        command_error
+    })?;
+
     emit_db_update(&app, "rooms");
 
     Ok(booking)
@@ -496,15 +544,25 @@ pub async fn confirm_reservation(
 pub async fn do_cancel_reservation(
     pool: &Pool<Sqlite>,
     app_handle: Option<&tauri::AppHandle>,
+    ctx: &WriteCommandContext,
     booking_id: &str,
-) -> BookingResult<()> {
-    reservation_lifecycle::cancel_reservation(pool, booking_id).await?;
+) -> CommandResult<ReservationCancelResponse> {
+    let cancel_result =
+        reservation_lifecycle::cancel_reservation_idempotent(pool, ctx, booking_id).await?;
+    let response: ReservationCancelResponse = serde_json::from_value(cancel_result.response)
+        .map_err(|error| {
+            CommandError::system(
+                codes::SYSTEM_INTERNAL_ERROR,
+                format!("Invalid cancel_reservation idempotent response: {error}"),
+            )
+            .with_request_id(ctx.request_id.clone())
+        })?;
 
     if let Some(app) = app_handle {
         emit_db_update(app, "rooms");
     }
 
-    Ok(())
+    Ok(response)
 }
 
 #[tauri::command]
@@ -512,8 +570,9 @@ pub async fn cancel_reservation(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     booking_id: String,
+    idempotency_key: String,
     correlation_id: Option<String>,
-) -> CommandResult<()> {
+) -> CommandResult<ReservationCancelResponse> {
     let effective_correlation_id = normalize_correlation_id(correlation_id);
     let error_context = reservation_booking_failure_context(&booking_id);
 
@@ -528,23 +587,31 @@ pub async fn cancel_reservation(
         return Err(command_error);
     }
 
-    do_cancel_reservation(&state.db, Some(&app), &booking_id)
+    let write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "cancel_reservation",
+    )
+    .inspect_err(|command_error| {
+        record_command_failure_with_db_group(
+            "cancel_reservation",
+            command_error,
+            &effective_correlation_id.value,
+            map_create_reservation_command_error_db_group(command_error),
+            error_context.clone(),
+        );
+    })?;
+
+    do_cancel_reservation(&state.db, Some(&app), &write_command_context, &booking_id)
         .await
-        .map_err(|error| {
-            let (command_error, db_error_group) = map_reservation_write_error(
-                "cancel_reservation",
-                &effective_correlation_id,
-                error,
-                error_context.clone(),
-            );
+        .inspect_err(|command_error| {
             record_command_failure_with_db_group(
                 "cancel_reservation",
-                &command_error,
+                command_error,
                 &effective_correlation_id.value,
-                db_error_group,
+                map_create_reservation_command_error_db_group(command_error),
                 error_context.clone(),
             );
-            command_error
         })
 }
 
@@ -553,9 +620,19 @@ pub async fn cancel_reservation(
 pub async fn do_modify_reservation(
     pool: &Pool<Sqlite>,
     app_handle: Option<&tauri::AppHandle>,
+    ctx: &WriteCommandContext,
     req: ModifyReservationRequest,
-) -> BookingResult<Booking> {
-    let booking = reservation_lifecycle::modify_reservation(pool, req).await?;
+) -> CommandResult<Booking> {
+    let modify_result =
+        reservation_lifecycle::modify_reservation_idempotent(pool, ctx, req).await?;
+    let booking: Booking = serde_json::from_value(modify_result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid modify_reservation idempotent response: {error}"),
+        )
+        .with_request_id(ctx.request_id.clone())
+    })?;
+
     if let Some(app) = app_handle {
         emit_db_update(app, "rooms");
     }
@@ -568,6 +645,7 @@ pub async fn modify_reservation(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     req: ModifyReservationRequest,
+    idempotency_key: String,
     correlation_id: Option<String>,
 ) -> CommandResult<Booking> {
     let effective_correlation_id = normalize_correlation_id(correlation_id);
@@ -584,23 +662,31 @@ pub async fn modify_reservation(
         return Err(command_error);
     }
 
-    do_modify_reservation(&state.db, Some(&app), req)
+    let write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "modify_reservation",
+    )
+    .inspect_err(|command_error| {
+        record_command_failure_with_db_group(
+            "modify_reservation",
+            command_error,
+            &effective_correlation_id.value,
+            map_create_reservation_command_error_db_group(command_error),
+            error_context.clone(),
+        );
+    })?;
+
+    do_modify_reservation(&state.db, Some(&app), &write_command_context, req)
         .await
-        .map_err(|error| {
-            let (command_error, db_error_group) = map_reservation_write_error(
-                "modify_reservation",
-                &effective_correlation_id,
-                error,
-                error_context.clone(),
-            );
+        .inspect_err(|command_error| {
             record_command_failure_with_db_group(
                 "modify_reservation",
-                &command_error,
+                command_error,
                 &effective_correlation_id.value,
-                db_error_group,
+                map_create_reservation_command_error_db_group(command_error),
                 error_context.clone(),
             );
-            command_error
         })
 }
 

--- a/mhm/src-tauri/src/gateway/models.rs
+++ b/mhm/src-tauri/src/gateway/models.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use rmcp::schemars::{self, JsonSchema};
+use serde::{Deserialize, Serialize};
 
 // ─── MCP Tool Input Schemas ───
 
@@ -47,7 +47,7 @@ pub struct CalculatePriceInput {
     pub pricing_type: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CreateReservationInput {
     /// Room ID to reserve
     pub room_id: String,
@@ -71,13 +71,13 @@ pub struct CreateReservationInput {
     pub notes: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CancelReservationInput {
     /// Booking ID to cancel
     pub booking_id: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ModifyReservationInput {
     /// Booking ID to modify
     pub booking_id: String,

--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -1,7 +1,9 @@
+use rmcp::handler::server::common::RequestId as McpRequestId;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::*;
 use rmcp::{tool, tool_handler, tool_router, ServerHandler};
+use serde::Serialize;
 use sqlx::{Pool, Sqlite};
 use tauri::AppHandle;
 
@@ -9,7 +11,11 @@ use super::models::*;
 use super::policy::{
     guard_write_tool, CANCEL_RESERVATION_META, CREATE_RESERVATION_META, MODIFY_RESERVATION_META,
 };
+use crate::app_error::{CommandError, CommandResult};
 use crate::app_identity;
+use crate::command_idempotency::{
+    stable_request_hash, system_error, ActorType, WriteCommandContext,
+};
 use crate::commands;
 use crate::models::{BookingFilter, CreateReservationRequest, InvoiceData};
 use crate::services::settings_store::get_setting;
@@ -98,24 +104,65 @@ fn format_invoice_text(inv: &InvoiceData) -> String {
 pub struct HotelTools {
     pub pool: Pool<Sqlite>,
     pub app_handle: Option<AppHandle>,
+    gateway_instance_id: String,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
+}
+
+fn gateway_tool_args_hash<T: Serialize>(args: &T) -> CommandResult<String> {
+    let value = serde_json::to_value(args).map_err(system_error)?;
+    stable_request_hash(&value)
+}
+
+fn mcp_request_id_string(request_id: &McpRequestId) -> String {
+    match &request_id.0 {
+        NumberOrString::Number(value) => format!("number:{value}"),
+        NumberOrString::String(value) => format!("string:{value}"),
+    }
+}
+
+fn tool_success_envelope<T: Serialize>(data: &T) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "data": data,
+    }))
+    .unwrap()
+}
+
+fn tool_error_envelope(tool: &str, request_id: &str, error: CommandError) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "ok": false,
+        "error": {
+            "code": error.code,
+            "kind": error.kind,
+            "message": error.message,
+            "support_id": error.support_id,
+            "tool": tool,
+            "retryable": error.retryable,
+            "request_id": request_id,
+        },
+    }))
+    .unwrap()
 }
 
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        CancelReservationInput, CreateReservationInput, GetInvoiceInput, GetSettingsInput,
-        HotelTools, ModifyReservationInput,
+        tool_error_envelope, CancelReservationInput, CreateReservationInput, GetInvoiceInput,
+        GetSettingsInput, HotelTools, ModifyReservationInput,
     };
-    use crate::app_error::codes;
+    use crate::app_error::{codes, CommandError};
     use crate::app_identity;
     use crate::commands::invoices;
+    use rmcp::handler::server::common::RequestId as McpRequestId;
     use rmcp::handler::server::wrapper::Parameters;
+    use rmcp::model::NumberOrString;
+    use rmcp::schemars;
     use serde_json::Value;
     use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite};
     use std::ffi::OsString;
+    use std::sync::Arc;
     use std::sync::OnceLock;
 
     async fn test_pool() -> Pool<Sqlite> {
@@ -289,6 +336,29 @@ mod tests {
         .execute(pool)
         .await
         .expect("seed invoice booking");
+    }
+
+    fn mcp_request_id(value: &str) -> McpRequestId {
+        McpRequestId(NumberOrString::String(Arc::from(value)))
+    }
+
+    fn numeric_mcp_request_id(value: i64) -> McpRequestId {
+        McpRequestId(NumberOrString::Number(value))
+    }
+
+    fn create_reservation_input(room_id: &str) -> CreateReservationInput {
+        CreateReservationInput {
+            room_id: room_id.to_string(),
+            guest_name: "Nguyen Van A".to_string(),
+            guest_phone: Some("0900000000".to_string()),
+            guest_doc_number: Some("079123456789".to_string()),
+            check_in_date: "2026-04-20".to_string(),
+            check_out_date: "2026-04-22".to_string(),
+            nights: 2,
+            deposit_amount: Some(50_000.0),
+            source: Some("phone".to_string()),
+            notes: Some("test reservation".to_string()),
+        }
     }
 
     struct EnvVarGuard {
@@ -476,18 +546,10 @@ mod tests {
         let tools = HotelTools::new(pool.clone(), None);
 
         let output = tools
-            .create_reservation(Parameters(CreateReservationInput {
-                room_id: "R199".to_string(),
-                guest_name: "Nguyen Van A".to_string(),
-                guest_phone: Some("0900000000".to_string()),
-                guest_doc_number: Some("079123456789".to_string()),
-                check_in_date: "2026-04-20".to_string(),
-                check_out_date: "2026-04-22".to_string(),
-                nights: 2,
-                deposit_amount: Some(50_000.0),
-                source: Some("phone".to_string()),
-                notes: Some("test reservation".to_string()),
-            }))
+            .create_reservation(
+                Parameters(create_reservation_input("R199")),
+                mcp_request_id("req-create-denied"),
+            )
             .await;
 
         let envelope: Value = serde_json::from_str(&output).expect("error envelope json");
@@ -532,23 +594,16 @@ mod tests {
         let tools = HotelTools::new(pool.clone(), None);
 
         let output = tools
-            .create_reservation(Parameters(CreateReservationInput {
-                room_id: "R200".to_string(),
-                guest_name: "Nguyen Van A".to_string(),
-                guest_phone: Some("0900000000".to_string()),
-                guest_doc_number: Some("079123456789".to_string()),
-                check_in_date: "2026-04-20".to_string(),
-                check_out_date: "2026-04-22".to_string(),
-                nights: 2,
-                deposit_amount: Some(50_000.0),
-                source: Some("phone".to_string()),
-                notes: Some("test reservation".to_string()),
-            }))
+            .create_reservation(
+                Parameters(create_reservation_input("R200")),
+                mcp_request_id("req-create-success"),
+            )
             .await;
 
-        let booking: Value = serde_json::from_str(&output).expect("booking json");
-        assert_eq!(booking["room_id"].as_str(), Some("R200"));
-        assert_eq!(booking["status"].as_str(), Some("booked"));
+        let envelope: Value = serde_json::from_str(&output).expect("success envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(true));
+        assert_eq!(envelope["data"]["room_id"].as_str(), Some("R200"));
+        assert_eq!(envelope["data"]["status"].as_str(), Some("booked"));
 
         let stored: String = sqlx::query("SELECT status FROM bookings WHERE room_id = ?")
             .bind("R200")
@@ -570,12 +625,18 @@ mod tests {
         let tools = HotelTools::new(pool.clone(), None);
 
         let output = tools
-            .cancel_reservation(Parameters(CancelReservationInput {
-                booking_id: "B201".to_string(),
-            }))
+            .cancel_reservation(
+                Parameters(CancelReservationInput {
+                    booking_id: "B201".to_string(),
+                }),
+                mcp_request_id("req-cancel-success"),
+            )
             .await;
 
-        assert_eq!(output, "Reservation B201 cancelled successfully");
+        let envelope: Value = serde_json::from_str(&output).expect("success envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(true));
+        assert_eq!(envelope["data"]["ok"].as_bool(), Some(true));
+        assert_eq!(envelope["data"]["booking_id"].as_str(), Some("B201"));
 
         let stored: String = sqlx::query("SELECT status FROM bookings WHERE id = ?")
             .bind("B201")
@@ -598,18 +659,206 @@ mod tests {
         let tools = HotelTools::new(pool.clone(), None);
 
         let output = tools
-            .modify_reservation(Parameters(ModifyReservationInput {
-                booking_id: "B202".to_string(),
-                new_check_in_date: "2026-04-24".to_string(),
-                new_check_out_date: "2026-04-26".to_string(),
-                new_nights: 2,
-            }))
+            .modify_reservation(
+                Parameters(ModifyReservationInput {
+                    booking_id: "B202".to_string(),
+                    new_check_in_date: "2026-04-24".to_string(),
+                    new_check_out_date: "2026-04-26".to_string(),
+                    new_nights: 2,
+                }),
+                mcp_request_id("req-modify-success"),
+            )
             .await;
 
-        let booking: Value = serde_json::from_str(&output).expect("booking json");
-        assert_eq!(booking["status"].as_str(), Some("booked"));
-        assert_eq!(booking["check_in_at"].as_str(), Some("2026-04-24"));
-        assert_eq!(booking["expected_checkout"].as_str(), Some("2026-04-26"));
+        let envelope: Value = serde_json::from_str(&output).expect("success envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(true));
+        assert_eq!(envelope["data"]["status"].as_str(), Some("booked"));
+        assert_eq!(envelope["data"]["check_in_at"].as_str(), Some("2026-04-24"));
+        assert_eq!(
+            envelope["data"]["expected_checkout"].as_str(),
+            Some("2026-04-26")
+        );
+    }
+
+    #[tokio::test]
+    async fn reservation_write_tool_schemas_do_not_expose_idempotency_fields() {
+        let pool = test_pool().await;
+        let tools = HotelTools::new(pool, None);
+
+        for tool_name in [
+            "create_reservation",
+            "modify_reservation",
+            "cancel_reservation",
+        ] {
+            let tool = tools
+                .tool_router
+                .get(tool_name)
+                .expect("reservation write tool exists");
+            let schema = serde_json::to_string(&tool.input_schema).expect("schema serializes");
+            assert!(!schema.contains("idempotency_key"));
+            assert!(!schema.contains("idempotencyKey"));
+        }
+
+        let create_schema = serde_json::to_string(&schemars::schema_for!(CreateReservationInput))
+            .expect("schema serializes");
+        let modify_schema = serde_json::to_string(&schemars::schema_for!(ModifyReservationInput))
+            .expect("schema serializes");
+        let cancel_schema = serde_json::to_string(&schemars::schema_for!(CancelReservationInput))
+            .expect("schema serializes");
+        for schema in [create_schema, modify_schema, cancel_schema] {
+            assert!(!schema.contains("idempotency_key"));
+            assert!(!schema.contains("idempotencyKey"));
+        }
+    }
+
+    #[tokio::test]
+    async fn create_reservation_same_mcp_request_id_and_args_replays_stored_command_row() {
+        let _env_lock = async_env_lock().lock().await;
+        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+
+        let pool = test_pool().await;
+        seed_room(&pool, "R203", "standard").await;
+        seed_pricing_rule(&pool, "standard", 600_000.0).await;
+        let tools = HotelTools::new(pool.clone(), None);
+
+        let first_output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R203")),
+                mcp_request_id("req-create-replay"),
+            )
+            .await;
+        let replay_output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R203")),
+                mcp_request_id("req-create-replay"),
+            )
+            .await;
+
+        let first: Value = serde_json::from_str(&first_output).expect("success envelope json");
+        let replay: Value = serde_json::from_str(&replay_output).expect("success envelope json");
+        assert_eq!(first["ok"].as_bool(), Some(true));
+        assert_eq!(replay["ok"].as_bool(), Some(true));
+        assert_eq!(first["data"]["id"], replay["data"]["id"]);
+
+        let command_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_idempotency WHERE command_name = 'create_reservation'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("command row count");
+        assert_eq!(command_rows, 1);
+
+        let bookings: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+            .bind("R203")
+            .fetch_one(&pool)
+            .await
+            .expect("booking count");
+        assert_eq!(bookings, 1);
+    }
+
+    #[tokio::test]
+    async fn create_reservation_same_mcp_request_id_and_different_args_use_distinct_hidden_keys() {
+        let _env_lock = async_env_lock().lock().await;
+        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+
+        let pool = test_pool().await;
+        seed_room(&pool, "R204A", "standard").await;
+        seed_room(&pool, "R204B", "standard").await;
+        seed_pricing_rule(&pool, "standard", 600_000.0).await;
+        let tools = HotelTools::new(pool.clone(), None);
+
+        let first_output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R204A")),
+                mcp_request_id("req-create-same-id-different-args"),
+            )
+            .await;
+        let second_output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R204B")),
+                mcp_request_id("req-create-same-id-different-args"),
+            )
+            .await;
+
+        let first: Value = serde_json::from_str(&first_output).expect("success envelope json");
+        let second: Value = serde_json::from_str(&second_output).expect("success envelope json");
+        assert_eq!(first["ok"].as_bool(), Some(true));
+        assert_eq!(second["ok"].as_bool(), Some(true));
+        assert_ne!(first["data"]["id"], second["data"]["id"]);
+
+        let command_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_idempotency WHERE command_name = 'create_reservation'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("command row count");
+        assert_eq!(command_rows, 2);
+    }
+
+    #[tokio::test]
+    async fn create_reservation_numeric_and_string_mcp_request_ids_use_distinct_hidden_keys() {
+        let _env_lock = async_env_lock().lock().await;
+        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+
+        let pool = test_pool().await;
+        seed_room(&pool, "R205", "standard").await;
+        seed_pricing_rule(&pool, "standard", 600_000.0).await;
+        let tools = HotelTools::new(pool.clone(), None);
+
+        let first_output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R205")),
+                numeric_mcp_request_id(1),
+            )
+            .await;
+        let second_output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R205")),
+                mcp_request_id("1"),
+            )
+            .await;
+
+        let first: Value = serde_json::from_str(&first_output).expect("success envelope json");
+        let second: Value = serde_json::from_str(&second_output).expect("error envelope json");
+        assert_eq!(first["ok"].as_bool(), Some(true));
+        assert_eq!(second["ok"].as_bool(), Some(false));
+
+        let command_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_idempotency WHERE command_name = 'create_reservation'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("command row count");
+        assert_eq!(command_rows, 2);
+
+        let idempotency_keys: Vec<String> = sqlx::query_scalar(
+            "SELECT idempotency_key FROM command_idempotency WHERE command_name = 'create_reservation'",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("idempotency keys");
+        assert_eq!(idempotency_keys.len(), 2);
+        assert_ne!(idempotency_keys[0], idempotency_keys[1]);
+    }
+
+    #[test]
+    fn tool_error_envelope_includes_support_id() {
+        let output = tool_error_envelope(
+            "create_reservation",
+            "req-support-id",
+            CommandError::with_support_id(
+                codes::SYSTEM_INTERNAL_ERROR,
+                "system failure",
+                "SUP-TEST0001",
+            ),
+        );
+
+        let envelope: Value = serde_json::from_str(&output).expect("error envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
+        assert_eq!(
+            envelope["error"]["support_id"].as_str(),
+            Some("SUP-TEST0001")
+        );
     }
 
     #[tokio::test]
@@ -665,8 +914,32 @@ impl HotelTools {
         Self {
             pool,
             app_handle,
+            gateway_instance_id: uuid::Uuid::new_v4().to_string(),
             tool_router: Self::tool_router(),
         }
+    }
+
+    fn write_context<T: Serialize>(
+        &self,
+        command_name: &str,
+        request_id: &McpRequestId,
+        args: &T,
+    ) -> CommandResult<WriteCommandContext> {
+        let request_id = mcp_request_id_string(request_id);
+        let argument_hash = gateway_tool_args_hash(args)?;
+        let idempotency_key = format!(
+            "mcp:{}:{}:{}:{}",
+            self.gateway_instance_id, command_name, request_id, argument_hash
+        );
+        let mut ctx = WriteCommandContext::for_scoped_command(
+            request_id.clone(),
+            idempotency_key,
+            command_name,
+        )?;
+        ctx.actor_type = ActorType::AiAgent;
+        ctx.actor_id = Some("mcp-gateway".to_string());
+        ctx.channel_id = Some("mcp".to_string());
+        Ok(ctx)
     }
 }
 
@@ -846,10 +1119,19 @@ impl HotelTools {
     async fn create_reservation(
         &self,
         Parameters(input): Parameters<CreateReservationInput>,
+        request_id: McpRequestId,
     ) -> String {
         if let Err(envelope) = guard_write_tool(&CREATE_RESERVATION_META) {
             return envelope.to_json_string();
         }
+
+        let request_id_text = mcp_request_id_string(&request_id);
+        let ctx = match self.write_context("create_reservation", &request_id, &input) {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                return tool_error_envelope("create_reservation", &request_id_text, error)
+            }
+        };
 
         let req = CreateReservationRequest {
             room_id: input.room_id,
@@ -864,7 +1146,8 @@ impl HotelTools {
             notes: input.notes,
         };
 
-        match commands::do_create_reservation(&self.pool, self.app_handle.as_ref(), req).await {
+        match commands::do_create_reservation(&self.pool, self.app_handle.as_ref(), &ctx, req).await
+        {
             Ok(booking) => {
                 if let Some(ref handle) = self.app_handle {
                     use tauri::Emitter;
@@ -877,9 +1160,9 @@ impl HotelTools {
                     );
                 }
 
-                serde_json::to_string_pretty(&booking).unwrap()
+                tool_success_envelope(&booking)
             }
-            Err(e) => format!("Error: {}", e),
+            Err(error) => tool_error_envelope("create_reservation", &request_id_text, error),
         }
     }
 
@@ -889,20 +1172,30 @@ impl HotelTools {
     async fn cancel_reservation(
         &self,
         Parameters(input): Parameters<CancelReservationInput>,
+        request_id: McpRequestId,
     ) -> String {
         if let Err(envelope) = guard_write_tool(&CANCEL_RESERVATION_META) {
             return envelope.to_json_string();
         }
 
+        let request_id_text = mcp_request_id_string(&request_id);
+        let ctx = match self.write_context("cancel_reservation", &request_id, &input) {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                return tool_error_envelope("cancel_reservation", &request_id_text, error)
+            }
+        };
+
         match commands::do_cancel_reservation(
             &self.pool,
             self.app_handle.as_ref(),
+            &ctx,
             &input.booking_id,
         )
         .await
         {
-            Ok(()) => format!("Reservation {} cancelled successfully", input.booking_id),
-            Err(e) => format!("Error: {}", e),
+            Ok(response) => tool_success_envelope(&response),
+            Err(error) => tool_error_envelope("cancel_reservation", &request_id_text, error),
         }
     }
 
@@ -912,10 +1205,19 @@ impl HotelTools {
     async fn modify_reservation(
         &self,
         Parameters(input): Parameters<ModifyReservationInput>,
+        request_id: McpRequestId,
     ) -> String {
         if let Err(envelope) = guard_write_tool(&MODIFY_RESERVATION_META) {
             return envelope.to_json_string();
         }
+
+        let request_id_text = mcp_request_id_string(&request_id);
+        let ctx = match self.write_context("modify_reservation", &request_id, &input) {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                return tool_error_envelope("modify_reservation", &request_id_text, error)
+            }
+        };
 
         let req = crate::models::ModifyReservationRequest {
             booking_id: input.booking_id,
@@ -924,9 +1226,10 @@ impl HotelTools {
             new_nights: input.new_nights,
         };
 
-        match commands::do_modify_reservation(&self.pool, self.app_handle.as_ref(), req).await {
-            Ok(booking) => serde_json::to_string_pretty(&booking).unwrap(),
-            Err(e) => format!("Error: {}", e),
+        match commands::do_modify_reservation(&self.pool, self.app_handle.as_ref(), &ctx, req).await
+        {
+            Ok(booking) => tool_success_envelope(&booking),
+            Err(error) => tool_error_envelope("modify_reservation", &request_id_text, error),
         }
     }
 

--- a/mhm/src-tauri/src/services/booking/billing_service.rs
+++ b/mhm/src-tauri/src/services/booking/billing_service.rs
@@ -124,7 +124,7 @@ pub async fn add_folio_line_idempotent(
     let category = category.to_string();
     let description = description.to_string();
     let created_by = created_by.map(ToString::to_string);
-    let origin_key = ctx.idempotency_key.clone();
+    let origin_key = format!("{}:{}", ctx.command_name, ctx.idempotency_key);
 
     WriteCommandExecutor::new(pool.clone())
         .execute_atomic(ctx, request, move |tx| {
@@ -171,6 +171,27 @@ pub async fn record_charge_tx(
 ) -> BookingResult<()> {
     record_money_tx(
         tx, booking_id, amount, note, "charge", created_at, false, None,
+    )
+    .await
+}
+
+pub async fn record_charge_with_origin_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    amount: f64,
+    note: impl Into<String>,
+    created_at: impl Into<String>,
+    origin: &OriginSideEffect,
+) -> BookingResult<()> {
+    record_money_tx(
+        tx,
+        booking_id,
+        amount,
+        note,
+        "charge",
+        created_at,
+        false,
+        Some(origin),
     )
     .await
 }
@@ -270,6 +291,26 @@ pub async fn record_cancellation_fee_tx(
         rfc3339_now(),
         false,
         None,
+    )
+    .await
+}
+
+pub async fn record_cancellation_fee_with_origin_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    amount: f64,
+    note: impl Into<String>,
+    origin: &OriginSideEffect,
+) -> BookingResult<()> {
+    record_money_tx(
+        tx,
+        booking_id,
+        amount,
+        note,
+        "cancellation_fee",
+        rfc3339_now(),
+        false,
+        Some(origin),
     )
     .await
 }

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -1,12 +1,15 @@
 use chrono::{Local, NaiveDate};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::{
+    aggregate_locks::{booking_key, global_manager, room_key, AggregateLockGuard},
     app_error::{codes, CommandError, CommandResult},
     command_idempotency::{
         system_error, CommandLedgerResultSummary, CommandLedgerSummary, IdempotentCommandResult,
-        SanitizedLedgerIntent, WriteCommandContext, WriteCommandExecutor, WriteCommandRequest,
+        ResolvedWriteCommandGuard, SanitizedLedgerIntent, WriteCommandContext,
+        WriteCommandExecutor, WriteCommandRequest,
     },
     db_error_monitoring::{classify_db_error_code, is_room_unavailable_conflict_message},
     domain::booking::{
@@ -17,15 +20,24 @@ use crate::{
 
 use super::{
     billing_service::{
-        record_cancellation_fee_tx, record_charge_tx, record_deposit_tx,
-        record_deposit_with_origin_tx,
+        record_cancellation_fee_tx, record_cancellation_fee_with_origin_tx, record_charge_tx,
+        record_charge_with_origin_tx, record_deposit_tx, record_deposit_with_origin_tx,
     },
     guest_service::{create_reservation_guest_manifest, link_booking_guests},
     support::{
-        begin_immediate_tx, ensure_one_row_affected, fetch_booking, insert_room_calendar_rows,
-        invalid_state_transition, lookup_booking_room_id, read_f64_strict,
+        ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
+        read_f64_strict,
     },
 };
+
+#[cfg(test)]
+use super::support::{begin_immediate_tx, fetch_booking, lookup_booking_room_id};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReservationCancelResponse {
+    pub ok: bool,
+    pub booking_id: String,
+}
 
 fn mark_write_db_error(error: BookingError) -> BookingError {
     match error {
@@ -79,6 +91,134 @@ fn map_create_reservation_command_error(error: BookingError) -> CommandError {
             CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
         }
     }
+}
+
+fn map_reservation_command_error(error: BookingError) -> CommandError {
+    match error {
+        BookingError::Validation(message)
+            if message == "Number of nights must be greater than 0" =>
+        {
+            CommandError::user(codes::BOOKING_INVALID_NIGHTS, "Số đêm phải lớn hơn 0")
+        }
+        BookingError::NotFound(message)
+            if message.starts_with("Không tìm thấy booking ")
+                || message.starts_with("Booking not found:") =>
+        {
+            CommandError::user(codes::BOOKING_NOT_FOUND, message)
+        }
+        BookingError::Validation(message) | BookingError::Conflict(message) => {
+            if message.contains(codes::CONFLICT_INVALID_STATE_TRANSITION) {
+                return CommandError::user(codes::CONFLICT_INVALID_STATE_TRANSITION, message);
+            }
+            if let Some(mapped) = map_known_reservation_command_error(&message) {
+                return mapped;
+            }
+            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+        }
+        BookingError::DatabaseWrite(message) | BookingError::Database(message) => {
+            if let Some(mapped) = map_known_reservation_command_error(&message) {
+                return mapped;
+            }
+            if message.contains("FOREIGN KEY constraint failed") {
+                return CommandError::user(codes::BOOKING_NOT_FOUND, "Booking not found");
+            }
+            CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
+        }
+        BookingError::DateTimeParse(message) | BookingError::NotFound(message) => {
+            CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
+        }
+    }
+}
+
+pub(crate) fn canonical_vnd_units(amount: Option<f64>) -> CommandResult<i64> {
+    let Some(amount) = amount else {
+        return Ok(0);
+    };
+
+    if !amount.is_finite() || amount < 0.0 || amount.fract() != 0.0 {
+        return Err(CommandError::user(
+            codes::BOOKING_INVALID_STATE,
+            "Reservation deposit must be a whole non-negative VND amount",
+        ));
+    }
+
+    let units_text = format!("{amount:.0}");
+    let units = units_text.parse::<u128>().map_err(system_error)?;
+    if units > i64::MAX as u128 {
+        return Err(CommandError::user(
+            codes::BOOKING_INVALID_STATE,
+            "Reservation deposit must be a whole non-negative VND amount",
+        ));
+    }
+
+    Ok(units as i64)
+}
+
+fn create_room_lock_keys(intent: &serde_json::Value) -> CommandResult<Vec<String>> {
+    let room_id = intent
+        .get("room_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| system_error("reservation create hash payload missing room_id"))?;
+    Ok(vec![room_key(room_id)?])
+}
+
+fn reservation_booking_lock_keys(intent: &serde_json::Value) -> CommandResult<Vec<String>> {
+    let booking_id = intent
+        .get("booking_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| system_error("reservation hash payload missing booking_id"))?;
+    Ok(vec![booking_key(booking_id)?])
+}
+
+struct ReservationResolvedGuard {
+    room_id: String,
+    _guard: AggregateLockGuard,
+}
+
+async fn resolve_room_lock(
+    room_id: String,
+) -> CommandResult<ResolvedWriteCommandGuard<ReservationResolvedGuard>> {
+    let lock_key = room_key(&room_id)?;
+    let guard = global_manager().acquire([lock_key.clone()]).await?;
+    Ok(ResolvedWriteCommandGuard::new(
+        ReservationResolvedGuard {
+            room_id,
+            _guard: guard,
+        },
+        [lock_key],
+    ))
+}
+
+async fn resolve_reservation_lock(
+    pool: Pool<Sqlite>,
+    booking_id: String,
+) -> CommandResult<ResolvedWriteCommandGuard<ReservationResolvedGuard>> {
+    let room_id = sqlx::query_scalar::<_, String>("SELECT room_id FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_optional(&pool)
+        .await
+        .map_err(BookingError::from)
+        .map_err(map_reservation_command_error)?
+        .ok_or_else(|| {
+            CommandError::user(
+                codes::BOOKING_NOT_FOUND,
+                format!("Booking not found: {}", booking_id),
+            )
+        })?;
+
+    let lock_keys = vec![booking_key(&booking_id)?, room_key(&room_id)?];
+    let guard = global_manager().acquire(lock_keys.clone()).await?;
+    Ok(ResolvedWriteCommandGuard::new(
+        ReservationResolvedGuard {
+            room_id,
+            _guard: guard,
+        },
+        lock_keys,
+    ))
+}
+
+fn command_origin_key(ctx: &WriteCommandContext) -> String {
+    format!("{}:{}", ctx.command_name, ctx.idempotency_key)
 }
 
 pub async fn create_reservation_tx(
@@ -194,6 +334,7 @@ pub async fn create_reservation_tx(
     Ok(booking_id)
 }
 
+#[cfg(test)]
 pub async fn fetch_booking_by_id(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
     fetch_booking(
         pool,
@@ -238,6 +379,7 @@ pub async fn fetch_booking_by_id_tx(
     })
 }
 
+#[cfg(test)]
 pub async fn create_reservation(
     pool: &Pool<Sqlite>,
     req: CreateReservationRequest,
@@ -268,10 +410,7 @@ pub async fn create_reservation_idempotent(
     let check_out_date = req.check_out_date.clone();
     let nights = req.nights;
     let source = req.source.clone();
-    let deposit_minor_units = req
-        .deposit_amount
-        .map(|amount| format!("{:.0}", amount * 100.0))
-        .unwrap_or_else(|| "0".to_string());
+    let deposit_vnd_units = canonical_vnd_units(req.deposit_amount)?;
 
     let hash_payload = json!({
         "schema": "reservation.create.v1",
@@ -284,67 +423,65 @@ pub async fn create_reservation_idempotent(
         "nights": nights,
         "source": source.clone(),
         "notes": req.notes.clone(),
-        "deposit_minor_units": deposit_minor_units,
+        "deposit_vnd_units": deposit_vnd_units,
     });
 
     let ledger_intent = SanitizedLedgerIntent::from_pairs([
         ("schema", json!("reservation.create.v1")),
-        ("room_id", json!(room_id.clone())),
+        ("room_present", json!(true)),
         ("check_in_date", json!(check_in_date.clone())),
         ("check_out_date", json!(check_out_date.clone())),
         ("nights", json!(nights)),
-        (
-            "deposit_present",
-            json!(req.deposit_amount.unwrap_or(0.0) > 0.0),
-        ),
+        ("deposit_present", json!(deposit_vnd_units > 0)),
+        ("deposit_vnd_units", json!(deposit_vnd_units)),
     ])?;
     let summary = CommandLedgerSummary::new("Create reservation")?
-        .with_aggregate_ref("room", room_id, None::<String>)?
-        .with_business_date(check_in_date)?;
+        .with_aggregate_ref("room", "room", None::<String>)?
+        .with_business_date(check_in_date.clone())?;
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("room:{room_id}"))
+        .with_lock_key_deriver(create_room_lock_keys)
         .with_success_summary(CommandLedgerResultSummary::success("Reservation created")?);
 
     let request_for_service = req;
-    let origin_idempotency_key = ctx.idempotency_key.clone();
+    let origin_idempotency_key = command_origin_key(ctx);
+    let room_id_for_guard = room_id.clone();
 
     WriteCommandExecutor::new(pool.clone())
-        .execute_atomic(ctx, request, move |tx| {
-            Box::pin(async move {
-                let origin =
-                    OriginSideEffect::new(origin_idempotency_key, 0).map_err(system_error)?;
-                let booking_id = create_reservation_tx(tx, request_for_service, Some(&origin))
-                    .await
-                    .map_err(map_create_reservation_command_error)?;
-                let booking = fetch_booking_by_id_tx(tx, &booking_id)
-                    .await
-                    .map_err(map_create_reservation_command_error)?;
-                serde_json::to_value(&booking).map_err(system_error)
-            })
-        })
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || resolve_room_lock(room_id_for_guard),
+            move |tx, _guard| {
+                Box::pin(async move {
+                    let origin =
+                        OriginSideEffect::new(origin_idempotency_key, 0).map_err(system_error)?;
+                    let booking_id = create_reservation_tx(tx, request_for_service, Some(&origin))
+                        .await
+                        .map_err(map_create_reservation_command_error)?;
+                    let booking = fetch_booking_by_id_tx(tx, &booking_id)
+                        .await
+                        .map_err(map_create_reservation_command_error)?;
+                    serde_json::to_value(&booking).map_err(system_error)
+                })
+            },
+        )
         .await
 }
 
-pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<()> {
-    let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
-    let _lock_guard = crate::aggregate_locks::global_manager()
-        .acquire([
-            crate::aggregate_locks::booking_key(booking_id)
-                .map_err(|error| BookingError::validation(error.message))?,
-            crate::aggregate_locks::room_key(&locked_room_id)
-                .map_err(|error| BookingError::validation(error.message))?,
-        ])
-        .await
-        .map_err(|error| BookingError::validation(error.message))?;
-
-    let mut tx = begin_immediate_tx(pool).await?;
-
+pub async fn cancel_reservation_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    locked_room_id: &str,
+    origin: Option<&OriginSideEffect>,
+) -> BookingResult<ReservationCancelResponse> {
     let booking = sqlx::query(
         "SELECT room_id, status, COALESCE(deposit_amount, 0) AS deposit_amount
          FROM bookings
          WHERE id = ?",
     )
     .bind(booking_id)
-    .fetch_optional(&mut *tx)
+    .fetch_optional(&mut **tx)
     .await?;
 
     let booking = booking
@@ -370,7 +507,7 @@ pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Bookin
         .bind(status::booking::CANCELLED)
         .bind(booking_id)
         .bind(status::booking::BOOKED)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
     ensure_one_row_affected(
         result,
@@ -380,64 +517,90 @@ pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Bookin
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ? AND status = ?")
         .bind(booking_id)
         .bind(status::calendar::BOOKED)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
 
     if deposit_amount > 0.0 {
-        record_cancellation_fee_tx(
-            &mut tx,
-            booking_id,
-            deposit_amount,
-            "Deposit retained (cancellation)",
-        )
-        .await?;
+        match origin {
+            Some(origin) => {
+                record_cancellation_fee_with_origin_tx(
+                    tx,
+                    booking_id,
+                    deposit_amount,
+                    "Deposit retained (cancellation)",
+                    origin,
+                )
+                .await?;
+            }
+            None => {
+                record_cancellation_fee_tx(
+                    tx,
+                    booking_id,
+                    deposit_amount,
+                    "Deposit retained (cancellation)",
+                )
+                .await?;
+            }
+        }
     }
 
     let remaining_booked: (i64,) =
         sqlx::query_as("SELECT COUNT(*) FROM room_calendar WHERE room_id = ? AND status = ?")
             .bind(&room_id)
             .bind(status::calendar::BOOKED)
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut **tx)
             .await?;
 
     let room_status = sqlx::query_scalar::<_, String>("SELECT status FROM rooms WHERE id = ?")
         .bind(&room_id)
-        .fetch_one(&mut *tx)
+        .fetch_one(&mut **tx)
         .await?;
 
     if room_status == status::room::BOOKED && remaining_booked.0 == 0 {
         sqlx::query("UPDATE rooms SET status = ? WHERE id = ?")
             .bind(status::room::VACANT)
             .bind(&room_id)
-            .execute(&mut *tx)
+            .execute(&mut **tx)
             .await?;
     }
 
-    tx.commit().await.map_err(BookingError::from)?;
-
-    Ok(())
+    Ok(ReservationCancelResponse {
+        ok: true,
+        booking_id: booking_id.to_string(),
+    })
 }
 
-pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
+#[cfg(test)]
+pub async fn cancel_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<()> {
     let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
-    let _lock_guard = crate::aggregate_locks::global_manager()
+    let _lock_guard = global_manager()
         .acquire([
-            crate::aggregate_locks::booking_key(booking_id)
-                .map_err(|error| BookingError::validation(error.message))?,
-            crate::aggregate_locks::room_key(&locked_room_id)
-                .map_err(|error| BookingError::validation(error.message))?,
+            booking_key(booking_id).map_err(|error| BookingError::validation(error.message))?,
+            room_key(&locked_room_id).map_err(|error| BookingError::validation(error.message))?,
         ])
         .await
         .map_err(|error| BookingError::validation(error.message))?;
 
     let mut tx = begin_immediate_tx(pool).await?;
-    let reservation = load_booked_reservation(&mut tx, booking_id).await?;
+    cancel_reservation_tx(&mut tx, booking_id, &locked_room_id, None).await?;
+    tx.commit().await.map_err(BookingError::from)?;
+
+    Ok(())
+}
+
+pub async fn confirm_reservation_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    locked_room_id: &str,
+    origin: Option<&OriginSideEffect>,
+) -> BookingResult<Booking> {
+    let reservation = load_booked_reservation(tx, booking_id).await?;
     if reservation.room_id != locked_room_id {
         return Err(invalid_state_transition(format!(
             "reservation {booking_id} changed rooms before confirmation"
         )));
     }
-    reject_no_show_confirmation(&mut tx, booking_id).await?;
+    reject_no_show_confirmation(tx, booking_id).await?;
 
     let now = Local::now();
     let today = now.date_naive();
@@ -449,7 +612,7 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
     };
     let effective_checkout = effective_checkout_date.format("%Y-%m-%d").to_string();
     let pricing = calculate_stay_price_tx(
-        &mut tx,
+        tx,
         &reservation.room_id,
         &today.format("%Y-%m-%d").to_string(),
         &effective_checkout,
@@ -461,11 +624,11 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
 
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ?")
         .bind(booking_id)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
 
     insert_calendar_rows(
-        &mut tx,
+        tx,
         &reservation.room_id,
         booking_id,
         today,
@@ -487,7 +650,7 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
     .bind(reservation.paid_amount)
     .bind(booking_id)
     .bind(status::booking::BOOKED)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await?;
     ensure_one_row_affected(
         result,
@@ -499,7 +662,7 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
         .bind(&reservation.room_id)
         .bind(status::room::VACANT)
         .bind(status::room::BOOKED)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
     ensure_one_row_affected(
         result,
@@ -509,29 +672,55 @@ pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> Booki
         ),
     )?;
 
-    record_charge_tx(
-        &mut tx,
-        booking_id,
-        pricing.total,
-        "Room charge (reservation)",
-        check_in_at,
-    )
-    .await?;
+    match origin {
+        Some(origin) => {
+            record_charge_with_origin_tx(
+                tx,
+                booking_id,
+                pricing.total,
+                "Room charge (reservation)",
+                check_in_at,
+                origin,
+            )
+            .await?;
+        }
+        None => {
+            record_charge_tx(
+                tx,
+                booking_id,
+                pricing.total,
+                "Room charge (reservation)",
+                check_in_at,
+            )
+            .await?;
+        }
+    }
 
-    tx.commit().await.map_err(BookingError::from)?;
-
-    fetch_booking(
-        pool,
-        booking_id,
-        format!("Booking not found: {}", booking_id),
-        read_f64_strict,
-    )
-    .await
+    fetch_booking_by_id_tx(tx, booking_id).await
 }
 
-pub async fn modify_reservation(
-    pool: &Pool<Sqlite>,
+#[cfg(test)]
+pub async fn confirm_reservation(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
+    let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
+    let _lock_guard = global_manager()
+        .acquire([
+            booking_key(booking_id).map_err(|error| BookingError::validation(error.message))?,
+            room_key(&locked_room_id).map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+    let booking = confirm_reservation_tx(&mut tx, booking_id, &locked_room_id, None).await?;
+    tx.commit().await.map_err(BookingError::from)?;
+
+    Ok(booking)
+}
+
+pub async fn modify_reservation_tx(
+    tx: &mut Transaction<'_, Sqlite>,
     req: ModifyReservationRequest,
+    locked_room_id: &str,
 ) -> BookingResult<Booking> {
     let derived_nights = validate_requested_nights(
         &req.new_check_in_date,
@@ -539,19 +728,7 @@ pub async fn modify_reservation(
         req.new_nights,
     )? as i64;
 
-    let locked_room_id = lookup_booking_room_id(pool, &req.booking_id).await?;
-    let _lock_guard = crate::aggregate_locks::global_manager()
-        .acquire([
-            crate::aggregate_locks::booking_key(&req.booking_id)
-                .map_err(|error| BookingError::validation(error.message))?,
-            crate::aggregate_locks::room_key(&locked_room_id)
-                .map_err(|error| BookingError::validation(error.message))?,
-        ])
-        .await
-        .map_err(|error| BookingError::validation(error.message))?;
-
-    let mut tx = begin_immediate_tx(pool).await?;
-    let reservation = load_booked_reservation(&mut tx, &req.booking_id).await?;
+    let reservation = load_booked_reservation(tx, &req.booking_id).await?;
     if reservation.room_id != locked_room_id {
         return Err(invalid_state_transition(format!(
             "reservation {} changed rooms before modification",
@@ -562,7 +739,7 @@ pub async fn modify_reservation(
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ? AND status = ?")
         .bind(&req.booking_id)
         .bind(status::calendar::BOOKED)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
 
     let conflicts = sqlx::query(
@@ -571,7 +748,7 @@ pub async fn modify_reservation(
     .bind(&reservation.room_id)
     .bind(&req.new_check_in_date)
     .bind(&req.new_check_out_date)
-    .fetch_all(&mut *tx)
+    .fetch_all(&mut **tx)
     .await?;
 
     if let Some(first_conflict) = conflicts.first() {
@@ -583,7 +760,7 @@ pub async fn modify_reservation(
     }
 
     let pricing = calculate_stay_price_tx(
-        &mut tx,
+        tx,
         &reservation.room_id,
         &req.new_check_in_date,
         &req.new_check_out_date,
@@ -604,8 +781,8 @@ pub async fn modify_reservation(
     .bind(pricing.total)
     .bind(&req.booking_id)
     .bind(status::booking::BOOKED)
-    .bind(&locked_room_id)
-    .execute(&mut *tx)
+    .bind(locked_room_id)
+    .execute(&mut **tx)
     .await?;
     ensure_one_row_affected(
         result,
@@ -613,7 +790,7 @@ pub async fn modify_reservation(
     )?;
 
     insert_booked_calendar_rows(
-        &mut tx,
+        tx,
         &reservation.room_id,
         &req.booking_id,
         &req.new_check_in_date,
@@ -621,15 +798,182 @@ pub async fn modify_reservation(
     )
     .await?;
 
+    fetch_booking_by_id_tx(tx, &req.booking_id).await
+}
+
+#[cfg(test)]
+pub async fn modify_reservation(
+    pool: &Pool<Sqlite>,
+    req: ModifyReservationRequest,
+) -> BookingResult<Booking> {
+    let locked_room_id = lookup_booking_room_id(pool, &req.booking_id).await?;
+    let _lock_guard = global_manager()
+        .acquire([
+            booking_key(&req.booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            room_key(&locked_room_id).map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+    let booking = modify_reservation_tx(&mut tx, req, &locked_room_id).await?;
     tx.commit().await.map_err(BookingError::from)?;
 
-    fetch_booking(
-        pool,
-        &req.booking_id,
-        format!("Booking not found: {}", req.booking_id),
-        read_f64_strict,
-    )
-    .await
+    Ok(booking)
+}
+
+pub async fn cancel_reservation_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    booking_id: &str,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let hash_payload = json!({
+        "schema": "reservation.cancel.v1",
+        "booking_id": booking_id,
+    });
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("reservation.cancel.v1")),
+        ("booking_present", json!(true)),
+    ])?;
+    let summary = CommandLedgerSummary::new("Cancel reservation")?.with_aggregate_ref(
+        "booking",
+        "booking",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{booking_id}"))
+        .with_lock_key_deriver(reservation_booking_lock_keys)
+        .with_success_summary(CommandLedgerResultSummary::success(
+            "Reservation cancelled",
+        )?);
+
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = booking_id.to_string();
+    let booking_id_for_service = booking_id.to_string();
+    let origin_idempotency_key = command_origin_key(ctx);
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || resolve_reservation_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, guard| {
+                Box::pin(async move {
+                    let origin =
+                        OriginSideEffect::new(origin_idempotency_key, 0).map_err(system_error)?;
+                    let response = cancel_reservation_tx(
+                        tx,
+                        &booking_id_for_service,
+                        &guard.room_id,
+                        Some(&origin),
+                    )
+                    .await
+                    .map_err(map_reservation_command_error)?;
+                    serde_json::to_value(response).map_err(system_error)
+                })
+            },
+        )
+        .await
+}
+
+pub async fn confirm_reservation_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    booking_id: &str,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let hash_payload = json!({
+        "schema": "reservation.confirm.v1",
+        "booking_id": booking_id,
+    });
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("reservation.confirm.v1")),
+        ("booking_present", json!(true)),
+    ])?;
+    let summary = CommandLedgerSummary::new("Confirm reservation")?.with_aggregate_ref(
+        "booking",
+        "booking",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{booking_id}"))
+        .with_lock_key_deriver(reservation_booking_lock_keys)
+        .with_success_summary(CommandLedgerResultSummary::success(
+            "Reservation confirmed",
+        )?);
+
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = booking_id.to_string();
+    let booking_id_for_service = booking_id.to_string();
+    let origin_idempotency_key = command_origin_key(ctx);
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || resolve_reservation_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, guard| {
+                Box::pin(async move {
+                    let origin =
+                        OriginSideEffect::new(origin_idempotency_key, 0).map_err(system_error)?;
+                    let booking = confirm_reservation_tx(
+                        tx,
+                        &booking_id_for_service,
+                        &guard.room_id,
+                        Some(&origin),
+                    )
+                    .await
+                    .map_err(map_reservation_command_error)?;
+                    serde_json::to_value(booking).map_err(system_error)
+                })
+            },
+        )
+        .await
+}
+
+pub async fn modify_reservation_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    req: ModifyReservationRequest,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let hash_payload = json!({
+        "schema": "reservation.modify.v1",
+        "booking_id": req.booking_id.clone(),
+        "new_check_in_date": req.new_check_in_date.clone(),
+        "new_check_out_date": req.new_check_out_date.clone(),
+        "new_nights": req.new_nights,
+    });
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("reservation.modify.v1")),
+        ("booking_present", json!(true)),
+        ("nights", json!(req.new_nights)),
+    ])?;
+    let summary = CommandLedgerSummary::new("Modify reservation")?
+        .with_aggregate_ref("booking", "booking", None::<String>)?
+        .with_business_date(req.new_check_in_date.clone())?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{}", req.booking_id))
+        .with_lock_key_deriver(reservation_booking_lock_keys)
+        .with_success_summary(CommandLedgerResultSummary::success("Reservation modified")?);
+
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = req.booking_id.clone();
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || resolve_reservation_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, guard| {
+                Box::pin(async move {
+                    let booking = modify_reservation_tx(tx, req, &guard.room_id)
+                        .await
+                        .map_err(map_reservation_command_error)?;
+                    serde_json::to_value(booking).map_err(system_error)
+                })
+            },
+        )
+        .await
 }
 
 fn validate_requested_nights(
@@ -775,5 +1119,14 @@ mod tests {
             mark_write_db_error(BookingError::database_write("disk full")),
             BookingError::database_write("disk full")
         );
+    }
+
+    #[test]
+    fn map_reservation_command_error_marks_locked_lookup_retryable() {
+        let error =
+            super::map_reservation_command_error(BookingError::database("database is locked"));
+
+        assert_eq!(error.code, crate::app_error::codes::DB_LOCKED_RETRYABLE);
+        assert!(error.retryable);
     }
 }

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -345,10 +345,8 @@ pub async fn test_pool() -> Pool<Sqlite> {
 }
 
 async fn shared_file_test_pools(label: &str) -> (Pool<Sqlite>, Pool<Sqlite>, std::path::PathBuf) {
-    let db_path = std::env::temp_dir().join(format!(
-        "capyinn-{label}-{}.sqlite",
-        uuid::Uuid::new_v4()
-    ));
+    let db_path =
+        std::env::temp_dir().join(format!("capyinn-{label}-{}.sqlite", uuid::Uuid::new_v4()));
     let database_url = format!("sqlite://{}?mode=rwc", db_path.display());
 
     let pool_a = SqlitePoolOptions::new()
@@ -1273,7 +1271,10 @@ async fn group_checkin_duplicate_in_flight_does_not_wait_for_room_lock() {
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    assert!(claim_seen, "first command should claim before waiting for room lock");
+    assert!(
+        claim_seen,
+        "first command should claim before waiting for room lock"
+    );
 
     let duplicate = tokio::time::timeout(
         std::time::Duration::from_millis(200),
@@ -1357,7 +1358,10 @@ async fn group_checkin_idempotent_non_positive_paid_amount_writes_no_payment_ori
     )
     .await
     .expect("negative reservation paid amount still creates group");
-    assert_eq!(negative_reservation.response["status"].as_str(), Some("booked"));
+    assert_eq!(
+        negative_reservation.response["status"].as_str(),
+        Some("booked")
+    );
 
     let zero_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE origin_idempotency_key = ?")
@@ -2228,7 +2232,7 @@ async fn create_reservation_idempotent_retry_does_not_duplicate_deposit() {
 
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE origin_idempotency_key = ?")
-            .bind("idem-reservation-1")
+            .bind("create_reservation:idem-reservation-1")
             .fetch_one(&pool)
             .await
             .expect("counts deposit rows");
@@ -2368,6 +2372,828 @@ async fn create_reservation_same_key_different_payload_conflicts() {
 }
 
 #[tokio::test]
+async fn reservation_command_idempotency_create_hashes_deposit_as_integer_vnd_units() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R690").await.expect("seeds room");
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .expect("seeds pricing");
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-reservation-deposit-vnd",
+        "idem-reservation-deposit-vnd",
+        "create_reservation",
+    );
+    let request = CreateReservationRequest {
+        room_id: "R690".to_string(),
+        guest_name: "Deposit Units Guest".to_string(),
+        guest_doc_number: Some("DOC690".to_string()),
+        guest_phone: None,
+        check_in_date: "2026-05-01".to_string(),
+        check_out_date: "2026-05-02".to_string(),
+        nights: 1,
+        source: Some("phone".to_string()),
+        notes: None,
+        deposit_amount: Some(500_000.0),
+    };
+
+    reservation_lifecycle::create_reservation_idempotent(&pool, &ctx, request)
+        .await
+        .expect("reservation succeeds");
+
+    let row = sqlx::query(
+        "SELECT request_hash, intent_json FROM command_idempotency
+         WHERE command_name = ? AND idempotency_key = ?",
+    )
+    .bind(&ctx.command_name)
+    .bind(&ctx.idempotency_key)
+    .fetch_one(&pool)
+    .await
+    .expect("reads command row");
+
+    let expected_payload = serde_json::json!({
+        "schema": "reservation.create.v1",
+        "room_id": "R690",
+        "guest_name": "Deposit Units Guest",
+        "guest_doc_number": "DOC690",
+        "guest_phone": null,
+        "check_in_date": "2026-05-01",
+        "check_out_date": "2026-05-02",
+        "nights": 1,
+        "source": "phone",
+        "notes": null,
+        "deposit_vnd_units": 500000,
+    });
+    let mut cents_payload = expected_payload.clone();
+    cents_payload["deposit_vnd_units"] = serde_json::json!(50000000);
+    let mut float_payload = expected_payload.clone();
+    float_payload["deposit_vnd_units"] = serde_json::json!(500000.0);
+    let mut string_payload = expected_payload.clone();
+    string_payload["deposit_vnd_units"] = serde_json::json!("500000");
+
+    assert_eq!(
+        row.get::<String, _>("request_hash"),
+        crate::command_idempotency::stable_request_hash(&expected_payload)
+            .expect("expected payload hashes")
+    );
+    assert_ne!(
+        row.get::<String, _>("request_hash"),
+        crate::command_idempotency::stable_request_hash(&cents_payload)
+            .expect("cents payload hashes")
+    );
+    assert_ne!(
+        row.get::<String, _>("request_hash"),
+        crate::command_idempotency::stable_request_hash(&float_payload)
+            .expect("float payload hashes")
+    );
+    assert_ne!(
+        row.get::<String, _>("request_hash"),
+        crate::command_idempotency::stable_request_hash(&string_payload)
+            .expect("string payload hashes")
+    );
+
+    let intent_json = row.get::<String, _>("intent_json");
+    assert!(intent_json.contains("\"deposit_present\":true"));
+    assert!(intent_json.contains("\"deposit_vnd_units\":500000"));
+}
+
+fn reservation_modify_request(
+    booking_id: &str,
+    check_in: &str,
+    check_out: &str,
+    nights: i32,
+) -> crate::models::ModifyReservationRequest {
+    crate::models::ModifyReservationRequest {
+        booking_id: booking_id.to_string(),
+        new_check_in_date: check_in.to_string(),
+        new_check_out_date: check_out.to_string(),
+        new_nights: nights,
+    }
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_create_replay_does_not_duplicate_booking_or_calendar() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R691").await.expect("seeds room");
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .expect("seeds pricing");
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-create-replay-no-dup",
+        "idem-create-replay-no-dup",
+        "reservation.create",
+    );
+
+    let first = reservation_lifecycle::create_reservation_idempotent(
+        &pool,
+        &ctx,
+        minimal_reservation_request("R691"),
+    )
+    .await
+    .expect("first create succeeds");
+    let replay = reservation_lifecycle::create_reservation_idempotent(
+        &pool,
+        &ctx,
+        minimal_reservation_request("R691"),
+    )
+    .await
+    .expect("create replays");
+
+    assert!(!first.replayed);
+    assert!(replay.replayed);
+    assert_eq!(first.response, replay.response);
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+            .bind("R691")
+            .fetch_one(&pool)
+            .await
+            .expect("counts bookings"),
+        1
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM room_calendar WHERE room_id = ?")
+            .bind("R691")
+            .fetch_one(&pool)
+            .await
+            .expect("counts calendar rows"),
+        2
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_modify_replay_returns_stored_snapshot() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R692").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B692", "R692")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-modify-snapshot",
+        "idem-modify-snapshot",
+        "reservation.modify",
+    );
+
+    let first = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B692", "2026-04-23", "2026-04-26", 3),
+    )
+    .await
+    .expect("first modify succeeds");
+    sqlx::query("UPDATE bookings SET total_price = 999 WHERE id = ?")
+        .bind("B692")
+        .execute(&pool)
+        .await
+        .expect("mutates booking after first response");
+    let replay = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B692", "2026-04-23", "2026-04-26", 3),
+    )
+    .await
+    .expect("modify replays");
+
+    assert!(replay.replayed);
+    assert_eq!(first.response, replay.response);
+    assert_eq!(
+        replay.response["total_price"],
+        serde_json::json!(1_800_000.0)
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_modify_replay_does_not_duplicate_calendar() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R693").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B693", "R693")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-modify-calendar",
+        "idem-modify-calendar",
+        "reservation.modify",
+    );
+    reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B693", "2026-04-23", "2026-04-26", 3),
+    )
+    .await
+    .expect("first modify succeeds");
+    reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B693", "2026-04-23", "2026-04-26", 3),
+    )
+    .await
+    .expect("modify replays");
+
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
+            .bind("B693")
+            .fetch_one(&pool)
+            .await
+            .expect("counts calendar rows"),
+        3
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_cancel_replay_does_not_duplicate_cancellation_fee() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R694").await.unwrap();
+    seed_booked_reservation(&pool, "B694", "R694")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-fee",
+        "idem-cancel-fee",
+        "reservation.cancel",
+    );
+
+    let first = reservation_lifecycle::cancel_reservation_idempotent(&pool, &ctx, "B694")
+        .await
+        .expect("first cancel succeeds");
+    let replay = reservation_lifecycle::cancel_reservation_idempotent(&pool, &ctx, "B694")
+        .await
+        .expect("cancel replays");
+
+    assert_eq!(first.response, replay.response);
+    assert!(replay.replayed);
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'cancellation_fee'",
+        )
+        .bind("B694")
+        .fetch_one(&pool)
+        .await
+        .expect("counts cancellation fees"),
+        1
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_confirm_replay_does_not_duplicate_room_charge() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R695").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B695", "R695")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-confirm-charge",
+        "idem-confirm-charge",
+        "reservation.confirm",
+    );
+
+    reservation_lifecycle::confirm_reservation_idempotent(&pool, &ctx, "B695")
+        .await
+        .expect("first confirm succeeds");
+    reservation_lifecycle::confirm_reservation_idempotent(&pool, &ctx, "B695")
+        .await
+        .expect("confirm replays");
+
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+        )
+        .bind("B695")
+        .fetch_one(&pool)
+        .await
+        .expect("counts room charges"),
+        1
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_confirm_replay_does_not_requery_or_reprice_later_retry() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R696").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B696", "R696")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-confirm-no-reprice",
+        "idem-confirm-no-reprice",
+        "reservation.confirm",
+    );
+
+    let first = reservation_lifecycle::confirm_reservation_idempotent(&pool, &ctx, "B696")
+        .await
+        .expect("first confirm succeeds");
+    sqlx::query("UPDATE pricing_rules SET daily_rate = 9999999 WHERE room_type = 'standard'")
+        .execute(&pool)
+        .await
+        .expect("mutates pricing");
+    sqlx::query("UPDATE bookings SET total_price = 123 WHERE id = ?")
+        .bind("B696")
+        .execute(&pool)
+        .await
+        .expect("mutates booking");
+    let replay = reservation_lifecycle::confirm_reservation_idempotent(&pool, &ctx, "B696")
+        .await
+        .expect("confirm replays");
+
+    assert!(replay.replayed);
+    assert_eq!(first.response, replay.response);
+    assert_ne!(replay.response["total_price"], serde_json::json!(123.0));
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_modify_cancel_confirm_same_key_different_payload_conflicts(
+) {
+    let pool = test_pool().await;
+    seed_room(&pool, "R697A").await.unwrap();
+    seed_room(&pool, "R697B").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B697A", "R697A")
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B697B", "R697B")
+        .await
+        .unwrap();
+
+    let modify_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-modify-hash-conflict",
+        "idem-modify-hash-conflict",
+        "reservation.modify",
+    );
+    reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &modify_ctx,
+        crate::models::ModifyReservationRequest {
+            booking_id: "B697A".to_string(),
+            new_check_in_date: "2026-04-23".to_string(),
+            new_check_out_date: "2026-04-25".to_string(),
+            new_nights: 2,
+        },
+    )
+    .await
+    .expect("first modify succeeds");
+    let modify_error = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &modify_ctx,
+        crate::models::ModifyReservationRequest {
+            booking_id: "B697B".to_string(),
+            new_check_in_date: "2026-04-23".to_string(),
+            new_check_out_date: "2026-04-25".to_string(),
+            new_nights: 2,
+        },
+    )
+    .await
+    .expect_err("different modify payload conflicts");
+    assert_eq!(
+        modify_error.code,
+        crate::app_error::codes::CONFLICT_IDEMPOTENCY_HASH_MISMATCH
+    );
+
+    let cancel_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-hash-conflict",
+        "idem-cancel-hash-conflict",
+        "reservation.cancel",
+    );
+    reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, "B697A")
+        .await
+        .expect("first cancel succeeds");
+    let cancel_error =
+        reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, "B697B")
+            .await
+            .expect_err("different cancel payload conflicts");
+    assert_eq!(
+        cancel_error.code,
+        crate::app_error::codes::CONFLICT_IDEMPOTENCY_HASH_MISMATCH
+    );
+
+    let confirm_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-confirm-hash-conflict",
+        "idem-confirm-hash-conflict",
+        "reservation.confirm",
+    );
+    reservation_lifecycle::confirm_reservation_idempotent(&pool, &confirm_ctx, "B697B")
+        .await
+        .expect("first confirm succeeds");
+    let confirm_error =
+        reservation_lifecycle::confirm_reservation_idempotent(&pool, &confirm_ctx, "B697A")
+            .await
+            .expect_err("different confirm payload conflicts");
+    assert_eq!(
+        confirm_error.code,
+        crate::app_error::codes::CONFLICT_IDEMPOTENCY_HASH_MISMATCH
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_modify_conflict_replays_terminal_room_unavailable() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R698").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B698", "R698")
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO room_calendar (room_id, date, booking_id, status)
+         VALUES (?, '2026-04-23', NULL, 'booked')",
+    )
+    .bind("R698")
+    .execute(&pool)
+    .await
+    .expect("seeds conflicting calendar");
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-modify-room-conflict",
+        "idem-modify-room-conflict",
+        "reservation.modify",
+    );
+    let first = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B698", "2026-04-23", "2026-04-25", 2),
+    )
+    .await
+    .expect_err("first conflict fails");
+    sqlx::query("DELETE FROM room_calendar WHERE room_id = ? AND booking_id IS NULL")
+        .bind("R698")
+        .execute(&pool)
+        .await
+        .expect("removes conflict");
+    let replay = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B698", "2026-04-23", "2026-04-25", 2),
+    )
+    .await
+    .expect_err("terminal conflict replays");
+
+    assert_eq!(
+        first.code,
+        crate::app_error::codes::CONFLICT_ROOM_UNAVAILABLE
+    );
+    assert_eq!(replay.code, first.code);
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_cancel_confirm_invalid_state_replays_terminal() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R699A").await.unwrap();
+    seed_room(&pool, "R699B").await.unwrap();
+    seed_booked_reservation(&pool, "B699A", "R699A")
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B699B", "R699B")
+        .await
+        .unwrap();
+    sqlx::query("UPDATE bookings SET status = 'active' WHERE id = ?")
+        .bind("B699A")
+        .execute(&pool)
+        .await
+        .expect("makes cancel invalid");
+    sqlx::query("UPDATE bookings SET status = 'cancelled' WHERE id = ?")
+        .bind("B699B")
+        .execute(&pool)
+        .await
+        .expect("makes confirm invalid");
+
+    let cancel_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-invalid-replay",
+        "idem-cancel-invalid-replay",
+        "reservation.cancel",
+    );
+    let cancel_first =
+        reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, "B699A")
+            .await
+            .expect_err("cancel invalid state fails");
+    sqlx::query("UPDATE bookings SET status = 'booked' WHERE id = ?")
+        .bind("B699A")
+        .execute(&pool)
+        .await
+        .expect("would make cancel valid");
+    let cancel_replay =
+        reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, "B699A")
+            .await
+            .expect_err("cancel invalid state replays");
+
+    let confirm_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-confirm-invalid-replay",
+        "idem-confirm-invalid-replay",
+        "reservation.confirm",
+    );
+    let confirm_first =
+        reservation_lifecycle::confirm_reservation_idempotent(&pool, &confirm_ctx, "B699B")
+            .await
+            .expect_err("confirm invalid state fails");
+    sqlx::query("UPDATE bookings SET status = 'booked' WHERE id = ?")
+        .bind("B699B")
+        .execute(&pool)
+        .await
+        .expect("would make confirm valid");
+    let confirm_replay =
+        reservation_lifecycle::confirm_reservation_idempotent(&pool, &confirm_ctx, "B699B")
+            .await
+            .expect_err("confirm invalid state replays");
+
+    assert_eq!(
+        cancel_first.code,
+        crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION
+    );
+    assert_eq!(cancel_replay.code, cancel_first.code);
+    assert_eq!(
+        confirm_first.code,
+        crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION
+    );
+    assert_eq!(confirm_replay.code, confirm_first.code);
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_missing_booking_for_cancel_modify_confirm_replays_terminal(
+) {
+    let pool = test_pool().await;
+    seed_room(&pool, "R700A").await.unwrap();
+    seed_room(&pool, "R700B").await.unwrap();
+    seed_room(&pool, "R700C").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+
+    let cancel_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-missing",
+        "idem-cancel-missing",
+        "reservation.cancel",
+    );
+    let cancel_first =
+        reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, "B700A")
+            .await
+            .expect_err("missing cancel booking fails");
+    seed_booked_reservation(&pool, "B700A", "R700A")
+        .await
+        .unwrap();
+    let cancel_replay =
+        reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, "B700A")
+            .await
+            .expect_err("missing cancel booking replays");
+
+    let modify_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-modify-missing",
+        "idem-modify-missing",
+        "reservation.modify",
+    );
+    let modify_first = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &modify_ctx,
+        reservation_modify_request("B700B", "2026-04-23", "2026-04-25", 2),
+    )
+    .await
+    .expect_err("missing modify booking fails");
+    seed_booked_reservation(&pool, "B700B", "R700B")
+        .await
+        .unwrap();
+    let modify_replay = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &modify_ctx,
+        reservation_modify_request("B700B", "2026-04-23", "2026-04-25", 2),
+    )
+    .await
+    .expect_err("missing modify booking replays");
+
+    let confirm_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-confirm-missing",
+        "idem-confirm-missing",
+        "reservation.confirm",
+    );
+    let confirm_first =
+        reservation_lifecycle::confirm_reservation_idempotent(&pool, &confirm_ctx, "B700C")
+            .await
+            .expect_err("missing confirm booking fails");
+    seed_booked_reservation(&pool, "B700C", "R700C")
+        .await
+        .unwrap();
+    let confirm_replay =
+        reservation_lifecycle::confirm_reservation_idempotent(&pool, &confirm_ctx, "B700C")
+            .await
+            .expect_err("missing confirm booking replays");
+
+    for error in [
+        cancel_first,
+        cancel_replay,
+        modify_first,
+        modify_replay,
+        confirm_first,
+        confirm_replay,
+    ] {
+        assert_eq!(error.code, crate::app_error::codes::BOOKING_NOT_FOUND);
+    }
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_duplicate_in_flight_returns_conflict() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R701").await.unwrap();
+    seed_booked_reservation(&pool, "B701", "R701")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-in-flight",
+        "idem-cancel-in-flight",
+        "reservation.cancel",
+    );
+    let payload = serde_json::json!({
+        "schema": "reservation.cancel.v1",
+        "booking_id": "B701",
+    });
+    let now = chrono::Utc::now().to_rfc3339();
+    let lease_expires_at = (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
+    sqlx::query(
+        "INSERT INTO command_idempotency (
+            idempotency_key, command_name, request_hash, intent_json, lock_keys_json,
+            status, claim_token, retryable, lease_expires_at, created_at, updated_at, last_attempt_at
+        ) VALUES (?, ?, ?, '{}', '[]', 'in_progress', 'other-claim', 0, ?, ?, ?, ?)",
+    )
+    .bind(&ctx.idempotency_key)
+    .bind(&ctx.command_name)
+    .bind(crate::command_idempotency::stable_request_hash(&payload).expect("payload hashes"))
+    .bind(&lease_expires_at)
+    .bind(&now)
+    .bind(&now)
+    .bind(&now)
+    .execute(&pool)
+    .await
+    .expect("seeds in-flight row");
+
+    let error = reservation_lifecycle::cancel_reservation_idempotent(&pool, &ctx, "B701")
+        .await
+        .expect_err("duplicate in-flight conflicts");
+
+    assert_eq!(
+        error.code,
+        crate::app_error::codes::CONFLICT_DUPLICATE_IN_FLIGHT
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_retryable_reclaimable_failure_can_be_reclaimed() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R702").await.unwrap();
+    seed_booked_reservation(&pool, "B702", "R702")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-reclaim",
+        "idem-cancel-reclaim",
+        "reservation.cancel",
+    );
+    let payload = serde_json::json!({
+        "schema": "reservation.cancel.v1",
+        "booking_id": "B702",
+    });
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query(
+        "INSERT INTO command_idempotency (
+            idempotency_key, command_name, request_hash, intent_json, lock_keys_json,
+            status, claim_token, error_code, error_json, retryable, created_at, updated_at,
+            last_attempt_at
+        ) VALUES (?, ?, ?, '{}', '[]', 'failed_retryable', 'failed-claim',
+            'DB_LOCKED_RETRYABLE', '{}', 1, ?, ?, ?)",
+    )
+    .bind(&ctx.idempotency_key)
+    .bind(&ctx.command_name)
+    .bind(crate::command_idempotency::stable_request_hash(&payload).expect("payload hashes"))
+    .bind(&now)
+    .bind(&now)
+    .bind(&now)
+    .execute(&pool)
+    .await
+    .expect("seeds retryable row");
+
+    let result = reservation_lifecycle::cancel_reservation_idempotent(&pool, &ctx, "B702")
+        .await
+        .expect("retryable row is reclaimed");
+
+    assert!(!result.replayed);
+    assert_eq!(result.response["ok"], true);
+    assert_eq!(
+        sqlx::query_scalar::<_, String>(
+            "SELECT status FROM command_idempotency WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads status"),
+        "completed"
+    );
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_invalid_modify_nights_replays_terminal_error() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R703").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    seed_booked_reservation(&pool, "B703", "R703")
+        .await
+        .unwrap();
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-modify-invalid-nights",
+        "idem-modify-invalid-nights",
+        "reservation.modify",
+    );
+
+    let first = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B703", "2026-04-23", "2026-04-26", 2),
+    )
+    .await
+    .expect_err("invalid nights should fail inside command boundary");
+
+    let status: String = sqlx::query_scalar(
+        "SELECT status FROM command_idempotency
+         WHERE command_name = ? AND idempotency_key = ?",
+    )
+    .bind(&ctx.command_name)
+    .bind(&ctx.idempotency_key)
+    .fetch_one(&pool)
+    .await
+    .expect("invalid command row is stored");
+    assert_eq!(status, "failed_terminal");
+
+    let replay = reservation_lifecycle::modify_reservation_idempotent(
+        &pool,
+        &ctx,
+        reservation_modify_request("B703", "2026-04-23", "2026-04-26", 2),
+    )
+    .await
+    .expect_err("invalid nights should replay stored terminal error");
+
+    assert_eq!(first.code, replay.code);
+    assert_eq!(first.message, replay.message);
+}
+
+#[tokio::test]
+async fn reservation_command_idempotency_same_plain_key_across_commands_scopes_origin_rows() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R704").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 600_000.0)
+        .await
+        .unwrap();
+    let plain_key = "idem-shared-reservation-origin";
+    let create_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-create-shared-origin",
+        plain_key,
+        "reservation.create",
+    );
+    let cancel_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-cancel-shared-origin",
+        plain_key,
+        "reservation.cancel",
+    );
+
+    let created = reservation_lifecycle::create_reservation_idempotent(
+        &pool,
+        &create_ctx,
+        minimal_reservation_request("R704"),
+    )
+    .await
+    .expect("create with deposit succeeds");
+    let booking_id = created.response["id"]
+        .as_str()
+        .expect("booking id in create response")
+        .to_string();
+
+    reservation_lifecycle::cancel_reservation_idempotent(&pool, &cancel_ctx, &booking_id)
+        .await
+        .expect("cancel with same plain key but different command succeeds");
+
+    let origins = sqlx::query_scalar::<_, String>(
+        "SELECT origin_idempotency_key
+         FROM transactions
+         WHERE booking_id = ? AND type IN ('deposit', 'cancellation_fee')
+         ORDER BY type ASC",
+    )
+    .bind(&booking_id)
+    .fetch_all(&pool)
+    .await
+    .expect("reads transaction origins");
+
+    assert_eq!(origins.len(), 2);
+    assert!(origins.contains(&format!("{}:{}", create_ctx.command_name, plain_key)));
+    assert!(origins.contains(&format!("{}:{}", cancel_ctx.command_name, plain_key)));
+}
+
+#[tokio::test]
 async fn cancel_reservation_releases_calendar_and_keeps_fee_record() {
     let pool = test_pool().await;
     seed_room(&pool, "R161").await.unwrap();
@@ -2454,8 +3280,13 @@ async fn do_create_reservation_returns_service_booking_and_leaves_room_vacant() 
         .await
         .unwrap();
 
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-do-create-reservation",
+        "idem-do-create-reservation",
+        "create_reservation",
+    );
     let booking =
-        reservations::do_create_reservation(&pool, None, minimal_reservation_request("R162"))
+        reservations::do_create_reservation(&pool, None, &ctx, minimal_reservation_request("R162"))
             .await
             .unwrap();
 
@@ -2495,9 +3326,16 @@ async fn do_cancel_reservation_cleans_legacy_booked_room_state() {
         .await
         .unwrap();
 
-    reservations::do_cancel_reservation(&pool, None, "B163")
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-do-cancel-reservation",
+        "idem-do-cancel-reservation",
+        "cancel_reservation",
+    );
+    let response = reservations::do_cancel_reservation(&pool, None, &ctx, "B163")
         .await
         .unwrap();
+    assert!(response.ok);
+    assert_eq!(response.booking_id, "B163");
 
     let room = sqlx::query("SELECT status FROM rooms WHERE id = ?")
         .bind("R163")
@@ -2906,9 +3744,15 @@ async fn do_modify_reservation_returns_service_booking_without_app_handle() {
         .await
         .unwrap();
 
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-do-modify-reservation",
+        "idem-do-modify-reservation",
+        "modify_reservation",
+    );
     let booking = reservations::do_modify_reservation(
         &pool,
         None,
+        &ctx,
         crate::models::ModifyReservationRequest {
             booking_id: "B167".to_string(),
             new_check_in_date: "2026-04-24".to_string(),
@@ -4351,7 +5195,7 @@ async fn add_folio_line_idempotent_retry_replays_and_does_not_duplicate_row() {
 
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM folio_lines WHERE origin_idempotency_key = ?")
-            .bind("idem-folio-line-1")
+            .bind("add_folio_line:idem-folio-line-1")
             .fetch_one(&pool)
             .await
             .unwrap();
@@ -4603,7 +5447,7 @@ async fn add_folio_line_idempotent_invalid_amount_does_not_consume_claim_or_ordi
     .unwrap();
     assert_eq!(
         row.get::<String, _>("origin_idempotency_key"),
-        "idem-folio-line-5"
+        "add_folio_line:idem-folio-line-5"
     );
     assert_eq!(row.get::<i64, _>("origin_line_ordinal"), 0);
 }

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -10,8 +10,7 @@ import {
 } from "@/lib/appError";
 
 const invoke = vi.hoisted(() => vi.fn());
-const invokeCommand = vi.hoisted(() => vi.fn());
-const createIdempotencyKey = vi.hoisted(() => vi.fn());
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
 const createCorrelationId = vi.hoisted(() => vi.fn());
 const toastError = vi.hoisted(() => vi.fn());
 const toastSuccess = vi.hoisted(() => vi.fn());
@@ -25,8 +24,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 vi.mock("@/lib/invokeCommand", () => ({
-  createIdempotencyKey,
-  invokeCommand,
+  invokeWriteCommand,
 }));
 
 vi.mock("@/lib/correlationId", () => ({
@@ -111,12 +109,11 @@ describe("ReservationSheet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     invoke.mockResolvedValue(undefined);
-    invokeCommand.mockResolvedValue(undefined);
-    createIdempotencyKey.mockReturnValue("create_reservation:IDEM-1");
+    invokeWriteCommand.mockResolvedValue(undefined);
     createCorrelationId.mockReturnValue("COR-5E6F7A8B");
   });
 
-  it("uses invokeCommand with scrubbed monitoring context for the create flow", async () => {
+  it("uses invokeWriteCommand with scrubbed monitoring context for the create flow", async () => {
     const user = userEvent.setup();
     render(<ReservationSheet open onOpenChange={vi.fn()} />);
 
@@ -149,7 +146,7 @@ describe("ReservationSheet", () => {
 
     expect(createCorrelationId).toHaveBeenCalledTimes(1);
     await waitFor(() => {
-      expect(invokeCommand).toHaveBeenCalledWith(
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
         "create_reservation",
         {
           req: {
@@ -164,7 +161,6 @@ describe("ReservationSheet", () => {
             source: "zalo",
             notes: "Khách thích tầng cao",
           },
-          idempotencyKey: "create_reservation:IDEM-1",
         },
         {
           correlationId: "COR-5E6F7A8B",
@@ -177,6 +173,67 @@ describe("ReservationSheet", () => {
         },
       );
     });
+    expect(invoke).not.toHaveBeenCalledWith("create_reservation", expect.anything());
+  });
+
+  it("uses invokeWriteCommand with correlation and monitoring context for the modify flow", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        editBooking={{
+          id: "B101",
+          room_id: "R101",
+          guest_name: "Nguyen Van A",
+          guest_phone: "0900000000",
+          check_in_at: "2026-04-20",
+          expected_checkout: "2026-04-22",
+          scheduled_checkin: "2026-04-20",
+          scheduled_checkout: "2026-04-22",
+          nights: 2,
+          total_price: 1000000,
+          source: "phone",
+          deposit_amount: 50000,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchRooms).toHaveBeenCalledTimes(1);
+    });
+
+    const [nightsInput] = screen.getAllByRole("spinbutton");
+    fireEvent.change(nightsInput, {
+      target: { value: "3" },
+    });
+
+    await user.click(screen.getByRole("button", { name: /lưu thay đổi/i }));
+
+    expect(createCorrelationId).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "modify_reservation",
+        {
+          req: {
+            booking_id: "B101",
+            new_check_in_date: "2026-04-20",
+            new_check_out_date: "2026-04-23",
+            new_nights: 3,
+          },
+        },
+        {
+          correlationId: "COR-5E6F7A8B",
+          monitoringContext: {
+            nights: 3,
+            deposit_present: false,
+            source: null,
+            notes_present: false,
+          },
+        },
+      );
+    });
+    expect(invoke).not.toHaveBeenCalledWith("modify_reservation", expect.anything());
   });
 
   it("formats create flow failures with formatAppError", async () => {
@@ -184,7 +241,7 @@ describe("ReservationSheet", () => {
     const error = createAppErrorException(createReservationError, undefined, {
       correlation_id: "COR-5E6F7A8B",
     });
-    invokeCommand.mockRejectedValue(error);
+    invokeWriteCommand.mockRejectedValue(error);
 
     render(<ReservationSheet open onOpenChange={vi.fn()} />);
 
@@ -201,14 +258,13 @@ describe("ReservationSheet", () => {
     await user.click(screen.getByRole("button", { name: /đặt phòng/i }));
 
     await waitFor(() => {
-      expect(invokeCommand).toHaveBeenCalledWith(
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
         "create_reservation",
         expect.objectContaining({
           req: expect.objectContaining({
             room_id: "R101",
             guest_name: "Nguyen Van A",
           }),
-          idempotencyKey: "create_reservation:IDEM-1",
         }),
         {
           correlationId: "COR-5E6F7A8B",

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { useHotelStore } from "../stores/useHotelStore";
 import { CalendarDays, User, Phone, CreditCard, AlertTriangle, FileText } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -9,7 +8,7 @@ import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { createCorrelationId } from "@/lib/correlationId";
 import { fmtNumber } from "@/lib/format";
-import { createIdempotencyKey, invokeCommand } from "@/lib/invokeCommand";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { toast } from "sonner";
 import InvoiceDialog from "./InvoiceDialog";
 import type { EditableBooking } from "@/types";
@@ -101,19 +100,27 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         }
         setLoading(true);
         try {
+            const correlationId = createCorrelationId();
             if (isEditMode && editBooking) {
-                await invoke("modify_reservation", {
+                await invokeWriteCommand("modify_reservation", {
                     req: {
                         booking_id: editBooking.id,
                         new_check_in_date: checkInDate,
                         new_check_out_date: checkOutDate,
                         new_nights: nights,
                     },
+                }, {
+                    correlationId,
+                    monitoringContext: {
+                        nights,
+                        deposit_present: false,
+                        source: null,
+                        notes_present: false,
+                    },
                 });
                 toast.success("Đã cập nhật đặt phòng!");
             } else {
-                const correlationId = createCorrelationId();
-                await invokeCommand("create_reservation", {
+                await invokeWriteCommand("create_reservation", {
                     req: {
                         room_id: roomId,
                         guest_name: guestName,
@@ -126,7 +133,6 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                         source,
                         notes: notes || null,
                     },
-                    idempotencyKey: createIdempotencyKey("create_reservation"),
                 }, {
                     correlationId,
                     monitoringContext: {

--- a/mhm/src/lib/invokeCommand.test.ts
+++ b/mhm/src/lib/invokeCommand.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.hoisted(() => vi.fn());
+const captureCommandFailure = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+}));
+
+vi.mock("./crashReporting/commandFailure", () => ({
+  captureCommandFailure,
+}));
+
+import { invokeWriteCommand } from "./invokeCommand";
+
+describe("invokeWriteCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invoke.mockResolvedValue("ok");
+  });
+
+  it("adds a command-scoped idempotency key", async () => {
+    await invokeWriteCommand("create_reservation", { req: { room_id: "R101" } });
+
+    expect(invoke).toHaveBeenCalledWith("create_reservation", {
+      req: { room_id: "R101" },
+      idempotencyKey: expect.stringMatching(/^create_reservation:/),
+    });
+  });
+
+  it("preserves correlation id and monitoring context without leaking monitoring into payload", async () => {
+    const monitoringContext = {
+      nights: 2,
+      deposit_present: true,
+      source: "phone",
+      notes_present: false,
+    } as const;
+
+    await invokeWriteCommand(
+      "modify_reservation",
+      { req: { booking_id: "B101" } },
+      {
+        correlationId: "COR-8F3A1C7D",
+        monitoringContext,
+      },
+    );
+
+    expect(invoke).toHaveBeenCalledWith("modify_reservation", {
+      req: { booking_id: "B101" },
+      idempotencyKey: expect.stringMatching(/^modify_reservation:/),
+      correlationId: "COR-8F3A1C7D",
+    });
+  });
+
+  it("normalizes structured errors through the existing invokeCommand path", async () => {
+    const structuredError = {
+      code: "AUTH_NOT_AUTHENTICATED",
+      message: "Chưa đăng nhập",
+      kind: "user",
+      support_id: null,
+    };
+    invoke.mockRejectedValueOnce(structuredError);
+
+    const promise = invokeWriteCommand(
+      "cancel_reservation",
+      { bookingId: "B101" },
+      {
+        correlationId: "COR-8F3A1C7D",
+        monitoringContext: { notes_present: false },
+      },
+    );
+
+    await expect(promise).rejects.toMatchObject({
+      name: "AppError",
+      code: "AUTH_NOT_AUTHENTICATED",
+      message: "Chưa đăng nhập",
+      kind: "user",
+      support_id: null,
+      correlation_id: "COR-8F3A1C7D",
+      cause: structuredError,
+    });
+    expect(captureCommandFailure).toHaveBeenCalledWith({
+      command: "cancel_reservation",
+      appError: structuredError,
+      correlationId: "COR-8F3A1C7D",
+      monitoringContext: { notes_present: false },
+    });
+  });
+});

--- a/mhm/src/lib/invokeCommand.ts
+++ b/mhm/src/lib/invokeCommand.ts
@@ -37,3 +37,18 @@ export async function invokeCommand<TResponse>(
     });
   }
 }
+
+export async function invokeWriteCommand<TResponse>(
+  command: string,
+  args?: Record<string, unknown>,
+  options?: { correlationId?: string; monitoringContext?: MonitoringContext },
+): Promise<TResponse> {
+  return invokeCommand<TResponse>(
+    command,
+    {
+      ...(args ?? {}),
+      idempotencyKey: createIdempotencyKey(command),
+    },
+    options,
+  );
+}

--- a/mhm/src/pages/Reservations.test.tsx
+++ b/mhm/src/pages/Reservations.test.tsx
@@ -1,0 +1,154 @@
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.hoisted(() => vi.fn());
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
+const createCorrelationId = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+const fetchRooms = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+}));
+
+vi.mock("@/lib/invokeCommand", () => ({
+  invokeWriteCommand,
+}));
+
+vi.mock("@/lib/correlationId", () => ({
+  createCorrelationId,
+}));
+
+vi.mock("@/stores/useHotelStore", () => ({
+  useHotelStore: () => ({
+    rooms: [
+      {
+        id: "R101",
+        name: "R101",
+        type: "standard",
+        status: "booked",
+      },
+    ],
+    fetchRooms,
+  }),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ReservationSheet", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/RoomDrawer", () => ({
+  default: () => null,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    error: vi.fn(),
+  },
+}));
+
+import Reservations from "./Reservations";
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function bookedReservation() {
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+
+  return {
+    id: "B101",
+    room_id: "R101",
+    guest_name: "Nguyen Van A",
+    guest_phone: "0900000000",
+    check_in_at: formatLocalDate(today),
+    expected_checkout: formatLocalDate(tomorrow),
+    scheduled_checkin: formatLocalDate(today),
+    scheduled_checkout: formatLocalDate(tomorrow),
+    nights: 1,
+    total_price: 500000,
+    paid_amount: 50000,
+    status: "booked",
+    source: "phone",
+    deposit_amount: 50000,
+  };
+}
+
+async function openBookedReservationActions(user: ReturnType<typeof userEvent.setup>) {
+  render(<Reservations />);
+
+  await waitFor(() => {
+    expect(screen.getAllByText("Nguyen Van A").length).toBeGreaterThan(0);
+  });
+
+  await user.click(screen.getAllByText("Nguyen Van A")[0]);
+}
+
+describe("Reservations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_all_bookings") return [bookedReservation()];
+      return undefined;
+    });
+    invokeWriteCommand.mockResolvedValue(undefined);
+    createCorrelationId.mockReturnValue("COR-5E6F7A8B");
+  });
+
+  it("confirms reservations through invokeWriteCommand with correlation id", async () => {
+    const user = userEvent.setup();
+    await openBookedReservationActions(user);
+
+    await user.click(screen.getByRole("button", { name: /check-in/i }));
+
+    expect(createCorrelationId).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "confirm_reservation",
+        { bookingId: "B101" },
+        { correlationId: "COR-5E6F7A8B" },
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Check-in reservation thành công!");
+  });
+
+  it("cancels reservations through invokeWriteCommand with correlation id", async () => {
+    const user = userEvent.setup();
+    await openBookedReservationActions(user);
+
+    await user.click(screen.getByRole("button", { name: /hủy/i }));
+
+    expect(createCorrelationId).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "cancel_reservation",
+        { bookingId: "B101" },
+        { correlationId: "COR-5E6F7A8B" },
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Đã hủy reservation. Tiền cọc được giữ lại.");
+  });
+});

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -6,8 +6,10 @@ import { Button } from "@/components/ui/button";
 import { useHotelStore } from "@/stores/useHotelStore";
 import { invoke } from "@tauri-apps/api/core";
 import { getRoomTypeLabel } from "@/lib/constants";
+import { createCorrelationId } from "@/lib/correlationId";
 import { formatAppError } from "@/lib/appError";
 import { fmtNumber } from "@/lib/format";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { toast } from "sonner";
 import ReservationSheet from "@/components/ReservationSheet";
 import RoomDrawer from "@/components/RoomDrawer";
@@ -163,20 +165,22 @@ export default function Reservations() {
     }
 
     async function handleConfirmReservation(bookingId: string) {
+        const correlationId = createCorrelationId();
         try {
-            await invoke("confirm_reservation", { bookingId });
+            await invokeWriteCommand("confirm_reservation", { bookingId }, { correlationId });
             toast.success("Check-in reservation thành công!");
             loadBookings();
             fetchRooms();
             setSelectedBooking(null);
         } catch (e) {
-            toast.error(String(e));
+            toast.error(formatAppError(e));
         }
     }
 
     async function handleCancelReservation(bookingId: string) {
+        const correlationId = createCorrelationId();
         try {
-            await invoke("cancel_reservation", { bookingId });
+            await invokeWriteCommand("cancel_reservation", { bookingId }, { correlationId });
             toast.success("Đã hủy reservation. Tiền cọc được giữ lại.");
             loadBookings();
             fetchRooms();


### PR DESCRIPTION
## Summary

Implements the durable command boundary for reservation create, modify, cancel, and confirm paths.

- Routes reservation writes through `WriteCommandExecutor` with canonical payload hashing, idempotency keys, stored replay responses, and hash mismatch rejection.
- Keeps calendar conflict behavior strict and structured while preventing duplicate booking, calendar, folio, and ledger side effects on retry.
- Adds hidden idempotency key generation for UI and MCP gateway flows; MCP schemas do not expose idempotency fields and confirm remains out of MCP scope.
- Scopes ledger/folio origin keys by command name to avoid cross-command collisions.
- Updates the #69 spec notes; group reservations and the broad money schema migration remain out of this PR, with the money work tracked separately in #102.

Closes #69.
Part of #64.

## Validation

- `cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml services::booking::tests::create_reservation_idempotent_retry_does_not_duplicate_deposit -- --nocapture`
- `npm run verify:repeat -- 3`
- `git diff --check`
- `git diff --cached --check`
- `gitnexus detect_changes` reported critical risk, expected for executor/gateway/UI/folio/reservation write-path changes.