### PR TITLE
[codex] Add outbox dispatch and startup recovery

### DIFF
--- a/docs/superpowers/specs/2026-05-03-outbox-dispatch-startup-recovery-verification-design.md
+++ b/docs/superpowers/specs/2026-05-03-outbox-dispatch-startup-recovery-verification-design.md
@@ -1,0 +1,285 @@
+# Outbox Dispatch, Startup Recovery, and Verification
+
+Issues: #79, #82, and #85
+
+Parent scope: #76 Outbox and agentic integration
+
+Source roadmap: `docs/superpowers/specs/capyinn-concurrency-spec-v2.2.md`
+
+Date: 2026-05-03
+
+## Status
+
+Approved design for the outbox dispatcher foundation.
+
+This spec covers only dispatcher core, startup notification recovery, and verification tests. It deliberately does not add the real MCP observer subscriber from #80 or the real UI refresh subscriber from #81.
+
+## Plain-Language Goal
+
+CapyInn already writes committed business events into `outbox_events`. The next step is to deliver those events safely.
+
+The business promise is:
+
+- committed notifications are not lost after app crash or restart
+- notification retry never re-runs the original business command
+- events for one booking, group, folio, invoice, or room are delivered in order
+- duplicate delivery is possible only in the safe, expected way, and subscribers must dedupe by event id
+
+This is a delivery foundation, not a new business workflow engine.
+
+## Scope Decisions
+
+Chosen scope:
+
+- Implement dispatcher core for `outbox_events`.
+- Claim events before dispatching.
+- Reclaim expired `processing` events.
+- Retry subscriber failures with bounded attempts.
+- Mark events `failed` after the retry limit.
+- Preserve FIFO order per `aggregate_key`.
+- Auto-resume pending and expired-processing outbox notifications on startup.
+- Keep command recovery read-only on startup.
+- Add Rust tests that prove rollback, crash reclaim, retry, FIFO, and startup behavior.
+- Use test subscribers to verify delivery behavior.
+
+Out of scope:
+
+- Real MCP observer stream subscriber.
+- Real UI refresh subscriber.
+- Replacing existing direct `emit_db_update` calls.
+- OTA sync, webhooks, notifications, or external integration delivery.
+- A generic background task queue.
+- Automatic replay of business commands.
+- Operator UI for failed outbox rows.
+- Outbox retention cleanup.
+
+## Current Baseline
+
+The existing foundation already provides:
+
+- `outbox_events` schema with `pending`, `processing`, `dispatched`, and `failed`-ready columns.
+- indexes for pending claim and expired processing scans.
+- origin command metadata: request id, idempotency key, command name, and request hash.
+- executor-owned event insertion in the same transaction as the business write.
+- tests proving successful commands persist one event and failed commands persist no event.
+- command startup recovery that scans expired `in_progress` and `failed_retryable` rows without replaying commands.
+
+The missing part is the worker that turns durable event rows into safe delivery attempts.
+
+## Recommended Approach
+
+Use a small backend dispatcher owned by `outbox.rs`.
+
+The dispatcher should expose clear, testable operations:
+
+- claim the next eligible event
+- dispatch one claimed event to subscribers
+- mark success
+- record retry
+- reclaim expired processing rows through the same claim path
+- run one batch for startup and background polling
+
+This is cleaner than wiring real UI or MCP subscribers immediately because it keeps #79, #82, and #85 focused on delivery correctness. Real subscribers can later plug into the same dispatcher without changing the claim and retry rules.
+
+## Event State Model
+
+Use the existing `status` column:
+
+| Status | Meaning |
+|---|---|
+| `pending` | committed and ready for a future delivery attempt |
+| `processing` | claimed by one worker token until `processing_expires_at` |
+| `dispatched` | delivered successfully to all subscribers in this dispatch scope |
+| `failed` | retry limit reached; needs later inspection or manual repair |
+
+`failed` rows do not block later events for the same aggregate. The FIFO guard blocks older `pending` and `processing` rows only. This keeps one permanently bad notification from freezing the whole aggregate stream.
+
+## Claim Rule
+
+Workers must claim before dispatching.
+
+An event is eligible when:
+
+- status is `pending`, or status is `processing` and `processing_expires_at` has passed
+- `next_attempt_at` is empty or due
+- no older event for the same `aggregate_key` is still `pending` or `processing`
+
+Claiming sets:
+
+- `status = 'processing'`
+- a fresh `worker_token`
+- `processing_started_at`
+- `processing_expires_at`
+
+The dispatcher must finalize only when the stored `worker_token` still matches. A stale worker cannot mark a row dispatched or failed after another worker has reclaimed it.
+
+## Delivery Contract
+
+Delivery is at least once.
+
+This means the same event may be delivered more than once if the app crashes after a subscriber receives it but before the row is marked `dispatched`. That is acceptable because subscribers must dedupe by `outbox_events.id`.
+
+There is no global ordering promise. Events for different aggregate keys may be delivered independently.
+
+Per-aggregate FIFO is required. For one `aggregate_key`, a later event cannot pass an older `pending` or `processing` event.
+
+## Retry Policy
+
+Use a small bounded retry policy in the dispatcher.
+
+Recommended defaults:
+
+- max attempts: 5
+- processing lease: 30 seconds
+- retry delays: short exponential backoff with a cap, stored as `next_attempt_at`
+
+On subscriber failure:
+
+1. increment `attempts`
+2. clear `worker_token`
+3. clear processing timestamps
+4. store a safe `last_error`
+5. set `next_attempt_at` if attempts remain
+6. mark `failed` if attempts reached the limit
+
+The stored error must be short and safe. It must not include guest PII, secrets, raw payloads, or large subscriber output.
+
+## Startup Behavior
+
+Startup may resume outbox notifications automatically.
+
+Startup must not replay business commands.
+
+Startup should do two separate things:
+
+1. run the existing command recovery startup scan and log counts for command rows that need attention
+2. start or trigger the outbox dispatcher so pending and expired notification rows can be delivered
+
+Logs and future UI wording must keep the difference clear:
+
+- outbox notification replay resumed
+- business command recovery attention required
+
+This separation preserves the PMS safety rule: hotel truth changes only through explicit, validated, authorized business commands.
+
+## Dispatcher Runtime
+
+The runtime should be conservative:
+
+- run once on startup to drain immediately eligible rows
+- continue polling on a modest interval while the app is open
+- process a bounded batch per tick
+- stop cleanly with the app runtime
+- expose a test helper that can run one batch without spawning a background loop
+
+The first implementation does not need multiple concurrent dispatcher workers. The SQL claim rule should still be correct if a later version adds more workers or another app process attempts delivery.
+
+## Subscriber Boundary
+
+For this scope, use test subscribers only.
+
+A subscriber receives a safe event envelope:
+
+- event id
+- event type
+- aggregate key
+- payload JSON
+- origin request id
+- origin command name
+- origin idempotency key
+- origin request hash
+- created timestamp
+- current attempt number
+
+Subscriber code must treat the event as a read-only fact. It must not mutate PMS tables directly and must not issue business commands.
+
+Future real subscribers:
+
+- #80 MCP observer stream
+- #81 UI refresh subscriber, if useful
+
+Those subscribers should dedupe by event id and re-read canonical state from SQLite when they need details.
+
+## Error Handling
+
+The dispatcher fails closed.
+
+Database claim failure:
+
+- leave rows unchanged
+- return/log a structured system error
+- try again on the next tick
+
+Subscriber failure:
+
+- retry according to policy
+- mark `failed` after the limit
+- do not replay business command
+
+Stale worker finalize:
+
+- update affects zero rows
+- treat as a lost race
+- do not overwrite the current row state
+
+Malformed event payload:
+
+- count as subscriber/dispatch failure for that event
+- retry up to the limit
+- mark `failed` after the limit
+
+## Verification Plan
+
+Required Rust tests:
+
+- same-transaction rollback creates no outbox row
+- pending event is claimed before dispatch
+- expired `processing` event is reclaimed after lease expiry
+- active `processing` event is not reclaimed before lease expiry
+- subscriber success marks event `dispatched`
+- subscriber failure retries with `next_attempt_at`
+- repeated subscriber failure marks event `failed` after the retry limit
+- stale worker token cannot mark a reclaimed event dispatched
+- two events with the same `aggregate_key` dispatch in id order
+- later event with the same `aggregate_key` does not pass an older pending or processing event
+- events for different aggregate keys do not require global ordering
+- startup outbox recovery processes pending or expired notification rows
+- startup command recovery remains scan/log only and does not execute business command paths
+
+Existing rollback tests from the persistence foundation should remain in place. Add new dispatcher tests near the dispatcher code so the core behavior is easy to reason about without UI or MCP setup.
+
+## Acceptance Mapping
+
+#79:
+
+- worker claims events before dispatching through the claim operation
+- expired processing events are reclaimable through the same claim path
+- per-aggregate FIFO is enforced by the older pending/processing guard
+- subscriber failure retries and then marks failed
+- delivery is at least once and subscriber dedupe is by event id
+
+#82:
+
+- startup resumes pending and expired outbox notifications
+- startup does not auto-execute business commands
+- logs distinguish notification replay from command recovery
+- high-risk command recovery remains under existing operator/caller intent rules
+
+#85:
+
+- rollback behavior remains covered
+- worker crash is modeled by expired `processing` rows
+- retry and failed behavior are covered
+- FIFO is covered
+- restart behavior is covered without business command replay
+
+## Definition of Done
+
+This slice is done when:
+
+- dispatcher core exists behind a small API in backend code
+- startup starts or triggers outbox notification recovery
+- real UI and MCP subscribers remain out of scope
+- tests cover crash, retry, rollback, FIFO, and startup separation
+- relevant Rust tests pass
+- GitNexus detect changes shows only the expected outbox/startup verification scope before implementation commits

