### PR TITLE
[codex] Add durable outbox persistence foundation

### DIFF
--- a/mhm/src-tauri/src/command_idempotency.rs
+++ b/mhm/src-tauri/src/command_idempotency.rs
@@ -1,5 +1,6 @@
 use crate::{
     app_error::{codes, CommandError, CommandResult},
+    outbox::{insert_outbox_event_tx, OutboxEventSpec},
     services::settings_store,
 };
 use chrono::{DateTime, FixedOffset, Utc};
@@ -372,6 +373,7 @@ pub struct WriteCommandRequest {
     success_summary: CommandLedgerResultSummary,
     primary_aggregate_key: Option<String>,
     lock_key_deriver: LockKeyDeriver,
+    outbox_event: Option<OutboxEventSpec>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -424,6 +426,7 @@ impl WriteCommandRequest {
             success_summary: CommandLedgerResultSummary::success("Command completed")?,
             primary_aggregate_key: None,
             lock_key_deriver: default_lock_key_deriver,
+            outbox_event: None,
         })
     }
 
@@ -448,6 +451,11 @@ impl WriteCommandRequest {
 
     pub fn with_success_summary(mut self, success_summary: CommandLedgerResultSummary) -> Self {
         self.success_summary = success_summary;
+        self
+    }
+
+    pub fn with_outbox_event(mut self, outbox_event: OutboxEventSpec) -> Self {
+        self.outbox_event = Some(outbox_event);
         self
     }
 }
@@ -488,6 +496,7 @@ struct PreparedWriteCommandRequest {
     result_summary_json: String,
     lock_keys_json: String,
     primary_aggregate_key: Option<String>,
+    outbox_event: Option<OutboxEventSpec>,
 }
 
 impl WriteCommandExecutor {
@@ -842,6 +851,26 @@ impl WriteCommandExecutor {
         };
 
         let response_json = stable_json_string(&response)?;
+
+        if let Some(outbox_event) = &prepared.outbox_event {
+            let prepared_event = match outbox_event.prepare(
+                ctx,
+                prepared.primary_aggregate_key.as_deref(),
+                &prepared.request_hash,
+                &response,
+            ) {
+                Ok(event) => event,
+                Err(error) => {
+                    let _ = tx.rollback().await;
+                    return Err(error.with_request_id(ctx.request_id.clone()));
+                }
+            };
+            if let Err(error) = insert_outbox_event_tx(&mut tx, &prepared_event).await {
+                let _ = tx.rollback().await;
+                return Err(error.with_request_id(ctx.request_id.clone()));
+            }
+        }
+
         let completed_at = chrono::Utc::now().to_rfc3339();
         let completion_result = sqlx::query(
             "UPDATE command_idempotency
@@ -1030,6 +1059,30 @@ impl WriteCommandExecutor {
         };
 
         let response_json = stable_json_string(&response)?;
+
+        if let Some(outbox_event) = &prepared.outbox_event {
+            let prepared_event = match outbox_event.prepare(
+                ctx,
+                prepared.primary_aggregate_key.as_deref(),
+                &prepared.request_hash,
+                &response,
+            ) {
+                Ok(event) => event,
+                Err(mut error) => {
+                    let _ = tx.rollback().await;
+                    error.request_id = Some(ctx.request_id.clone());
+                    self.finalize_failure(ctx, claim_token, &error).await?;
+                    return Err(error);
+                }
+            };
+            if let Err(mut error) = insert_outbox_event_tx(&mut tx, &prepared_event).await {
+                let _ = tx.rollback().await;
+                error.request_id = Some(ctx.request_id.clone());
+                self.finalize_failure(ctx, claim_token, &error).await?;
+                return Err(error);
+            }
+        }
+
         let completed_at = chrono::Utc::now().to_rfc3339();
         let completion_result = sqlx::query(
             "UPDATE command_idempotency
@@ -1309,6 +1362,7 @@ fn prepare_write_command_request(
         result_summary_json,
         lock_keys_json,
         primary_aggregate_key: request.primary_aggregate_key,
+        outbox_event: request.outbox_event,
     })
 }
 
@@ -1515,6 +1569,192 @@ mod tests {
 
     async fn test_pool() -> Pool<Sqlite> {
         test_pool_with_max_connections(5).await
+    }
+
+    async fn outbox_count(pool: &Pool<Sqlite>, command_name: &str, idempotency_key: &str) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*)
+             FROM outbox_events
+             WHERE origin_command_name = ? AND origin_idempotency_key = ?",
+        )
+        .bind(command_name)
+        .bind(idempotency_key)
+        .fetch_one(pool)
+        .await
+        .expect("counts outbox rows")
+    }
+
+    fn test_outbox_spec() -> crate::outbox::OutboxEventSpec {
+        crate::outbox::OutboxEventSpec::new(
+            "booking.checked_out",
+            crate::outbox::OutboxAggregateKeySource::response_field("booking", "booking_id"),
+            &["bookings", "rooms", "folio"],
+        )
+        .expect("outbox spec builds")
+    }
+
+    #[tokio::test]
+    async fn outbox_execute_atomic_success_persists_one_pending_event() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "req-outbox-atomic-success",
+            "idem-outbox-atomic-success",
+            "test.outbox_atomic_success",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "outbox-atomic-success" }),
+            "Outbox atomic success",
+        )
+        .expect("request builds")
+        .with_outbox_event(test_outbox_spec());
+
+        let result = WriteCommandExecutor::new(pool.clone())
+            .execute_atomic(&ctx, request, |_tx| {
+                Box::pin(async move { Ok(serde_json::json!({ "booking_id": "B1", "ok": true })) })
+            })
+            .await
+            .expect("command succeeds");
+
+        assert!(!result.replayed);
+        assert_eq!(
+            outbox_count(&pool, &ctx.command_name, &ctx.idempotency_key).await,
+            1
+        );
+
+        let status: String = sqlx::query_scalar(
+            "SELECT status
+             FROM outbox_events
+             WHERE origin_command_name = ? AND origin_idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads outbox status");
+        assert_eq!(status, "pending");
+    }
+
+    #[tokio::test]
+    async fn outbox_execute_atomic_replay_does_not_duplicate_or_rerun_service() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "req-outbox-atomic-replay",
+            "idem-outbox-atomic-replay",
+            "test.outbox_atomic_replay",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "outbox-atomic-replay" }),
+            "Outbox atomic replay",
+        )
+        .expect("request builds")
+        .with_outbox_event(test_outbox_spec());
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let first_attempts = attempts.clone();
+        let first = WriteCommandExecutor::new(pool.clone())
+            .execute_atomic(&ctx, request.clone(), move |_tx| {
+                let attempts = first_attempts.clone();
+                Box::pin(async move {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(serde_json::json!({ "booking_id": "B2", "ok": true }))
+                })
+            })
+            .await
+            .expect("first command succeeds");
+
+        let second_attempts = attempts.clone();
+        let second = WriteCommandExecutor::new(pool.clone())
+            .execute_atomic(&ctx, request, move |_tx| {
+                let attempts = second_attempts.clone();
+                Box::pin(async move {
+                    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(serde_json::json!({ "unexpected": true }))
+                })
+            })
+            .await
+            .expect("second command replays");
+
+        assert!(!first.replayed);
+        assert!(second.replayed);
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            outbox_count(&pool, &ctx.command_name, &ctx.idempotency_key).await,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn outbox_execute_success_persists_one_pending_event() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "req-outbox-execute-success",
+            "idem-outbox-execute-success",
+            "test.outbox_execute_success",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "outbox-execute-success" }),
+            "Outbox execute success",
+        )
+        .expect("request builds")
+        .with_outbox_event(test_outbox_spec());
+
+        let result = WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request, |_tx| {
+                Box::pin(async move { Ok(serde_json::json!({ "booking_id": "B3", "ok": true })) })
+            })
+            .await
+            .expect("command succeeds");
+
+        assert!(!result.replayed);
+        assert_eq!(
+            outbox_count(&pool, &ctx.command_name, &ctx.idempotency_key).await,
+            1
+        );
+
+        let status: String = sqlx::query_scalar(
+            "SELECT status
+             FROM outbox_events
+             WHERE origin_command_name = ? AND origin_idempotency_key = ?",
+        )
+        .bind(&ctx.command_name)
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool)
+        .await
+        .expect("reads outbox status");
+        assert_eq!(status, "pending");
+    }
+
+    #[tokio::test]
+    async fn outbox_service_failure_writes_no_event() {
+        let pool = test_pool().await;
+        let ctx = WriteCommandContext::for_internal_test(
+            "req-outbox-service-fail",
+            "idem-outbox-service-fail",
+            "test.outbox_service_fail",
+        );
+        let request = WriteCommandRequest::new_low_risk(
+            serde_json::json!({ "case": "outbox-service-fail" }),
+            "Outbox service fail",
+        )
+        .expect("request builds")
+        .with_outbox_event(test_outbox_spec());
+
+        WriteCommandExecutor::new(pool.clone())
+            .execute(&ctx, request, |_tx| {
+                Box::pin(async move {
+                    Err(CommandError::system(
+                        codes::SYSTEM_INTERNAL_ERROR,
+                        "forced service failure",
+                    ))
+                })
+            })
+            .await
+            .expect_err("service failure returns error");
+
+        assert_eq!(
+            outbox_count(&pool, &ctx.command_name, &ctx.idempotency_key).await,
+            0
+        );
     }
 
     #[test]
