### PR TITLE
[codex] Add MCP observer stream

### DIFF
--- a/mhm/skills/mcp-manifest.json
+++ b/mhm/skills/mcp-manifest.json
@@ -11,6 +11,18 @@
             }
         }
     },
+    "observer": {
+        "sse": {
+            "url": "http://127.0.0.1:<gateway-port>/observer/events",
+            "headers": {
+                "Authorization": "Bearer <your-api-key>"
+            },
+            "cursor": {
+                "query": "last_event_id",
+                "header": "Last-Event-ID"
+            }
+        }
+    },
     "tools": [
         {
             "name": "get_hotel_context",

--- a/mhm/skills/openapi.yaml
+++ b/mhm/skills/openapi.yaml
@@ -47,7 +47,46 @@ paths:
                 type: string
                 example: OK
 
+  /observer/events:
+    get:
+      summary: PMS Observer Event Stream
+      description: |
+        Read-only Server-Sent Events stream for committed PMS outbox facts.
+        No cursor starts after the current latest event.
+        last_event_id replays events after the cursor, then streams new events.
+        Payloads are observer-safe facts, not commands.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: last_event_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: Replay events after this observer cursor before streaming new events.
+      responses:
+        '200':
+          description: Observer event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        '400':
+          description: Invalid cursor
+        '401':
+          description: Missing or invalid API key
+        '409':
+          description: Cursor expired; rebuild snapshot
+        '500':
+          description: Observer unavailable
+
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+
   schemas:
     JsonRpcRequest:
       type: object

--- a/mhm/src-tauri/Cargo.lock
+++ b/mhm/src-tauri/Cargo.lock
@@ -246,6 +246,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,10 +638,12 @@ dependencies = [
 name = "capyinn"
 version = "0.1.4"
 dependencies = [
+ "async-stream",
  "axum",
  "chrono",
  "dirs",
  "env_logger",
+ "futures-util",
  "image",
  "log",
  "notify",

--- a/mhm/src-tauri/Cargo.toml
+++ b/mhm/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ regex = "1"
 sha2 = "0.10"
 # MCP Gateway
 rmcp = { version = "1.2", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
+async-stream = "0.3"
+futures-util = "0.3"
 schemars = "0.8"
 axum = "0.8"
 rand = "0.8"

--- a/mhm/src-tauri/src/backup/types.rs
+++ b/mhm/src-tauri/src/backup/types.rs
@@ -77,9 +77,9 @@ impl BackupRequestError {
     pub fn kind(&self) -> BackupRequestErrorKind {
         match self {
             Self::ShutdownInProgress => BackupRequestErrorKind::ShutdownSkip,
-            Self::MissingHomeDirectory
-            | Self::BackupFailed(_)
-            | Self::ShutdownTimedOut => BackupRequestErrorKind::Failure,
+            Self::MissingHomeDirectory | Self::BackupFailed(_) | Self::ShutdownTimedOut => {
+                BackupRequestErrorKind::Failure
+            }
         }
     }
 }

--- a/mhm/src-tauri/src/command_failure_log.rs
+++ b/mhm/src-tauri/src/command_failure_log.rs
@@ -189,9 +189,9 @@ mod tests {
         assert!(parsed
             .iter()
             .any(|line| line["command"] == "check_in" && line.get("db_error_group").is_none()));
-        assert!(parsed.iter().any(
-            |line| line["command"] == "check_out" && line["db_error_group"] == "locked"
-        ));
+        assert!(parsed
+            .iter()
+            .any(|line| line["command"] == "check_out" && line["db_error_group"] == "locked"));
         assert!(parsed
             .iter()
             .all(|line| line["context"].get("correlation_id").is_none()));
@@ -201,9 +201,7 @@ mod tests {
         assert!(parsed
             .iter()
             .any(|line| line["context"]["guest_count"] == 0));
-        assert!(parsed
-            .iter()
-            .any(|line| line["context"]["nights"] == 0));
+        assert!(parsed.iter().any(|line| line["context"]["nights"] == 0));
         assert!(parsed
             .iter()
             .any(|line| line["context"]["booking_id"] == "B202"));

--- a/mhm/src-tauri/src/commands/audit.rs
+++ b/mhm/src-tauri/src/commands/audit.rs
@@ -85,18 +85,16 @@ fn map_audit_error(
     context: Value,
 ) -> (CommandError, Option<DbErrorGroup>) {
     match error {
-        BookingError::Validation(message) if message == "Ngày audit không hợp lệ" => {
-            (
-                map_audit_user_error(
-                    codes::AUDIT_INVALID_DATE,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                None,
-            )
-        }
+        BookingError::Validation(message) if message == "Ngày audit không hợp lệ" => (
+            map_audit_user_error(
+                codes::AUDIT_INVALID_DATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            ),
+            None,
+        ),
         BookingError::Validation(message) | BookingError::Conflict(message)
             if message.starts_with("Đã audit ngày ") =>
         {
@@ -111,18 +109,16 @@ fn map_audit_error(
                 None,
             )
         }
-        BookingError::Validation(message) | BookingError::Conflict(message) => {
-            (
-                map_audit_user_error(
-                    codes::AUDIT_INVALID_DATE,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                None,
-            )
-        }
+        BookingError::Validation(message) | BookingError::Conflict(message) => (
+            map_audit_user_error(
+                codes::AUDIT_INVALID_DATE,
+                command_name,
+                effective_correlation_id,
+                message,
+                &context,
+            ),
+            None,
+        ),
         BookingError::DatabaseWrite(message) => {
             let db_error_group = classify_db_failure(MonitoredDbFailure::DatabaseWrite(&message));
             (

--- a/mhm/src-tauri/src/commands/command_ledger.rs
+++ b/mhm/src-tauri/src/commands/command_ledger.rs
@@ -2,8 +2,8 @@ use super::{require_admin, AppState};
 use crate::command_ledger::{
     get_command_ledger_detail as get_command_ledger_detail_query,
     list_command_ledger as list_command_ledger_query,
-    list_command_ledger_attention as list_command_ledger_attention_query,
-    CommandLedgerDetail, CommandLedgerListItem, CommandLedgerListOptions,
+    list_command_ledger_attention as list_command_ledger_attention_query, CommandLedgerDetail,
+    CommandLedgerListItem, CommandLedgerListOptions,
 };
 use tauri::State;
 

--- a/mhm/src-tauri/src/gateway/mod.rs
+++ b/mhm/src-tauri/src/gateway/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod models;
+pub mod observer;
 pub mod policy;
 pub mod proxy;
 pub mod server;

--- a/mhm/src-tauri/src/gateway/observer.rs
+++ b/mhm/src-tauri/src/gateway/observer.rs
@@ -1,4 +1,8 @@
 use axum::http::HeaderMap;
+use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Row, Sqlite};
+
+const OBSERVER_BATCH_LIMIT: i64 = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ObserverErrorCode {
@@ -11,6 +15,36 @@ pub enum ObserverErrorCode {
 pub struct ObserverError {
     pub code: ObserverErrorCode,
     pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ObserverEvent {
+    pub event_id: i64,
+    pub event_type: String,
+    pub aggregate: ObserverAggregate,
+    pub created_at: String,
+    pub refresh: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ObserverAggregate {
+    #[serde(rename = "type")]
+    pub ref_type: String,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredOutboxPayload {
+    schema_version: i64,
+    aggregate: StoredOutboxAggregate,
+    refresh: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredOutboxAggregate {
+    #[serde(rename = "type")]
+    ref_type: String,
+    id: String,
 }
 
 pub fn parse_cursor(
@@ -46,6 +80,122 @@ fn invalid_cursor(message: &str) -> ObserverError {
         code: ObserverErrorCode::InvalidCursor,
         message: message.to_string(),
     }
+}
+
+fn observer_unavailable() -> ObserverError {
+    ObserverError {
+        code: ObserverErrorCode::ObserverUnavailable,
+        message: "observer stream is unavailable".to_string(),
+    }
+}
+
+fn cursor_expired() -> ObserverError {
+    ObserverError {
+        code: ObserverErrorCode::CursorExpired,
+        message: "last_event_id is older than the earliest observer event still available"
+            .to_string(),
+    }
+}
+
+fn parse_safe_payload(
+    payload_json: &str,
+) -> Result<(ObserverAggregate, Vec<String>), ObserverError> {
+    let payload: StoredOutboxPayload =
+        serde_json::from_str(payload_json).map_err(|_| observer_unavailable())?;
+
+    if payload.schema_version != 1 {
+        return Err(observer_unavailable());
+    }
+
+    let ref_type = payload.aggregate.ref_type.trim();
+    let id = payload.aggregate.id.trim();
+    if ref_type.is_empty() || id.is_empty() || payload.refresh.is_empty() {
+        return Err(observer_unavailable());
+    }
+
+    let mut refresh = Vec::with_capacity(payload.refresh.len());
+    for item in payload.refresh {
+        let trimmed = item.trim();
+        if trimmed.is_empty() {
+            return Err(observer_unavailable());
+        }
+        refresh.push(trimmed.to_string());
+    }
+
+    Ok((
+        ObserverAggregate {
+            ref_type: ref_type.to_string(),
+            id: id.to_string(),
+        },
+        refresh,
+    ))
+}
+
+pub async fn resolve_start_after_event_id(
+    pool: &Pool<Sqlite>,
+    cursor: Option<i64>,
+) -> Result<i64, ObserverError> {
+    let row = sqlx::query("SELECT MIN(id) AS min_id, MAX(id) AS max_id FROM outbox_events")
+        .fetch_one(pool)
+        .await
+        .map_err(|_| observer_unavailable())?;
+
+    let min_id: Option<i64> = row.try_get("min_id").map_err(|_| observer_unavailable())?;
+    let max_id: Option<i64> = row.try_get("max_id").map_err(|_| observer_unavailable())?;
+
+    match (cursor, min_id, max_id) {
+        (None, _, Some(max_id)) => Ok(max_id),
+        (None, _, None) => Ok(0),
+        (Some(cursor), Some(min_id), _) if cursor < min_id => Err(cursor_expired()),
+        (Some(cursor), _, Some(max_id)) if cursor > max_id => Err(invalid_cursor(
+            "Cursor is newer than the latest observer event",
+        )),
+        (Some(cursor), None, None) if cursor > 0 => Err(invalid_cursor(
+            "Cursor is newer than the latest observer event",
+        )),
+        (Some(cursor), _, _) => Ok(cursor),
+    }
+}
+
+pub async fn load_observer_events_after(
+    pool: &Pool<Sqlite>,
+    after_event_id: i64,
+    limit: i64,
+) -> Result<Vec<ObserverEvent>, ObserverError> {
+    let limit = limit.clamp(1, OBSERVER_BATCH_LIMIT);
+    let rows = sqlx::query(
+        "SELECT id, event_type, payload_json, created_at
+         FROM outbox_events
+         WHERE id > ?
+         ORDER BY id
+         LIMIT ?",
+    )
+    .bind(after_event_id)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(|_| observer_unavailable())?;
+
+    rows.into_iter()
+        .map(|row| {
+            let payload_json: String = row
+                .try_get("payload_json")
+                .map_err(|_| observer_unavailable())?;
+            let (aggregate, refresh) = parse_safe_payload(&payload_json)?;
+
+            Ok(ObserverEvent {
+                event_id: row.try_get("id").map_err(|_| observer_unavailable())?,
+                event_type: row
+                    .try_get("event_type")
+                    .map_err(|_| observer_unavailable())?,
+                aggregate,
+                created_at: row
+                    .try_get("created_at")
+                    .map_err(|_| observer_unavailable())?,
+                refresh,
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -125,6 +275,153 @@ mod tests {
         headers.insert("Last-Event-ID", HeaderValue::from_static("abc"));
 
         let error = parse_cursor(None, &headers).expect_err("non-numeric cursor is invalid");
+
+        assert_eq!(error.code, ObserverErrorCode::InvalidCursor);
+    }
+}
+
+#[cfg(test)]
+mod db_tests {
+    use super::{load_observer_events_after, resolve_start_after_event_id, ObserverErrorCode};
+    use serde_json::json;
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite connects");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("migrations run");
+        pool
+    }
+
+    async fn seed_outbox_event(pool: &Pool<Sqlite>, aggregate_id: &str, created_at: &str) -> i64 {
+        let payload = json!({
+            "schema_version": 1,
+            "command_name": "check_out",
+            "aggregate": { "type": "booking", "id": aggregate_id },
+            "refresh": ["bookings", "rooms", "folio"],
+            "guest_name": "Private Guest",
+            "guest_phone": "0900000000",
+            "doc_number": "P1234567",
+            "email": "private@example.com"
+        });
+
+        let result = sqlx::query(
+            "INSERT INTO outbox_events (
+                event_type, aggregate_key, payload_json,
+                origin_request_id, origin_idempotency_key,
+                origin_command_name, origin_request_hash,
+                status, attempts, created_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("pms.command.completed")
+        .bind(format!("booking:{aggregate_id}"))
+        .bind(payload.to_string())
+        .bind(format!("req-{aggregate_id}"))
+        .bind(format!("idem-{aggregate_id}"))
+        .bind("check_out")
+        .bind(format!("hash-{aggregate_id}"))
+        .bind("pending")
+        .bind(3_i64)
+        .bind(created_at)
+        .execute(pool)
+        .await
+        .expect("seeds outbox event");
+
+        result.last_insert_rowid()
+    }
+
+    #[tokio::test]
+    async fn no_cursor_starts_after_current_max_id() {
+        let pool = test_pool().await;
+        let first_id = seed_outbox_event(&pool, "booking-1", "2026-05-03T09:00:00+00:00").await;
+        let second_id = seed_outbox_event(&pool, "booking-2", "2026-05-03T09:01:00+00:00").await;
+
+        let start_after = resolve_start_after_event_id(&pool, None)
+            .await
+            .expect("resolves no cursor");
+        let events = load_observer_events_after(&pool, start_after, 100)
+            .await
+            .expect("loads observer events");
+
+        assert!(second_id > first_id);
+        assert_eq!(start_after, second_id);
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cursor_replays_only_newer_events_with_safe_payload() {
+        let pool = test_pool().await;
+        let first_id = seed_outbox_event(&pool, "booking-1", "2026-05-03T09:00:00+00:00").await;
+        let second_id = seed_outbox_event(&pool, "booking-2", "2026-05-03T09:01:00+00:00").await;
+
+        let start_after = resolve_start_after_event_id(&pool, Some(first_id))
+            .await
+            .expect("resolves cursor");
+        let events = load_observer_events_after(&pool, start_after, 100)
+            .await
+            .expect("loads observer events");
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.event_id, second_id);
+        assert_eq!(event.event_type, "pms.command.completed");
+        assert_eq!(event.aggregate.ref_type, "booking");
+        assert_eq!(event.aggregate.id, "booking-2");
+        assert_eq!(event.created_at, "2026-05-03T09:01:00+00:00");
+        assert_eq!(event.refresh, vec!["bookings", "rooms", "folio"]);
+
+        let serialized = serde_json::to_string(event).expect("serializes observer event");
+        for forbidden in [
+            "origin_request_id",
+            "origin_idempotency_key",
+            "origin_request_hash",
+            "origin_command_name",
+            "status",
+            "attempts",
+            "worker_token",
+            "last_error",
+            "payload_json",
+            "guest_name",
+            "guest_phone",
+            "doc_number",
+            "email",
+        ] {
+            assert!(
+                !serialized.contains(forbidden),
+                "serialized observer event exposed {forbidden}: {serialized}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_below_existing_min_id_is_expired() {
+        let pool = test_pool().await;
+        seed_outbox_event(&pool, "booking-1", "2026-05-03T09:00:00+00:00").await;
+
+        let error = resolve_start_after_event_id(&pool, Some(0))
+            .await
+            .expect_err("cursor below min is expired");
+
+        assert_eq!(error.code, ObserverErrorCode::CursorExpired);
+        assert_eq!(
+            error.message,
+            "last_event_id is older than the earliest observer event still available"
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_above_current_max_id_is_invalid() {
+        let pool = test_pool().await;
+        let current_id = seed_outbox_event(&pool, "booking-1", "2026-05-03T09:00:00+00:00").await;
+
+        let error = resolve_start_after_event_id(&pool, Some(current_id + 1))
+            .await
+            .expect_err("cursor above max is invalid");
 
         assert_eq!(error.code, ObserverErrorCode::InvalidCursor);
     }

--- a/mhm/src-tauri/src/gateway/observer.rs
+++ b/mhm/src-tauri/src/gateway/observer.rs
@@ -1,6 +1,17 @@
-use axum::http::HeaderMap;
+use async_stream::stream;
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse,
+    },
+    Json,
+};
+use futures_util::Stream;
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Row, Sqlite};
+use std::{convert::Infallible, time::Duration};
 
 const OBSERVER_BATCH_LIMIT: i64 = 100;
 
@@ -15,6 +26,23 @@ pub enum ObserverErrorCode {
 pub struct ObserverError {
     pub code: ObserverErrorCode,
     pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ObserverErrorResponse<'a> {
+    ok: bool,
+    error: ObserverErrorBody<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct ObserverErrorBody<'a> {
+    code: &'a str,
+    message: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ObserverQuery {
+    pub last_event_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -45,6 +73,39 @@ struct StoredOutboxAggregate {
     #[serde(rename = "type")]
     ref_type: String,
     id: String,
+}
+
+impl ObserverErrorCode {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ObserverErrorCode::InvalidCursor => "invalid_cursor",
+            ObserverErrorCode::CursorExpired => "cursor_expired",
+            ObserverErrorCode::ObserverUnavailable => "observer_unavailable",
+        }
+    }
+
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ObserverErrorCode::InvalidCursor => StatusCode::BAD_REQUEST,
+            ObserverErrorCode::CursorExpired => StatusCode::CONFLICT,
+            ObserverErrorCode::ObserverUnavailable => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl IntoResponse for ObserverError {
+    fn into_response(self) -> axum::response::Response {
+        let status = self.code.status_code();
+        let body = ObserverErrorResponse {
+            ok: false,
+            error: ObserverErrorBody {
+                code: self.code.as_str(),
+                message: &self.message,
+            },
+        };
+
+        (status, Json(body)).into_response()
+    }
 }
 
 pub fn parse_cursor(
@@ -196,6 +257,74 @@ pub async fn load_observer_events_after(
             })
         })
         .collect()
+}
+
+pub async fn observe_events(
+    State(pool): State<Pool<Sqlite>>,
+    Query(query): Query<ObserverQuery>,
+    headers: HeaderMap,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ObserverError> {
+    let cursor = parse_cursor(query.last_event_id.as_deref(), &headers)?;
+    let start_after = resolve_start_after_event_id(&pool, cursor).await?;
+
+    Ok(Sse::new(build_observer_sse_stream(
+        pool,
+        start_after,
+        Duration::from_secs(1),
+    ))
+    .keep_alive(KeepAlive::default()))
+}
+
+pub fn build_observer_sse_stream(
+    pool: Pool<Sqlite>,
+    start_after: i64,
+    poll_interval: Duration,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    stream! {
+        let mut last_sent_id = start_after;
+
+        loop {
+            match load_observer_events_after(&pool, last_sent_id, OBSERVER_BATCH_LIMIT).await {
+                Ok(events) => {
+                    for observer_event in events {
+                        last_sent_id = observer_event.event_id;
+                        let event_id = observer_event.event_id.to_string();
+                        let event = Event::default()
+                            .event("pms.changed")
+                            .id(event_id)
+                            .json_data(observer_event)
+                            .unwrap_or_else(|_| observer_error_event(observer_unavailable()));
+
+                        yield Ok(event);
+                    }
+                }
+                Err(error) => {
+                    yield Ok(observer_error_event(error));
+                }
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+}
+
+fn observer_error_event(error: ObserverError) -> Event {
+    let payload = ObserverErrorResponse {
+        ok: false,
+        error: ObserverErrorBody {
+            code: error.code.as_str(),
+            message: &error.message,
+        },
+    };
+
+    Event::default()
+        .event("observer.error")
+        .json_data(payload)
+        .unwrap_or_else(|_| {
+            Event::default().event("observer.error").data(
+                r#"{"ok":false,"error":{"code":"observer_unavailable","message":"observer stream is unavailable"}}"#,
+            )
+        })
 }
 
 #[cfg(test)]

--- a/mhm/src-tauri/src/gateway/observer.rs
+++ b/mhm/src-tauri/src/gateway/observer.rs
@@ -1,0 +1,131 @@
+use axum::http::HeaderMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObserverErrorCode {
+    InvalidCursor,
+    CursorExpired,
+    ObserverUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserverError {
+    pub code: ObserverErrorCode,
+    pub message: String,
+}
+
+pub fn parse_cursor(
+    query_last_event_id: Option<&str>,
+    headers: &HeaderMap,
+) -> Result<Option<i64>, ObserverError> {
+    let cursor = match query_last_event_id {
+        Some(cursor) => Some(cursor),
+        None => headers
+            .get("Last-Event-ID")
+            .map(|value| value.to_str())
+            .transpose()
+            .map_err(|_| invalid_cursor("Last-Event-ID header must be a valid integer cursor"))?,
+    };
+
+    cursor.map(parse_cursor_value).transpose()
+}
+
+fn parse_cursor_value(cursor: &str) -> Result<i64, ObserverError> {
+    let parsed = cursor
+        .parse::<i64>()
+        .map_err(|_| invalid_cursor("Cursor must be a non-negative integer"))?;
+
+    if parsed < 0 {
+        return Err(invalid_cursor("Cursor must be a non-negative integer"));
+    }
+
+    Ok(parsed)
+}
+
+fn invalid_cursor(message: &str) -> ObserverError {
+    ObserverError {
+        code: ObserverErrorCode::InvalidCursor,
+        message: message.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_cursor, ObserverErrorCode};
+    use axum::http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn parse_cursor_missing_cursor_returns_none() {
+        let headers = HeaderMap::new();
+
+        let cursor = parse_cursor(None, &headers).expect("missing cursor is valid");
+
+        assert_eq!(cursor, None);
+    }
+
+    #[test]
+    fn parse_cursor_reads_query_last_event_id() {
+        let headers = HeaderMap::new();
+
+        let cursor = parse_cursor(Some("42"), &headers).expect("query cursor is valid");
+
+        assert_eq!(cursor, Some(42));
+    }
+
+    #[test]
+    fn parse_cursor_reads_last_event_id_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Last-Event-ID", HeaderValue::from_static("84"));
+
+        let cursor = parse_cursor(None, &headers).expect("header cursor is valid");
+
+        assert_eq!(cursor, Some(84));
+    }
+
+    #[test]
+    fn parse_cursor_query_wins_over_last_event_id_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Last-Event-ID", HeaderValue::from_static("84"));
+
+        let cursor = parse_cursor(Some("42"), &headers).expect("query cursor is valid");
+
+        assert_eq!(cursor, Some(42));
+    }
+
+    #[test]
+    fn parse_cursor_rejects_negative_query_cursor() {
+        let headers = HeaderMap::new();
+
+        let error = parse_cursor(Some("-1"), &headers).expect_err("negative cursor is invalid");
+
+        assert_eq!(error.code, ObserverErrorCode::InvalidCursor);
+    }
+
+    #[test]
+    fn parse_cursor_rejects_non_numeric_query_cursor() {
+        let headers = HeaderMap::new();
+
+        let error = parse_cursor(Some("abc"), &headers).expect_err("non-numeric cursor is invalid");
+
+        assert_eq!(error.code, ObserverErrorCode::InvalidCursor);
+    }
+
+    #[test]
+    fn parse_cursor_rejects_negative_header_cursor() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Last-Event-ID", HeaderValue::from_static("-1"));
+
+        let error = parse_cursor(None, &headers).expect_err("negative cursor is invalid");
+
+        assert_eq!(error.code, ObserverErrorCode::InvalidCursor);
+    }
+
+    #[test]
+    fn parse_cursor_rejects_non_numeric_header_cursor() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Last-Event-ID", HeaderValue::from_static("abc"));
+
+        let error = parse_cursor(None, &headers).expect_err("non-numeric cursor is invalid");
+
+        assert_eq!(error.code, ObserverErrorCode::InvalidCursor);
+    }
+}

--- a/mhm/src-tauri/src/gateway/observer.rs
+++ b/mhm/src-tauri/src/gateway/observer.rs
@@ -1,12 +1,12 @@
 use async_stream::stream;
 use axum::{
+    Json,
     extract::{Query, State},
     http::{HeaderMap, StatusCode},
     response::{
-        sse::{Event, KeepAlive, Sse},
         IntoResponse,
+        sse::{Event, KeepAlive, Sse},
     },
-    Json,
 };
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
@@ -52,6 +52,12 @@ pub struct ObserverEvent {
     pub aggregate: ObserverAggregate,
     pub created_at: String,
     pub refresh: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserverEventBatch {
+    pub events: Vec<ObserverEvent>,
+    pub high_watermark_event_id: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -222,7 +228,7 @@ pub async fn load_observer_events_after(
     pool: &Pool<Sqlite>,
     after_event_id: i64,
     limit: i64,
-) -> Result<Vec<ObserverEvent>, ObserverError> {
+) -> Result<ObserverEventBatch, ObserverError> {
     let limit = limit.clamp(1, OBSERVER_BATCH_LIMIT);
     let rows = sqlx::query(
         "SELECT id, event_type, payload_json, created_at
@@ -237,26 +243,36 @@ pub async fn load_observer_events_after(
     .await
     .map_err(|_| observer_unavailable())?;
 
-    rows.into_iter()
-        .map(|row| {
-            let payload_json: String = row
-                .try_get("payload_json")
-                .map_err(|_| observer_unavailable())?;
-            let (aggregate, refresh) = parse_safe_payload(&payload_json)?;
+    let mut events = Vec::new();
+    let mut high_watermark_event_id = after_event_id;
+    for row in rows {
+        let event_id = row.try_get("id").map_err(|_| observer_unavailable())?;
+        high_watermark_event_id = event_id;
 
-            Ok(ObserverEvent {
-                event_id: row.try_get("id").map_err(|_| observer_unavailable())?,
-                event_type: row
-                    .try_get("event_type")
-                    .map_err(|_| observer_unavailable())?,
-                aggregate,
-                created_at: row
-                    .try_get("created_at")
-                    .map_err(|_| observer_unavailable())?,
-                refresh,
-            })
-        })
-        .collect()
+        let payload_json: String = row
+            .try_get("payload_json")
+            .map_err(|_| observer_unavailable())?;
+        let Ok((aggregate, refresh)) = parse_safe_payload(&payload_json) else {
+            continue;
+        };
+
+        events.push(ObserverEvent {
+            event_id,
+            event_type: row
+                .try_get("event_type")
+                .map_err(|_| observer_unavailable())?,
+            aggregate,
+            created_at: row
+                .try_get("created_at")
+                .map_err(|_| observer_unavailable())?,
+            refresh,
+        });
+    }
+
+    Ok(ObserverEventBatch {
+        events,
+        high_watermark_event_id,
+    })
 }
 
 pub async fn observe_events(
@@ -285,9 +301,8 @@ pub fn build_observer_sse_stream(
 
         loop {
             match load_observer_events_after(&pool, last_sent_id, OBSERVER_BATCH_LIMIT).await {
-                Ok(events) => {
-                    for observer_event in events {
-                        last_sent_id = observer_event.event_id;
+                Ok(batch) => {
+                    for observer_event in batch.events {
                         let event_id = observer_event.event_id.to_string();
                         let event = Event::default()
                             .event("pms.changed")
@@ -297,6 +312,7 @@ pub fn build_observer_sse_stream(
 
                         yield Ok(event);
                     }
+                    last_sent_id = batch.high_watermark_event_id;
                 }
                 Err(error) => {
                     yield Ok(observer_error_event(error));
@@ -329,7 +345,7 @@ fn observer_error_event(error: ObserverError) -> Event {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_cursor, ObserverErrorCode};
+    use super::{ObserverErrorCode, parse_cursor};
     use axum::http::{HeaderMap, HeaderValue};
 
     #[test]
@@ -411,9 +427,9 @@ mod tests {
 
 #[cfg(test)]
 mod db_tests {
-    use super::{load_observer_events_after, resolve_start_after_event_id, ObserverErrorCode};
+    use super::{ObserverErrorCode, load_observer_events_after, resolve_start_after_event_id};
     use serde_json::json;
-    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+    use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
 
     async fn test_pool() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()
@@ -464,6 +480,32 @@ mod db_tests {
         result.last_insert_rowid()
     }
 
+    async fn seed_malformed_outbox_event(pool: &Pool<Sqlite>, created_at: &str) -> i64 {
+        let result = sqlx::query(
+            "INSERT INTO outbox_events (
+                event_type, aggregate_key, payload_json,
+                origin_request_id, origin_idempotency_key,
+                origin_command_name, origin_request_hash,
+                status, attempts, created_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("pms.command.completed")
+        .bind("booking:malformed")
+        .bind(r#"{"schema_version":2,"aggregate":{"type":"booking","id":"malformed"},"refresh":["bookings"]}"#)
+        .bind("req-malformed")
+        .bind("idem-malformed")
+        .bind("check_out")
+        .bind("hash-malformed")
+        .bind("pending")
+        .bind(3_i64)
+        .bind(created_at)
+        .execute(pool)
+        .await
+        .expect("seeds malformed outbox event");
+
+        result.last_insert_rowid()
+    }
+
     #[tokio::test]
     async fn no_cursor_starts_after_current_max_id() {
         let pool = test_pool().await;
@@ -473,13 +515,14 @@ mod db_tests {
         let start_after = resolve_start_after_event_id(&pool, None)
             .await
             .expect("resolves no cursor");
-        let events = load_observer_events_after(&pool, start_after, 100)
+        let batch = load_observer_events_after(&pool, start_after, 100)
             .await
             .expect("loads observer events");
 
         assert!(second_id > first_id);
         assert_eq!(start_after, second_id);
-        assert!(events.is_empty());
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.high_watermark_event_id, second_id);
     }
 
     #[tokio::test]
@@ -491,12 +534,13 @@ mod db_tests {
         let start_after = resolve_start_after_event_id(&pool, Some(first_id))
             .await
             .expect("resolves cursor");
-        let events = load_observer_events_after(&pool, start_after, 100)
+        let batch = load_observer_events_after(&pool, start_after, 100)
             .await
             .expect("loads observer events");
 
-        assert_eq!(events.len(), 1);
-        let event = &events[0];
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.high_watermark_event_id, second_id);
+        let event = &batch.events[0];
         assert_eq!(event.event_id, second_id);
         assert_eq!(event.event_type, "pms.command.completed");
         assert_eq!(event.aggregate.ref_type, "booking");
@@ -525,6 +569,38 @@ mod db_tests {
                 "serialized observer event exposed {forbidden}: {serialized}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn malformed_payload_rows_do_not_block_later_events() {
+        let pool = test_pool().await;
+        let first_id = seed_outbox_event(&pool, "booking-1", "2026-05-03T09:00:00+00:00").await;
+        let malformed_id = seed_malformed_outbox_event(&pool, "2026-05-03T09:01:00+00:00").await;
+        let second_id = seed_outbox_event(&pool, "booking-2", "2026-05-03T09:02:00+00:00").await;
+
+        let batch = load_observer_events_after(&pool, first_id, 100)
+            .await
+            .expect("loads observer events");
+
+        assert!(first_id < malformed_id);
+        assert!(malformed_id < second_id);
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0].event_id, second_id);
+        assert_eq!(batch.high_watermark_event_id, second_id);
+    }
+
+    #[tokio::test]
+    async fn malformed_only_batches_advance_high_watermark() {
+        let pool = test_pool().await;
+        let first_id = seed_outbox_event(&pool, "booking-1", "2026-05-03T09:00:00+00:00").await;
+        let malformed_id = seed_malformed_outbox_event(&pool, "2026-05-03T09:01:00+00:00").await;
+
+        let batch = load_observer_events_after(&pool, first_id, 100)
+            .await
+            .expect("loads observer events");
+
+        assert_eq!(batch.events, Vec::new());
+        assert_eq!(batch.high_watermark_event_id, malformed_id);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/gateway/server.rs
+++ b/mhm/src-tauri/src/gateway/server.rs
@@ -3,6 +3,7 @@ use axum::{
     http::StatusCode,
     middleware::{self, Next},
     response::Response,
+    routing::get,
     Router,
 };
 use log::error;
@@ -87,11 +88,16 @@ pub async fn start_server(
     let protected = Router::new()
         .route_service("/mcp", mcp_service.clone())
         .route_service("/mcp/{*path}", mcp_service)
-        .route_layer(middleware::from_fn_with_state(pool.clone(), require_api_key));
+        .route("/observer/events", get(super::observer::observe_events))
+        .route_layer(middleware::from_fn_with_state(
+            pool.clone(),
+            require_api_key,
+        ))
+        .with_state(pool.clone());
 
     // Build axum router: health at /health (public), MCP at /mcp (protected)
     let app = Router::new()
-        .route("/health", axum::routing::get(|| async { "OK" }))
+        .route("/health", get(|| async { "OK" }))
         .merge(protected);
 
     // Try ports in range
@@ -140,7 +146,7 @@ mod tests {
     use super::require_api_key;
     use axum::{
         body::Body,
-        http::{Request, StatusCode},
+        http::{header, Request, StatusCode},
         middleware,
         routing::get,
         Router,
@@ -165,7 +171,15 @@ mod tests {
     fn test_router(pool: Pool<Sqlite>) -> Router {
         Router::new()
             .route("/mcp", get(|| async { StatusCode::OK }))
-            .route_layer(middleware::from_fn_with_state(pool, require_api_key))
+            .route(
+                "/observer/events",
+                get(crate::gateway::observer::observe_events),
+            )
+            .route_layer(middleware::from_fn_with_state(
+                pool.clone(),
+                require_api_key,
+            ))
+            .with_state(pool)
     }
 
     #[tokio::test]
@@ -173,12 +187,7 @@ mod tests {
         let pool = test_pool().await;
 
         let response = test_router(pool)
-            .oneshot(
-                Request::builder()
-                    .uri("/mcp")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri("/mcp").body(Body::empty()).unwrap())
             .await
             .unwrap();
 
@@ -194,9 +203,25 @@ mod tests {
             .unwrap();
 
         let response = test_router(pool)
+            .oneshot(Request::builder().uri("/mcp").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn observer_events_requires_auth_after_setup() {
+        let pool = test_pool().await;
+        sqlx::query("UPDATE settings SET value = 'true' WHERE key = 'setup_completed'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = test_router(pool)
             .oneshot(
                 Request::builder()
-                    .uri("/mcp")
+                    .uri("/observer/events")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -204,5 +229,38 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn observer_events_accepts_valid_api_key_with_sse_content_type() {
+        let pool = test_pool().await;
+        sqlx::query("UPDATE settings SET value = 'true' WHERE key = 'setup_completed'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let (key, hash) = crate::gateway::auth::generate_api_key();
+        crate::gateway::auth::store_api_key(&pool, &hash, "observer-test")
+            .await
+            .unwrap();
+
+        let response = test_router(pool)
+            .oneshot(
+                Request::builder()
+                    .uri("/observer/events")
+                    .header(header::AUTHORIZATION, format!("Bearer {}", key))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        assert!(content_type.starts_with("text/event-stream"));
     }
 }


### PR DESCRIPTION
## Summary
- add a read-only `/observer/events` SSE endpoint protected by the existing gateway API key middleware
- stream committed outbox facts with cursor replay/dedupe and minimal privacy-safe payloads
- document the observer endpoint in OpenAPI and the MCP manifest

## Validation
- `cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `npm --prefix mhm run verify:full`
- GitNexus compare: low risk, no affected execution flows for observer branch scope

## Notes
- The stream only reads `outbox_events`; it does not claim, dispatch, or mutate PMS state.
- Existing unrelated dirty local files were not included in this branch.