### PR TITLE
M2.5-09 Add command recovery queue and operator inspection actions

### DIFF
--- a/docs/superpowers/specs/2026-05-02-command-recovery-queue-68-design.md
+++ b/docs/superpowers/specs/2026-05-02-command-recovery-queue-68-design.md
@@ -1,0 +1,408 @@
+# Issue #68 Command Recovery Queue Design
+
+Source issue: https://github.com/chuanman2707/CapyInn/issues/68
+
+Source roadmap: `docs/superpowers/specs/capyinn-concurrency-spec-v2.2.md`
+
+Related designs:
+
+- `docs/superpowers/specs/2026-04-26-write-command-executor-65-design.md`
+- `docs/superpowers/specs/2026-04-26-command-ledger-66-design.md`
+
+## Plain-Language Goal
+
+Issue #68 exposes safe recovery handling for command rows that need operator attention after a crash, app restart, database lock, or retryable failure.
+
+The app must be able to find:
+
+- expired `in_progress` command rows
+- `failed_retryable` command rows
+
+It must not replay business commands during startup. A recovery action may inspect, request a retry, dismiss the current queue item, or mark the command terminal, but hotel truth still changes only through the existing command boundary.
+
+## Scope Decision
+
+Chosen scope: **backend recovery actions with no new UI screen**.
+
+This issue adds:
+
+- read-only startup scan
+- backend recovery queue and inspection APIs
+- Tauri admin recovery actions
+- read-only MCP/gateway recovery tools
+- recovery audit table
+- dismiss markers for queue filtering
+- structured `RECOVERY_REQUIRED` outcomes where the system refuses to auto-mutate hotel truth
+
+This issue does not add:
+
+- a new recovery screen
+- frontend buttons
+- automatic command replay
+- command-specific replay handlers
+- MCP/gateway write recovery tools
+- outbox recovery behavior
+
+## Current Baseline
+
+The codebase already has:
+
+- `command_idempotency` as the durable command ledger
+- statuses `in_progress`, `completed`, `failed_retryable`, and `failed_terminal`
+- read-only command ledger APIs for list, attention list, and detail
+- expired `in_progress` detection through `lease_expires_at`
+- retryable reclaim behavior inside the write command executor
+- sanitized ledger intent, summary, result summary, and error summary
+- Tauri admin gating for command ledger reads
+
+#68 should build on that baseline instead of replacing the ledger or executor.
+
+## Design Principles
+
+1. **Startup is read-only for business commands.**
+   Startup may identify recovery rows and log counts, but it must not replay, dismiss, mark terminal, or otherwise mutate hotel truth.
+
+2. **Retry request is not replay.**
+   A recovery retry action records an operator decision and returns a structured `RECOVERY_REQUIRED` outcome. The original business command must still be sent again through its normal command boundary with a valid payload.
+
+3. **Audit decisions, not reads.**
+   `inspect` is read-only and does not write an audit action. `retry_requested`, `dismissed`, and `marked_terminal` are operator decisions and must be audited.
+
+4. **Dismiss is reversible queue cleanup.**
+   `dismiss` hides the current recovery item from the default queue. It does not block future inspect or retry.
+
+5. **Mark terminal closes the command.**
+   `mark terminal` intentionally changes the command row to `failed_terminal` so the executor cannot reclaim that same command row later.
+
+6. **MCP is read-only.**
+   Agents may inspect recovery problems, but they cannot retry, dismiss, or mark terminal through MCP.
+
+## Data Model
+
+Add a recovery action audit table:
+
+```sql
+CREATE TABLE command_recovery_actions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    command_idempotency_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    operator_id TEXT,
+    operator_role TEXT,
+    reason TEXT,
+    confirmed INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(command_idempotency_id) REFERENCES command_idempotency(id)
+);
+```
+
+Allowed action values:
+
+- `retry_requested`
+- `dismissed`
+- `marked_terminal`
+
+Add queue-filter markers to `command_idempotency`:
+
+```sql
+ALTER TABLE command_idempotency ADD COLUMN recovery_dismissed_at TEXT;
+ALTER TABLE command_idempotency ADD COLUMN recovery_dismissed_by TEXT;
+```
+
+Add indexes focused on the default queue and action history:
+
+```sql
+CREATE INDEX IF NOT EXISTS command_recovery_actions_command_idx
+    ON command_recovery_actions(command_idempotency_id, created_at);
+
+CREATE INDEX IF NOT EXISTS command_idempotency_recovery_queue_idx
+    ON command_idempotency(status, lease_expires_at, updated_at)
+    WHERE status IN ('in_progress', 'failed_retryable')
+      AND recovery_dismissed_at IS NULL;
+```
+
+The action table is the audit history. The dismiss columns are only the current queue-filter state.
+
+## Recovery Queue
+
+The default recovery queue includes only rows that can still require an operator decision:
+
+- `in_progress` rows whose `lease_expires_at` is present and expired
+- `failed_retryable` rows
+- rows where `recovery_dismissed_at IS NULL`
+
+The default queue excludes:
+
+- live `in_progress`
+- `completed`
+- `failed_terminal`
+- dismissed rows
+
+`failed_terminal` rows remain available through command ledger detail. They are not recovery queue items by default.
+
+Queue items should reuse the safe ledger fields from #66 and add recovery-specific metadata:
+
+- `recovery_status`
+- `risk_level`
+- `requires_confirmation`
+- `allowed_actions`
+
+Suggested `recovery_status` values:
+
+- `expired_in_progress`
+- `failed_retryable`
+- `dismissed`
+- `terminal`
+
+The default queue should normally return only `expired_in_progress` and `failed_retryable`.
+
+## Risk and Confirmation
+
+#68 uses a hybrid risk model.
+
+For now, risk is computed from `command_name` with a small backend function. The DTO still returns `risk_level` and `requires_confirmation` so a later manifest-based implementation can replace the source without changing the API contract.
+
+Initial high-risk examples:
+
+- checkout
+- payment posting
+- folio charge posting
+- room move or stay modification
+- reservation cancellation
+- check-in
+- group checkout
+- night audit
+- invoice generation
+
+High-risk `request retry` and `mark terminal` actions require:
+
+- `confirmed: true`
+- a non-empty `reason`
+
+`inspect` never requires confirmation. `dismiss` does not require confirmation because it only hides the current queue item and does not block future recovery.
+
+## Backend APIs
+
+Add backend recovery functions in a focused module such as `command_recovery.rs`.
+
+Tauri/admin commands:
+
+- `list_command_recovery_queue`
+- `inspect_command_recovery`
+- `request_command_recovery_retry`
+- `dismiss_command_recovery`
+- `mark_command_recovery_terminal`
+
+MCP/gateway read-only tools:
+
+- list recovery queue
+- inspect recovery detail
+
+MCP/gateway must not expose:
+
+- retry request
+- dismiss
+- mark terminal
+
+## Action Behavior
+
+### Inspect
+
+`inspect_command_recovery(id)` returns sanitized command detail plus recovery metadata and action history. It does not write an audit row.
+
+### Request Retry
+
+`request_command_recovery_retry(id, confirmed, reason)`:
+
+1. Loads and validates the command row.
+2. Allows only expired `in_progress` or `failed_retryable` rows.
+3. Applies high-risk confirmation rules.
+4. Inserts `command_recovery_actions(action = 'retry_requested')`.
+5. Leaves the command row status unchanged.
+6. Does not run the business command.
+7. Returns a structured outcome with `RECOVERY_REQUIRED`.
+
+The response must say that the command must be retried through the normal command boundary with the original valid business payload.
+
+### Dismiss
+
+`dismiss_command_recovery(id, reason)`:
+
+1. Loads and validates the command row.
+2. Allows only rows currently eligible for the recovery queue.
+3. Inserts `command_recovery_actions(action = 'dismissed')`.
+4. Sets `recovery_dismissed_at` and `recovery_dismissed_by`.
+5. Leaves command status unchanged.
+
+Dismiss does not prevent later inspect or retry. It only hides the current recovery item from the default queue.
+
+### Mark Terminal
+
+`mark_command_recovery_terminal(id, confirmed, reason)`:
+
+1. Loads and validates the command row.
+2. Allows only expired `in_progress` or `failed_retryable` rows.
+3. Applies high-risk confirmation rules.
+4. Inserts `command_recovery_actions(action = 'marked_terminal')`.
+5. Updates the command row to `failed_terminal`.
+6. Writes `error_code = 'RECOVERY_REQUIRED'`.
+7. Writes a safe structured `error_json` and `error_summary_json`.
+8. Clears `retryable`, `lease_expires_at`, and dismiss markers.
+9. Sets `completed_at` and `updated_at`.
+
+After this action, retrying the same command and idempotency key should return the stored terminal error instead of reclaiming the command.
+
+## Dismiss Marker Clearing
+
+Dismiss applies only to the current recovery condition.
+
+The executor should clear `recovery_dismissed_at` and `recovery_dismissed_by` when a command row gets a new attempt or a new failure, including reclaim paths that rotate the claim token. This prevents an old dismiss decision from hiding a later failure on the same command row.
+
+## Startup Behavior
+
+After database initialization, startup should run a read-only scan that counts rows needing command recovery by reason:
+
+- expired `in_progress`
+- `failed_retryable`
+
+Startup may log a safe message such as:
+
+```text
+Command recovery attention required: expired_in_progress=1 failed_retryable=2
+```
+
+Startup must not:
+
+- run business commands
+- reclaim command rows
+- mark rows terminal
+- dismiss rows
+- write recovery actions
+- change hotel truth
+
+## Error Model
+
+Add `RECOVERY_REQUIRED` to the command error registry.
+
+Use `attention_reason` and `recovery_status` for queue/list state. Do not use `RECOVERY_REQUIRED` for every row that appears in the queue.
+
+Use `RECOVERY_REQUIRED` when a recovery action needs to explain that safe automatic completion is not possible. Examples:
+
+- `request retry` returns `RECOVERY_REQUIRED` because the operator decision has been recorded but the business command must be sent again through the command boundary.
+- `mark terminal` stores a terminal structured error with `RECOVERY_REQUIRED` so a later exact retry receives a clear terminal outcome.
+
+All recovery errors and outcomes should use the structured command error envelope:
+
+- `code`
+- `message`
+- `kind`
+- `retryable`
+- optional `support_id`
+- optional `request_id`
+
+## Security and Privacy
+
+Recovery APIs must keep the #66 privacy boundary:
+
+- do not expose `claim_token`
+- do not expose `request_hash`
+- do not expose raw `lock_keys_json`
+- do not expose raw request payloads
+- do not expose raw replay `response_json` or unsafe `error_json`
+- do not expose idempotency internals through MCP tool arguments
+
+Operator and MCP inspection use sanitized ledger intent, summary, result summary, and error summary.
+
+MCP read tools may help an agent understand the failure and propose next steps. MCP must not mutate recovery state.
+
+## Out Of Scope
+
+- Recovery UI
+- One-click replay from ledger
+- Storing raw payloads for replay
+- Command-specific replay handlers
+- MCP recovery write tools
+- Outbox event recovery
+- Retention cleanup
+- Risk manifests or policy metadata migration
+- Full supervised high-risk write enablement
+
+## Required Tests
+
+Migration tests:
+
+- fresh database creates `command_recovery_actions`
+- fresh database adds `recovery_dismissed_at` and `recovery_dismissed_by`
+- fresh database creates recovery queue and action history indexes
+- existing database upgrades cleanly
+
+Queue tests:
+
+- expired `in_progress` appears
+- live `in_progress` does not appear
+- `failed_retryable` appears
+- `completed` does not appear
+- `failed_terminal` does not appear in the default recovery queue
+- dismissed rows do not appear
+
+Startup tests:
+
+- startup scan returns counts by reason
+- startup scan is read-only and does not change command rows
+- startup does not call business command execution paths
+
+Action tests:
+
+- inspect is read-only and writes no recovery action
+- retry request writes `retry_requested` audit action
+- retry request does not change command status
+- retry request does not run a business command
+- retry request returns `RECOVERY_REQUIRED`
+- dismiss writes `dismissed` audit action
+- dismiss sets dismiss markers
+- dismiss does not change command status
+- mark terminal writes `marked_terminal` audit action
+- mark terminal updates status to `failed_terminal`
+- mark terminal stores structured `RECOVERY_REQUIRED` error data
+- mark terminal prevents later reclaim of the same row
+- high-risk retry request and mark terminal require confirmation and non-empty reason
+- low-risk retry request and mark terminal do not require confirmation
+- dismiss reason is optional
+- dismiss marker clears on new attempt or new failure
+
+MCP/gateway tests:
+
+- MCP can list recovery queue
+- MCP can inspect recovery detail
+- MCP does not expose retry, dismiss, or mark-terminal tools
+- MCP recovery DTOs do not expose raw idempotency internals
+
+## Acceptance Mapping
+
+Issue #68 acceptance criteria:
+
+- Startup can identify expired `in_progress` and `failed_retryable` command rows.
+  Covered by read-only startup scan and recovery queue query.
+
+- Business commands are not automatically replayed on startup.
+  Covered by startup rules and tests that assert no business execution path is called.
+
+- Operator-facing actions exist for inspect, retry now, dismiss, or mark terminal.
+  Covered by Tauri/admin recovery commands.
+
+- High-risk recovery actions require explicit operator confirmation.
+  Covered by risk calculation plus `confirmed` and non-empty `reason` checks for high-risk retry request and mark terminal.
+
+- Recovery errors use the structured error envelope and `RECOVERY_REQUIRED` where appropriate.
+  Covered by registry addition, structured action outcomes, and terminal recovery error storage.
+
+## Implementation Notes
+
+Keep the implementation small and layered:
+
+- `command_ledger` remains the read-only ledger surface.
+- `command_recovery` owns recovery queue, startup scan, action validation, audit writes, and mark-terminal update.
+- `command_idempotency` only needs targeted changes to clear dismiss markers on new attempts or failures.
+- `commands/command_recovery.rs` exposes Tauri admin commands.
+- `gateway/tools.rs` exposes only read-only recovery tools.
+
+Before editing any function, class, or method, run GitNexus upstream impact analysis for that symbol as required by the project rules. Before committing implementation work, run `gitnexus_detect_changes()`.