@@ -3002,7 +3242,8 @@ mod tests {
             serde_json::json!({ "case": "stale" }),
             "Stale claim",
         )
-        .expect("request builds");
+        .expect("request builds")
+        .with_outbox_event(test_outbox_spec());
         let command_name = ctx.command_name.clone();
         let idempotency_key = ctx.idempotency_key.clone();
 
@@ -3024,7 +3265,7 @@ mod tests {
                     .await
                     .map_err(system_error)?;
 
-                    Ok(serde_json::json!({ "ok": true }))
+                    Ok(serde_json::json!({ "booking_id": "B-stale", "ok": true }))
                 })
             })
             .await
@@ -3053,5 +3294,9 @@ mod tests {
 
         assert_eq!(row.get::<String, _>("status"), "in_progress");
         assert_eq!(row.get::<Option<String>, _>("response_json"), None);
+        assert_eq!(
+            outbox_count(&pool, &ctx.command_name, &ctx.idempotency_key).await,
+            0
+        );
     }
 }

--- a/mhm/src-tauri/src/commands/invoices.rs
+++ b/mhm/src-tauri/src/commands/invoices.rs
@@ -138,6 +138,23 @@ mod tests {
         pool
     }
 
+    async fn invoice_outbox_event_count(
+        pool: &Pool<Sqlite>,
+        command_name: &str,
+        idempotency_key: &str,
+    ) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*)
+             FROM outbox_events
+             WHERE origin_command_name = ? AND origin_idempotency_key = ?",
+        )
+        .bind(command_name)
+        .bind(idempotency_key)
+        .fetch_one(pool)
+        .await
+        .expect("counts invoice outbox events")
+    }
+
     async fn seed_invoice_booking(pool: &Pool<Sqlite>, booking_id: &str) {
         let room_id = format!("room-{booking_id}");
         let guest_id = format!("guest-{booking_id}");
@@ -245,6 +262,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 1);
+        assert_eq!(
+            invoice_outbox_event_count(&pool, &ctx.command_name, &ctx.idempotency_key).await,
+            1
+        );
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -923,6 +923,61 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         set_schema_version(&mut tx, 15).await?;
         tx.commit().await?;
     }