--- a/docs/superpowers/specs/2026-05-03-outbox-dispatch-startup-recovery-verification-design.md
+++ b/docs/superpowers/specs/2026-05-03-outbox-dispatch-startup-recovery-verification-design.md
@@ -37,7 +37,8 @@ Chosen scope:
 - Retry subscriber failures with bounded attempts.
 - Mark events `failed` after the retry limit.
 - Preserve FIFO order per `aggregate_key`.
-- Auto-resume pending and expired-processing outbox notifications on startup.
+- Add a startup recovery hook for pending and expired-processing outbox notifications.
+- Leave production rows pending when no real subscriber is registered in this slice.
 - Keep command recovery read-only on startup.
 - Add Rust tests that prove rollback, crash reclaim, retry, FIFO, and startup behavior.
 - Use test subscribers to verify delivery behavior.
@@ -81,6 +82,8 @@ The dispatcher should expose clear, testable operations:
 
 This is cleaner than wiring real UI or MCP subscribers immediately because it keeps #79, #82, and #85 focused on delivery correctness. Real subscribers can later plug into the same dispatcher without changing the claim and retry rules.
 
+The dispatcher must not mark production events `dispatched` unless at least one real subscriber is registered for the running app. In this slice, production startup wires the recovery hook but has no real subscriber, so rows remain `pending` and available for #80 or #81. Tests inject test subscribers to prove the recovery path works without losing events.
+
 ## Event State Model
 
 Use the existing `status` column:
@@ -102,14 +105,20 @@ An event is eligible when:
 
 - status is `pending`, or status is `processing` and `processing_expires_at` has passed
 - `next_attempt_at` is empty or due
+- `attempts` is lower than the max-attempt limit
 - no older event for the same `aggregate_key` is still `pending` or `processing`
 
 Claiming sets:
 
 - `status = 'processing'`
 - a fresh `worker_token`
+- `attempts = attempts + 1`
 - `processing_started_at`
 - `processing_expires_at`
+
+`attempts` means delivery attempts started, not failures recorded. Incrementing during claim prevents repeated crash-after-claim loops from retrying forever without moving the counter. The subscriber receives the claimed attempt number.
+
+Before claiming work, the dispatcher must mark due `pending` or expired `processing` rows as `failed` when `attempts >= max_attempts`. Those rows must not call subscribers again. This prevents a crash after the final allowed claim from becoming an unbounded attempt 6, 7, or later.
 
 The dispatcher must finalize only when the stored `worker_token` still matches. A stale worker cannot mark a row dispatched or failed after another worker has reclaimed it.
 
@@ -135,25 +144,44 @@ Recommended defaults:
 
 On subscriber failure:
 
-1. increment `attempts`
+1. keep the already-incremented `attempts` value from claim
 2. clear `worker_token`
 3. clear processing timestamps
 4. store a safe `last_error`
 5. set `next_attempt_at` if attempts remain
-6. mark `failed` if attempts reached the limit
+6. mark `failed` if the claimed attempt reached the limit
 
 The stored error must be short and safe. It must not include guest PII, secrets, raw payloads, or large subscriber output.
 
+On expired processing recovery:
+
+- if `attempts < max_attempts`, the row may be reclaimed and `attempts` increments during claim
+- if `attempts >= max_attempts`, mark the row `failed` without subscriber delivery
+
+## Schema Support
+
+Add a small migration after V16 for the FIFO guard:
+
+```sql
+CREATE INDEX IF NOT EXISTS outbox_events_aggregate_open_idx
+    ON outbox_events(aggregate_key, id)
+    WHERE status IN ('pending', 'processing');
+```
+
+The existing `outbox_events_pending_idx` helps find due pending work, and `outbox_events_processing_idx` helps find expired processing rows. The new partial index keeps the per-aggregate older-row guard cheap as outbox volume grows.
+
 ## Startup Behavior
 
-Startup may resume outbox notifications automatically.
+Startup may resume outbox notifications automatically when a subscriber is registered.
 
 Startup must not replay business commands.
 
 Startup should do two separate things:
 
 1. run the existing command recovery startup scan and log counts for command rows that need attention
-2. start or trigger the outbox dispatcher so pending and expired notification rows can be delivered
+2. start or trigger the outbox dispatcher only if at least one subscriber is registered
+
+In this Option A slice, production has no real subscriber, so startup must not mark outbox rows dispatched. It should keep rows pending, log that no production subscriber is registered, and let #80 or #81 attach a real subscriber later. The startup recovery behavior is still covered by tests that inject a test subscriber.
 
 Logs and future UI wording must keep the difference clear:
 
@@ -171,6 +199,7 @@ The runtime should be conservative:
 - process a bounded batch per tick
 - stop cleanly with the app runtime
 - expose a test helper that can run one batch without spawning a background loop
+- no-op safely when the subscriber list is empty
 
 The first implementation does not need multiple concurrent dispatcher workers. The SQL claim rule should still be correct if a later version adds more workers or another app process attempts delivery.
 
@@ -236,14 +265,18 @@ Required Rust tests:
 - pending event is claimed before dispatch
 - expired `processing` event is reclaimed after lease expiry
 - active `processing` event is not reclaimed before lease expiry
+- claiming increments `attempts` before subscriber delivery
 - subscriber success marks event `dispatched`
 - subscriber failure retries with `next_attempt_at`
 - repeated subscriber failure marks event `failed` after the retry limit
+- repeated crash-after-claim attempts eventually reach the retry limit
+- expired processing rows at the retry limit are marked `failed` without another subscriber call
 - stale worker token cannot mark a reclaimed event dispatched
 - two events with the same `aggregate_key` dispatch in id order
 - later event with the same `aggregate_key` does not pass an older pending or processing event
 - events for different aggregate keys do not require global ordering
-- startup outbox recovery processes pending or expired notification rows
+- startup outbox recovery with an injected subscriber processes pending or expired notification rows
+- production startup with no subscriber leaves rows pending
 - startup command recovery remains scan/log only and does not execute business command paths
 
 Existing rollback tests from the persistence foundation should remain in place. Add new dispatcher tests near the dispatcher code so the core behavior is easy to reason about without UI or MCP setup.
@@ -255,12 +288,14 @@ Existing rollback tests from the persistence foundation should remain in place. 
 - worker claims events before dispatching through the claim operation
 - expired processing events are reclaimable through the same claim path
 - per-aggregate FIFO is enforced by the older pending/processing guard
+- FIFO guard is supported by `outbox_events_aggregate_open_idx`
 - subscriber failure retries and then marks failed
 - delivery is at least once and subscriber dedupe is by event id
 
 #82:
 
-- startup resumes pending and expired outbox notifications
+- startup can resume pending and expired outbox notifications when a subscriber is registered
+- startup does not mark rows dispatched when no production subscriber exists
 - startup does not auto-execute business commands
 - logs distinguish notification replay from command recovery
 - high-risk command recovery remains under existing operator/caller intent rules
@@ -278,7 +313,9 @@ Existing rollback tests from the persistence foundation should remain in place. 
 This slice is done when:
 
 - dispatcher core exists behind a small API in backend code
-- startup starts or triggers outbox notification recovery
+- startup starts or triggers outbox notification recovery only when subscriber registration is non-empty
+- no-subscriber startup keeps rows pending for #80 or #81
+- migration adds the aggregate FIFO support index
 - real UI and MCP subscribers remain out of scope
 - tests cover crash, retry, rollback, FIFO, and startup separation
 - relevant Rust tests pass

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -978,6 +978,22 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         set_schema_version(&mut tx, 16).await?;
         tx.commit().await?;
     }
+
+    // -- V17: Outbox per-aggregate open-row FIFO support --
+    if current < 17 {
+        let mut tx = pool.begin().await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS outbox_events_aggregate_open_idx
+             ON outbox_events(aggregate_key, id)
+             WHERE status IN ('pending', 'processing')",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        set_schema_version(&mut tx, 17).await?;
+        tx.commit().await?;
+    }
     Ok(())
 }
 
@@ -1147,7 +1163,7 @@ mod tests {
         .expect("checks outbox_events column")
     }
 
-    async fn assert_outbox_v16_shape(pool: &SqlitePool) {
+    async fn assert_outbox_shape(pool: &SqlitePool) {
         assert_eq!(sqlite_table_count(pool, "outbox_events").await, 1);
 
         for column in [
@@ -1186,6 +1202,10 @@ mod tests {
         );
         assert_eq!(
             sqlite_index_count(pool, "outbox_events_origin_command_uq").await,
+            1
+        );
+        assert_eq!(
+            sqlite_index_count(pool, "outbox_events_aggregate_open_idx").await,
             1
         );
     }
@@ -1317,7 +1337,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
     }
 
     #[tokio::test]
@@ -1333,7 +1353,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1621,7 +1641,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
     }
 
     #[tokio::test]
@@ -1688,7 +1708,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
     }
 
     #[tokio::test]