--- a/docs/superpowers/specs/2026-05-02-command-recovery-queue-68-design.md
+++ b/docs/superpowers/specs/2026-05-02-command-recovery-queue-68-design.md
@@ -163,15 +163,18 @@ For now, risk is computed from `command_name` with a small backend function. The
 
 Initial high-risk examples:
 
-- checkout
-- payment posting
-- folio charge posting
-- room move or stay modification
-- reservation cancellation
-- check-in
-- group checkout
-- night audit
-- invoice generation
+- `check_out`
+- `record_payment`
+- `add_folio_line`
+- `modify_reservation`
+- `cancel_reservation`
+- `confirm_reservation`
+- `check_in`
+- `extend_stay`
+- `group_checkin`
+- `group_checkout`
+- `generate_invoice`
+- night-audit commands if or when they enter the command boundary
 
 High-risk `request retry` and `mark terminal` actions require:
 
@@ -203,6 +206,42 @@ MCP/gateway must not expose:
 - dismiss
 - mark terminal
 
+## Action Response Contract
+
+Recovery action commands return `Ok(RecoveryActionResponse)` when the recovery action itself was accepted and recorded. They return `Err(CommandError)` only when the recovery action fails validation, authorization, confirmation, row eligibility, stale-state checks, or persistence.
+
+`request_command_recovery_retry` therefore returns `Ok` with:
+
+- `action = "retry_requested"`
+- `status = "recovery_required"`
+- `code = "RECOVERY_REQUIRED"`
+- `next_step` explaining that the caller must retry the original business command through the command boundary
+
+This is not treated as a failed Tauri command. It is a successful operator decision whose outcome is that CapyInn refuses to auto-mutate hotel truth.
+
+`mark_command_recovery_terminal` returns `Ok` when the terminal mark succeeds, and stores a structured terminal `CommandError` with `code = "RECOVERY_REQUIRED"` in the command row for future exact retries.
+
+Stale recovery actions return `Err(CommandError)` using `CONFLICT_INVALID_STATE_TRANSITION` with an operator-safe message such as "Recovery state changed, refresh the queue." A stale action includes cases where the row was reclaimed, completed, marked terminal, dismissed, or otherwise stopped being eligible between the caller's view and the attempted action.
+
+## Action Atomicity and Stale Guards
+
+Every mutating recovery action must use one short database transaction for validation, audit write, and any command-row update.
+
+Required pattern:
+
+1. Start a short transaction.
+2. Load the command row by `command_idempotency.id`.
+3. Recompute eligibility inside the transaction using the current status, current `lease_expires_at`, current `recovery_dismissed_at`, and the current time.
+4. Reject stale or ineligible rows with a structured `CommandError`.
+5. Insert the `command_recovery_actions` audit row.
+6. For `dismiss` and `mark terminal`, update the command row with a conditional `WHERE` that repeats the expected id, eligible status, expired lease condition where applicable, and dismiss marker condition.
+7. Require `rows_affected == 1`; otherwise roll back and return the stale-state error.
+8. Commit.
+
+This prevents an operator action based on an old queue view from hiding or terminal-marking a newer command attempt.
+
+`request retry` does not update the command row, but it still validates and writes its audit row inside one transaction so the audit action is only recorded for a currently eligible row.
+
 ## Action Behavior
 
 ### Inspect
@@ -216,10 +255,10 @@ MCP/gateway must not expose:
 1. Loads and validates the command row.
 2. Allows only expired `in_progress` or `failed_retryable` rows.
 3. Applies high-risk confirmation rules.
-4. Inserts `command_recovery_actions(action = 'retry_requested')`.
+4. Inserts `command_recovery_actions(action = 'retry_requested')` inside the same validation transaction.
 5. Leaves the command row status unchanged.
 6. Does not run the business command.
-7. Returns a structured outcome with `RECOVERY_REQUIRED`.
+7. Returns `Ok(RecoveryActionResponse)` with `code = 'RECOVERY_REQUIRED'`.
 
 The response must say that the command must be retried through the normal command boundary with the original valid business payload.
 
@@ -229,8 +268,8 @@ The response must say that the command must be retried through the normal comman
 
 1. Loads and validates the command row.
 2. Allows only rows currently eligible for the recovery queue.
-3. Inserts `command_recovery_actions(action = 'dismissed')`.
-4. Sets `recovery_dismissed_at` and `recovery_dismissed_by`.
+3. Inserts `command_recovery_actions(action = 'dismissed')` in the same transaction as the row update.
+4. Sets `recovery_dismissed_at` and `recovery_dismissed_by` through a conditional update guarded by the current eligible row state.
 5. Leaves command status unchanged.
 
 Dismiss does not prevent later inspect or retry. It only hides the current recovery item from the default queue.
@@ -242,8 +281,8 @@ Dismiss does not prevent later inspect or retry. It only hides the current recov
 1. Loads and validates the command row.
 2. Allows only expired `in_progress` or `failed_retryable` rows.
 3. Applies high-risk confirmation rules.
-4. Inserts `command_recovery_actions(action = 'marked_terminal')`.
-5. Updates the command row to `failed_terminal`.
+4. Inserts `command_recovery_actions(action = 'marked_terminal')` in the same transaction as the row update.
+5. Updates the command row to `failed_terminal` through a conditional update guarded by the current eligible row state.
 6. Writes `error_code = 'RECOVERY_REQUIRED'`.
 7. Writes a safe structured `error_json` and `error_summary_json`.
 8. Clears `retryable`, `lease_expires_at`, and dismiss markers.