+
+    // ── V16: Durable outbox events ──
+    if current < 16 {
+        let mut tx = pool.begin().await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS outbox_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                aggregate_key TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                origin_request_id TEXT NOT NULL,
+                origin_idempotency_key TEXT NOT NULL,
+                origin_command_name TEXT NOT NULL,
+                origin_request_hash TEXT NOT NULL,
+                status TEXT NOT NULL,
+                worker_token TEXT,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at TEXT,
+                processing_started_at TEXT,
+                processing_expires_at TEXT,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                dispatched_at TEXT
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS outbox_events_pending_idx
+             ON outbox_events(next_attempt_at, aggregate_key, id)
+             WHERE status = 'pending'",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS outbox_events_processing_idx
+             ON outbox_events(processing_expires_at)
+             WHERE status = 'processing'",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS outbox_events_origin_command_uq
+             ON outbox_events(origin_command_name, origin_idempotency_key)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        set_schema_version(&mut tx, 16).await?;
+        tx.commit().await?;
+    }
     Ok(())
 }
 
@@ -1068,6 +1123,73 @@ mod tests {
         .expect("checks sqlite index")
     }
 
+    async fn sqlite_table_count(pool: &SqlitePool, name: &str) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*)
+             FROM sqlite_master
+             WHERE type = 'table' AND name = ?",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .expect("checks sqlite table")
+    }
+
+    async fn outbox_column_count(pool: &SqlitePool, name: &str) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*)
+             FROM pragma_table_info('outbox_events')
+             WHERE name = ?",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .expect("checks outbox_events column")
+    }
+
+    async fn assert_outbox_v16_shape(pool: &SqlitePool) {
+        assert_eq!(sqlite_table_count(pool, "outbox_events").await, 1);
+
+        for column in [
+            "id",
+            "event_type",
+            "aggregate_key",
+            "payload_json",
+            "origin_request_id",
+            "origin_idempotency_key",
+            "origin_command_name",
+            "origin_request_hash",
+            "status",
+            "worker_token",
+            "attempts",
+            "next_attempt_at",
+            "processing_started_at",
+            "processing_expires_at",
+            "last_error",
+            "created_at",
+            "dispatched_at",
+        ] {
+            assert_eq!(
+                outbox_column_count(pool, column).await,
+                1,
+                "missing outbox_events column {column}"
+            );
+        }
+
+        assert_eq!(
+            sqlite_index_count(pool, "outbox_events_pending_idx").await,
+            1
+        );
+        assert_eq!(
+            sqlite_index_count(pool, "outbox_events_processing_idx").await,
+            1
+        );
+        assert_eq!(
+            sqlite_index_count(pool, "outbox_events_origin_command_uq").await,
+            1
+        );
+    }
+
     async fn column_type(pool: &SqlitePool, table: &str, column: &str) -> String {
         let sql = format!(
             "SELECT type FROM pragma_table_info('{}') WHERE name = ?",
@@ -1195,7 +1317,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 15);
+        assert_eq!(version, 16);
     }
 
     #[tokio::test]
@@ -1211,7 +1333,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 15);
+        assert_eq!(version, 16);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1499,7 +1621,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 15);
+        assert_eq!(version, 16);
     }
 
     #[tokio::test]
@@ -1566,7 +1688,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 15);
+        assert_eq!(version, 16);
     }
 
     #[tokio::test]
@@ -1646,7 +1768,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 15);
+        assert_eq!(version, 16);
     }
 
     #[tokio::test]
@@ -1674,6 +1796,85 @@ mod tests {
             sqlite_index_count(&pool, "command_idempotency_recovery_queue_idx").await,
             1
         );
