### PR TITLE
Fix MCP idempotency key stability

### DIFF
--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -104,7 +104,6 @@ fn format_invoice_text(inv: &InvoiceData) -> String {
 pub struct HotelTools {
     pub pool: Pool<Sqlite>,
     pub app_handle: Option<AppHandle>,
-    gateway_instance_id: String,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
@@ -757,6 +756,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_context_uses_stable_hidden_key_across_gateway_instances() {
+        let pool = test_pool().await;
+        let first_tools = HotelTools::new(pool.clone(), None);
+        let second_tools = HotelTools::new(pool, None);
+        let input = create_reservation_input("R206");
+        let request_id = mcp_request_id("req-create-after-restart");
+
+        let first_ctx = first_tools
+            .write_context("create_reservation", &request_id, &input)
+            .expect("first context");
+        let second_ctx = second_tools
+            .write_context("create_reservation", &request_id, &input)
+            .expect("second context");
+
+        assert_eq!(first_ctx.idempotency_key, second_ctx.idempotency_key);
+        assert_eq!(first_ctx.request_id, "string:req-create-after-restart");
+        assert!(first_ctx
+            .idempotency_key
+            .starts_with("mcp:create_reservation:string:req-create-after-restart:"));
+    }
+
+    #[tokio::test]
     async fn create_reservation_same_mcp_request_id_and_different_args_use_distinct_hidden_keys() {
         let _env_lock = async_env_lock().lock().await;
         let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
@@ -914,7 +935,6 @@ impl HotelTools {
         Self {
             pool,
             app_handle,
-            gateway_instance_id: uuid::Uuid::new_v4().to_string(),
             tool_router: Self::tool_router(),
         }
     }
@@ -927,10 +947,7 @@ impl HotelTools {
     ) -> CommandResult<WriteCommandContext> {
         let request_id = mcp_request_id_string(request_id);
         let argument_hash = gateway_tool_args_hash(args)?;
-        let idempotency_key = format!(
-            "mcp:{}:{}:{}:{}",
-            self.gateway_instance_id, command_name, request_id, argument_hash
-        );
+        let idempotency_key = format!("mcp:{command_name}:{request_id}:{argument_hash}");
         let mut ctx = WriteCommandContext::for_scoped_command(
             request_id.clone(),
             idempotency_key,


### PR DESCRIPTION
## Summary
- Remove the per-process gateway UUID from MCP write idempotency keys
- Keep MCP hidden keys scoped by command, request id, and canonical args hash
- Add regression coverage for stable keys across gateway instances/restarts

Addresses review comment: https://github.com/chuanman2707/CapyInn/pull/103#discussion_r3165051285

## Verification
- cargo test --manifest-path mhm/src-tauri/Cargo.toml gateway::tools::tests:: --lib
- rustfmt --edition 2021 --check mhm/src-tauri/src/gateway/tools.rs
- cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings
- npm run verify:quick
- git diff --check
- GitNexus detect_changes: 1 file, low risk