### PR TITLE
[codex] Verification gate and supervised MCP writes

### DIFF
--- a/mhm/src-tauri/src/aggregate_locks.rs
+++ b/mhm/src-tauri/src/aggregate_locks.rs
@@ -125,6 +125,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mixed_group_booking_room_and_folio_keys_are_canonicalized() {
+        let left = canonicalize_lock_keys(vec![
+            group_key("G1").unwrap(),
+            booking_key("B2").unwrap(),
+            room_key("R2").unwrap(),
+            folio_key("B2").unwrap(),
+            booking_key("B1").unwrap(),
+            room_key("R1").unwrap(),
+            folio_key("B1").unwrap(),
+            group_key("G1").unwrap(),
+        ])
+        .unwrap();
+        let right = canonicalize_lock_keys(vec![
+            folio_key("B1").unwrap(),
+            room_key("R1").unwrap(),
+            booking_key("B1").unwrap(),
+            folio_key("B2").unwrap(),
+            room_key("R2").unwrap(),
+            booking_key("B2").unwrap(),
+            group_key("G1").unwrap(),
+        ])
+        .unwrap();
+
+        assert_eq!(left, right);
+        assert_eq!(
+            left,
+            vec![
+                "booking:B1".to_string(),
+                "booking:B2".to_string(),
+                "folio:B1".to_string(),
+                "folio:B2".to_string(),
+                "group:G1".to_string(),
+                "room:R1".to_string(),
+                "room:R2".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn canonicalize_lock_keys_rejects_empty_input() {
         let err = canonicalize_lock_keys(Vec::<String>::new()).expect_err("empty keys reject");
 
@@ -139,7 +178,10 @@ mod tests {
 
         let second_manager = manager.clone();
         let second = tokio::spawn(async move {
-            second_manager.acquire(["room:R1"]).await.expect("second lock")
+            second_manager
+                .acquire(["room:R1"])
+                .await
+                .expect("second lock")
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
@@ -158,7 +200,10 @@ mod tests {
 
         let second_manager = manager.clone();
         let second = tokio::spawn(async move {
-            let second_guard = second_manager.acquire(["room:R2"]).await.expect("second lock");
+            let second_guard = second_manager
+                .acquire(["room:R2"])
+                .await
+                .expect("second lock");
             acquired_tx
                 .send(second_guard.keys().to_vec())
                 .expect("main task waits for acquired signal");

--- a/mhm/src-tauri/src/gateway/policy.rs
+++ b/mhm/src-tauri/src/gateway/policy.rs
@@ -1,7 +1,6 @@
 use serde::Serialize;
 
 use crate::app_error::codes;
-use crate::runtime_config;
 use crate::write_manifest::LockDeriverId;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -10,6 +9,25 @@ pub enum RiskLevel {
     Low,
     Medium,
     High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAutonomyLevel {
+    ReadOnly,
+    Supervised,
+    Full,
+}
+
+impl McpAutonomyLevel {
+    fn parse(value: &str) -> Self {
+        match value {
+            "read_only" | "readonly" | "read-only" => Self::ReadOnly,
+            "supervised" => Self::Supervised,
+            "full" => Self::Full,
+            _ => Self::Supervised,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -73,20 +91,38 @@ pub struct McpToolError {
 }
 
 impl McpToolErrorEnvelope {
-    fn write_tool_disabled(meta: &WriteToolMeta) -> Self {
+    fn write_tool_disabled(meta: &WriteToolMeta, request_id: Option<String>) -> Self {
         Self {
             ok: false,
             error: McpToolError {
                 code: codes::WRITE_TOOL_DISABLED,
                 kind: "policy",
                 message: format!(
-                    "MCP write tool '{}' is disabled. Set CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES=1 to enable high-risk MCP writes.",
+                    "MCP write tool '{}' is disabled by the current autonomy policy.",
                     meta.command_name
                 ),
                 tool: meta.command_name,
                 risk_level: meta.risk_level,
                 retryable: false,
-                request_id: None,
+                request_id,
+            },
+        }
+    }
+
+    fn approval_required(meta: &WriteToolMeta, request_id: Option<String>) -> Self {
+        Self {
+            ok: false,
+            error: McpToolError {
+                code: codes::APPROVAL_REQUIRED,
+                kind: "policy",
+                message: format!(
+                    "MCP write tool '{}' requires human approval in supervised mode.",
+                    meta.command_name
+                ),
+                tool: meta.command_name,
+                risk_level: meta.risk_level,
+                retryable: false,
+                request_id,
             },
         }
     }
@@ -96,21 +132,68 @@ impl McpToolErrorEnvelope {
     }
 }
 
-pub fn high_risk_mcp_writes_enabled() -> bool {
-    runtime_config::env_flag("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES")
+pub fn configured_mcp_autonomy_level() -> McpAutonomyLevel {
+    std::env::var("CAPYINN_MCP_AUTONOMY")
+        .map(|value| McpAutonomyLevel::parse(&value))
+        .unwrap_or(McpAutonomyLevel::Supervised)
 }
 
-pub fn guard_write_tool(meta: &WriteToolMeta) -> Result<(), McpToolErrorEnvelope> {
-    if meta.risk_level == RiskLevel::High && !high_risk_mcp_writes_enabled() {
-        return Err(McpToolErrorEnvelope::write_tool_disabled(meta));
+pub fn guard_write_tool(
+    meta: &WriteToolMeta,
+    request_id: Option<String>,
+) -> Result<(), McpToolErrorEnvelope> {
+    if meta.risk_level != RiskLevel::High {
+        return Ok(());
     }
 
-    Ok(())
+    match configured_mcp_autonomy_level() {
+        McpAutonomyLevel::ReadOnly | McpAutonomyLevel::Full => {
+            Err(McpToolErrorEnvelope::write_tool_disabled(meta, request_id))
+        }
+        McpAutonomyLevel::Supervised => {
+            Err(McpToolErrorEnvelope::approval_required(meta, request_id))
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+
+        fn set(key: &'static str, value: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn write_tool_manifest_carries_required_policy_metadata() {
@@ -138,5 +221,88 @@ mod tests {
                 meta.command_name
             );
         }
+    }
+
+    #[test]
+    fn default_autonomy_is_supervised_when_autonomy_and_legacy_env_are_absent() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _autonomy = EnvVarGuard::unset("CAPYINN_MCP_AUTONOMY");
+        let _legacy = EnvVarGuard::unset("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
+
+        assert_eq!(
+            configured_mcp_autonomy_level(),
+            McpAutonomyLevel::Supervised
+        );
+    }
+
+    #[test]
+    fn read_only_high_risk_write_returns_disabled_with_request_id() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "read_only");
+        let request_id = Some("req-read-only".to_string());
+
+        let err = guard_write_tool(&CREATE_RESERVATION_META, request_id.clone())
+            .expect_err("read-only mode should disable high-risk writes");
+
+        assert_eq!(err.error.code, codes::WRITE_TOOL_DISABLED);
+        assert_eq!(err.error.request_id, request_id);
+    }
+
+    #[test]
+    fn supervised_high_risk_write_returns_approval_required_with_request_id() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "supervised");
+        let request_id = Some("req-supervised".to_string());
+
+        let err = guard_write_tool(&CREATE_RESERVATION_META, request_id.clone())
+            .expect_err("supervised mode should require approval for high-risk writes");
+
+        assert_eq!(err.error.code, codes::APPROVAL_REQUIRED);
+        assert_eq!(err.error.request_id, request_id);
+    }
+
+    #[test]
+    fn full_autonomy_is_represented_but_high_risk_writes_remain_disabled() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "full");
+        let request_id = Some("req-full".to_string());
+
+        assert_eq!(configured_mcp_autonomy_level(), McpAutonomyLevel::Full);
+
+        let err = guard_write_tool(&CREATE_RESERVATION_META, request_id.clone())
+            .expect_err("full mode is represented but not launched for high-risk writes");
+
+        assert_eq!(err.error.code, codes::WRITE_TOOL_DISABLED);
+        assert_eq!(err.error.request_id, request_id);
+    }
+
+    #[test]
+    fn legacy_high_risk_env_does_not_enable_high_risk_writes() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _autonomy = EnvVarGuard::unset("CAPYINN_MCP_AUTONOMY");
+        let _legacy = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+        let request_id = Some("req-legacy".to_string());
+
+        assert_eq!(
+            configured_mcp_autonomy_level(),
+            McpAutonomyLevel::Supervised
+        );
+
+        let err = guard_write_tool(&CREATE_RESERVATION_META, request_id.clone())
+            .expect_err("legacy env must not enable high-risk writes");
+
+        assert_eq!(err.error.code, codes::APPROVAL_REQUIRED);
+        assert_eq!(err.error.request_id, request_id);
+    }
+
+    #[test]
+    fn invalid_autonomy_config_falls_back_to_supervised() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "invalid");
+
+        assert_eq!(
+            configured_mcp_autonomy_level(),
+            McpAutonomyLevel::Supervised
+        );
     }
 }

--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -537,29 +537,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_reservation_is_default_denied_without_creating_booking() {
+    async fn create_reservation_is_default_supervised_approval_required_without_creating_booking() {
         let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
+        let _autonomy = EnvVarGuard::remove("CAPYINN_MCP_AUTONOMY");
+        let _legacy = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
 
         let pool = test_pool().await;
         seed_room(&pool, "R199", "standard").await;
         seed_pricing_rule(&pool, "standard", 600_000).await;
         let tools = HotelTools::new(pool.clone(), None);
+        let request_id = mcp_request_id("req-create-supervised");
 
         let output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R199")),
-                mcp_request_id("req-create-denied"),
-            )
+            .create_reservation(Parameters(create_reservation_input("R199")), request_id)
             .await;
 
         let envelope: Value = serde_json::from_str(&output).expect("error envelope json");
         assert_eq!(envelope["ok"].as_bool(), Some(false));
         assert_eq!(
             envelope["error"]["code"].as_str(),
-            Some(codes::WRITE_TOOL_DISABLED)
+            Some(codes::APPROVAL_REQUIRED)
         );
         assert_eq!(envelope["error"]["kind"].as_str(), Some("policy"));
+        assert_eq!(
+            envelope["error"]["request_id"].as_str(),
+            Some("string:req-create-supervised")
+        );
 
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
             .bind("R199")
@@ -570,8 +573,120 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_reservation_read_only_disabled_without_creating_booking() {
+        let _env_lock = async_env_lock().lock().await;
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "read_only");
+        let _legacy = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
+
+        let pool = test_pool().await;
+        seed_room(&pool, "R197", "standard").await;
+        seed_pricing_rule(&pool, "standard", 600_000).await;
+        let tools = HotelTools::new(pool.clone(), None);
+
+        let output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R197")),
+                mcp_request_id("req-create-read-only"),
+            )
+            .await;
+
+        let envelope: Value = serde_json::from_str(&output).expect("error envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
+        assert_eq!(
+            envelope["error"]["code"].as_str(),
+            Some(codes::WRITE_TOOL_DISABLED)
+        );
+        assert_eq!(
+            envelope["error"]["request_id"].as_str(),
+            Some("string:req-create-read-only")
+        );
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+            .bind("R197")
+            .fetch_one(&pool)
+            .await
+            .expect("booking count");
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn create_reservation_full_disabled_without_creating_booking() {
+        let _env_lock = async_env_lock().lock().await;
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "full");
+        let _legacy = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
+
+        let pool = test_pool().await;
+        seed_room(&pool, "R198", "standard").await;
+        seed_pricing_rule(&pool, "standard", 600_000).await;
+        let tools = HotelTools::new(pool.clone(), None);
+
+        let output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R198")),
+                mcp_request_id("req-create-full"),
+            )
+            .await;
+
+        let envelope: Value = serde_json::from_str(&output).expect("error envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
+        assert_eq!(
+            envelope["error"]["code"].as_str(),
+            Some(codes::WRITE_TOOL_DISABLED)
+        );
+        assert_eq!(
+            envelope["error"]["request_id"].as_str(),
+            Some("string:req-create-full")
+        );
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+            .bind("R198")
+            .fetch_one(&pool)
+            .await
+            .expect("booking count");
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn create_reservation_legacy_flag_still_requires_approval_without_creating_booking() {
+        let _env_lock = async_env_lock().lock().await;
+        let _autonomy = EnvVarGuard::remove("CAPYINN_MCP_AUTONOMY");
+        let _legacy = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+
+        let pool = test_pool().await;
+        seed_room(&pool, "R196", "standard").await;
+        seed_pricing_rule(&pool, "standard", 600_000).await;
+        let tools = HotelTools::new(pool.clone(), None);
+
+        let output = tools
+            .create_reservation(
+                Parameters(create_reservation_input("R196")),
+                mcp_request_id("req-create-legacy"),
+            )
+            .await;
+
+        let envelope: Value = serde_json::from_str(&output).expect("error envelope json");
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
+        assert_eq!(
+            envelope["error"]["code"].as_str(),
+            Some(codes::APPROVAL_REQUIRED)
+        );
+        assert_eq!(
+            envelope["error"]["request_id"].as_str(),
+            Some("string:req-create-legacy")
+        );
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+            .bind("R196")
+            .fetch_one(&pool)
+            .await
+            .expect("booking count");
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
     async fn get_hotel_context_still_works_when_high_risk_writes_are_disabled() {
         let _env_lock = async_env_lock().lock().await;
+        let _autonomy = EnvVarGuard::remove("CAPYINN_MCP_AUTONOMY");
         let _env = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
 
         let pool = test_pool().await;
@@ -585,9 +700,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_reservation_tool_returns_booking_json() {
+    async fn create_reservation_tool_with_legacy_flag_requires_approval() {
         let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+        let _autonomy = EnvVarGuard::remove("CAPYINN_MCP_AUTONOMY");
+        let _legacy = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
 
         let pool = test_pool().await;
         seed_room(&pool, "R200", "standard").await;
@@ -602,17 +718,18 @@ mod tests {
             .await;
 
         let envelope: Value = serde_json::from_str(&output).expect("success envelope json");
-        assert_eq!(envelope["ok"].as_bool(), Some(true));
-        assert_eq!(envelope["data"]["room_id"].as_str(), Some("R200"));
-        assert_eq!(envelope["data"]["status"].as_str(), Some("booked"));
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
+        assert_eq!(
+            envelope["error"]["code"].as_str(),
+            Some(codes::APPROVAL_REQUIRED)
+        );
 
-        let stored: String = sqlx::query("SELECT status FROM bookings WHERE room_id = ?")
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
             .bind("R200")
             .fetch_one(&pool)
             .await
-            .expect("booking row")
-            .get("status");
-        assert_eq!(stored, "booked");
+            .expect("booking count");
+        assert_eq!(count, 0);
     }
 
     #[tokio::test]
@@ -635,9 +752,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_reservation_tool_returns_success_message_and_updates_status() {
+    async fn cancel_reservation_tool_requires_approval_and_leaves_status_unchanged() {
         let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "supervised");
+        let _legacy = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
 
         let pool = test_pool().await;
         seed_room(&pool, "R201", "standard").await;
@@ -654,9 +772,15 @@ mod tests {
             .await;
 
         let envelope: Value = serde_json::from_str(&output).expect("success envelope json");
-        assert_eq!(envelope["ok"].as_bool(), Some(true));
-        assert_eq!(envelope["data"]["ok"].as_bool(), Some(true));
-        assert_eq!(envelope["data"]["booking_id"].as_str(), Some("B201"));
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
+        assert_eq!(
+            envelope["error"]["code"].as_str(),
+            Some(codes::APPROVAL_REQUIRED)
+        );
+        assert_eq!(
+            envelope["error"]["request_id"].as_str(),
+            Some("string:req-cancel-success")
+        );
 
         let stored: String = sqlx::query("SELECT status FROM bookings WHERE id = ?")
             .bind("B201")
@@ -664,13 +788,14 @@ mod tests {
             .await
             .expect("booking row")
             .get("status");
-        assert_eq!(stored, "cancelled");
+        assert_eq!(stored, "booked");
     }
 
     #[tokio::test]
-    async fn modify_reservation_tool_returns_updated_booking_json() {
+    async fn modify_reservation_tool_requires_approval_and_leaves_booking_unchanged() {
         let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
+        let _autonomy = EnvVarGuard::set("CAPYINN_MCP_AUTONOMY", "supervised");
+        let _legacy = EnvVarGuard::remove("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES");
 
         let pool = test_pool().await;
         seed_room(&pool, "R202", "standard").await;
@@ -691,13 +816,25 @@ mod tests {
             .await;
 
         let envelope: Value = serde_json::from_str(&output).expect("success envelope json");
-        assert_eq!(envelope["ok"].as_bool(), Some(true));
-        assert_eq!(envelope["data"]["status"].as_str(), Some("booked"));
-        assert_eq!(envelope["data"]["check_in_at"].as_str(), Some("2026-04-24"));
+        assert_eq!(envelope["ok"].as_bool(), Some(false));
         assert_eq!(
-            envelope["data"]["expected_checkout"].as_str(),
-            Some("2026-04-26")
+            envelope["error"]["code"].as_str(),
+            Some(codes::APPROVAL_REQUIRED)
         );
+        assert_eq!(
+            envelope["error"]["request_id"].as_str(),
+            Some("string:req-modify-success")
+        );
+
+        let row = sqlx::query("SELECT check_in_at, expected_checkout FROM bookings WHERE id = ?")
+            .bind("B202")
+            .fetch_one(&pool)
+            .await
+            .expect("booking row");
+        let check_in: String = row.get("check_in_at");
+        let checkout: String = row.get("expected_checkout");
+        assert_eq!(check_in, "2026-04-20");
+        assert_eq!(checkout, "2026-04-22");
     }
 
     #[tokio::test]
@@ -760,48 +897,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_reservation_same_mcp_request_id_and_args_replays_stored_command_row() {
-        let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
-
+    async fn write_context_uses_stable_hidden_key_for_same_request_id_and_args() {
         let pool = test_pool().await;
-        seed_room(&pool, "R203", "standard").await;
-        seed_pricing_rule(&pool, "standard", 600_000).await;
-        let tools = HotelTools::new(pool.clone(), None);
+        let tools = HotelTools::new(pool, None);
+        let input = create_reservation_input("R203");
+        let request_id = mcp_request_id("req-create-replay");
 
-        let first_output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R203")),
-                mcp_request_id("req-create-replay"),
-            )
-            .await;
-        let replay_output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R203")),
-                mcp_request_id("req-create-replay"),
-            )
-            .await;
+        let first_ctx = tools
+            .write_context("create_reservation", &request_id, &input)
+            .expect("first context");
+        let replay_ctx = tools
+            .write_context("create_reservation", &request_id, &input)
+            .expect("replay context");
 
-        let first: Value = serde_json::from_str(&first_output).expect("success envelope json");
-        let replay: Value = serde_json::from_str(&replay_output).expect("success envelope json");
-        assert_eq!(first["ok"].as_bool(), Some(true));
-        assert_eq!(replay["ok"].as_bool(), Some(true));
-        assert_eq!(first["data"]["id"], replay["data"]["id"]);
-
-        let command_rows: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM command_idempotency WHERE command_name = 'create_reservation'",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("command row count");
-        assert_eq!(command_rows, 1);
-
-        let bookings: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
-            .bind("R203")
-            .fetch_one(&pool)
-            .await
-            .expect("booking count");
-        assert_eq!(bookings, 1);
+        assert_eq!(first_ctx.idempotency_key, replay_ctx.idempotency_key);
+        assert_eq!(first_ctx.request_id, "string:req-create-replay");
     }
 
     #[tokio::test]
@@ -827,88 +937,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_reservation_same_mcp_request_id_and_different_args_use_distinct_hidden_keys() {
-        let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
-
+    async fn write_context_changes_hidden_key_when_same_request_id_has_different_args() {
         let pool = test_pool().await;
-        seed_room(&pool, "R204A", "standard").await;
-        seed_room(&pool, "R204B", "standard").await;
-        seed_pricing_rule(&pool, "standard", 600_000).await;
-        let tools = HotelTools::new(pool.clone(), None);
+        let tools = HotelTools::new(pool, None);
+        let first_input = create_reservation_input("R204A");
+        let second_input = create_reservation_input("R204B");
+        let request_id = mcp_request_id("req-create-same-id-different-args");
 
-        let first_output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R204A")),
-                mcp_request_id("req-create-same-id-different-args"),
-            )
-            .await;
-        let second_output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R204B")),
-                mcp_request_id("req-create-same-id-different-args"),
-            )
-            .await;
+        let first_ctx = tools
+            .write_context("create_reservation", &request_id, &first_input)
+            .expect("first context");
+        let second_ctx = tools
+            .write_context("create_reservation", &request_id, &second_input)
+            .expect("second context");
 
-        let first: Value = serde_json::from_str(&first_output).expect("success envelope json");
-        let second: Value = serde_json::from_str(&second_output).expect("success envelope json");
-        assert_eq!(first["ok"].as_bool(), Some(true));
-        assert_eq!(second["ok"].as_bool(), Some(true));
-        assert_ne!(first["data"]["id"], second["data"]["id"]);
-
-        let command_rows: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM command_idempotency WHERE command_name = 'create_reservation'",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("command row count");
-        assert_eq!(command_rows, 2);
+        assert_ne!(first_ctx.idempotency_key, second_ctx.idempotency_key);
+        assert!(first_ctx
+            .idempotency_key
+            .starts_with("mcp:create_reservation:string:req-create-same-id-different-args:"));
+        assert!(second_ctx
+            .idempotency_key
+            .starts_with("mcp:create_reservation:string:req-create-same-id-different-args:"));
     }
 
     #[tokio::test]
-    async fn create_reservation_numeric_and_string_mcp_request_ids_use_distinct_hidden_keys() {
-        let _env_lock = async_env_lock().lock().await;
-        let _env = EnvVarGuard::set("CAPYINN_ENABLE_HIGH_RISK_MCP_WRITES", "1");
-
+    async fn write_context_numeric_and_string_mcp_request_ids_use_distinct_hidden_keys() {
         let pool = test_pool().await;
-        seed_room(&pool, "R205", "standard").await;
-        seed_pricing_rule(&pool, "standard", 600_000).await;
-        let tools = HotelTools::new(pool.clone(), None);
+        let tools = HotelTools::new(pool, None);
+        let input = create_reservation_input("R205");
 
-        let first_output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R205")),
-                numeric_mcp_request_id(1),
-            )
-            .await;
-        let second_output = tools
-            .create_reservation(
-                Parameters(create_reservation_input("R205")),
-                mcp_request_id("1"),
-            )
-            .await;
+        let numeric_ctx = tools
+            .write_context("create_reservation", &numeric_mcp_request_id(1), &input)
+            .expect("numeric context");
+        let string_ctx = tools
+            .write_context("create_reservation", &mcp_request_id("1"), &input)
+            .expect("string context");
 
-        let first: Value = serde_json::from_str(&first_output).expect("success envelope json");
-        let second: Value = serde_json::from_str(&second_output).expect("error envelope json");
-        assert_eq!(first["ok"].as_bool(), Some(true));
-        assert_eq!(second["ok"].as_bool(), Some(false));
-
-        let command_rows: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM command_idempotency WHERE command_name = 'create_reservation'",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("command row count");
-        assert_eq!(command_rows, 2);
-
-        let idempotency_keys: Vec<String> = sqlx::query_scalar(
-            "SELECT idempotency_key FROM command_idempotency WHERE command_name = 'create_reservation'",
-        )
-        .fetch_all(&pool)
-        .await
-        .expect("idempotency keys");
-        assert_eq!(idempotency_keys.len(), 2);
-        assert_ne!(idempotency_keys[0], idempotency_keys[1]);
+        assert_ne!(numeric_ctx.idempotency_key, string_ctx.idempotency_key);
+        assert!(numeric_ctx
+            .idempotency_key
+            .starts_with("mcp:create_reservation:number:1:"));
+        assert!(string_ctx
+            .idempotency_key
+            .starts_with("mcp:create_reservation:string:1:"));
     }
 
     #[test]
@@ -1215,11 +1286,13 @@ impl HotelTools {
         Parameters(input): Parameters<CreateReservationInput>,
         request_id: McpRequestId,
     ) -> String {
-        if let Err(envelope) = guard_write_tool(&CREATE_RESERVATION_META) {
+        let request_id_text = mcp_request_id_string(&request_id);
+        if let Err(envelope) =
+            guard_write_tool(&CREATE_RESERVATION_META, Some(request_id_text.clone()))
+        {
             return envelope.to_json_string();
         }
 
-        let request_id_text = mcp_request_id_string(&request_id);
         let ctx = match self.write_context("create_reservation", &request_id, &input) {
             Ok(ctx) => ctx,
             Err(error) => {
@@ -1279,11 +1352,13 @@ impl HotelTools {
         Parameters(input): Parameters<CancelReservationInput>,
         request_id: McpRequestId,
     ) -> String {
-        if let Err(envelope) = guard_write_tool(&CANCEL_RESERVATION_META) {
+        let request_id_text = mcp_request_id_string(&request_id);
+        if let Err(envelope) =
+            guard_write_tool(&CANCEL_RESERVATION_META, Some(request_id_text.clone()))
+        {
             return envelope.to_json_string();
         }
 
-        let request_id_text = mcp_request_id_string(&request_id);
         let ctx = match self.write_context("cancel_reservation", &request_id, &input) {
             Ok(ctx) => ctx,
             Err(error) => {
@@ -1312,11 +1387,13 @@ impl HotelTools {
         Parameters(input): Parameters<ModifyReservationInput>,
         request_id: McpRequestId,
     ) -> String {
-        if let Err(envelope) = guard_write_tool(&MODIFY_RESERVATION_META) {
+        let request_id_text = mcp_request_id_string(&request_id);
+        if let Err(envelope) =
+            guard_write_tool(&MODIFY_RESERVATION_META, Some(request_id_text.clone()))
+        {
             return envelope.to_json_string();
         }
 
-        let request_id_text = mcp_request_id_string(&request_id);
         let ctx = match self.write_context("modify_reservation", &request_id, &input) {
             Ok(ctx) => ctx,
             Err(error) => {

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -998,17 +998,23 @@ async fn extend_stay_tx(
     origin_key: Option<String>,
 ) -> BookingResult<Booking> {
     let booking = sqlx::query(
-        "SELECT room_id, nights, total_price, expected_checkout, pricing_type
-         FROM bookings WHERE id = ? AND status = ?",
+        "SELECT room_id, nights, total_price, expected_checkout, pricing_type, status
+         FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
-    .bind(status::booking::ACTIVE)
     .fetch_optional(&mut **tx)
     .await?;
 
     let booking = booking.ok_or_else(|| {
         BookingError::not_found(format!("Không tìm thấy booking đang active {}", booking_id))
     })?;
+
+    let booking_status: String = booking.get("status");
+    if booking_status != status::booking::ACTIVE {
+        return Err(invalid_state_transition(format!(
+            "booking {booking_id} is not active for extend-stay (status: {booking_status})"
+        )));
+    }
 
     let room_id: String = booking.get("room_id");
     ensure_locked_room_matches_booking(

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -20,7 +20,7 @@ use super::{
     billing_service::{
         add_folio_line, add_folio_line_idempotent, record_cancellation_fee_tx, record_deposit_tx,
         record_deposit_with_origin_tx, record_payment, record_payment_idempotent,
-        record_payment_returning_id_tx, record_payment_tx,
+        record_payment_returning_id_tx, record_payment_tx, record_payment_with_origin_tx,
     },
     group_lifecycle, group_service_management, guest_service, reservation_lifecycle,
     stay_lifecycle,
@@ -1294,6 +1294,13 @@ async fn group_checkout_idempotent_final_payment_locks_group_and_candidate_folio
     .await
     .unwrap();
     let lock_keys: Vec<String> = serde_json::from_str(&lock_keys_json).unwrap();
+    let mut sorted_lock_keys = lock_keys.clone();
+    sorted_lock_keys.sort();
+    sorted_lock_keys.dedup();
+    assert_eq!(
+        lock_keys, sorted_lock_keys,
+        "group checkout lock keys must be sorted and deduplicated: {lock_keys_json}"
+    );
 
     assert!(lock_keys.contains(&format!("group:{}", group.id)));
     let folio_lock_count = lock_keys
@@ -2982,6 +2989,54 @@ async fn record_deposit_with_origin_rejects_blank_key_before_write() {
         .await
         .unwrap();
     assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn duplicate_transaction_origin_is_blocked_by_unique_origin_ordinal() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-TXN-ORIGIN-DUP").await.unwrap();
+    seed_active_booking(&pool, "B-TXN-ORIGIN-DUP", "R-TXN-ORIGIN-DUP")
+        .await
+        .unwrap();
+    let origin = OriginSideEffect::new("origin-duplicate-transaction", 0).unwrap();
+
+    let mut first_tx = crate::services::booking::support::begin_tx(&pool)
+        .await
+        .unwrap();
+    record_payment_with_origin_tx(
+        &mut first_tx,
+        "B-TXN-ORIGIN-DUP",
+        25_000,
+        "Duplicate origin payment",
+        &origin,
+    )
+    .await
+    .unwrap();
+    first_tx.commit().await.unwrap();
+
+    let mut second_tx = crate::services::booking::support::begin_tx(&pool)
+        .await
+        .unwrap();
+    let duplicate = record_payment_with_origin_tx(
+        &mut second_tx,
+        "B-TXN-ORIGIN-DUP",
+        25_000,
+        "Duplicate origin payment",
+        &origin,
+    )
+    .await;
+    assert!(duplicate.is_err(), "duplicate transaction origin must fail");
+    second_tx.rollback().await.unwrap();
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions
+         WHERE origin_idempotency_key = ? AND origin_transaction_ordinal = 0",
+    )
+    .bind("origin-duplicate-transaction")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1);
 }
 
 #[tokio::test]
@@ -5034,6 +5089,72 @@ async fn check_in_idempotent_retry_replays_and_does_not_duplicate_rows() {
 }
 
 #[tokio::test]
+async fn two_check_in_commands_for_same_room_leave_one_booking_and_consistent_calendar() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-CHECKIN-RACE").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 250_000).await.unwrap();
+    let first_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-checkin-race-1",
+        "idem-checkin-race-1",
+        "check_in",
+    );
+    let second_ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-checkin-race-2",
+        "idem-checkin-race-2",
+        "check_in",
+    );
+
+    let (first, second) = tokio::join!(
+        stay_lifecycle::check_in_idempotent(
+            &pool,
+            &first_ctx,
+            minimal_checkin_request("R-CHECKIN-RACE"),
+            Some("user-1".to_string())
+        ),
+        stay_lifecycle::check_in_idempotent(
+            &pool,
+            &second_ctx,
+            minimal_checkin_request("R-CHECKIN-RACE"),
+            Some("user-2".to_string())
+        )
+    );
+
+    assert_eq!(
+        usize::from(first.is_ok()) + usize::from(second.is_ok()),
+        1,
+        "exactly one concurrent check-in should succeed"
+    );
+    assert_eq!(
+        usize::from(first.is_err()) + usize::from(second.is_err()),
+        1,
+        "exactly one concurrent check-in should fail"
+    );
+
+    let booking_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+        .bind("R-CHECKIN-RACE")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(booking_count, 1);
+
+    let room_status: String = sqlx::query_scalar("SELECT status FROM rooms WHERE id = ?")
+        .bind("R-CHECKIN-RACE")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(room_status, "occupied");
+
+    let occupied_calendar_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM room_calendar WHERE room_id = ? AND status = 'occupied'",
+    )
+    .bind("R-CHECKIN-RACE")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(occupied_calendar_count, 2);
+}
+
+#[tokio::test]
 async fn check_in_idempotent_same_key_changed_guest_conflicts() {
     let pool = test_pool().await;
     seed_room(&pool, "R-CHECKIN-HASH").await.unwrap();
@@ -5130,6 +5251,55 @@ async fn check_in_idempotent_duplicate_in_flight_returns_conflict() {
         error.code,
         crate::app_error::codes::CONFLICT_DUPLICATE_IN_FLIGHT
     );
+}
+
+#[tokio::test]
+async fn check_in_fails_when_second_pool_blocks_room_calendar_first() {
+    let (pool_a, pool_b, db_path) = shared_file_test_pools("second-pool-calendar").await;
+    seed_room(&pool_a, "R-2POOL-CALENDAR").await.unwrap();
+    seed_pricing_rule(&pool_a, "standard", 250_000)
+        .await
+        .unwrap();
+
+    let today = Local::now().date_naive().to_string();
+    sqlx::query(
+        "INSERT INTO room_calendar (room_id, date, booking_id, status) VALUES (?, ?, NULL, 'occupied')",
+    )
+    .bind("R-2POOL-CALENDAR")
+    .bind(today)
+    .execute(&pool_b)
+    .await
+    .unwrap();
+
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-checkin-2pool-calendar",
+        "idem-checkin-2pool-calendar",
+        "check_in",
+    );
+    let error = stay_lifecycle::check_in_idempotent(
+        &pool_a,
+        &ctx,
+        minimal_checkin_request("R-2POOL-CALENDAR"),
+        Some("user-1".to_string()),
+    )
+    .await
+    .expect_err("check-in should reject calendar row inserted by second pool");
+
+    assert_eq!(
+        error.code,
+        crate::app_error::codes::CONFLICT_ROOM_UNAVAILABLE
+    );
+
+    let booking_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = ?")
+        .bind("R-2POOL-CALENDAR")
+        .fetch_one(&pool_a)
+        .await
+        .unwrap();
+    assert_eq!(booking_count, 0);
+
+    pool_a.close().await;
+    pool_b.close().await;
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -6163,6 +6333,46 @@ async fn extend_stay_idempotent_duplicate_in_flight_returns_conflict() {
         error.code,
         crate::app_error::codes::CONFLICT_DUPLICATE_IN_FLIGHT
     );
+}
+
+#[tokio::test]
+async fn extend_stay_fails_when_second_pool_checked_out_booking_first() {
+    let (pool_a, pool_b, db_path) =
+        shared_file_test_pools("second-pool-extend-after-checkout").await;
+    seed_room(&pool_a, "R-2POOL-EXTEND").await.unwrap();
+    seed_active_booking(&pool_a, "B-2POOL-EXTEND", "R-2POOL-EXTEND")
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'checked_out' WHERE id = ?")
+        .bind("B-2POOL-EXTEND")
+        .execute(&pool_b)
+        .await
+        .unwrap();
+
+    let ctx = crate::command_idempotency::WriteCommandContext::for_internal_test(
+        "req-extend-2pool-checkout",
+        "idem-extend-2pool-checkout",
+        "extend_stay",
+    );
+    let error = stay_lifecycle::extend_stay_idempotent(&pool_a, &ctx, "B-2POOL-EXTEND")
+        .await
+        .expect_err("extend stay should reject booking checked out by second pool");
+
+    assert_eq!(error.code, crate::app_error::codes::BOOKING_INVALID_STATE);
+
+    let charge_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND note = ?")
+            .bind("B-2POOL-EXTEND")
+            .bind("Extended stay +1 night")
+            .fetch_one(&pool_a)
+            .await
+            .unwrap();
+    assert_eq!(charge_count, 0);
+
+    pool_a.close().await;
+    pool_b.close().await;
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -7287,4 +7497,59 @@ async fn insert_folio_line_with_origin_writes_origin_key_and_ordinal() {
         "idem-folio-1"
     );
     assert_eq!(row.get::<i64, _>("origin_line_ordinal"), 0);
+}
+
+#[tokio::test]
+async fn duplicate_folio_origin_is_blocked_by_unique_origin_ordinal() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-FOLIO-ORIGIN-DUP").await.unwrap();
+    seed_active_booking(&pool, "B-FOLIO-ORIGIN-DUP", "R-FOLIO-ORIGIN-DUP")
+        .await
+        .unwrap();
+    let origin = OriginSideEffect::new("origin-duplicate-folio", 0).unwrap();
+
+    let mut first_tx = crate::services::booking::support::begin_tx(&pool)
+        .await
+        .unwrap();
+    crate::repositories::booking::folio_repository::insert_folio_line_with_origin_tx(
+        &mut first_tx,
+        "B-FOLIO-ORIGIN-DUP",
+        "laundry",
+        "Duplicate origin folio",
+        25_000,
+        Some("staff-1"),
+        "2026-04-27T08:00:00+07:00",
+        &origin,
+    )
+    .await
+    .unwrap();
+    first_tx.commit().await.unwrap();
+
+    let mut second_tx = crate::services::booking::support::begin_tx(&pool)
+        .await
+        .unwrap();
+    let duplicate =
+        crate::repositories::booking::folio_repository::insert_folio_line_with_origin_tx(
+            &mut second_tx,
+            "B-FOLIO-ORIGIN-DUP",
+            "laundry",
+            "Duplicate origin folio",
+            25_000,
+            Some("staff-1"),
+            "2026-04-27T08:00:00+07:00",
+            &origin,
+        )
+        .await;
+    assert!(duplicate.is_err(), "duplicate folio origin must fail");
+    second_tx.rollback().await.unwrap();
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM folio_lines
+         WHERE origin_idempotency_key = ? AND origin_line_ordinal = 0",
+    )
+    .bind("origin-duplicate-folio")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1);
 }


### PR DESCRIPTION
## Summary
- Add MCP autonomy policy levels and keep high-risk write tools in supervised/disabled envelopes only.
- Add verification-gate coverage for command idempotency, two-pool booking races, group lock ordering, and origin idempotency side effects.
- Fix extend-stay stale checkout handling so concurrent checkout is reported as invalid state before mutation.

## Verification
- cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path mhm/src-tauri/Cargo.toml
- cargo test --manifest-path mhm/src-tauri/Cargo.toml

Refs #74, #75