@@ -287,10 +326,10 @@ Use `attention_reason` and `recovery_status` for queue/list state. Do not use `R
 
 Use `RECOVERY_REQUIRED` when a recovery action needs to explain that safe automatic completion is not possible. Examples:
 
-- `request retry` returns `RECOVERY_REQUIRED` because the operator decision has been recorded but the business command must be sent again through the command boundary.
+- `request retry` returns `Ok(RecoveryActionResponse)` with `code = 'RECOVERY_REQUIRED'` because the operator decision has been recorded but the business command must be sent again through the command boundary.
 - `mark terminal` stores a terminal structured error with `RECOVERY_REQUIRED` so a later exact retry receives a clear terminal outcome.
 
-All recovery errors and outcomes should use the structured command error envelope:
+Failed recovery actions should use the structured command error envelope:
 
 - `code`
 - `message`
@@ -354,14 +393,19 @@ Action tests:
 
 - inspect is read-only and writes no recovery action
 - retry request writes `retry_requested` audit action
+- retry request validates and audits in one transaction
 - retry request does not change command status
 - retry request does not run a business command
-- retry request returns `RECOVERY_REQUIRED`
+- retry request returns `Ok(RecoveryActionResponse)` with `RECOVERY_REQUIRED`
 - dismiss writes `dismissed` audit action
 - dismiss sets dismiss markers
+- dismiss audit and marker update are atomic
+- dismiss uses stale-row guards and rejects stale queue views
 - dismiss does not change command status
 - mark terminal writes `marked_terminal` audit action
 - mark terminal updates status to `failed_terminal`
+- mark terminal audit and row update are atomic
+- mark terminal uses stale-row guards and rejects stale queue views
 - mark terminal stores structured `RECOVERY_REQUIRED` error data
 - mark terminal prevents later reclaim of the same row
 - high-risk retry request and mark terminal require confirmation and non-empty reason

--- a/mhm/shared/error-codes.json
+++ b/mhm/shared/error-codes.json
@@ -150,6 +150,16 @@
     "defaultMessage": "Dữ liệu đã thay đổi, vui lòng tải lại trước khi thao tác."
   },
   {
+    "code": "COMMAND_LEDGER_ROW_NOT_FOUND",
+    "kind": "user",
+    "defaultMessage": "Không tìm thấy dòng lệnh."
+  },
+  {
+    "code": "RECOVERY_REQUIRED",
+    "kind": "user",
+    "defaultMessage": "Cần xử lý khôi phục lệnh trước khi tiếp tục."
+  },
+  {
     "code": "SYSTEM_INTERNAL_ERROR",
     "kind": "system",
     "defaultMessage": "Có lỗi hệ thống, vui lòng thử lại"

--- a/mhm/src-tauri/src/app_error.rs
+++ b/mhm/src-tauri/src/app_error.rs
@@ -41,6 +41,7 @@ pub mod codes {
     pub const CONFLICT_INVALID_STATE_TRANSITION_DEFAULT_MESSAGE: &str =
         "Dữ liệu đã thay đổi, vui lòng tải lại trước khi thao tác.";
     pub const COMMAND_LEDGER_ROW_NOT_FOUND: &str = "COMMAND_LEDGER_ROW_NOT_FOUND";
+    pub const RECOVERY_REQUIRED: &str = "RECOVERY_REQUIRED";
     pub const SYSTEM_INTERNAL_ERROR: &str = "SYSTEM_INTERNAL_ERROR";
 
     pub const ALL: &[&str] = &[
@@ -75,6 +76,7 @@ pub mod codes {
         CONFLICT_DUPLICATE_IN_FLIGHT,
         CONFLICT_INVALID_STATE_TRANSITION,
         COMMAND_LEDGER_ROW_NOT_FOUND,
+        RECOVERY_REQUIRED,
         SYSTEM_INTERNAL_ERROR,
     ];
 }
@@ -582,6 +584,16 @@ mod tests {
                 codes::CONFLICT_INVALID_STATE_TRANSITION,
                 AppErrorKind::User,
                 codes::CONFLICT_INVALID_STATE_TRANSITION_DEFAULT_MESSAGE,
+            ),
+            (
+                codes::COMMAND_LEDGER_ROW_NOT_FOUND,
+                AppErrorKind::User,
+                "Không tìm thấy dòng lệnh.",
+            ),
+            (
+                codes::RECOVERY_REQUIRED,
+                AppErrorKind::User,
+                "Cần xử lý khôi phục lệnh trước khi tiếp tục.",
             ),
             (
                 codes::SYSTEM_INTERNAL_ERROR,

--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -2947,9 +2947,27 @@ mod tests {
         .await
         .expect("marks recovery dismissed");
 
+        let command_name = ctx.command_name.clone();
+        let idempotency_key = ctx.idempotency_key.clone();
         let second = WriteCommandExecutor::new(pool.clone())
-            .execute(&ctx, request, |_tx| {
-                Box::pin(async move { Ok(serde_json::json!({ "ok": true })) })
+            .execute(&ctx, request, |tx| {
+                Box::pin(async move {
+                    let row = sqlx::query(
+                        "SELECT recovery_dismissed_at, recovery_dismissed_by
+                         FROM command_idempotency
+                         WHERE command_name = ? AND idempotency_key = ?",
+                    )
+                    .bind(&command_name)
+                    .bind(&idempotency_key)
+                    .fetch_one(&mut **tx)
+                    .await
+                    .map_err(system_error)?;
+
+                    assert_eq!(row.get::<Option<String>, _>("recovery_dismissed_at"), None);
+                    assert_eq!(row.get::<Option<String>, _>("recovery_dismissed_by"), None);
+
+                    Ok(serde_json::json!({ "ok": true }))
+                })
             })
             .await
             .expect("retryable failure is reclaimed and rerun");

--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -853,6 +853,8 @@ impl WriteCommandExecutor {
                  error_summary_json = NULL,
                  retryable = 0,
                  lease_expires_at = NULL,
+                 recovery_dismissed_at = NULL,
+                 recovery_dismissed_by = NULL,
                  updated_at = ?,
                  completed_at = ?
              WHERE command_name = ?
@@ -1039,6 +1041,8 @@ impl WriteCommandExecutor {
                  error_summary_json = NULL,
                  retryable = 0,
                  lease_expires_at = NULL,
+                 recovery_dismissed_at = NULL,
+                 recovery_dismissed_by = NULL,
                  updated_at = ?,
                  completed_at = ?
              WHERE command_name = ?
@@ -1115,6 +1119,8 @@ impl WriteCommandExecutor {
                  error_summary_json = ?,
                  retryable = ?,
                  lease_expires_at = NULL,
+                 recovery_dismissed_at = NULL,
+                 recovery_dismissed_by = NULL,
                  updated_at = ?,
                  completed_at = ?
              WHERE command_name = ?
@@ -1338,6 +1344,8 @@ async fn reclaim_claim(
              error_summary_json = NULL,
              retryable = 0,
              lease_expires_at = ?,
+             recovery_dismissed_at = NULL,
+             recovery_dismissed_by = NULL,
              updated_at = ?,
              completed_at = NULL,
              last_attempt_at = ?
@@ -2894,6 +2902,74 @@ mod tests {
         assert_eq!(row.get::<i64, _>("retryable"), 0);
         assert_eq!(row.get::<Option<String>, _>("error_json"), None);
         assert_eq!(row.get::<Option<String>, _>("lease_expires_at"), None);
+    }
+
+    #[tokio::test]
+    async fn reclaim_clears_recovery_dismiss_marker() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "test-request-dismissed-recovery",
+            "idem-dismissed-recovery",
+            "test.dismissed_recovery",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "dismissed_recovery" }),
+            "Dismissed recovery",
+        )
+        .expect("request builds");
+
+        let first_error = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request.clone(), |_tx| {
+                Box::pin(async move {
+                    Err(
+                        CommandError::system(codes::DB_LOCKED_RETRYABLE, "database locked")
+                            .retryable(true),
+                    )
+                })
+            })
+            .await
+            .expect_err("first retryable failure is returned");
+
+        assert_eq!(first_error.code, codes::DB_LOCKED_RETRYABLE);
+        assert!(first_error.retryable);
+
+        sqlx::query(
+            "UPDATE command_idempotency
+             SET recovery_dismissed_at = ?,
+                 recovery_dismissed_by = ?
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind("2026-01-02T03:04:05Z")
+        .bind("operator-1")
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .execute(&pool)
+        .await
+        .expect("marks recovery dismissed");
+
+        let second = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request, |_tx| {
+                Box::pin(async move { Ok(serde_json::json!({ "ok": true })) })
+            })
+            .await
+            .expect("retryable failure is reclaimed and rerun");
+
+        assert_eq!(second.response, serde_json::json!({ "ok": true }));
+        assert!(!second.replayed);
+
+        let row = sqlx::query(
+            "SELECT recovery_dismissed_at, recovery_dismissed_by
+             FROM command_idempotency
+             WHERE command_name = ? AND idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads recovery dismiss marker");
+
+        assert_eq!(row.get::<Option<String>, _>("recovery_dismissed_at"), None);
+        assert_eq!(row.get::<Option<String>, _>("recovery_dismissed_by"), None);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -139,7 +139,7 @@ pub struct CommandRecoveryActionRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandRecoveryActionRequest {
     pub command_idempotency_id: i64,
-    pub confirmed: bool,
+    pub confirmed: Option<bool>,
     pub reason: Option<String>,
 }
 
@@ -148,9 +148,9 @@ pub struct RecoveryActionResponse {
     pub command_idempotency_id: i64,
     pub action: String,
     pub status: String,
-    pub code: String,
+    pub code: Option<String>,
     pub message: String,
-    pub next_step: String,
+    pub next_step: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -290,7 +290,8 @@ fn validate_confirmation(
     request: &CommandRecoveryActionRequest,
     reason: Option<&str>,
 ) -> CommandResult<()> {
-    if requires_confirmation(command_name) && (!request.confirmed || reason.is_none()) {
+    if requires_confirmation(command_name) && (request.confirmed != Some(true) || reason.is_none())
+    {
         return Err(approval_required_error());
     }
     Ok(())
@@ -359,15 +360,17 @@ fn recovery_action_response(
     command_idempotency_id: i64,
     action: &str,
     status: &str,
-    next_step: &str,
+    code: Option<&str>,
+    message: &str,
+    next_step: Option<&str>,
 ) -> RecoveryActionResponse {
     RecoveryActionResponse {
         command_idempotency_id,
         action: action.to_string(),
         status: status.to_string(),
-        code: codes::RECOVERY_REQUIRED.to_string(),
-        message: "Cần xử lý khôi phục lệnh trước khi tiếp tục.".to_string(),
-        next_step: next_step.to_string(),
+        code: code.map(str::to_string),
+        message: message.to_string(),
+        next_step: next_step.map(str::to_string),
     }
 }
 
@@ -410,7 +413,7 @@ pub async fn request_command_recovery_retry(
             "retry_requested",
             &operator,
             reason.as_deref(),
-            request.confirmed,
+            request.confirmed.unwrap_or(false),
             &now,
         )
         .await?;
@@ -419,7 +422,11 @@ pub async fn request_command_recovery_retry(
             request.command_idempotency_id,
             "retry_requested",
             "recovery_required",
-            "Retry request recorded for operator review.",
+            Some(codes::RECOVERY_REQUIRED),
+            "Recovery retry was requested; CapyInn will not replay the business command automatically.",
+            Some(
+                "Retry the original business command through the command boundary with the original valid payload.",
+            ),
         ))
     }
     .await;
@@ -456,7 +463,7 @@ pub async fn dismiss_command_recovery(
             "dismissed",
             &operator,
             reason.as_deref(),
-            request.confirmed,
+            request.confirmed.unwrap_or(false),
             &now,
         )
         .await?;
@@ -490,7 +497,9 @@ pub async fn dismiss_command_recovery(
             request.command_idempotency_id,
             "dismissed",
             "dismissed",
+            None,
             "Recovery item dismissed from the active queue.",
+            None,
         ))
     }
     .await;
@@ -528,7 +537,7 @@ pub async fn mark_command_recovery_terminal(
             "marked_terminal",
             &operator,
             reason.as_deref(),
-            request.confirmed,
+            request.confirmed.unwrap_or(false),
             &now,
         )
         .await?;
@@ -574,7 +583,9 @@ pub async fn mark_command_recovery_terminal(
             request.command_idempotency_id,
             "marked_terminal",
             "failed_terminal",
+            Some(codes::RECOVERY_REQUIRED),
             "Command marked terminal with recovery-required error details.",
+            None,
         ))
     }
     .await;
@@ -671,7 +682,7 @@ mod tests {
 
     fn recovery_request(
         command_idempotency_id: i64,
-        confirmed: bool,
+        confirmed: Option<bool>,
         reason: Option<&str>,
     ) -> CommandRecoveryActionRequest {
         CommandRecoveryActionRequest {
@@ -710,7 +721,7 @@ mod tests {
         let response = request_command_recovery_retry(
             &pool,
             recovery_operator(),
-            recovery_request(id, true, Some("operator reviewed retry")),
+            recovery_request(id, Some(true), Some("operator reviewed retry")),
         )
         .await
         .expect("requests retry");
@@ -718,7 +729,11 @@ mod tests {
         assert_eq!(response.command_idempotency_id, id);
         assert_eq!(response.action, "retry_requested");
         assert_eq!(response.status, "recovery_required");
-        assert_eq!(response.code, codes::RECOVERY_REQUIRED);
+        assert_eq!(response.code.as_deref(), Some(codes::RECOVERY_REQUIRED));
+        assert!(response
+            .next_step
+            .as_deref()
+            .is_some_and(|step| step.contains("command boundary")));
         assert_eq!(
             sqlx::query_scalar::<_, String>("SELECT status FROM command_idempotency WHERE id = ?")
                 .bind(id)
@@ -739,13 +754,15 @@ mod tests {
         let response = dismiss_command_recovery(
             &pool,
             recovery_operator(),
-            recovery_request(id, false, Some("handled manually")),
+            recovery_request(id, None, Some("handled manually")),
         )
         .await
         .expect("dismisses recovery row");
 
         assert_eq!(response.action, "dismissed");
         assert_eq!(response.status, "dismissed");
+        assert!(response.code.is_none());
+        assert!(response.next_step.is_none());
         let row = sqlx::query(
             "SELECT status, recovery_dismissed_at, recovery_dismissed_by
              FROM command_idempotency WHERE id = ?",
@@ -775,7 +792,7 @@ mod tests {
         let missing_confirmation = mark_command_recovery_terminal(
             &pool,
             recovery_operator(),
-            recovery_request(id, false, Some("reviewed")),
+            recovery_request(id, Some(false), Some("reviewed")),
         )
         .await
         .expect_err("requires confirmation");
@@ -784,7 +801,7 @@ mod tests {
         let missing_reason = mark_command_recovery_terminal(
             &pool,
             recovery_operator(),
-            recovery_request(id, true, Some("   ")),
+            recovery_request(id, Some(true), Some("   ")),
         )
         .await
         .expect_err("requires reason");
@@ -800,7 +817,7 @@ mod tests {
         let missing_confirmation = request_command_recovery_retry(
             &pool,
             recovery_operator(),
-            recovery_request(id, false, Some("reviewed")),
+            recovery_request(id, Some(false), Some("reviewed")),
         )
         .await
         .expect_err("requires confirmation");
@@ -809,7 +826,7 @@ mod tests {
         let missing_reason = request_command_recovery_retry(
             &pool,
             recovery_operator(),
-            recovery_request(id, true, None),
+            recovery_request(id, Some(true), None),
         )
         .await
         .expect_err("requires reason");
@@ -825,7 +842,7 @@ mod tests {
         let response = mark_command_recovery_terminal(
             &pool,
             recovery_operator(),
-            recovery_request(id, true, Some("cannot safely retry")),
+            recovery_request(id, Some(true), Some("cannot safely retry")),
         )
         .await
         .expect("marks terminal");
@@ -875,7 +892,7 @@ mod tests {
         let response = mark_command_recovery_terminal(
             &pool,
             recovery_operator(),
-            recovery_request(id, false, None),
+            recovery_request(id, None, None),
         )
         .await
         .expect("marks low risk command terminal without confirmation");
@@ -896,7 +913,7 @@ mod tests {
         let dismissed_error = dismiss_command_recovery(
             &pool,
             recovery_operator(),
-            recovery_request(already_dismissed, false, None),
+            recovery_request(already_dismissed, None, None),
         )
         .await
         .expect_err("already dismissed is stale");
@@ -908,7 +925,7 @@ mod tests {
         let live_error = dismiss_command_recovery(
             &pool,
             recovery_operator(),
-            recovery_request(live_in_progress, false, None),
+            recovery_request(live_in_progress, None, None),
         )
         .await
         .expect_err("live in-progress row is not eligible");

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -1,5 +1,7 @@
 use crate::app_error::{codes, CommandError, CommandResult};
-use crate::command_ledger::{get_command_ledger_detail, CommandLedgerListItem};
+use crate::command_ledger::{
+    get_command_ledger_detail, CommandLedgerDetail, CommandLedgerListItem,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Row, Sqlite};
 
@@ -123,6 +125,115 @@ pub async fn list_command_recovery_queue(
     Ok(items)
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandRecoveryActionRecord {
+    pub id: i64,
+    pub action: String,
+    pub operator_id: Option<String>,
+    pub operator_role: Option<String>,
+    pub reason: Option<String>,
+    pub confirmed: bool,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandRecoveryDetail {
+    pub ledger: CommandLedgerDetail,
+    pub recovery_status: Option<String>,
+    pub risk_level: RecoveryRiskLevel,
+    pub requires_confirmation: bool,
+    pub allowed_actions: Vec<String>,
+    pub actions: Vec<CommandRecoveryActionRecord>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandRecoveryStartupScan {
+    pub expired_in_progress: i64,
+    pub failed_retryable: i64,
+}
+
+async fn recovery_actions(
+    pool: &Pool<Sqlite>,
+    command_idempotency_id: i64,
+) -> CommandResult<Vec<CommandRecoveryActionRecord>> {
+    let rows = sqlx::query(
+        "SELECT id, action, operator_id, operator_role, reason, confirmed, created_at
+         FROM command_recovery_actions
+         WHERE command_idempotency_id = ?
+         ORDER BY created_at DESC, id DESC",
+    )
+    .bind(command_idempotency_id)
+    .fetch_all(pool)
+    .await
+    .map_err(system_error)?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(CommandRecoveryActionRecord {
+                id: row.try_get("id").map_err(system_error)?,
+                action: row.try_get("action").map_err(system_error)?,
+                operator_id: row.try_get("operator_id").map_err(system_error)?,
+                operator_role: row.try_get("operator_role").map_err(system_error)?,
+                reason: row.try_get("reason").map_err(system_error)?,
+                confirmed: row.try_get::<i64, _>("confirmed").map_err(system_error)? != 0,
+                created_at: row.try_get("created_at").map_err(system_error)?,
+            })
+        })
+        .collect()
+}
+
+pub async fn inspect_command_recovery(
+    pool: &Pool<Sqlite>,
+    id: i64,
+) -> CommandResult<CommandRecoveryDetail> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let detail = get_command_ledger_detail(pool, id).await?;
+    let recovery_status = recovery_status(&detail.status, detail.lease_expires_at.as_deref(), &now);
+    let risk_level = command_recovery_risk_level(&detail.command_name);
+    let actions = recovery_actions(pool, id).await?;
+    Ok(CommandRecoveryDetail {
+        ledger: detail,
+        recovery_status,
+        requires_confirmation: risk_level == RecoveryRiskLevel::High,
+        risk_level,
+        allowed_actions: allowed_actions_for_queue_item(),
+        actions,
+    })
+}
+
+pub async fn scan_command_recovery_startup(
+    pool: &Pool<Sqlite>,
+) -> CommandResult<CommandRecoveryStartupScan> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let expired_in_progress: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM command_idempotency
+         WHERE status = 'in_progress'
+           AND lease_expires_at IS NOT NULL
+           AND lease_expires_at <= ?
+           AND recovery_dismissed_at IS NULL",
+    )
+    .bind(&now)
+    .fetch_one(pool)
+    .await
+    .map_err(system_error)?;
+
+    let failed_retryable: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM command_idempotency
+         WHERE status = 'failed_retryable'
+           AND recovery_dismissed_at IS NULL",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(system_error)?;
+
+    Ok(CommandRecoveryStartupScan {
+        expired_in_progress,
+        failed_retryable,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +332,71 @@ mod tests {
             .iter()
             .all(|row| row.allowed_actions.contains(&"inspect".to_string())));
         assert!(rows.iter().all(|row| row.requires_confirmation));
+    }
+
+    #[tokio::test]
+    async fn inspect_recovery_detail_returns_actions_without_writing_an_action() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+        sqlx::query(
+            "INSERT INTO command_recovery_actions (
+                command_idempotency_id, action, operator_id, operator_role,
+                reason, confirmed, created_at
+            ) VALUES (?, 'dismissed', 'admin-1', 'admin', 'checked', 0, ?)",
+        )
+        .bind(id)
+        .bind(Utc::now().to_rfc3339())
+        .execute(&pool)
+        .await
+        .expect("seed action");
+
+        let detail = inspect_command_recovery(&pool, id)
+            .await
+            .expect("inspect recovery detail");
+
+        assert_eq!(detail.ledger.id, id);
+        assert_eq!(detail.recovery_status.as_deref(), Some("failed_retryable"));
+        assert_eq!(detail.actions.len(), 1);
+        assert_eq!(detail.actions[0].action, "dismissed");
+
+        let action_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_recovery_actions WHERE command_idempotency_id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("action count");
+        assert_eq!(action_count, 1);
+    }
+
+    #[tokio::test]
+    async fn startup_scan_counts_recovery_rows_without_mutating() {
+        let pool = test_pool().await;
+        let expired = (Utc::now() - chrono::Duration::seconds(5)).to_rfc3339();
+        let expired_id =
+            seed_recovery_row(&pool, "check_out", "in_progress", Some(expired), false).await;
+        seed_recovery_row(&pool, "record_payment", "failed_retryable", None, false).await;
+
+        let before_updated_at: String =
+            sqlx::query_scalar("SELECT updated_at FROM command_idempotency WHERE id = ?")
+                .bind(expired_id)
+                .fetch_one(&pool)
+                .await
+                .expect("before updated_at");
+
+        let scan = scan_command_recovery_startup(&pool)
+            .await
+            .expect("startup scan");
+
+        assert_eq!(scan.expired_in_progress, 1);
+        assert_eq!(scan.failed_retryable, 1);
+
+        let after_updated_at: String =
+            sqlx::query_scalar("SELECT updated_at FROM command_idempotency WHERE id = ?")
+                .bind(expired_id)
+                .fetch_one(&pool)
+                .await
+                .expect("after updated_at");
+        assert_eq!(after_updated_at, before_updated_at);
     }
 }

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -1,0 +1,225 @@
+use crate::app_error::{codes, CommandError, CommandResult};
+use crate::command_ledger::{get_command_ledger_detail, CommandLedgerListItem};
+use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Row, Sqlite};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryRiskLevel {
+    Low,
+    High,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandRecoveryQueueItem {
+    pub ledger: CommandLedgerListItem,
+    pub recovery_status: String,
+    pub risk_level: RecoveryRiskLevel,
+    pub requires_confirmation: bool,
+    pub allowed_actions: Vec<String>,
+}
+
+fn system_error(error: impl std::fmt::Display) -> CommandError {
+    CommandError::system(codes::SYSTEM_INTERNAL_ERROR, error.to_string())
+}
+
+fn recovery_status(status: &str, lease_expires_at: Option<&str>, now: &str) -> Option<String> {
+    match status {
+        "in_progress" if lease_expires_at.is_some_and(|lease| lease <= now) => {
+            Some("expired_in_progress".to_string())
+        }
+        "failed_retryable" => Some("failed_retryable".to_string()),
+        _ => None,
+    }
+}
+
+pub fn command_recovery_risk_level(command_name: &str) -> RecoveryRiskLevel {
+    match command_name {
+        "check_out"
+        | "record_payment"
+        | "add_folio_line"
+        | "modify_reservation"
+        | "cancel_reservation"
+        | "confirm_reservation"
+        | "check_in"
+        | "extend_stay"
+        | "group_checkin"
+        | "group_checkout"
+        | "generate_invoice" => RecoveryRiskLevel::High,
+        name if name.contains("night_audit") => RecoveryRiskLevel::High,
+        _ => RecoveryRiskLevel::Low,
+    }
+}
+
+fn requires_confirmation(command_name: &str) -> bool {
+    command_recovery_risk_level(command_name) == RecoveryRiskLevel::High
+}
+
+fn allowed_actions_for_queue_item() -> Vec<String> {
+    ["inspect", "request_retry", "dismiss", "mark_terminal"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+pub async fn list_command_recovery_queue(
+    pool: &Pool<Sqlite>,
+) -> CommandResult<Vec<CommandRecoveryQueueItem>> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let rows = sqlx::query(
+        "SELECT id
+         FROM command_idempotency
+         WHERE recovery_dismissed_at IS NULL
+           AND (
+                (status = 'in_progress' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?)
+                OR status = 'failed_retryable'
+           )
+         ORDER BY
+            CASE
+                WHEN status = 'in_progress' THEN 0
+                WHEN status = 'failed_retryable' THEN 1
+                ELSE 2
+            END,
+            updated_at DESC",
+    )
+    .bind(&now)
+    .fetch_all(pool)
+    .await
+    .map_err(system_error)?;
+
+    let mut items = Vec::with_capacity(rows.len());
+    for row in rows {
+        let id: i64 = row.try_get("id").map_err(system_error)?;
+        let detail = get_command_ledger_detail(pool, id).await?;
+        let Some(status) =
+            recovery_status(&detail.status, detail.lease_expires_at.as_deref(), &now)
+        else {
+            continue;
+        };
+        let risk_level = command_recovery_risk_level(&detail.command_name);
+        items.push(CommandRecoveryQueueItem {
+            ledger: CommandLedgerListItem {
+                id: detail.id,
+                command_name: detail.command_name.clone(),
+                status: detail.status.clone(),
+                attention_reason: Some(status.clone()),
+                source: detail.source.clone(),
+                primary_aggregate_key: detail.primary_aggregate_key.clone(),
+                summary: detail.summary.clone(),
+                error_code: detail.error_code.clone(),
+                retryable: detail.retryable,
+                created_at: detail.created_at.clone(),
+                updated_at: detail.updated_at.clone(),
+                last_attempt_at: detail.last_attempt_at.clone(),
+                completed_at: detail.completed_at.clone(),
+                lease_expires_at: detail.lease_expires_at.clone(),
+            },
+            recovery_status: status,
+            requires_confirmation: requires_confirmation(&detail.command_name),
+            risk_level,
+            allowed_actions: allowed_actions_for_queue_item(),
+        });
+    }
+    Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let database_url = format!(
+            "sqlite://file:{}?mode=memory&cache=shared",
+            uuid::Uuid::new_v4()
+        );
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("opens sqlite test pool");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("runs migrations");
+        pool
+    }
+
+    async fn seed_recovery_row(
+        pool: &Pool<Sqlite>,
+        command_name: &str,
+        status: &str,
+        lease_expires_at: Option<String>,
+        dismissed: bool,
+    ) -> i64 {
+        let now = Utc::now().to_rfc3339();
+        let dismissed_at = if dismissed { Some(now.clone()) } else { None };
+        let result = sqlx::query(
+            "INSERT INTO command_idempotency (
+                idempotency_key, command_name, request_hash, intent_json,
+                primary_aggregate_key, lock_keys_json, status, claim_token,
+                response_json, error_code, error_json, retryable, lease_expires_at,
+                created_at, updated_at, completed_at, last_attempt_at, request_id,
+                actor_type, actor_id, issued_at, summary_json, result_summary_json,
+                error_summary_json, recovery_dismissed_at, recovery_dismissed_by
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
+        )
+        .bind(format!("{command_name}-{status}-{}", uuid::Uuid::new_v4()))
+        .bind(command_name)
+        .bind("hash")
+        .bind(r#"{"fields":{"safe":"value"}}"#)
+        .bind("booking:123")
+        .bind(r#"["booking:123"]"#)
+        .bind(status)
+        .bind("claim-token")
+        .bind(if status.starts_with("failed") { Some("DB_LOCKED_RETRYABLE") } else { None })
+        .bind(if status.starts_with("failed") { Some(r#"{"code":"DB_LOCKED_RETRYABLE","message":"locked","kind":"system","support_id":"SUP-TEST","retryable":true,"request_id":null}"#) } else { None })
+        .bind(if status == "failed_retryable" { 1_i64 } else { 0_i64 })
+        .bind(lease_expires_at)
+        .bind(&now)
+        .bind(&now)
+        .bind(if status == "failed_terminal" || status == "completed" { Some(now.clone()) } else { None })
+        .bind(&now)
+        .bind("req-recovery")
+        .bind("human")
+        .bind("admin-1")
+        .bind(&now)
+        .bind(r#"{"label":"Booking #123","aggregate_refs":[{"type":"booking","id":"123"}],"business_dates":[],"safe_fields":{}}"#)
+        .bind(if status.starts_with("failed") { Some(r#"{"code":"DB_LOCKED_RETRYABLE","kind":"system","retryable":true,"message":"locked","support_id":"SUP-TEST"}"#) } else { None })
+        .bind(dismissed_at)
+        .bind(if dismissed { Some("admin-1") } else { None })
+        .execute(pool)
+        .await
+        .expect("seeds recovery row");
+        result.last_insert_rowid()
+    }
+
+    #[tokio::test]
+    async fn recovery_queue_includes_expired_in_progress_and_failed_retryable_only() {
+        let pool = test_pool().await;
+        let expired = (Utc::now() - chrono::Duration::seconds(5)).to_rfc3339();
+        let live = (Utc::now() + chrono::Duration::seconds(60)).to_rfc3339();
+
+        let expired_id =
+            seed_recovery_row(&pool, "check_out", "in_progress", Some(expired), false).await;
+        let retryable_id =
+            seed_recovery_row(&pool, "record_payment", "failed_retryable", None, false).await;
+        seed_recovery_row(&pool, "check_in", "in_progress", Some(live), false).await;
+        seed_recovery_row(&pool, "check_in", "completed", None, false).await;
+        seed_recovery_row(&pool, "check_in", "failed_terminal", None, false).await;
+        seed_recovery_row(&pool, "check_in", "failed_retryable", None, true).await;
+
+        let rows = list_command_recovery_queue(&pool)
+            .await
+            .expect("lists recovery queue");
+        let ids = rows.iter().map(|row| row.ledger.id).collect::<Vec<_>>();
+
+        assert_eq!(rows.len(), 2);
+        assert!(ids.contains(&expired_id));
+        assert!(ids.contains(&retryable_id));
+        assert!(rows
+            .iter()
+            .all(|row| row.allowed_actions.contains(&"inspect".to_string())));
+        assert!(rows.iter().all(|row| row.requires_confirmation));
+    }
+}

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -456,7 +456,8 @@ pub async fn dismiss_command_recovery(
         .map_err(system_error)?;
 
     let result = async {
-        eligible_recovery_row_tx(&mut tx, request.command_idempotency_id, &now).await?;
+        let row = eligible_recovery_row_tx(&mut tx, request.command_idempotency_id, &now).await?;
+        validate_confirmation(&row.command_name, &request, reason.as_deref())?;
         insert_recovery_action_tx(
             &mut tx,
             request.command_idempotency_id,
@@ -749,7 +750,7 @@ mod tests {
     #[tokio::test]
     async fn dismiss_audits_sets_marker_and_leaves_status_unchanged() {
         let pool = test_pool().await;
-        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+        let id = seed_recovery_row(&pool, "refresh_cache", "failed_retryable", None, false).await;
 
         let response = dismiss_command_recovery(
             &pool,
@@ -782,6 +783,31 @@ mod tests {
         );
         assert_eq!(action_count(&pool, id).await, 1);
         assert_eq!(action_field(&pool, id, "action").await, "dismissed");
+    }
+
+    #[tokio::test]
+    async fn high_risk_dismiss_requires_confirmation_and_reason() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+
+        let missing_confirmation = dismiss_command_recovery(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, Some(false), Some("reviewed")),
+        )
+        .await
+        .expect_err("requires confirmation");
+        assert_eq!(missing_confirmation.code, codes::APPROVAL_REQUIRED);
+
+        let missing_reason = dismiss_command_recovery(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, Some(true), Some("   ")),
+        )
+        .await
+        .expect_err("requires reason");
+        assert_eq!(missing_reason.code, codes::APPROVAL_REQUIRED);
+        assert_eq!(action_count(&pool, id).await, 0);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -3,7 +3,7 @@ use crate::command_ledger::{
     get_command_ledger_detail, CommandLedgerDetail, CommandLedgerListItem,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{Pool, Row, Sqlite};
+use sqlx::{Pool, Row, Sqlite, Transaction};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -136,6 +136,29 @@ pub struct CommandRecoveryActionRecord {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandRecoveryActionRequest {
+    pub command_idempotency_id: i64,
+    pub confirmed: bool,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryActionResponse {
+    pub command_idempotency_id: i64,
+    pub action: String,
+    pub status: String,
+    pub code: String,
+    pub message: String,
+    pub next_step: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryOperator {
+    pub id: String,
+    pub role: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CommandRecoveryDetail {
     pub ledger: CommandLedgerDetail,
@@ -234,6 +257,340 @@ pub async fn scan_command_recovery_startup(
     })
 }
 
+#[derive(Debug)]
+struct EligibleRecoveryRow {
+    command_name: String,
+}
+
+fn invalid_recovery_state_error() -> CommandError {
+    CommandError::user(
+        codes::CONFLICT_INVALID_STATE_TRANSITION,
+        codes::CONFLICT_INVALID_STATE_TRANSITION_DEFAULT_MESSAGE,
+    )
+}
+
+fn approval_required_error() -> CommandError {
+    CommandError::user(
+        codes::APPROVAL_REQUIRED,
+        "High-risk recovery actions require confirmation and a reason.",
+    )
+}
+
+fn normalized_reason(request: &CommandRecoveryActionRequest) -> Option<String> {
+    request
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .map(str::to_string)
+}
+
+fn validate_confirmation(
+    command_name: &str,
+    request: &CommandRecoveryActionRequest,
+    reason: Option<&str>,
+) -> CommandResult<()> {
+    if requires_confirmation(command_name) && (!request.confirmed || reason.is_none()) {
+        return Err(approval_required_error());
+    }
+    Ok(())
+}
+
+async fn eligible_recovery_row_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    id: i64,
+    now: &str,
+) -> CommandResult<EligibleRecoveryRow> {
+    let row = sqlx::query(
+        "SELECT command_name
+         FROM command_idempotency
+         WHERE id = ?
+           AND recovery_dismissed_at IS NULL
+           AND (
+                status = 'failed_retryable'
+                OR (status = 'in_progress' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?)
+           )",
+    )
+    .bind(id)
+    .bind(now)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(system_error)?;
+
+    let Some(row) = row else {
+        return Err(invalid_recovery_state_error());
+    };
+
+    Ok(EligibleRecoveryRow {
+        command_name: row.try_get("command_name").map_err(system_error)?,
+    })
+}
+
+async fn insert_recovery_action_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    command_idempotency_id: i64,
+    action: &str,
+    operator: &RecoveryOperator,
+    reason: Option<&str>,
+    confirmed: bool,
+    now: &str,
+) -> CommandResult<()> {
+    sqlx::query(
+        "INSERT INTO command_recovery_actions (
+            command_idempotency_id, action, operator_id, operator_role,
+            reason, confirmed, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(command_idempotency_id)
+    .bind(action)
+    .bind(&operator.id)
+    .bind(&operator.role)
+    .bind(reason)
+    .bind(if confirmed { 1_i64 } else { 0_i64 })
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .map_err(system_error)?;
+
+    Ok(())
+}
+
+fn recovery_action_response(
+    command_idempotency_id: i64,
+    action: &str,
+    status: &str,
+    next_step: &str,
+) -> RecoveryActionResponse {
+    RecoveryActionResponse {
+        command_idempotency_id,
+        action: action.to_string(),
+        status: status.to_string(),
+        code: codes::RECOVERY_REQUIRED.to_string(),
+        message: "Cần xử lý khôi phục lệnh trước khi tiếp tục.".to_string(),
+        next_step: next_step.to_string(),
+    }
+}
+
+fn recovery_required_error_json() -> CommandResult<(String, String)> {
+    let error = CommandError::user(
+        codes::RECOVERY_REQUIRED,
+        "Command recovery was marked terminal by an operator.",
+    );
+    let error_json = serde_json::to_string(&error).map_err(system_error)?;
+    let error_summary_json = serde_json::to_string(&serde_json::json!({
+        "code": codes::RECOVERY_REQUIRED,
+        "kind": "user",
+        "retryable": false,
+        "message": error.message,
+        "support_id": null,
+    }))
+    .map_err(system_error)?;
+
+    Ok((error_json, error_summary_json))
+}
+
+pub async fn request_command_recovery_retry(
+    pool: &Pool<Sqlite>,
+    operator: RecoveryOperator,
+    request: CommandRecoveryActionRequest,
+) -> CommandResult<RecoveryActionResponse> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let reason = normalized_reason(&request);
+    let mut tx = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(system_error)?;
+
+    let result = async {
+        let row = eligible_recovery_row_tx(&mut tx, request.command_idempotency_id, &now).await?;
+        validate_confirmation(&row.command_name, &request, reason.as_deref())?;
+        insert_recovery_action_tx(
+            &mut tx,
+            request.command_idempotency_id,
+            "retry_requested",
+            &operator,
+            reason.as_deref(),
+            request.confirmed,
+            &now,
+        )
+        .await?;
+
+        Ok(recovery_action_response(
+            request.command_idempotency_id,
+            "retry_requested",
+            "recovery_required",
+            "Retry request recorded for operator review.",
+        ))
+    }
+    .await;
+
+    match result {
+        Ok(response) => {
+            tx.commit().await.map_err(system_error)?;
+            Ok(response)
+        }
+        Err(error) => {
+            tx.rollback().await.map_err(system_error)?;
+            Err(error)
+        }
+    }
+}
+
+pub async fn dismiss_command_recovery(
+    pool: &Pool<Sqlite>,
+    operator: RecoveryOperator,
+    request: CommandRecoveryActionRequest,
+) -> CommandResult<RecoveryActionResponse> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let reason = normalized_reason(&request);
+    let mut tx = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(system_error)?;
+
+    let result = async {
+        eligible_recovery_row_tx(&mut tx, request.command_idempotency_id, &now).await?;
+        insert_recovery_action_tx(
+            &mut tx,
+            request.command_idempotency_id,
+            "dismissed",
+            &operator,
+            reason.as_deref(),
+            request.confirmed,
+            &now,
+        )
+        .await?;
+
+        let update_result = sqlx::query(
+            "UPDATE command_idempotency
+             SET recovery_dismissed_at = ?,
+                 recovery_dismissed_by = ?,
+                 updated_at = ?
+             WHERE id = ?
+               AND recovery_dismissed_at IS NULL
+               AND (
+                    status = 'failed_retryable'
+                    OR (status = 'in_progress' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?)
+               )",
+        )
+        .bind(&now)
+        .bind(&operator.id)
+        .bind(&now)
+        .bind(request.command_idempotency_id)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
+
+        if update_result.rows_affected() != 1 {
+            return Err(invalid_recovery_state_error());
+        }
+
+        Ok(recovery_action_response(
+            request.command_idempotency_id,
+            "dismissed",
+            "dismissed",
+            "Recovery item dismissed from the active queue.",
+        ))
+    }
+    .await;
+
+    match result {
+        Ok(response) => {
+            tx.commit().await.map_err(system_error)?;
+            Ok(response)
+        }
+        Err(error) => {
+            tx.rollback().await.map_err(system_error)?;
+            Err(error)
+        }
+    }
+}
+
+pub async fn mark_command_recovery_terminal(
+    pool: &Pool<Sqlite>,
+    operator: RecoveryOperator,
+    request: CommandRecoveryActionRequest,
+) -> CommandResult<RecoveryActionResponse> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let reason = normalized_reason(&request);
+    let mut tx = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(system_error)?;
+
+    let result = async {
+        let row = eligible_recovery_row_tx(&mut tx, request.command_idempotency_id, &now).await?;
+        validate_confirmation(&row.command_name, &request, reason.as_deref())?;
+        insert_recovery_action_tx(
+            &mut tx,
+            request.command_idempotency_id,
+            "marked_terminal",
+            &operator,
+            reason.as_deref(),
+            request.confirmed,
+            &now,
+        )
+        .await?;
+
+        let (error_json, error_summary_json) = recovery_required_error_json()?;
+        let update_result = sqlx::query(
+            "UPDATE command_idempotency
+             SET status = 'failed_terminal',
+                 response_json = NULL,
+                 result_summary_json = NULL,
+                 error_code = ?,
+                 error_json = ?,
+                 error_summary_json = ?,
+                 retryable = 0,
+                 lease_expires_at = NULL,
+                 updated_at = ?,
+                 completed_at = ?,
+                 recovery_dismissed_at = NULL,
+                 recovery_dismissed_by = NULL
+             WHERE id = ?
+               AND recovery_dismissed_at IS NULL
+               AND (
+                    status = 'failed_retryable'
+                    OR (status = 'in_progress' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?)
+               )",
+        )
+        .bind(codes::RECOVERY_REQUIRED)
+        .bind(&error_json)
+        .bind(&error_summary_json)
+        .bind(&now)
+        .bind(&now)
+        .bind(request.command_idempotency_id)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
+
+        if update_result.rows_affected() != 1 {
+            return Err(invalid_recovery_state_error());
+        }
+
+        Ok(recovery_action_response(
+            request.command_idempotency_id,
+            "marked_terminal",
+            "failed_terminal",
+            "Command marked terminal with recovery-required error details.",
+        ))
+    }
+    .await;
+
+    match result {
+        Ok(response) => {
+            tx.commit().await.map_err(system_error)?;
+            Ok(response)
+        }
+        Err(error) => {
+            tx.rollback().await.map_err(system_error)?;
+            Err(error)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -303,6 +660,261 @@ mod tests {
         .await
         .expect("seeds recovery row");
         result.last_insert_rowid()
+    }
+
+    fn recovery_operator() -> RecoveryOperator {
+        RecoveryOperator {
+            id: "ops-1".to_string(),
+            role: "admin".to_string(),
+        }
+    }
+
+    fn recovery_request(
+        command_idempotency_id: i64,
+        confirmed: bool,
+        reason: Option<&str>,
+    ) -> CommandRecoveryActionRequest {
+        CommandRecoveryActionRequest {
+            command_idempotency_id,
+            confirmed,
+            reason: reason.map(str::to_string),
+        }
+    }
+
+    async fn action_count(pool: &Pool<Sqlite>, command_idempotency_id: i64) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_recovery_actions WHERE command_idempotency_id = ?",
+        )
+        .bind(command_idempotency_id)
+        .fetch_one(pool)
+        .await
+        .expect("counts recovery actions")
+    }
+
+    async fn action_field(pool: &Pool<Sqlite>, command_idempotency_id: i64, field: &str) -> String {
+        let sql = format!(
+            "SELECT {field} FROM command_recovery_actions WHERE command_idempotency_id = ? ORDER BY id DESC LIMIT 1"
+        );
+        sqlx::query_scalar(&sql)
+            .bind(command_idempotency_id)
+            .fetch_one(pool)
+            .await
+            .expect("reads recovery action field")
+    }
+
+    #[tokio::test]
+    async fn retry_request_audits_and_returns_recovery_required_without_status_change() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+
+        let response = request_command_recovery_retry(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, true, Some("operator reviewed retry")),
+        )
+        .await
+        .expect("requests retry");
+
+        assert_eq!(response.command_idempotency_id, id);
+        assert_eq!(response.action, "retry_requested");
+        assert_eq!(response.status, "recovery_required");
+        assert_eq!(response.code, codes::RECOVERY_REQUIRED);
+        assert_eq!(
+            sqlx::query_scalar::<_, String>("SELECT status FROM command_idempotency WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .expect("reads status"),
+            "failed_retryable"
+        );
+        assert_eq!(action_count(&pool, id).await, 1);
+        assert_eq!(action_field(&pool, id, "action").await, "retry_requested");
+    }
+
+    #[tokio::test]
+    async fn dismiss_audits_sets_marker_and_leaves_status_unchanged() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+
+        let response = dismiss_command_recovery(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, false, Some("handled manually")),
+        )
+        .await
+        .expect("dismisses recovery row");
+
+        assert_eq!(response.action, "dismissed");
+        assert_eq!(response.status, "dismissed");
+        let row = sqlx::query(
+            "SELECT status, recovery_dismissed_at, recovery_dismissed_by
+             FROM command_idempotency WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("reads recovery marker");
+        assert_eq!(row.get::<String, _>("status"), "failed_retryable");
+        assert!(row
+            .get::<Option<String>, _>("recovery_dismissed_at")
+            .is_some());
+        assert_eq!(
+            row.get::<Option<String>, _>("recovery_dismissed_by")
+                .as_deref(),
+            Some("ops-1")
+        );
+        assert_eq!(action_count(&pool, id).await, 1);
+        assert_eq!(action_field(&pool, id, "action").await, "dismissed");
+    }
+
+    #[tokio::test]
+    async fn high_risk_mark_terminal_requires_confirmation_and_reason() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+
+        let missing_confirmation = mark_command_recovery_terminal(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, false, Some("reviewed")),
+        )
+        .await
+        .expect_err("requires confirmation");
+        assert_eq!(missing_confirmation.code, codes::APPROVAL_REQUIRED);
+
+        let missing_reason = mark_command_recovery_terminal(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, true, Some("   ")),
+        )
+        .await
+        .expect_err("requires reason");
+        assert_eq!(missing_reason.code, codes::APPROVAL_REQUIRED);
+        assert_eq!(action_count(&pool, id).await, 0);
+    }
+
+    #[tokio::test]
+    async fn high_risk_retry_request_requires_confirmation_and_reason() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "record_payment", "failed_retryable", None, false).await;
+
+        let missing_confirmation = request_command_recovery_retry(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, false, Some("reviewed")),
+        )
+        .await
+        .expect_err("requires confirmation");
+        assert_eq!(missing_confirmation.code, codes::APPROVAL_REQUIRED);
+
+        let missing_reason = request_command_recovery_retry(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, true, None),
+        )
+        .await
+        .expect_err("requires reason");
+        assert_eq!(missing_reason.code, codes::APPROVAL_REQUIRED);
+        assert_eq!(action_count(&pool, id).await, 0);
+    }
+
+    #[tokio::test]
+    async fn mark_terminal_closes_row_with_recovery_required_error() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "check_out", "failed_retryable", None, false).await;
+
+        let response = mark_command_recovery_terminal(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, true, Some("cannot safely retry")),
+        )
+        .await
+        .expect("marks terminal");
+
+        assert_eq!(response.action, "marked_terminal");
+        assert_eq!(response.status, "failed_terminal");
+        let row = sqlx::query(
+            "SELECT status, retryable, lease_expires_at, completed_at, error_code, error_json,
+                    error_summary_json, recovery_dismissed_at, recovery_dismissed_by
+             FROM command_idempotency WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("reads terminal row");
+
+        assert_eq!(row.get::<String, _>("status"), "failed_terminal");
+        assert_eq!(row.get::<i64, _>("retryable"), 0);
+        assert!(row.get::<Option<String>, _>("lease_expires_at").is_none());
+        assert!(row.get::<Option<String>, _>("completed_at").is_some());
+        assert_eq!(
+            row.get::<Option<String>, _>("error_code").as_deref(),
+            Some(codes::RECOVERY_REQUIRED)
+        );
+        assert!(row
+            .get::<Option<String>, _>("error_json")
+            .expect("stores error json")
+            .contains(codes::RECOVERY_REQUIRED));
+        assert!(row
+            .get::<Option<String>, _>("error_summary_json")
+            .expect("stores error summary")
+            .contains(codes::RECOVERY_REQUIRED));
+        assert!(row
+            .get::<Option<String>, _>("recovery_dismissed_at")
+            .is_none());
+        assert!(row
+            .get::<Option<String>, _>("recovery_dismissed_by")
+            .is_none());
+        assert_eq!(action_count(&pool, id).await, 1);
+    }
+
+    #[tokio::test]
+    async fn low_risk_mark_terminal_does_not_require_confirmation() {
+        let pool = test_pool().await;
+        let id = seed_recovery_row(&pool, "refresh_cache", "failed_retryable", None, false).await;
+
+        let response = mark_command_recovery_terminal(
+            &pool,
+            recovery_operator(),
+            recovery_request(id, false, None),
+        )
+        .await
+        .expect("marks low risk command terminal without confirmation");
+
+        assert_eq!(response.status, "failed_terminal");
+        assert_eq!(action_field(&pool, id, "action").await, "marked_terminal");
+    }
+
+    #[tokio::test]
+    async fn dismiss_rejects_stale_or_already_dismissed_row() {
+        let pool = test_pool().await;
+        let live = (Utc::now() + chrono::Duration::seconds(60)).to_rfc3339();
+        let already_dismissed =
+            seed_recovery_row(&pool, "check_out", "failed_retryable", None, true).await;
+        let live_in_progress =
+            seed_recovery_row(&pool, "check_out", "in_progress", Some(live), false).await;
+
+        let dismissed_error = dismiss_command_recovery(
+            &pool,
+            recovery_operator(),
+            recovery_request(already_dismissed, false, None),
+        )
+        .await
+        .expect_err("already dismissed is stale");
+        assert_eq!(
+            dismissed_error.code,
+            codes::CONFLICT_INVALID_STATE_TRANSITION
+        );
+
+        let live_error = dismiss_command_recovery(
+            &pool,
+            recovery_operator(),
+            recovery_request(live_in_progress, false, None),
+        )
+        .await
+        .expect_err("live in-progress row is not eligible");
+        assert_eq!(live_error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+        assert_eq!(action_count(&pool, already_dismissed).await, 0);
+        assert_eq!(action_count(&pool, live_in_progress).await, 0);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/commands/command_recovery.rs
+++ b/mhm/src-tauri/src/commands/command_recovery.rs
@@ -1,0 +1,100 @@
+use super::{require_admin, AppState};
+use crate::app_error::CommandResult;
+use crate::command_recovery::{
+    dismiss_command_recovery as dismiss_command_recovery_action,
+    inspect_command_recovery as inspect_command_recovery_query,
+    list_command_recovery_queue as list_command_recovery_queue_query,
+    mark_command_recovery_terminal as mark_command_recovery_terminal_action,
+    request_command_recovery_retry as request_command_recovery_retry_action,
+    CommandRecoveryActionRequest, CommandRecoveryDetail, CommandRecoveryQueueItem,
+    RecoveryActionResponse, RecoveryOperator,
+};
+use crate::models::User;
+use tauri::State;
+
+fn recovery_operator_from_admin(user: &User) -> RecoveryOperator {
+    RecoveryOperator {
+        id: user.id.clone(),
+        role: user.role.clone(),
+    }
+}
+
+#[tauri::command]
+pub async fn list_command_recovery_queue(
+    state: State<'_, AppState>,
+) -> CommandResult<Vec<CommandRecoveryQueueItem>> {
+    require_admin(&state)?;
+    list_command_recovery_queue_query(&state.db).await
+}
+
+#[tauri::command]
+pub async fn inspect_command_recovery(
+    state: State<'_, AppState>,
+    id: i64,
+) -> CommandResult<CommandRecoveryDetail> {
+    require_admin(&state)?;
+    inspect_command_recovery_query(&state.db, id).await
+}
+
+#[tauri::command]
+pub async fn request_command_recovery_retry(
+    state: State<'_, AppState>,
+    request: CommandRecoveryActionRequest,
+) -> CommandResult<RecoveryActionResponse> {
+    let user = require_admin(&state)?;
+    request_command_recovery_retry_action(&state.db, recovery_operator_from_admin(&user), request)
+        .await
+}
+
+#[tauri::command]
+pub async fn dismiss_command_recovery(
+    state: State<'_, AppState>,
+    request: CommandRecoveryActionRequest,
+) -> CommandResult<RecoveryActionResponse> {
+    let user = require_admin(&state)?;
+    dismiss_command_recovery_action(&state.db, recovery_operator_from_admin(&user), request).await
+}
+
+#[tauri::command]
+pub async fn mark_command_recovery_terminal(
+    state: State<'_, AppState>,
+    request: CommandRecoveryActionRequest,
+) -> CommandResult<RecoveryActionResponse> {
+    let user = require_admin(&state)?;
+    mark_command_recovery_terminal_action(&state.db, recovery_operator_from_admin(&user), request)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(role: &str) -> User {
+        User {
+            id: "admin-1".to_string(),
+            name: "Admin".to_string(),
+            role: role.to_string(),
+            active: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn recovery_operator_uses_current_admin_identity() {
+        let admin = user("admin");
+
+        let operator = recovery_operator_from_admin(&admin);
+
+        assert_eq!(operator.id, "admin-1");
+        assert_eq!(operator.role, "admin");
+    }
+
+    #[test]
+    fn wrapper_functions_remain_registered_at_compile_time() {
+        let _ = list_command_recovery_queue;
+        let _ = inspect_command_recovery;
+        let _ = request_command_recovery_retry;
+        let _ = dismiss_command_recovery;
+        let _ = mark_command_recovery_terminal;
+    }
+}

--- a/mhm/src-tauri/src/commands/mod.rs
+++ b/mhm/src-tauri/src/commands/mod.rs
@@ -86,6 +86,7 @@ pub mod auth;
 pub mod billing;
 pub mod bookings;
 pub mod command_ledger;
+pub mod command_recovery;
 pub mod diagnostics;
 pub mod groups;
 pub mod guests;

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -876,6 +876,53 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
 
         restore_foreign_keys_after_v14_migration(&mut conn, migration_result).await?;
     }
+
+    // ── V15: Command recovery queue and audit actions ──
+    if current < 15 {
+        let mut tx = pool.begin().await?;
+
+        for alter in [
+            "ALTER TABLE command_idempotency ADD COLUMN recovery_dismissed_at TEXT",
+            "ALTER TABLE command_idempotency ADD COLUMN recovery_dismissed_by TEXT",
+        ] {
+            execute_compat_alter(&mut tx, alter).await?;
+        }
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS command_recovery_actions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                command_idempotency_id INTEGER NOT NULL,
+                action TEXT NOT NULL,
+                operator_id TEXT,
+                operator_role TEXT,
+                reason TEXT,
+                confirmed INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(command_idempotency_id) REFERENCES command_idempotency(id)
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS command_recovery_actions_command_idx
+             ON command_recovery_actions(command_idempotency_id, created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS command_idempotency_recovery_queue_idx
+             ON command_idempotency(status, lease_expires_at, updated_at)
+             WHERE status IN ('in_progress', 'failed_retryable')
+               AND recovery_dismissed_at IS NULL",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        set_schema_version(&mut tx, 15).await?;
+        tx.commit().await?;
+    }
     Ok(())
 }
 
@@ -1148,7 +1195,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 14);
+        assert_eq!(version, 15);
     }
 
     #[tokio::test]
@@ -1164,7 +1211,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 14);
+        assert_eq!(version, 15);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1452,7 +1499,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 14);
+        assert_eq!(version, 15);
     }
 
     #[tokio::test]
@@ -1519,7 +1566,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 14);
+        assert_eq!(version, 15);
     }
 
     #[tokio::test]
@@ -1560,6 +1607,71 @@ mod tests {
         );
         assert_eq!(
             sqlite_index_count(&pool, "folio_lines_origin_command_uq").await,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_v15_adds_command_recovery_schema() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("migrations run");
+
+        assert_eq!(
+            command_idempotency_column_count(&pool, "recovery_dismissed_at").await,
+            1
+        );
+        assert_eq!(
+            command_idempotency_column_count(&pool, "recovery_dismissed_by").await,
+            1
+        );
+
+        let table_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'table' AND name = 'command_recovery_actions'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("reads recovery action table count");
+        assert_eq!(table_count, 1);
+
+        assert_eq!(
+            sqlite_index_count(&pool, "command_recovery_actions_command_idx").await,
+            1
+        );
+        assert_eq!(
+            sqlite_index_count(&pool, "command_idempotency_recovery_queue_idx").await,
+            1
+        );
+
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 15);
+    }
+
+    #[tokio::test]
+    async fn migration_v15_upgrades_existing_v14_database() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("initial migrations run");
+        sqlx::query("UPDATE schema_version SET version = 14")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version");
+
+        run_migrations(&pool).await.expect("v15 migration reruns");
+
+        assert_eq!(
+            command_idempotency_column_count(&pool, "recovery_dismissed_at").await,
+            1
+        );
+        assert_eq!(
+            command_idempotency_column_count(&pool, "recovery_dismissed_by").await,
+            1
+        );
+        assert_eq!(
+            sqlite_index_count(&pool, "command_idempotency_recovery_queue_idx").await,
             1
         );
     }

--- a/mhm/src-tauri/src/gateway/models.rs
+++ b/mhm/src-tauri/src/gateway/models.rs
@@ -96,3 +96,9 @@ pub struct GetInvoiceInput {
     /// Booking ID to get invoice for
     pub booking_id: String,
 }
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InspectCommandRecoveryInput {
+    /// Command ledger row id to inspect.
+    pub command_idempotency_id: i64,
+}

--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -732,6 +732,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mcp_exposes_recovery_read_tools_only() {
+        let pool = test_pool().await;
+        let tools = HotelTools::new(pool, None);
+
+        assert!(tools
+            .tool_router
+            .get("list_command_recovery_queue")
+            .is_some());
+        assert!(tools.tool_router.get("inspect_command_recovery").is_some());
+        assert!(tools
+            .tool_router
+            .get("request_command_recovery_retry")
+            .is_none());
+        assert!(tools.tool_router.get("dismiss_command_recovery").is_none());
+        assert!(tools
+            .tool_router
+            .get("mark_command_recovery_terminal")
+            .is_none());
+
+        let inspect = tools
+            .tool_router
+            .get("inspect_command_recovery")
+            .expect("inspect recovery read tool exists");
+        let schema = serde_json::to_string(&inspect.input_schema).expect("schema serializes");
+        assert!(schema.contains("command_idempotency_id"));
+    }
+
+    #[tokio::test]
     async fn create_reservation_same_mcp_request_id_and_args_replays_stored_command_row() {
         let _env_lock = async_env_lock().lock().await;
         let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
@@ -983,7 +1011,7 @@ impl HotelTools {
 
 #[tool_router]
 impl HotelTools {
-    // ─── Read Tools (11) ───
+    // ─── Read Tools (13) ───
 
     #[tool(
         description = "Get the current date/time, timezone, and hotel context. ALWAYS call this first to ground your responses in reality and avoid date hallucinations."
@@ -1146,6 +1174,34 @@ impl HotelTools {
         {
             Ok(result) => serde_json::to_string_pretty(&result).unwrap(),
             Err(e) => format!("Error: {}", e),
+        }
+    }
+
+    #[tool(
+        description = "List command recovery rows needing operator attention. Read-only: this does not retry, dismiss, or mark terminal."
+    )]
+    async fn list_command_recovery_queue(&self) -> String {
+        match crate::command_recovery::list_command_recovery_queue(&self.pool).await {
+            Ok(rows) => serde_json::to_string_pretty(&rows).unwrap(),
+            Err(error) => serde_json::to_string_pretty(&error).unwrap(),
+        }
+    }
+
+    #[tool(
+        description = "Inspect one command recovery row and its safe recovery history. Read-only: this does not retry, dismiss, or mark terminal."
+    )]
+    async fn inspect_command_recovery(
+        &self,
+        Parameters(input): Parameters<InspectCommandRecoveryInput>,
+    ) -> String {
+        match crate::command_recovery::inspect_command_recovery(
+            &self.pool,
+            input.command_idempotency_id,
+        )
+        .await
+        {
+            Ok(detail) => serde_json::to_string_pretty(&detail).unwrap(),
+            Err(error) => serde_json::to_string_pretty(&error).unwrap(),
         }
     }
 

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -160,6 +160,17 @@ pub fn run() {
 
             let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
             let pool = rt.block_on(db::init_db()).expect("Failed to init database");
+            match rt.block_on(command_recovery::scan_command_recovery_startup(&pool)) {
+                Ok(scan) if scan.expired_in_progress > 0 || scan.failed_retryable > 0 => info!(
+                    "Command recovery attention required: expired_in_progress={} failed_retryable={}",
+                    scan.expired_in_progress, scan.failed_retryable
+                ),
+                Ok(_) => {}
+                Err(error) => error!(
+                    "Command recovery startup scan failed: {} {}",
+                    error.code, error.message
+                ),
+            }
 
             // Start MCP Gateway server on a dedicated background thread.
             // The runtime must outlive the setup closure, otherwise the spawned
@@ -256,6 +267,11 @@ pub fn run() {
             commands::command_ledger::list_command_ledger,
             commands::command_ledger::list_command_ledger_attention,
             commands::command_ledger::get_command_ledger_detail,
+            commands::command_recovery::list_command_recovery_queue,
+            commands::command_recovery::inspect_command_recovery,
+            commands::command_recovery::request_command_recovery_retry,
+            commands::command_recovery::dismiss_command_recovery,
+            commands::command_recovery::mark_command_recovery_terminal,
             commands::onboarding::get_bootstrap_status,
             commands::onboarding::complete_onboarding,
             // Auth & RBAC

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod backup;
 mod command_failure_log;
 pub mod command_idempotency;
 pub mod command_ledger;
+pub mod command_recovery;
 mod crash_index;
 mod commands;
 pub mod db_error_monitoring;

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -351,6 +351,8 @@ pub async fn test_pool() -> Pool<Sqlite> {
             error_summary_json TEXT,
             retryable INTEGER NOT NULL DEFAULT 0,
             lease_expires_at TEXT,
+            recovery_dismissed_at TEXT,
+            recovery_dismissed_by TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             completed_at TEXT,


### PR DESCRIPTION
## Summary

- Adds backend command recovery queue handling for expired `in_progress` and `failed_retryable` command rows.
- Adds operator inspection and recovery actions: inspect, request retry, dismiss, and mark terminal.
- Keeps startup recovery read-only and exposes MCP recovery access as read-only list/inspect tools.

## What Changed

- Adds recovery schema fields/action audit table and `RECOVERY_REQUIRED` structured error coverage.
- Adds atomic recovery action handling with explicit confirmation for high-risk operations.
- Wires Tauri admin commands, startup scan logging, and MCP read-only tools.
- Merges latest `origin/main` locally before publishing.

## Verification

```bash
cargo clippy --all-targets --all-features -- -D warnings
npm run verify:full
cargo test
npm run build
```

## Risks / Follow-up

- No UI is included in this PR; backend returns operator-ready data for a later UI.
- `cargo fmt --check` was not included as a gate in CI and currently reports pre-existing Rust formatting drift if the old local formatting stash is not applied.

Closes #68