@@ -1768,7 +1788,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
     }
 
     #[tokio::test]
@@ -1806,9 +1826,9 @@ mod tests {
 
         run_migrations(&pool).await.expect("runs migrations");
 
-        assert_outbox_v16_shape(&pool).await;
+        assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
     }
 
     #[tokio::test]
@@ -1824,9 +1844,30 @@ mod tests {
 
         run_migrations(&pool).await.expect("v16 migration reruns");
 
-        assert_outbox_v16_shape(&pool).await;
+        assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 16);
+        assert_eq!(version, 17);
+    }
+
+    #[tokio::test]
+    async fn migration_v17_adds_outbox_fifo_support_index() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("initial migrations run");
+        sqlx::query("UPDATE schema_version SET version = 16")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version");
+
+        run_migrations(&pool).await.expect("v17 migration reruns");
+
+        assert_eq!(
+            sqlite_index_count(&pool, "outbox_events_aggregate_open_idx").await,
+            1
+        );
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 17);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -1859,6 +1859,15 @@ mod tests {
             .execute(&pool)
             .await
             .expect("rewinds schema version");
+        sqlx::query("DROP INDEX outbox_events_aggregate_open_idx")
+            .execute(&pool)
+            .await
+            .expect("removes v17 index");
+
+        assert_eq!(
+            sqlite_index_count(&pool, "outbox_events_aggregate_open_idx").await,
+            0
+        );
 
         run_migrations(&pool).await.expect("v17 migration reruns");
 

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -1,18 +1,18 @@
 use log::{error, info};
 use tauri::Manager;
 
+pub mod aggregate_locks;
 pub mod app_error;
 pub mod app_identity;
-pub mod aggregate_locks;
 mod backup;
 mod command_failure_log;
 pub mod command_idempotency;
 pub mod command_ledger;
 pub mod command_recovery;
-mod crash_index;
 mod commands;
-pub mod db_error_monitoring;
+mod crash_index;
 mod db;
+pub mod db_error_monitoring;
 mod diagnostics;
 mod domain;
 pub mod gateway;
@@ -197,11 +197,12 @@ pub fn run() {
             };
 
             app.manage(AppState {
-                db: pool,
+                db: pool.clone(),
                 current_user: Arc::new(Mutex::new(None)),
             });
             app.manage(backup::BackupCoordinator::new());
             app.manage(backup::start_backup_scheduler(app.handle().clone()));
+            app.manage(outbox::start_outbox_dispatcher(pool.clone(), Vec::new()));
             app.manage(GatewayRuntimeState::new(rt, gateway_runtime));
 
             let _ = std::fs::create_dir_all(app_identity::models_dir());

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -11,6 +11,83 @@ const OUTBOX_STATUS_PROCESSING: &str = "processing";
 const OUTBOX_STATUS_FAILED: &str = "failed";
 const OUTBOX_SAFE_TEXT_MAX_CHARS: usize = 160;
 const OUTBOX_RETRY_LIMIT_ERROR: &str = "outbox retry limit reached";
+const CLAIM_NEXT_OUTBOX_EVENT_CANDIDATE_SQL: &str = "
+SELECT id
+FROM (
+    SELECT candidate.id AS id
+    FROM outbox_events candidate INDEXED BY outbox_events_pending_idx
+    WHERE candidate.status = 'pending'
+      AND candidate.attempts < ?
+      AND candidate.next_attempt_at IS NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM outbox_events older
+          WHERE older.aggregate_key = candidate.aggregate_key
+            AND older.id < candidate.id
+            AND older.status IN ('pending', 'processing')
+      )
+    UNION ALL
+    SELECT candidate.id AS id
+    FROM outbox_events candidate INDEXED BY outbox_events_pending_idx
+    WHERE candidate.status = 'pending'
+      AND candidate.attempts < ?
+      AND candidate.next_attempt_at <= ?
+      AND NOT EXISTS (
+          SELECT 1
+          FROM outbox_events older
+          WHERE older.aggregate_key = candidate.aggregate_key
+            AND older.id < candidate.id
+            AND older.status IN ('pending', 'processing')
+      )
+    UNION ALL
+    SELECT candidate.id AS id
+    FROM outbox_events candidate INDEXED BY outbox_events_processing_idx
+    WHERE candidate.status = 'processing'
+      AND candidate.attempts < ?
+      AND candidate.processing_expires_at <= ?
+      AND NOT EXISTS (
+          SELECT 1
+          FROM outbox_events older
+          WHERE older.aggregate_key = candidate.aggregate_key
+            AND older.id < candidate.id
+            AND older.status IN ('pending', 'processing')
+      )
+)
+ORDER BY id
+LIMIT 1";
+const FAIL_RETRY_LIMIT_PENDING_NULL_SQL: &str = "
+UPDATE outbox_events INDEXED BY outbox_events_pending_idx
+SET status = ?,
+    worker_token = NULL,
+    next_attempt_at = NULL,
+    processing_started_at = NULL,
+    processing_expires_at = NULL,
+    last_error = ?
+WHERE status = 'pending'
+  AND attempts >= ?
+  AND next_attempt_at IS NULL";
+const FAIL_RETRY_LIMIT_PENDING_DUE_SQL: &str = "
+UPDATE outbox_events INDEXED BY outbox_events_pending_idx
+SET status = ?,
+    worker_token = NULL,
+    next_attempt_at = NULL,
+    processing_started_at = NULL,
+    processing_expires_at = NULL,
+    last_error = ?
+WHERE status = 'pending'
+  AND attempts >= ?
+  AND next_attempt_at <= ?";
+const FAIL_RETRY_LIMIT_PROCESSING_SQL: &str = "
+UPDATE outbox_events INDEXED BY outbox_events_processing_idx
+SET status = ?,
+    worker_token = NULL,
+    next_attempt_at = NULL,
+    processing_started_at = NULL,
+    processing_expires_at = NULL,
+    last_error = ?
+WHERE status = 'processing'
+  AND attempts >= ?
+  AND processing_expires_at <= ?";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutboxDispatchConfig {
@@ -143,40 +220,35 @@ pub async fn fail_retry_limit_rows(
         .await
         .map_err(system_error)?;
 
-    let result = sqlx::query(
-        "UPDATE outbox_events
-         SET status = ?,
-             worker_token = NULL,
-             next_attempt_at = NULL,
-             processing_started_at = NULL,
-             processing_expires_at = NULL,
-             last_error = ?
-         WHERE attempts >= ?
-           AND (
-                (
-                    status = ?
-                    AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
-                )
-                OR (
-                    status = ?
-                    AND processing_expires_at <= ?
-                )
-           )",
-    )
-    .bind(OUTBOX_STATUS_FAILED)
-    .bind(OUTBOX_RETRY_LIMIT_ERROR)
-    .bind(config.max_attempts)
-    .bind(OUTBOX_STATUS_PENDING)
-    .bind(&now)
-    .bind(OUTBOX_STATUS_PROCESSING)
-    .bind(&now)
-    .execute(&mut *tx)
-    .await
-    .map_err(system_error)?;
+    let pending_null_result = sqlx::query(FAIL_RETRY_LIMIT_PENDING_NULL_SQL)
+        .bind(OUTBOX_STATUS_FAILED)
+        .bind(OUTBOX_RETRY_LIMIT_ERROR)
+        .bind(config.max_attempts)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
+    let pending_due_result = sqlx::query(FAIL_RETRY_LIMIT_PENDING_DUE_SQL)
+        .bind(OUTBOX_STATUS_FAILED)
+        .bind(OUTBOX_RETRY_LIMIT_ERROR)
+        .bind(config.max_attempts)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
+    let processing_result = sqlx::query(FAIL_RETRY_LIMIT_PROCESSING_SQL)
+        .bind(OUTBOX_STATUS_FAILED)
+        .bind(OUTBOX_RETRY_LIMIT_ERROR)
+        .bind(config.max_attempts)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
 
     tx.commit().await.map_err(system_error)?;
 
-    Ok(result.rows_affected())
+    Ok(pending_null_result.rows_affected()
+        + pending_due_result.rows_affected()
+        + processing_result.rows_affected())
 }
 
 pub async fn claim_next_outbox_event(
@@ -194,41 +266,15 @@ pub async fn claim_next_outbox_event(
         .map_err(system_error)?;
 
     let result = async {
-        let claimable_id = sqlx::query_scalar::<_, i64>(
-            "SELECT candidate.id
-             FROM outbox_events candidate
-             WHERE candidate.attempts < ?
-               AND (
-                    (
-                        candidate.status = ?
-                        AND (
-                            candidate.next_attempt_at IS NULL
-                            OR candidate.next_attempt_at <= ?
-                        )
-                    )
-                    OR (
-                        candidate.status = ?
-                        AND candidate.processing_expires_at <= ?
-                    )
-               )
-               AND NOT EXISTS (
-                    SELECT 1
-                    FROM outbox_events older
-                    WHERE older.aggregate_key = candidate.aggregate_key
-                      AND older.id < candidate.id
-                      AND older.status IN ('pending', 'processing')
-               )
-             ORDER BY candidate.id
-             LIMIT 1",
-        )
-        .bind(config.max_attempts)
-        .bind(OUTBOX_STATUS_PENDING)
-        .bind(&now_string)
-        .bind(OUTBOX_STATUS_PROCESSING)
-        .bind(&now_string)
-        .fetch_optional(&mut *tx)
-        .await
-        .map_err(system_error)?;
+        let claimable_id = sqlx::query_scalar::<_, i64>(CLAIM_NEXT_OUTBOX_EVENT_CANDIDATE_SQL)
+            .bind(config.max_attempts)
+            .bind(config.max_attempts)
+            .bind(&now_string)
+            .bind(config.max_attempts)
+            .bind(&now_string)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(system_error)?;
 
         let Some(claimable_id) = claimable_id else {
             return Ok(None);
@@ -966,5 +1012,103 @@ mod tests {
                 Some("outbox retry limit reached".to_string())
             );
         }
+    }
+
+    async fn explain_query_plan(
+        pool: &sqlx::Pool<Sqlite>,
+        sql: &str,
+        binds: &[&str],
+    ) -> Vec<String> {
+        let explain_sql = format!("EXPLAIN QUERY PLAN {sql}");
+        let mut query = sqlx::query(&explain_sql);
+        for bind in binds {
+            query = query.bind(*bind);
+        }
+        query
+            .fetch_all(pool)
+            .await
+            .expect("query plan explains")
+            .into_iter()
+            .map(|row| row.get::<String, _>("detail"))
+            .collect()
+    }
+
+    fn assert_uses_index(plan: &[String], index_name: &str) {
+        assert!(
+            plan.iter().any(|detail| detail.contains(index_name)),
+            "expected plan to use {index_name}; plan: {plan:?}"
+        );
+    }
+
+    fn assert_no_plain_scan(plan: &[String], table_or_alias: &str) {
+        let plain_scan = format!("SCAN {table_or_alias}");
+        assert!(
+            plan.iter()
+                .all(|detail| { !detail.contains(&plain_scan) || detail.contains("USING INDEX") }),
+            "expected plan not to scan {table_or_alias} without an index; plan: {plan:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_candidate_query_uses_outbox_partial_indexes() {
+        let pool = test_pool().await;
+        let plan = explain_query_plan(
+            &pool,
+            CLAIM_NEXT_OUTBOX_EVENT_CANDIDATE_SQL,
+            &[
+                "5",
+                "5",
+                "2026-05-03T09:00:00+00:00",
+                "5",
+                "2026-05-03T09:00:00+00:00",
+            ],
+        )
+        .await;
+
+        assert_uses_index(&plan, "outbox_events_pending_idx");
+        assert_uses_index(&plan, "outbox_events_processing_idx");
+        assert_uses_index(&plan, "outbox_events_aggregate_open_idx");
+        assert_no_plain_scan(&plan, "candidate");
+    }
+
+    #[tokio::test]
+    async fn retry_limit_failover_queries_use_outbox_partial_indexes() {
+        let pool = test_pool().await;
+
+        let pending_null_plan = explain_query_plan(
+            &pool,
+            FAIL_RETRY_LIMIT_PENDING_NULL_SQL,
+            &[OUTBOX_STATUS_FAILED, OUTBOX_RETRY_LIMIT_ERROR, "5"],
+        )
+        .await;
+        let pending_due_plan = explain_query_plan(
+            &pool,
+            FAIL_RETRY_LIMIT_PENDING_DUE_SQL,
+            &[
+                OUTBOX_STATUS_FAILED,
+                OUTBOX_RETRY_LIMIT_ERROR,
+                "5",
+                "2026-05-03T09:00:00+00:00",
+            ],
+        )
+        .await;
+        let processing_plan = explain_query_plan(
+            &pool,
+            FAIL_RETRY_LIMIT_PROCESSING_SQL,
+            &[
+                OUTBOX_STATUS_FAILED,
+                OUTBOX_RETRY_LIMIT_ERROR,
+                "5",
+                "2026-05-03T09:00:00+00:00",
+            ],
+        )
+        .await;
+
+        assert_uses_index(&pending_null_plan, "outbox_events_pending_idx");
+        assert_uses_index(&pending_due_plan, "outbox_events_pending_idx");
+        assert_uses_index(&processing_plan, "outbox_events_processing_idx");
+        assert_no_plain_scan(&pending_null_plan, "outbox_events");
+        assert_no_plain_scan(&pending_due_plan, "outbox_events");
+        assert_no_plain_scan(&processing_plan, "outbox_events");
     }
 }

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -3,9 +3,16 @@ use crate::{
     command_idempotency::{system_error, WriteCommandContext},
 };
 use chrono::{Duration, Utc};
+use log::{error, info};
 use serde_json::{json, Value};
 use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, Transaction};
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::Duration as StdDuration,
+};
+use tokio::sync::oneshot;
 
 const OUTBOX_STATUS_PENDING: &str = "pending";
 const OUTBOX_STATUS_PROCESSING: &str = "processing";