+    }
+
+    #[tokio::test]
+    async fn migration_v16_adds_outbox_events_schema() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+
+        run_migrations(&pool).await.expect("runs migrations");
+
+        assert_outbox_v16_shape(&pool).await;
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 16);
+    }
+
+    #[tokio::test]
+    async fn migration_v16_upgrades_existing_v15_database() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("initial migrations run");
+        sqlx::query("UPDATE schema_version SET version = 15")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version");
+
+        run_migrations(&pool).await.expect("v16 migration reruns");
+
+        assert_outbox_v16_shape(&pool).await;
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 16);
+    }
+
+    #[tokio::test]
+    async fn migration_v16_pending_outbox_defaults_are_insertable() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("runs migrations");
+
+        sqlx::query(
+            "INSERT INTO outbox_events (
+                event_type, aggregate_key, payload_json,
+                origin_request_id, origin_idempotency_key,
+                origin_command_name, origin_request_hash,
+                status, created_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("booking.checked_out")
+        .bind("booking:B1")
+        .bind(r#"{"schema_version":1}"#)
+        .bind("req-1")
+        .bind("idem-1")
+        .bind("check_out")
+        .bind("hash-1")
+        .bind("pending")
+        .bind("2026-05-03T09:00:00+07:00")
+        .execute(&pool)
+        .await
+        .expect("inserts pending outbox row");
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, next_attempt_at,
+                    processing_started_at, processing_expires_at,
+                    last_error, dispatched_at
+             FROM outbox_events WHERE origin_command_name = 'check_out'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("reads outbox row");
+
+        assert_eq!(row.get::<String, _>("status"), "pending");
+        assert_eq!(row.get::<i64, _>("attempts"), 0);
+        assert_eq!(row.get::<Option<String>, _>("worker_token"), None);
+        assert_eq!(row.get::<Option<String>, _>("next_attempt_at"), None);
+        assert_eq!(row.get::<Option<String>, _>("processing_started_at"), None);
+        assert_eq!(row.get::<Option<String>, _>("processing_expires_at"), None);
+        assert_eq!(row.get::<Option<String>, _>("last_error"), None);
+        assert_eq!(row.get::<Option<String>, _>("dispatched_at"), None);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod models;
 pub mod money;
 mod money_migration;
 mod ocr;
+pub mod outbox;
 mod pricing;
 mod queries;
 mod repositories;

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -1,0 +1,433 @@
+use crate::{
+    app_error::{codes, CommandError, CommandResult},
+    command_idempotency::{system_error, WriteCommandContext},
+};
+use chrono::Utc;
+use serde_json::{json, Value};
+use sqlx::{Sqlite, Transaction};
+
+const OUTBOX_STATUS_PENDING: &str = "pending";
+const OUTBOX_SAFE_TEXT_MAX_CHARS: usize = 160;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboxAggregateKeySource {
+    PrimaryAggregateKey,
+    ResponseField {
+        aggregate_type: &'static str,
+        field: &'static str,
+    },
+}
+
+impl OutboxAggregateKeySource {
+    pub const fn primary() -> Self {
+        Self::PrimaryAggregateKey
+    }
+
+    pub const fn response_field(aggregate_type: &'static str, field: &'static str) -> Self {
+        Self::ResponseField {
+            aggregate_type,
+            field,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboxEventSpec {
+    event_type: &'static str,
+    aggregate_key_source: OutboxAggregateKeySource,
+    refresh: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedOutboxEvent {
+    pub event_type: String,
+    pub aggregate_key: String,
+    pub payload_json: String,
+    pub origin_request_id: String,
+    pub origin_idempotency_key: String,
+    pub origin_command_name: String,
+    pub origin_request_hash: String,
+    pub created_at: String,
+}
+
+pub async fn insert_outbox_event_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    event: &PreparedOutboxEvent,
+) -> CommandResult<()> {
+    validate_prepared_event(event)?;
+
+    sqlx::query(
+        "INSERT INTO outbox_events (
+            event_type,
+            aggregate_key,
+            payload_json,
+            origin_request_id,
+            origin_idempotency_key,
+            origin_command_name,
+            origin_request_hash,
+            status,
+            attempts,
+            created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&event.event_type)
+    .bind(&event.aggregate_key)
+    .bind(&event.payload_json)
+    .bind(&event.origin_request_id)
+    .bind(&event.origin_idempotency_key)
+    .bind(&event.origin_command_name)
+    .bind(&event.origin_request_hash)
+    .bind(OUTBOX_STATUS_PENDING)
+    .bind(0_i64)
+    .bind(&event.created_at)
+    .execute(&mut **tx)
+    .await
+    .map_err(system_error)?;
+
+    Ok(())
+}
+
+impl OutboxEventSpec {
+    pub fn new(
+        event_type: &'static str,
+        aggregate_key_source: OutboxAggregateKeySource,
+        refresh: &'static [&'static str],
+    ) -> CommandResult<Self> {
+        validate_safe_outbox_text(event_type)?;
+        validate_aggregate_key_source(&aggregate_key_source)?;
+        if refresh.is_empty() {
+            return Err(system_error("outbox refresh areas are required"));
+        }
+        for area in refresh {
+            validate_safe_outbox_text(area)?;
+        }
+        Ok(Self {
+            event_type,
+            aggregate_key_source,
+            refresh: refresh.to_vec(),
+        })
+    }
+
+    pub fn prepare(
+        &self,
+        ctx: &WriteCommandContext,
+        primary_aggregate_key: Option<&str>,
+        origin_request_hash: &str,
+        response: &Value,
+    ) -> CommandResult<PreparedOutboxEvent> {
+        let (aggregate_type, aggregate_id, aggregate_key) =
+            resolve_aggregate(&self.aggregate_key_source, primary_aggregate_key, response)?;
+
+        validate_safe_outbox_text(&ctx.command_name)?;
+        validate_safe_outbox_text(origin_request_hash)?;
+
+        let payload = json!({
+            "schema_version": 1,
+            "command_name": ctx.command_name,
+            "aggregate": {
+                "type": aggregate_type,
+                "id": aggregate_id,
+            },
+            "refresh": self.refresh,
+        });
+        let payload_json = canonical_json_string(&payload)?;
+
+        Ok(PreparedOutboxEvent {
+            event_type: self.event_type.to_string(),
+            aggregate_key,
+            payload_json,
+            origin_request_id: validate_non_empty(ctx.request_id.clone(), "origin_request_id")?,
+            origin_idempotency_key: validate_non_empty(
+                ctx.idempotency_key.clone(),
+                "origin_idempotency_key",
+            )?,
+            origin_command_name: ctx.command_name.clone(),
+            origin_request_hash: origin_request_hash.to_string(),
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+}
+
+fn resolve_aggregate(
+    source: &OutboxAggregateKeySource,
+    primary_aggregate_key: Option<&str>,
+    response: &Value,
+) -> CommandResult<(String, String, String)> {
+    match source {
+        OutboxAggregateKeySource::PrimaryAggregateKey => {
+            let aggregate_key = primary_aggregate_key
+                .ok_or_else(|| system_error("outbox event missing primary aggregate key"))?;
+            let (aggregate_type, aggregate_id) = aggregate_key
+                .split_once(':')
+                .ok_or_else(|| system_error("outbox primary aggregate key must be type:id"))?;
+            validate_safe_outbox_text(aggregate_type)?;
+            validate_safe_outbox_text(aggregate_id)?;
+            validate_safe_outbox_text(aggregate_key)?;
+            Ok((
+                aggregate_type.to_string(),
+                aggregate_id.to_string(),
+                aggregate_key.to_string(),
+            ))
+        }
+        OutboxAggregateKeySource::ResponseField {
+            aggregate_type,
+            field,
+        } => {
+            let aggregate_id = response
+                .get(*field)
+                .and_then(Value::as_str)
+                .ok_or_else(|| system_error(format!("outbox response missing field {field}")))?;
+            validate_safe_outbox_text(aggregate_type)?;
+            validate_safe_outbox_text(aggregate_id)?;
+            Ok((
+                aggregate_type.to_string(),
+                aggregate_id.to_string(),
+                format!("{aggregate_type}:{aggregate_id}"),
+            ))
+        }
+    }
+}
+
+fn validate_aggregate_key_source(source: &OutboxAggregateKeySource) -> CommandResult<()> {
+    match source {
+        OutboxAggregateKeySource::PrimaryAggregateKey => Ok(()),
+        OutboxAggregateKeySource::ResponseField {
+            aggregate_type,
+            field,
+        } => {
+            validate_safe_outbox_text(aggregate_type)?;
+            validate_safe_outbox_text(field)
+        }
+    }
+}
+
+fn validate_prepared_event(event: &PreparedOutboxEvent) -> CommandResult<()> {
+    validate_safe_outbox_text(&event.event_type)?;
+    validate_safe_outbox_text(&event.aggregate_key)?;
+    validate_non_empty(event.origin_request_id.clone(), "origin_request_id")?;
+    validate_non_empty(
+        event.origin_idempotency_key.clone(),
+        "origin_idempotency_key",
+    )?;
+    validate_safe_outbox_text(&event.origin_command_name)?;
+    validate_safe_outbox_text(&event.origin_request_hash)?;
+    validate_non_empty(event.created_at.clone(), "created_at")?;
+    serde_json::from_str::<Value>(&event.payload_json)
+        .map_err(|error| CommandError::system(codes::SYSTEM_INTERNAL_ERROR, error.to_string()))?;
+    Ok(())
+}
+
+fn validate_non_empty(value: String, field: &str) -> CommandResult<String> {
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(system_error(format!("{field} is required")));
+    }
+    Ok(trimmed)
+}
+
+fn validate_safe_outbox_text(value: &str) -> CommandResult<()> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > OUTBOX_SAFE_TEXT_MAX_CHARS
+        || trimmed.contains('@')
+        || contains_forbidden_payload_term(trimmed)
+    {
+        return Err(system_error("unsafe outbox text"));
+    }
+    Ok(())
+}
+
+fn contains_forbidden_payload_term(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    [
+        "phone", "email", "card", "token", "secret", "password", "passport", "cccd", "prompt",
+        "raw",
+    ]
+    .iter()
+    .any(|term| lower.contains(term))
+}
+
+fn canonicalize_json_value(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries = map.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            let mut canonical = serde_json::Map::new();
+            for (key, value) in entries {
+                canonical.insert(key, canonicalize_json_value(value));
+            }
+            Value::Object(canonical)
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(canonicalize_json_value)
+                .collect::<Vec<_>>(),
+        ),
+        primitive => primitive,
+    }
+}
+
+fn canonical_json_string(value: &Value) -> CommandResult<String> {
+    serde_json::to_string(&canonicalize_json_value(value.clone())).map_err(system_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_idempotency::WriteCommandContext;
+    use chrono::DateTime;
+    use serde_json::json;
+    use sqlx::{sqlite::SqlitePoolOptions, Row};
+
+    fn test_ctx(command_name: &str) -> WriteCommandContext {
+        let issued_at = DateTime::parse_from_rfc3339("2026-05-03T09:00:00+07:00")
+            .expect("fixed test timestamp parses");
+        WriteCommandContext {
+            request_id: "req-outbox".to_string(),
+            idempotency_key: "idem-outbox".to_string(),
+            command_name: command_name.to_string(),
+            actor_id: Some("operator-1".to_string()),
+            actor_type: crate::command_idempotency::ActorType::Human,
+            client_id: None,
+            session_id: None,
+            channel_id: None,
+            issued_at,
+        }
+    }
+
+    #[test]
+    fn outbox_spec_builds_canonical_minimal_payload() {
+        let spec = OutboxEventSpec::new(
+            "booking.checked_out",
+            OutboxAggregateKeySource::response_field("booking", "booking_id"),
+            &["bookings", "rooms", "folio"],
+        )
+        .expect("spec builds");
+        let ctx = test_ctx("check_out");
+        let prepared = spec
+            .prepare(
+                &ctx,
+                Some("booking:B1"),
+                "hash-1",
+                &json!({ "booking_id": "B1", "room_id": "R1", "ok": true }),
+            )
+            .expect("event prepares");
+
+        assert_eq!(prepared.event_type, "booking.checked_out");
+        assert_eq!(prepared.aggregate_key, "booking:B1");
+        assert_eq!(prepared.origin_request_id, "req-outbox");
+        assert_eq!(prepared.origin_idempotency_key, "idem-outbox");
+        assert_eq!(prepared.origin_command_name, "check_out");
+        assert_eq!(prepared.origin_request_hash, "hash-1");
+        assert_eq!(
+            prepared.payload_json,
+            r#"{"aggregate":{"id":"B1","type":"booking"},"command_name":"check_out","refresh":["bookings","rooms","folio"],"schema_version":1}"#
+        );
+    }
+
+    #[test]
+    fn outbox_spec_rejects_sensitive_refresh_area() {
+        let error = OutboxEventSpec::new(
+            "folio.payment_recorded",
+            OutboxAggregateKeySource::response_field("folio", "booking_id"),
+            &["folio", "payment_token"],
+        )
+        .expect_err("sensitive refresh area rejected");
+
+        assert!(error.message.contains("unsafe outbox text"));
+    }
+
+    #[test]
+    fn outbox_spec_allows_payment_event_name() {
+        OutboxEventSpec::new(
+            "folio.payment_recorded",
+            OutboxAggregateKeySource::response_field("folio", "booking_id"),
+            &["folio", "bookings"],
+        )
+        .expect("payment event name is business-safe");
+    }
+
+    #[tokio::test]
+    async fn insert_outbox_event_tx_persists_pending_event_contract() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite connects");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("migrations run");
+
+        let spec = OutboxEventSpec::new(
+            "booking.checked_out",
+            OutboxAggregateKeySource::response_field("booking", "booking_id"),
+            &["bookings", "rooms", "folio"],
+        )
+        .expect("spec builds");
+        let ctx = test_ctx("check_out");
+        let prepared = spec
+            .prepare(
+                &ctx,
+                Some("booking:B1"),
+                "hash-1",
+                &json!({ "booking_id": "B1", "room_id": "R1", "ok": true }),
+            )
+            .expect("event prepares");
+
+        let mut tx = pool.begin().await.expect("transaction begins");
+        insert_outbox_event_tx(&mut tx, &prepared)
+            .await
+            .expect("outbox event inserts");
+        tx.commit().await.expect("transaction commits");
+
+        let row = sqlx::query(
+            "SELECT
+                event_type,
+                aggregate_key,
+                payload_json,
+                origin_request_id,
+                origin_idempotency_key,
+                origin_command_name,
+                origin_request_hash,
+                status,
+                attempts,
+                worker_token,
+                next_attempt_at,
+                processing_started_at,
+                processing_expires_at,
+                last_error,
+                dispatched_at
+             FROM outbox_events",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("outbox row exists");
+
+        assert_eq!(row.get::<String, _>("event_type"), "booking.checked_out");
+        assert_eq!(row.get::<String, _>("aggregate_key"), "booking:B1");
+        assert_eq!(
+            row.get::<String, _>("payload_json"),
+            r#"{"aggregate":{"id":"B1","type":"booking"},"command_name":"check_out","refresh":["bookings","rooms","folio"],"schema_version":1}"#
+        );
+        assert_eq!(row.get::<String, _>("origin_request_id"), "req-outbox");
+        assert_eq!(
+            row.get::<String, _>("origin_idempotency_key"),
+            "idem-outbox"
+        );
+        assert_eq!(row.get::<String, _>("origin_command_name"), "check_out");
+        assert_eq!(row.get::<String, _>("origin_request_hash"), "hash-1");
+        assert_eq!(row.get::<String, _>("status"), "pending");
+        assert_eq!(row.get::<i64, _>("attempts"), 0);
+        assert!(row.get::<Option<String>, _>("worker_token").is_none());
+        assert!(row.get::<Option<String>, _>("next_attempt_at").is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_started_at")
+            .is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_expires_at")
+            .is_none());
+        assert!(row.get::<Option<String>, _>("last_error").is_none());
+        assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
+    }
+}

--- a/mhm/src-tauri/src/services/booking/billing_service.rs
+++ b/mhm/src-tauri/src/services/booking/billing_service.rs
@@ -11,6 +11,7 @@ use crate::{
     db_error_monitoring::classify_db_error_code,
     domain::booking::{BookingError, BookingResult, OriginSideEffect},
     money::{validate_transport_money_vnd, MoneyVnd},
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 use serde_json::json;
 
@@ -141,7 +142,12 @@ pub async fn add_folio_line_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("booking:{booking_id}"))
         .with_lock_key_deriver(add_folio_line_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Folio line added")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Folio line added")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "folio.line_added",
+            OutboxAggregateKeySource::response_field("folio", "booking_id"),
+            &["folio", "bookings"],
+        )?);
 
     let booking_id = booking_id.to_string();
     let category = category.to_string();
@@ -245,7 +251,12 @@ pub async fn record_payment_idempotent(
                 crate::aggregate_locks::folio_key(booking_id)?,
             ])
         })
-        .with_success_summary(CommandLedgerResultSummary::success("Credit recorded")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Credit recorded")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "folio.payment_recorded",
+            OutboxAggregateKeySource::response_field("folio", "booking_id"),
+            &["folio", "bookings"],
+        )?);
 
     let booking_id_for_guard = booking_id.to_string();
     let booking_id_for_service = booking_id.to_string();

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -17,6 +17,7 @@ use crate::{
         status, BookingGroup, GroupCheckinRequest, GroupCheckoutRequest, GroupCheckoutResponse,
     },
     money::MoneyVnd,
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 
 use super::{
@@ -297,7 +298,12 @@ pub async fn group_checkin_idempotent(
     let runtime_lock_keys = group_checkin_lock_keys_from_payload(&hash_payload)?;
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_lock_key_deriver(group_checkin_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Group checked in")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Group checked in")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "group.checked_in",
+            OutboxAggregateKeySource::response_field("group", "id"),
+            &["groups", "bookings", "rooms", "folio"],
+        )?);
 
     let req_for_service = req;
     let user_id_for_service = user_id;
@@ -811,7 +817,12 @@ pub async fn group_checkout_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("group:{}", req.group_id))
         .with_lock_key_deriver(group_checkout_initial_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Group checked out")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Group checked out")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "group.checked_out",