@@ -140,6 +147,48 @@ pub type OutboxSubscriberFuture<'a> = Pin<Box<dyn Future<Output = CommandResult<
 pub trait OutboxSubscriber: Send + Sync {
     fn name(&self) -> &'static str;
     fn handle<'a>(&'a self, event: &'a OutboxEvent) -> OutboxSubscriberFuture<'a>;
+}
+
+pub struct OutboxDispatcherHandle {
+    task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl OutboxDispatcherHandle {
+    pub fn inactive() -> Self {
+        Self {
+            task: Mutex::new(None),
+            shutdown_tx: Mutex::new(None),
+        }
+    }
+
+    fn new(task: tauri::async_runtime::JoinHandle<()>, shutdown_tx: oneshot::Sender<()>) -> Self {
+        Self {
+            task: Mutex::new(Some(task)),
+            shutdown_tx: Mutex::new(Some(shutdown_tx)),
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.task
+            .lock()
+            .map(|guard| guard.is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn shutdown(&self) {
+        let shutdown_tx = self
+            .shutdown_tx
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take());
+
+        if let Some(shutdown_tx) = shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
+
+        let _task = self.task.lock().ok().and_then(|mut guard| guard.take());
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -461,6 +510,23 @@ pub async fn run_outbox_dispatch_batch(
     Ok(summary)
 }
 
+pub fn start_outbox_dispatcher(
+    pool: Pool<Sqlite>,
+    subscribers: Vec<Arc<dyn OutboxSubscriber>>,
+) -> OutboxDispatcherHandle {
+    if subscribers.is_empty() {
+        info!("Outbox dispatcher inactive: no subscribers registered");
+        return OutboxDispatcherHandle::inactive();
+    }
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let task = tauri::async_runtime::spawn(async move {
+        run_outbox_dispatcher_loop(pool, subscribers, shutdown_rx).await;
+    });
+
+    OutboxDispatcherHandle::new(task, shutdown_tx)
+}
+
 pub async fn run_outbox_startup_recovery_once(
     pool: &Pool<Sqlite>,
     subscribers: &[Arc<dyn OutboxSubscriber>],
@@ -471,6 +537,40 @@ pub async fn run_outbox_startup_recovery_once(
         .map(|subscriber| subscriber.as_ref())
         .collect::<Vec<&dyn OutboxSubscriber>>();
     run_outbox_dispatch_batch(pool, &subscriber_refs, config).await
+}
+
+async fn run_outbox_dispatcher_loop(
+    pool: Pool<Sqlite>,
+    subscribers: Vec<Arc<dyn OutboxSubscriber>>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut shutdown_rx => {
+                break;
+            }
+            _ = tokio::time::sleep(StdDuration::from_secs(5)) => {
+                let subscriber_refs = subscribers
+                    .iter()
+                    .map(|subscriber| subscriber.as_ref())
+                    .collect::<Vec<&dyn OutboxSubscriber>>();
+
+                if let Err(error) = run_outbox_dispatch_batch(
+                    &pool,
+                    &subscriber_refs,
+                    OutboxDispatchConfig::default(),
+                )
+                .await
+                {
+                    error!(
+                        "Outbox dispatcher batch failed: code={} message={}",
+                        error.code, error.message
+                    );
+                }
+            }
+        }
+    }
 }
 
 impl OutboxEventSpec {
@@ -843,6 +943,12 @@ mod tests {
                 Ok(())
             })
         }
+    }
+
+    #[test]
+    fn dispatcher_handle_is_inactive_without_subscribers() {
+        let handle = OutboxDispatcherHandle::inactive();
+        assert!(!handle.is_active());
     }
 
     #[test]

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -2,12 +2,58 @@ use crate::{
     app_error::{codes, CommandError, CommandResult},
     command_idempotency::{system_error, WriteCommandContext},
 };
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use serde_json::{json, Value};
-use sqlx::{Sqlite, Transaction};
+use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, Transaction};
 
 const OUTBOX_STATUS_PENDING: &str = "pending";
+const OUTBOX_STATUS_PROCESSING: &str = "processing";
+const OUTBOX_STATUS_FAILED: &str = "failed";
 const OUTBOX_SAFE_TEXT_MAX_CHARS: usize = 160;
+const OUTBOX_RETRY_LIMIT_ERROR: &str = "outbox retry limit reached";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutboxDispatchConfig {
+    pub max_attempts: i64,
+    pub processing_lease_seconds: i64,
+    pub batch_size: usize,
+}
+
+impl Default for OutboxDispatchConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            processing_lease_seconds: 30,
+            batch_size: 25,
+        }
+    }
+}
+
+impl OutboxDispatchConfig {
+    #[cfg(test)]
+    fn test() -> Self {
+        Self {
+            max_attempts: 5,
+            processing_lease_seconds: 30,
+            batch_size: 10,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboxEvent {
+    pub id: i64,
+    pub event_type: String,
+    pub aggregate_key: String,
+    pub payload_json: String,
+    pub origin_request_id: String,
+    pub origin_idempotency_key: String,
+    pub origin_command_name: String,
+    pub origin_request_hash: String,
+    pub created_at: String,
+    pub attempts: i64,
+    pub worker_token: String,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutboxAggregateKeySource {
@@ -85,6 +131,163 @@ pub async fn insert_outbox_event_tx(
     .map_err(system_error)?;
 
     Ok(())
+}
+
+pub async fn fail_retry_limit_rows(
+    pool: &Pool<Sqlite>,
+    config: OutboxDispatchConfig,
+) -> CommandResult<u64> {
+    let now = Utc::now().to_rfc3339();
+    let mut tx = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(system_error)?;
+
+    let result = sqlx::query(
+        "UPDATE outbox_events
+         SET status = ?,
+             worker_token = NULL,
+             next_attempt_at = NULL,
+             processing_started_at = NULL,
+             processing_expires_at = NULL,
+             last_error = ?
+         WHERE attempts >= ?
+           AND (
+                (
+                    status = ?
+                    AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                )
+                OR (
+                    status = ?
+                    AND processing_expires_at <= ?
+                )
+           )",
+    )
+    .bind(OUTBOX_STATUS_FAILED)
+    .bind(OUTBOX_RETRY_LIMIT_ERROR)
+    .bind(config.max_attempts)
+    .bind(OUTBOX_STATUS_PENDING)
+    .bind(&now)
+    .bind(OUTBOX_STATUS_PROCESSING)
+    .bind(&now)
+    .execute(&mut *tx)
+    .await
+    .map_err(system_error)?;
+
+    tx.commit().await.map_err(system_error)?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn claim_next_outbox_event(
+    pool: &Pool<Sqlite>,
+    config: OutboxDispatchConfig,
+) -> CommandResult<Option<OutboxEvent>> {
+    let now = Utc::now();
+    let now_string = now.to_rfc3339();
+    let processing_expires_at =
+        (now + Duration::seconds(config.processing_lease_seconds)).to_rfc3339();
+    let worker_token = uuid::Uuid::new_v4().to_string();
+    let mut tx = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(system_error)?;
+
+    let result = async {
+        let claimable_id = sqlx::query_scalar::<_, i64>(
+            "SELECT candidate.id
+             FROM outbox_events candidate
+             WHERE candidate.attempts < ?
+               AND (
+                    (
+                        candidate.status = ?
+                        AND (
+                            candidate.next_attempt_at IS NULL
+                            OR candidate.next_attempt_at <= ?
+                        )
+                    )
+                    OR (
+                        candidate.status = ?
+                        AND candidate.processing_expires_at <= ?
+                    )
+               )
+               AND NOT EXISTS (
+                    SELECT 1
+                    FROM outbox_events older
+                    WHERE older.aggregate_key = candidate.aggregate_key
+                      AND older.id < candidate.id
+                      AND older.status IN ('pending', 'processing')
+               )
+             ORDER BY candidate.id
+             LIMIT 1",
+        )
+        .bind(config.max_attempts)
+        .bind(OUTBOX_STATUS_PENDING)
+        .bind(&now_string)
+        .bind(OUTBOX_STATUS_PROCESSING)
+        .bind(&now_string)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(system_error)?;
+
+        let Some(claimable_id) = claimable_id else {
+            return Ok(None);
+        };
+
+        sqlx::query(
+            "UPDATE outbox_events
+             SET status = ?,
+                 worker_token = ?,
+                 attempts = attempts + 1,
+                 processing_started_at = ?,
+                 processing_expires_at = ?,
+                 last_error = NULL
+             WHERE id = ?",
+        )
+        .bind(OUTBOX_STATUS_PROCESSING)
+        .bind(&worker_token)
+        .bind(&now_string)
+        .bind(&processing_expires_at)
+        .bind(claimable_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(system_error)?;
+
+        let row = sqlx::query(
+            "SELECT
+                id,
+                event_type,
+                aggregate_key,
+                payload_json,
+                origin_request_id,
+                origin_idempotency_key,
+                origin_command_name,
+                origin_request_hash,
+                created_at,
+                attempts,
+                worker_token
+             FROM outbox_events
+             WHERE id = ?",
+        )
+        .bind(claimable_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(system_error)?;
+
+        Ok(Some(outbox_event_from_row(row)?))
+    }
+    .await;
+
+    match result {
+        Ok(event) => {
+            tx.commit().await.map_err(system_error)?;
+            Ok(event)
+        }
+        Err(error) => {
+            tx.rollback().await.map_err(system_error)?;
+            Err(error)
+        }
+    }
 }
 
 impl OutboxEventSpec {
@@ -272,13 +475,91 @@ fn canonical_json_string(value: &Value) -> CommandResult<String> {
     serde_json::to_string(&canonicalize_json_value(value.clone())).map_err(system_error)
 }
 
+fn outbox_event_from_row(row: SqliteRow) -> CommandResult<OutboxEvent> {
+    let worker_token = row
+        .try_get::<Option<String>, _>("worker_token")
+        .map_err(system_error)?
+        .ok_or_else(|| system_error("claimed outbox event missing worker token"))?;
+
+    Ok(OutboxEvent {
+        id: row.try_get("id").map_err(system_error)?,
+        event_type: row.try_get("event_type").map_err(system_error)?,
+        aggregate_key: row.try_get("aggregate_key").map_err(system_error)?,
+        payload_json: row.try_get("payload_json").map_err(system_error)?,
+        origin_request_id: row.try_get("origin_request_id").map_err(system_error)?,
+        origin_idempotency_key: row
+            .try_get("origin_idempotency_key")
+            .map_err(system_error)?,
+        origin_command_name: row.try_get("origin_command_name").map_err(system_error)?,
+        origin_request_hash: row.try_get("origin_request_hash").map_err(system_error)?,
+        created_at: row.try_get("created_at").map_err(system_error)?,
+        attempts: row.try_get("attempts").map_err(system_error)?,
+        worker_token,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::command_idempotency::WriteCommandContext;
     use chrono::DateTime;
     use serde_json::json;
-    use sqlx::{sqlite::SqlitePoolOptions, Row};
+    use sqlx::{sqlite::SqlitePoolOptions, Row, Sqlite};
+
+    async fn test_pool() -> sqlx::Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite connects");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("migrations run");
+        pool
+    }
+
+    async fn seed_outbox_event(
+        pool: &sqlx::Pool<Sqlite>,
+        event_type: &str,
+        aggregate_key: &str,
+        status: &str,
+        attempts: i64,
+        next_attempt_at: Option<&str>,
+        processing_expires_at: Option<&str>,
+    ) -> i64 {
+        let result = sqlx::query(
+            "INSERT INTO outbox_events (
+                event_type, aggregate_key, payload_json,
+                origin_request_id, origin_idempotency_key,
+                origin_command_name, origin_request_hash,
+                status, attempts, next_attempt_at,
+                processing_started_at, processing_expires_at,
+                created_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(event_type)
+        .bind(aggregate_key)
+        .bind(r#"{"schema_version":1}"#)
+        .bind(format!("req-{event_type}-{aggregate_key}"))
+        .bind(format!("idem-{event_type}-{aggregate_key}"))
+        .bind("test.command")
+        .bind("hash-test")
+        .bind(status)
+        .bind(attempts)
+        .bind(next_attempt_at)
+        .bind(if status == "processing" {
+            Some("2026-05-03T08:59:00+00:00")
+        } else {
+            None
+        })
+        .bind(processing_expires_at)
+        .bind("2026-05-03T09:00:00+00:00")
+        .execute(pool)
+        .await
+        .expect("seeds outbox event");
+
+        result.last_insert_rowid()
+    }
 
     fn test_ctx(command_name: &str) -> WriteCommandContext {
         let issued_at = DateTime::parse_from_rfc3339("2026-05-03T09:00:00+07:00")
@@ -350,14 +631,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_outbox_event_tx_persists_pending_event_contract() {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory sqlite connects");
-        crate::db::run_migrations(&pool)
-            .await
-            .expect("migrations run");
+        let pool = test_pool().await;
 
         let spec = OutboxEventSpec::new(
             "booking.checked_out",
@@ -429,5 +703,268 @@ mod tests {
             .is_none());
         assert!(row.get::<Option<String>, _>("last_error").is_none());
         assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_pending_event_sets_processing_and_increments_attempts() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+
+        let claimed = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("claim succeeds")
+            .expect("event is claimed");
+
+        assert_eq!(claimed.id, id);
+        assert_eq!(claimed.event_type, "booking.checked_out");
+        assert_eq!(claimed.aggregate_key, "booking:B1");
+        assert_eq!(claimed.payload_json, r#"{"schema_version":1}"#);
+        assert_eq!(
+            claimed.origin_request_id,
+            "req-booking.checked_out-booking:B1"
+        );
+        assert_eq!(
+            claimed.origin_idempotency_key,
+            "idem-booking.checked_out-booking:B1"
+        );
+        assert_eq!(claimed.origin_command_name, "test.command");
+        assert_eq!(claimed.origin_request_hash, "hash-test");
+        assert_eq!(claimed.attempts, 1);
+        assert!(!claimed.worker_token.is_empty());
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, next_attempt_at,
+                    processing_started_at, processing_expires_at, last_error
+             FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("claimed row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "processing");
+        assert_eq!(row.get::<i64, _>("attempts"), 1);
+        assert_eq!(
+            row.get::<Option<String>, _>("worker_token"),
+            Some(claimed.worker_token)
+        );
+        assert!(row.get::<Option<String>, _>("next_attempt_at").is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_started_at")
+            .is_some());
+        assert!(row
+            .get::<Option<String>, _>("processing_expires_at")
+            .is_some());
+        assert!(row.get::<Option<String>, _>("last_error").is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_preserves_fifo_for_same_aggregate() {
+        let pool = test_pool().await;
+        let first_id = seed_outbox_event(
+            &pool,
+            "booking.first",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let second_id = seed_outbox_event(
+            &pool,
+            "booking.second",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+
+        let first_claim = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("claim succeeds")
+            .expect("first event is claimed");
+        let second_claim = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("second claim succeeds");
+
+        assert_eq!(first_claim.id, first_id);
+        assert_eq!(second_claim, None);
+
+        let second_status: String =
+            sqlx::query_scalar("SELECT status FROM outbox_events WHERE id = ?")
+                .bind(second_id)
+                .fetch_one(&pool)
+                .await
+                .expect("second row exists");
+        assert_eq!(second_status, "pending");
+    }
+
+    #[tokio::test]
+    async fn claim_reclaims_expired_processing_event() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "processing",
+            2,
+            None,
+            Some("2000-01-01T00:00:00+00:00"),
+        )
+        .await;
+
+        let claimed = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("claim succeeds")
+            .expect("expired processing event is reclaimed");
+
+        assert_eq!(claimed.id, id);
+        assert_eq!(claimed.attempts, 3);
+        assert!(!claimed.worker_token.is_empty());
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, processing_expires_at
+             FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("claimed row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "processing");
+        assert_eq!(row.get::<i64, _>("attempts"), 3);
+        assert_eq!(
+            row.get::<Option<String>, _>("worker_token"),
+            Some(claimed.worker_token)
+        );
+        let expires_at = row
+            .get::<Option<String>, _>("processing_expires_at")
+            .expect("processing expiry set");
+        assert!(expires_at > "2000-01-01T00:00:00+00:00".to_string());
+    }
+
+    #[tokio::test]
+    async fn claim_does_not_reclaim_active_processing_event() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "processing",
+            2,
+            None,
+            Some("2999-05-03T09:00:30+00:00"),
+        )
+        .await;
+
+        let claimed = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("claim succeeds");
+
+        assert_eq!(claimed, None);
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, processing_expires_at
+             FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("processing row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "processing");
+        assert_eq!(row.get::<i64, _>("attempts"), 2);
+        assert!(row.get::<Option<String>, _>("worker_token").is_none());
+        assert_eq!(
+            row.get::<Option<String>, _>("processing_expires_at"),
+            Some("2999-05-03T09:00:30+00:00".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_limit_rows_fail_before_subscriber_claim() {
+        let pool = test_pool().await;
+        let pending_retry_limited_id = seed_outbox_event(
+            &pool,
+            "booking.pending_limited",
+            "booking:B1",
+            "pending",
+            5,
+            None,
+            None,
+        )
+        .await;
+        let expired_processing_retry_limited_id = seed_outbox_event(
+            &pool,
+            "booking.processing_limited",
+            "booking:B2",
+            "processing",
+            5,
+            None,
+            Some("2000-01-01T00:00:00+00:00"),
+        )
+        .await;
+        let claimable_id = seed_outbox_event(
+            &pool,
+            "booking.claimable",
+            "booking:B3",
+            "pending",
+            4,
+            None,
+            None,
+        )
+        .await;
+
+        let failed = fail_retry_limit_rows(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("retry-limit rows fail");
+        let claimed = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("claim succeeds")
+            .expect("remaining event is claimable");
+
+        assert_eq!(failed, 2);
+        assert_eq!(claimed.id, claimable_id);
+
+        for id in [
+            pending_retry_limited_id,
+            expired_processing_retry_limited_id,
+        ] {
+            let row = sqlx::query(
+                "SELECT status, worker_token, next_attempt_at,
+                        processing_started_at, processing_expires_at, last_error
+                 FROM outbox_events WHERE id = ?",
+            )
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .expect("retry-limited row exists");
+
+            assert_eq!(row.get::<String, _>("status"), "failed");
+            assert!(row.get::<Option<String>, _>("worker_token").is_none());
+            assert!(row.get::<Option<String>, _>("next_attempt_at").is_none());
+            assert!(row
+                .get::<Option<String>, _>("processing_started_at")
+                .is_none());
+            assert!(row
+                .get::<Option<String>, _>("processing_expires_at")
+                .is_none());
+            assert_eq!(
+                row.get::<Option<String>, _>("last_error"),
+                Some("outbox retry limit reached".to_string())
+            );
+        }
     }
 }

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -5,7 +5,7 @@ use crate::{
 use chrono::{Duration, Utc};
 use serde_json::{json, Value};
 use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, Transaction};
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 const OUTBOX_STATUS_PENDING: &str = "pending";
 const OUTBOX_STATUS_PROCESSING: &str = "processing";
@@ -459,6 +459,18 @@ pub async fn run_outbox_dispatch_batch(
     }
 
     Ok(summary)
+}
+
+pub async fn run_outbox_startup_recovery_once(
+    pool: &Pool<Sqlite>,
+    subscribers: &[Arc<dyn OutboxSubscriber>],
+    config: OutboxDispatchConfig,
+) -> CommandResult<OutboxDispatchSummary> {
+    let subscriber_refs = subscribers
+        .iter()
+        .map(|subscriber| subscriber.as_ref())
+        .collect::<Vec<&dyn OutboxSubscriber>>();
+    run_outbox_dispatch_batch(pool, &subscriber_refs, config).await
 }
 
 impl OutboxEventSpec {
@@ -1222,6 +1234,147 @@ mod tests {
                 Some("outbox retry limit reached".to_string())
             );
         }
+    }
+
+    #[tokio::test]
+    async fn batch_with_empty_subscribers_leaves_pending_rows_unchanged() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+
+        let summary = run_outbox_dispatch_batch(&pool, &[], OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch batch skips without subscribers");
+
+        assert_eq!(summary, OutboxDispatchSummary::default());
+
+        let row = sqlx::query("SELECT status, attempts FROM outbox_events WHERE id = ?")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .expect("pending row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "pending");
+        assert_eq!(row.get::<i64, _>("attempts"), 0);
+    }
+
+    #[tokio::test]
+    async fn batch_dispatches_same_aggregate_in_id_order() {
+        let pool = test_pool().await;
+        let first_id = seed_outbox_event(
+            &pool,
+            "booking.first",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let second_id = seed_outbox_event(
+            &pool,
+            "booking.second",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = RecordingSubscriber {
+            calls: calls.clone(),
+            ..RecordingSubscriber::default()
+        };
+        let subscribers: [&dyn OutboxSubscriber; 1] = [&subscriber];
+
+        let summary = run_outbox_dispatch_batch(&pool, &subscribers, OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch batch succeeds");
+
+        assert_eq!(summary.dispatched, 2);
+        assert_eq!(
+            *calls.lock().expect("calls lock"),
+            vec![first_id, second_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_allows_different_aggregates_without_global_order_dependency() {
+        let pool = test_pool().await;
+        let blocked_id = seed_outbox_event(
+            &pool,
+            "booking.blocked",
+            "booking:B1",
+            "pending",
+            0,
+            Some("2999-05-03T09:00:30+00:00"),
+            None,
+        )
+        .await;
+        let due_id =
+            seed_outbox_event(&pool, "booking.due", "booking:B2", "pending", 0, None, None).await;
+        let subscriber = RecordingSubscriber::default();
+        let subscribers: [&dyn OutboxSubscriber; 1] = [&subscriber];
+
+        let summary = run_outbox_dispatch_batch(&pool, &subscribers, OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch batch succeeds");
+
+        assert_eq!(summary.dispatched, 1);
+        assert_eq!(
+            *subscriber.calls.lock().expect("calls lock"),
+            vec![due_id],
+            "due event on a different aggregate dispatches"
+        );
+
+        let blocked_status: String =
+            sqlx::query_scalar("SELECT status FROM outbox_events WHERE id = ?")
+                .bind(blocked_id)
+                .fetch_one(&pool)
+                .await
+                .expect("blocked row exists");
+        assert_eq!(blocked_status, "pending");
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_with_injected_subscriber_processes_expired_processing() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "processing",
+            2,
+            None,
+            Some("2000-01-01T00:00:00+00:00"),
+        )
+        .await;
+        let subscriber: std::sync::Arc<dyn OutboxSubscriber> =
+            std::sync::Arc::new(RecordingSubscriber::default());
+        let subscribers = vec![subscriber];
+
+        let summary =
+            run_outbox_startup_recovery_once(&pool, &subscribers, OutboxDispatchConfig::test())
+                .await
+                .expect("startup recovery dispatches expired processing row");
+
+        assert_eq!(summary.dispatched, 1);
+
+        let status: String = sqlx::query_scalar("SELECT status FROM outbox_events WHERE id = ?")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .expect("recovered row exists");
+        assert_eq!(status, "dispatched");
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -1226,7 +1226,7 @@ mod tests {
         let expires_at = row
             .get::<Option<String>, _>("processing_expires_at")
             .expect("processing expiry set");
-        assert!(expires_at > "2000-01-01T00:00:00+00:00".to_string());
+        assert!(expires_at.as_str() > "2000-01-01T00:00:00+00:00");
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -5,11 +5,14 @@ use crate::{
 use chrono::{Duration, Utc};
 use serde_json::{json, Value};
 use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, Transaction};
+use std::{future::Future, pin::Pin};
 
 const OUTBOX_STATUS_PENDING: &str = "pending";
 const OUTBOX_STATUS_PROCESSING: &str = "processing";
+const OUTBOX_STATUS_DISPATCHED: &str = "dispatched";
 const OUTBOX_STATUS_FAILED: &str = "failed";
 const OUTBOX_SAFE_TEXT_MAX_CHARS: usize = 160;
+const OUTBOX_ERROR_MAX_CHARS: usize = 512;
 const OUTBOX_RETRY_LIMIT_ERROR: &str = "outbox retry limit reached";
 const CLAIM_NEXT_OUTBOX_EVENT_CANDIDATE_SQL: &str = "
 SELECT id
@@ -130,6 +133,22 @@ pub struct OutboxEvent {
     pub created_at: String,
     pub attempts: i64,
     pub worker_token: String,
+}
+
+pub type OutboxSubscriberFuture<'a> = Pin<Box<dyn Future<Output = CommandResult<()>> + Send + 'a>>;
+
+pub trait OutboxSubscriber: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn handle<'a>(&'a self, event: &'a OutboxEvent) -> OutboxSubscriberFuture<'a>;
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct OutboxDispatchSummary {
+    pub claimed: u64,
+    pub dispatched: u64,
+    pub retried: u64,
+    pub failed: u64,
+    pub retry_limit_failed: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -336,6 +355,112 @@ pub async fn claim_next_outbox_event(
     }
 }
 
+pub async fn mark_outbox_dispatched(
+    pool: &Pool<Sqlite>,
+    id: i64,
+    worker_token: &str,
+) -> CommandResult<bool> {
+    let now = Utc::now().to_rfc3339();
+    let result = sqlx::query(
+        "UPDATE outbox_events
+         SET status = ?,
+             worker_token = NULL,
+             next_attempt_at = NULL,
+             processing_started_at = NULL,
+             processing_expires_at = NULL,
+             last_error = NULL,
+             dispatched_at = ?
+         WHERE id = ?
+           AND status = ?
+           AND worker_token = ?",
+    )
+    .bind(OUTBOX_STATUS_DISPATCHED)
+    .bind(&now)
+    .bind(id)
+    .bind(OUTBOX_STATUS_PROCESSING)
+    .bind(worker_token)
+    .execute(pool)
+    .await
+    .map_err(system_error)?;
+
+    Ok(result.rows_affected() == 1)
+}
+
+pub async fn record_outbox_failure(
+    pool: &Pool<Sqlite>,
+    event: &OutboxEvent,
+    error: &CommandError,
+    config: OutboxDispatchConfig,
+) -> CommandResult<bool> {
+    let terminal_failure = event.attempts >= config.max_attempts;
+    let status = if terminal_failure {
+        OUTBOX_STATUS_FAILED
+    } else {
+        OUTBOX_STATUS_PENDING
+    };
+    let next_attempt_at = if terminal_failure {
+        None
+    } else {
+        Some(next_attempt_at_for_attempt(event.attempts))
+    };
+    let last_error = sanitize_outbox_error(error);
+
+    let result = sqlx::query(
+        "UPDATE outbox_events
+         SET status = ?,
+             worker_token = NULL,
+             next_attempt_at = ?,
+             processing_started_at = NULL,
+             processing_expires_at = NULL,
+             last_error = ?
+         WHERE id = ?
+           AND status = ?
+           AND worker_token = ?",
+    )
+    .bind(status)
+    .bind(next_attempt_at)
+    .bind(last_error)
+    .bind(event.id)
+    .bind(OUTBOX_STATUS_PROCESSING)
+    .bind(&event.worker_token)
+    .execute(pool)
+    .await
+    .map_err(system_error)?;
+
+    Ok(result.rows_affected() == 1)
+}
+
+pub async fn run_outbox_dispatch_batch(
+    pool: &Pool<Sqlite>,
+    subscribers: &[&dyn OutboxSubscriber],
+    config: OutboxDispatchConfig,
+) -> CommandResult<OutboxDispatchSummary> {
+    if subscribers.is_empty() {
+        return Ok(OutboxDispatchSummary::default());
+    }
+
+    let mut summary = OutboxDispatchSummary {
+        retry_limit_failed: fail_retry_limit_rows(pool, config).await?,
+        ..OutboxDispatchSummary::default()
+    };
+
+    for _ in 0..config.batch_size {
+        let Some(event) = claim_next_outbox_event(pool, config).await? else {
+            break;
+        };
+
+        summary.claimed += 1;
+        match dispatch_claimed_event(pool, event, subscribers, config).await? {
+            ClaimedDispatchOutcome::Dispatched => summary.dispatched += 1,
+            ClaimedDispatchOutcome::Retried => summary.retried += 1,
+            ClaimedDispatchOutcome::Failed => summary.failed += 1,
+            ClaimedDispatchOutcome::Stale => {}
+        }
+    }
+
+    Ok(summary)
+}
+
 impl OutboxEventSpec {
     pub fn new(
         event_type: &'static str,
@@ -437,6 +562,42 @@ fn resolve_aggregate(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimedDispatchOutcome {
+    Dispatched,
+    Retried,
+    Failed,
+    Stale,
+}
+
+async fn dispatch_claimed_event(
+    pool: &Pool<Sqlite>,
+    event: OutboxEvent,
+    subscribers: &[&dyn OutboxSubscriber],
+    config: OutboxDispatchConfig,
+) -> CommandResult<ClaimedDispatchOutcome> {
+    for subscriber in subscribers {
+        if let Err(error) = subscriber.handle(&event).await {
+            let terminal_failure = event.attempts >= config.max_attempts;
+            let finalized = record_outbox_failure(pool, &event, &error, config).await?;
+            if !finalized {
+                return Ok(ClaimedDispatchOutcome::Stale);
+            }
+            return Ok(if terminal_failure {
+                ClaimedDispatchOutcome::Failed
+            } else {
+                ClaimedDispatchOutcome::Retried
+            });
+        }
+    }
+
+    if mark_outbox_dispatched(pool, event.id, &event.worker_token).await? {
+        Ok(ClaimedDispatchOutcome::Dispatched)
+    } else {
+        Ok(ClaimedDispatchOutcome::Stale)
+    }
+}
+
 fn validate_aggregate_key_source(source: &OutboxAggregateKeySource) -> CommandResult<()> {
     match source {
         OutboxAggregateKeySource::PrimaryAggregateKey => Ok(()),
@@ -494,6 +655,26 @@ fn contains_forbidden_payload_term(value: &str) -> bool {
     ]
     .iter()
     .any(|term| lower.contains(term))
+}
+
+fn sanitize_outbox_error(error: &CommandError) -> String {
+    let message = error.message.trim();
+    let value = if message.is_empty() {
+        error.code.trim()
+    } else {
+        message
+    };
+    value.chars().take(OUTBOX_ERROR_MAX_CHARS).collect()
+}
+
+fn next_attempt_at_for_attempt(attempts: i64) -> String {
+    let delay_seconds = match attempts {
+        i64::MIN..=1 => 1,
+        2 => 5,
+        3 => 15,
+        _ => 30,
+    };
+    (Utc::now() + Duration::seconds(delay_seconds)).to_rfc3339()
 }
 
 fn canonicalize_json_value(value: Value) -> Value {
@@ -620,6 +801,31 @@ mod tests {
             session_id: None,
             channel_id: None,
             issued_at,
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingSubscriber {
+        calls: std::sync::Arc<std::sync::Mutex<Vec<i64>>>,
+        fail: bool,
+    }
+
+    impl OutboxSubscriber for RecordingSubscriber {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+
+        fn handle<'a>(&'a self, event: &'a OutboxEvent) -> OutboxSubscriberFuture<'a> {
+            Box::pin(async move {
+                self.calls.lock().expect("calls lock").push(event.id);
+                if self.fail {
+                    return Err(CommandError::system(
+                        codes::SYSTEM_INTERNAL_ERROR,
+                        "subscriber failed",
+                    ));
+                }
+                Ok(())
+            })
         }
     }
 
@@ -1012,6 +1218,231 @@ mod tests {
                 Some("outbox retry limit reached".to_string())
             );
         }
+    }
+
+    #[tokio::test]
+    async fn dispatch_success_marks_event_dispatched() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let subscriber = RecordingSubscriber::default();
+        let subscribers: [&dyn OutboxSubscriber; 1] = [&subscriber];
+
+        let summary = run_outbox_dispatch_batch(&pool, &subscribers, OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch succeeds");
+
+        assert_eq!(
+            summary,
+            OutboxDispatchSummary {
+                claimed: 1,
+                dispatched: 1,
+                retried: 0,
+                failed: 0,
+                retry_limit_failed: 0,
+            }
+        );
+        assert_eq!(
+            *subscriber.calls.lock().expect("calls lock"),
+            vec![id],
+            "subscriber receives claimed event"
+        );
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, next_attempt_at,
+                    processing_started_at, processing_expires_at,
+                    last_error, dispatched_at
+             FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("dispatched row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "dispatched");
+        assert_eq!(row.get::<i64, _>("attempts"), 1);
+        assert!(row.get::<Option<String>, _>("worker_token").is_none());
+        assert!(row.get::<Option<String>, _>("next_attempt_at").is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_started_at")
+            .is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_expires_at")
+            .is_none());
+        assert!(row.get::<Option<String>, _>("last_error").is_none());
+        assert!(row.get::<Option<String>, _>("dispatched_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn dispatch_failure_retries_pending_with_backoff() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let subscriber = RecordingSubscriber {
+            fail: true,
+            ..RecordingSubscriber::default()
+        };
+        let subscribers: [&dyn OutboxSubscriber; 1] = [&subscriber];
+
+        let summary = run_outbox_dispatch_batch(&pool, &subscribers, OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch batch records failure");
+
+        assert_eq!(
+            summary,
+            OutboxDispatchSummary {
+                claimed: 1,
+                dispatched: 0,
+                retried: 1,
+                failed: 0,
+                retry_limit_failed: 0,
+            }
+        );
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, next_attempt_at,
+                    processing_started_at, processing_expires_at,
+                    last_error, dispatched_at
+             FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("retried row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "pending");
+        assert_eq!(row.get::<i64, _>("attempts"), 1);
+        assert!(row.get::<Option<String>, _>("worker_token").is_none());
+        assert!(row.get::<Option<String>, _>("next_attempt_at").is_some());
+        assert!(row
+            .get::<Option<String>, _>("processing_started_at")
+            .is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_expires_at")
+            .is_none());
+        assert_eq!(
+            row.get::<Option<String>, _>("last_error"),
+            Some("subscriber failed".to_string())
+        );
+        assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_failure_at_limit_marks_failed() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            4,
+            None,
+            None,
+        )
+        .await;
+        let subscriber = RecordingSubscriber {
+            fail: true,
+            ..RecordingSubscriber::default()
+        };
+        let subscribers: [&dyn OutboxSubscriber; 1] = [&subscriber];
+
+        let summary = run_outbox_dispatch_batch(&pool, &subscribers, OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch batch records terminal failure");
+
+        assert_eq!(
+            summary,
+            OutboxDispatchSummary {
+                claimed: 1,
+                dispatched: 0,
+                retried: 0,
+                failed: 1,
+                retry_limit_failed: 0,
+            }
+        );
+
+        let row = sqlx::query(
+            "SELECT status, attempts, worker_token, next_attempt_at,
+                    processing_started_at, processing_expires_at,
+                    last_error, dispatched_at
+             FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("failed row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "failed");
+        assert_eq!(row.get::<i64, _>("attempts"), 5);
+        assert!(row.get::<Option<String>, _>("worker_token").is_none());
+        assert!(row.get::<Option<String>, _>("next_attempt_at").is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_started_at")
+            .is_none());
+        assert!(row
+            .get::<Option<String>, _>("processing_expires_at")
+            .is_none());
+        assert_eq!(
+            row.get::<Option<String>, _>("last_error"),
+            Some("subscriber failed".to_string())
+        );
+        assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_worker_token_cannot_mark_dispatched() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let claimed = claim_next_outbox_event(&pool, OutboxDispatchConfig::test())
+            .await
+            .expect("claim succeeds")
+            .expect("event is claimed");
+
+        let updated = mark_outbox_dispatched(&pool, id, "stale-worker-token")
+            .await
+            .expect("stale finalization is ignored");
+
+        assert!(!updated);
+
+        let row = sqlx::query(
+            "SELECT status, worker_token, dispatched_at FROM outbox_events WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("claimed row exists");
+
+        assert_eq!(row.get::<String, _>("status"), "processing");
+        assert_eq!(
+            row.get::<Option<String>, _>("worker_token"),
+            Some(claimed.worker_token)
+        );
+        assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
     }
 
     async fn explain_query_plan(

--- a/mhm/src-tauri/src/outbox.rs
+++ b/mhm/src-tauri/src/outbox.rs
@@ -658,13 +658,16 @@ fn contains_forbidden_payload_term(value: &str) -> bool {
 }
 
 fn sanitize_outbox_error(error: &CommandError) -> String {
-    let message = error.message.trim();
-    let value = if message.is_empty() {
-        error.code.trim()
+    let safe_code = error.code.trim();
+    let safe_code = if validate_safe_outbox_text(safe_code).is_ok() {
+        safe_code
     } else {
-        message
+        codes::SYSTEM_INTERNAL_ERROR
     };
-    value.chars().take(OUTBOX_ERROR_MAX_CHARS).collect()
+    format!("{safe_code}: subscriber delivery failed")
+        .chars()
+        .take(OUTBOX_ERROR_MAX_CHARS)
+        .collect()
 }
 
 fn next_attempt_at_for_attempt(attempts: i64) -> String {
@@ -808,6 +811,7 @@ mod tests {
     struct RecordingSubscriber {
         calls: std::sync::Arc<std::sync::Mutex<Vec<i64>>>,
         fail: bool,
+        error_message: Option<String>,
     }
 
     impl OutboxSubscriber for RecordingSubscriber {
@@ -821,7 +825,7 @@ mod tests {
                 if self.fail {
                     return Err(CommandError::system(
                         codes::SYSTEM_INTERNAL_ERROR,
-                        "subscriber failed",
+                        self.error_message.as_deref().unwrap_or("subscriber failed"),
                     ));
                 }
                 Ok(())
@@ -1338,7 +1342,7 @@ mod tests {
             .is_none());
         assert_eq!(
             row.get::<Option<String>, _>("last_error"),
-            Some("subscriber failed".to_string())
+            Some("SYSTEM_INTERNAL_ERROR: subscriber delivery failed".to_string())
         );
         assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
     }
@@ -1400,9 +1404,55 @@ mod tests {
             .is_none());
         assert_eq!(
             row.get::<Option<String>, _>("last_error"),
-            Some("subscriber failed".to_string())
+            Some("SYSTEM_INTERNAL_ERROR: subscriber delivery failed".to_string())
         );
         assert!(row.get::<Option<String>, _>("dispatched_at").is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_failure_does_not_store_unsafe_subscriber_error() {
+        let pool = test_pool().await;
+        let id = seed_outbox_event(
+            &pool,
+            "booking.checked_out",
+            "booking:B1",
+            "pending",
+            0,
+            None,
+            None,
+        )
+        .await;
+        let unsafe_message = format!(
+            "delivery failed for guest@example.com with token=secret-token passport CCCD {}",
+            "x".repeat(700)
+        );
+        let subscriber = RecordingSubscriber {
+            fail: true,
+            error_message: Some(unsafe_message),
+            ..RecordingSubscriber::default()
+        };
+        let subscribers: [&dyn OutboxSubscriber; 1] = [&subscriber];
+
+        run_outbox_dispatch_batch(&pool, &subscribers, OutboxDispatchConfig::test())
+            .await
+            .expect("dispatch batch records sanitized failure");
+
+        let last_error: String =
+            sqlx::query_scalar("SELECT last_error FROM outbox_events WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .expect("last_error is stored");
+
+        assert_eq!(
+            last_error,
+            "SYSTEM_INTERNAL_ERROR: subscriber delivery failed"
+        );
+        assert!(last_error.chars().count() <= OUTBOX_ERROR_MAX_CHARS);
+        assert!(!last_error.contains("guest@example.com"));
+        assert!(!last_error.to_ascii_lowercase().contains("token"));
+        assert!(!last_error.to_ascii_lowercase().contains("passport"));
+        assert!(!last_error.to_ascii_lowercase().contains("cccd"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add durable outbox dispatch claim/reclaim with retry limits, worker tokens, and per-aggregate FIFO behavior.
- Add subscriber dispatch/finalization paths, safe no-subscriber startup behavior, and startup recovery that resumes outbox notifications without replaying business commands.
- Add V17 FIFO support index plus tests covering crash reclaim, retry/failed behavior, rollback/no ghost event, FIFO ordering, no-subscriber startup, command recovery scan-only semantics, and hash/id validation false positives.

## Notes
- #112 has merged, so this PR is now based directly on `main`.
- Production startup currently leaves the dispatcher inactive until a real subscriber is registered; this avoids marking events dispatched without delivery.
- Addresses the #112 review comment about not scanning machine-generated hashes/IDs for forbidden human payload terms.

## Verification
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml outbox::tests::outbox_spec_allows_forbidden_substrings_in_machine_identifiers --lib -- --nocapture`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml outbox::tests::outbox_spec_rejects_sensitive_refresh_area --lib -- --nocapture`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml outbox::tests::outbox_spec_builds_canonical_minimal_payload --lib -- --nocapture`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml outbox::tests:: --lib -- --nocapture`
- `cargo test --manifest-path mhm/src-tauri/Cargo.toml command_idempotency::tests::outbox --lib -- --nocapture`
- `cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets -- -D warnings`
- Prior full validation on this branch: `npm run verify:full`, `npm test -- tests/e2e`
- Final implementation review subagent: PASS

Closes #79.
Closes #82.
Closes #85.