+            OutboxAggregateKeySource::response_field("group", "group_id"),
+            &["groups", "bookings", "rooms", "folio"],
+        )?);
 
     let pool_for_locks = pool.clone();
     let req_for_locks = GroupCheckoutRequest {

--- a/mhm/src-tauri/src/services/booking/group_service_management.rs
+++ b/mhm/src-tauri/src/services/booking/group_service_management.rs
@@ -10,6 +10,7 @@ use crate::{
     domain::booking::BookingError,
     models::{AddGroupServiceRequest, GroupService, RemoveGroupServiceResponse},
     money::{validate_non_negative_money_vnd, MoneyVnd},
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 use serde_json::json;
 
@@ -171,7 +172,12 @@ pub async fn add_group_service_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload.clone(), ledger_intent, summary)?
         .with_primary_aggregate_key(format!("group:{}", req.group_id))
         .with_lock_key_deriver(add_group_service_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Group service added")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Group service added")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "group.service_added",
+            OutboxAggregateKeySource::response_field("group", "group_id"),
+            &["groups", "folio"],
+        )?);
     let runtime_lock_keys = add_group_service_lock_keys_from_payload(&hash_payload)?;
     let actor_id = actor_id.to_string();
 
@@ -320,6 +326,11 @@ pub async fn remove_group_service_idempotent(
         })
         .with_success_summary(CommandLedgerResultSummary::success(
             "Group service removed",
+        )?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "group.service_removed",
+            OutboxAggregateKeySource::response_field("group", "group_id"),
+            &["groups", "folio"],
         )?);
     let pool_for_locks = pool.clone();
     let service_id = service_id.to_string();

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     commands::{get_money_vnd, get_optional_money_vnd},
     models::InvoiceData,
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite, Transaction};
@@ -306,7 +307,12 @@ pub async fn generate_invoice_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("booking:{booking_id}"))
         .with_lock_key_deriver(generate_invoice_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Invoice generated")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Invoice generated")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "invoice.generated",
+            OutboxAggregateKeySource::response_field("invoice", "id"),
+            &["invoice", "bookings", "folio"],
+        )?);
     let booking_id = booking_id.to_string();
 
     WriteCommandExecutor::new(pool.clone())

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     models::{status, Booking, CreateReservationRequest, ModifyReservationRequest},
     money::{validate_non_negative_money_vnd, MoneyVnd},
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 
 use super::{
@@ -431,7 +432,12 @@ pub async fn create_reservation_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("room:{room_id}"))
         .with_lock_key_deriver(create_room_lock_keys)
-        .with_success_summary(CommandLedgerResultSummary::success("Reservation created")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Reservation created")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.reservation_created",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms"],
+        )?);
 
     let request_for_service = req;
     let origin_idempotency_key = command_origin_key(ctx);
@@ -838,6 +844,11 @@ pub async fn cancel_reservation_idempotent(
         .with_lock_key_deriver(reservation_booking_lock_keys)
         .with_success_summary(CommandLedgerResultSummary::success(
             "Reservation cancelled",
+        )?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.reservation_cancelled",
+            OutboxAggregateKeySource::response_field("booking", "booking_id"),
+            &["bookings", "rooms", "folio"],
         )?);
 
     let pool_for_guard = pool.clone();
@@ -892,6 +903,11 @@ pub async fn confirm_reservation_idempotent(
         .with_lock_key_deriver(reservation_booking_lock_keys)
         .with_success_summary(CommandLedgerResultSummary::success(
             "Reservation confirmed",
+        )?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.reservation_confirmed",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms", "folio"],
         )?);
 
     let pool_for_guard = pool.clone();
@@ -946,7 +962,12 @@ pub async fn modify_reservation_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("booking:{}", req.booking_id))
         .with_lock_key_deriver(reservation_booking_lock_keys)
-        .with_success_summary(CommandLedgerResultSummary::success("Reservation modified")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Reservation modified")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.reservation_modified",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms"],
+        )?);
 
     let pool_for_guard = pool.clone();
     let booking_id_for_guard = req.booking_id.clone();

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -18,6 +18,7 @@ use crate::{
         CheckoutSettlementPreview, CheckoutSettlementPreviewRequest,
     },
     money::MoneyVnd,
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 
 use super::{
@@ -484,7 +485,12 @@ pub async fn check_in_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload.clone(), ledger_intent, summary)?
         .with_primary_aggregate_key(format!("room:{}", req.room_id))
         .with_lock_key_deriver(check_in_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Checked in")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Checked in")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.checked_in",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms", "folio"],
+        )?);
 
     let runtime_lock_keys = check_in_lock_keys_from_payload(&hash_payload)?;
     let origin_key = format!("{}:{}", ctx.command_name, ctx.idempotency_key);
@@ -952,7 +958,12 @@ pub async fn check_out_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload.clone(), ledger_intent, summary)?
         .with_primary_aggregate_key(format!("booking:{}", req.booking_id))
         .with_lock_key_deriver(check_out_initial_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Checked out")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Checked out")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.checked_out",
+            OutboxAggregateKeySource::response_field("booking", "booking_id"),
+            &["bookings", "rooms", "folio"],
+        )?);
 
     let pool_for_lookup = pool.clone();
     let booking_id_for_lookup = req.booking_id.clone();
@@ -1149,7 +1160,12 @@ pub async fn extend_stay_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("booking:{booking_id}"))
         .with_lock_key_deriver(extend_stay_initial_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Stay extended")?);
+        .with_success_summary(CommandLedgerResultSummary::success("Stay extended")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.stay_extended",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms", "folio"],
+        )?);
 
     let pool_for_lookup = pool.clone();
     let booking_id_for_lookup = booking_id.to_string();

--- a/mhm/src-tauri/src/services/booking/tests.rs
+++ b/mhm/src-tauri/src/services/booking/tests.rs
@@ -364,7 +364,98 @@ pub async fn test_pool() -> Pool<Sqlite> {
     .await
     .expect("failed to create command_idempotency table");
 
+    sqlx::query(
+        "CREATE TABLE outbox_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL,
+            aggregate_key TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            origin_request_id TEXT NOT NULL,
+            origin_idempotency_key TEXT NOT NULL,
+            origin_command_name TEXT NOT NULL,
+            origin_request_hash TEXT NOT NULL,
+            status TEXT NOT NULL,
+            worker_token TEXT,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at TEXT,
+            processing_started_at TEXT,
+            processing_expires_at TEXT,
+            last_error TEXT,
+            created_at TEXT NOT NULL,
+            dispatched_at TEXT
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to create outbox_events table");
+
+    sqlx::query(
+        "CREATE UNIQUE INDEX outbox_events_origin_command_uq
+         ON outbox_events (origin_command_name, origin_idempotency_key)",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to create outbox origin command index");
+
     pool
+}
+
+async fn outbox_event_count(pool: &Pool<Sqlite>, command_name: &str, idempotency_key: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM outbox_events
+         WHERE origin_command_name = ? AND origin_idempotency_key = ?",
+    )
+    .bind(command_name)
+    .bind(idempotency_key)
+    .fetch_one(pool)
+    .await
+    .expect("counts outbox events")
+}
+
+async fn assert_single_outbox_event(
+    pool: &Pool<Sqlite>,
+    ctx: &crate::command_idempotency::WriteCommandContext,
+    event_type: &str,
+) -> serde_json::Value {
+    assert_eq!(
+        outbox_event_count(pool, &ctx.command_name, &ctx.idempotency_key).await,
+        1
+    );
+
+    let row = sqlx::query(
+        "SELECT event_type, status, attempts, origin_request_id,
+                origin_request_hash, payload_json
+         FROM outbox_events
+         WHERE origin_command_name = ? AND origin_idempotency_key = ?",
+    )
+    .bind(&ctx.command_name)
+    .bind(&ctx.idempotency_key)
+    .fetch_one(pool)
+    .await
+    .expect("reads outbox event");
+
+    assert_eq!(row.get::<String, _>("event_type"), event_type);
+    assert_eq!(row.get::<String, _>("status"), "pending");
+    assert_eq!(row.get::<i64, _>("attempts"), 0);
+    assert_eq!(
+        row.get::<String, _>("origin_request_id"),
+        ctx.request_id.as_str()
+    );
+    assert!(!row.get::<String, _>("origin_request_hash").is_empty());
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&row.get::<String, _>("payload_json")).expect("payload is JSON");
+    assert_eq!(payload["schema_version"], serde_json::json!(1));
+    assert_eq!(
+        payload["command_name"],
+        serde_json::json!(ctx.command_name.as_str())
+    );
+    assert!(payload
+        .get("refresh")
+        .and_then(|value| value.as_array())
+        .is_some());
+    payload
 }
 
 async fn shared_file_test_pools(label: &str) -> (Pool<Sqlite>, Pool<Sqlite>, std::path::PathBuf) {
@@ -1947,6 +2038,7 @@ async fn group_checkin_idempotent_retry_does_not_duplicate_groups_bookings_or_pa
     assert!(!first.replayed);
     assert!(replay.replayed);
     assert_eq!(first.response["id"], replay.response["id"]);
+    assert_single_outbox_event(&pool, &ctx, "group.checked_in").await;
 
     let group_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM booking_groups")
         .fetch_one(&pool)
@@ -2302,6 +2394,7 @@ async fn add_group_service_idempotent_retry_replays_without_duplicate_row() {
         second.response["total_price"]
     );
     assert_eq!(first.response["total_price"], 50_000);
+    assert_single_outbox_event(&pool, &ctx, "group.service_added").await;
 
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM group_services WHERE group_id = ?")
         .bind("G-SVC-IDEM")
@@ -2376,10 +2469,9 @@ async fn add_group_service_idempotent_rejects_negative_unit_price_without_writin
         note: None,
     };
 
-    let error =
-        group_service_management::add_group_service_idempotent(&pool, &ctx, req, "staff-1")
-            .await
-            .expect_err("negative unit price is rejected");
+    let error = group_service_management::add_group_service_idempotent(&pool, &ctx, req, "staff-1")
+        .await
+        .expect_err("negative unit price is rejected");
 
     assert_eq!(error.code, crate::app_error::codes::BOOKING_INVALID_STATE);
 
@@ -2767,6 +2859,11 @@ async fn record_payment_idempotent_retry_replays_and_does_not_double_post() {
         .await
         .unwrap();
     assert_eq!(paid_amount, 125_000);
+
+    let payload = assert_single_outbox_event(&pool, &ctx, "folio.payment_recorded").await;
+    assert_eq!(payload["aggregate"]["type"], "folio");
+    assert_eq!(payload["aggregate"]["id"], "B-PAY-IDEM");
+    assert_eq!(payload["refresh"], serde_json::json!(["folio", "bookings"]));
 }
 
 #[tokio::test]
@@ -3362,6 +3459,7 @@ async fn create_reservation_idempotent_retry_does_not_duplicate_deposit() {
     assert_eq!(first.response["id"], second.response["id"]);
     assert!(!first.replayed);
     assert!(second.replayed);
+    assert_single_outbox_event(&pool, &ctx, "booking.reservation_created").await;
 
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE origin_idempotency_key = ?")
@@ -5031,6 +5129,7 @@ async fn check_in_idempotent_retry_replays_and_does_not_duplicate_rows() {
             .await
             .unwrap();
     assert_eq!(calendar_count, 2);
+    assert_single_outbox_event(&pool, &ctx, "booking.checked_in").await;
 }
 
 #[tokio::test]
@@ -5187,6 +5286,7 @@ async fn check_out_idempotent_retry_replays_without_duplicate_money_or_housekeep
     .await
     .unwrap();
     assert_eq!(checkout_money_count, 2);
+    assert_single_outbox_event(&pool, &ctx, "booking.checked_out").await;
 }
 
 #[tokio::test]
@@ -6086,6 +6186,7 @@ async fn extend_stay_idempotent_retry_replays_without_extra_night_or_charge() {
             .await
             .unwrap();
     assert_eq!(charge_count, 1);
+    assert_single_outbox_event(&pool, &ctx, "booking.stay_extended").await;
 }
 
 #[tokio::test]
@@ -6777,6 +6878,7 @@ async fn add_folio_line_idempotent_retry_replays_and_does_not_duplicate_row() {
             .await
             .unwrap();
     assert_eq!(count, 1);
+    assert_single_outbox_event(&pool, &ctx, "folio.line_added").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add the `outbox_events` persistence table and migration coverage for durable pending events.
- Add outbox event preparation/insertion inside the PMS write-command transaction boundary.
- Wire representative booking, stay, group, billing, and invoice commands to persist UI refresh/observer event specs without dispatching side effects yet.

## Validation
- `npm run verify:full`
- `cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets -- -D warnings`
- Local `main` fast-forward merge followed by `npm run verify:quick`
- GitNexus `detect_changes` reviewed; high blast radius is expected for DB migration + command executor + PMS write-command wiring.