### PR TITLE
[codex] CEO agent safety foundation

### DIFF
--- a/docs/superpowers/specs/2026-05-05-agentic-ai-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-05-agentic-ai-roadmap-design.md
@@ -1,0 +1,528 @@
+# Agentic AI Roadmap
+
+Date: 2026-05-05
+
+## Status
+
+Approved roadmap direction, pending implementation planning.
+
+This is a roadmap spec. It does not implement code, change gateway behavior, add Telegram, add OpenAI calls, or expose any new PMS write capability.
+
+## Plain-Language Goal
+
+CapyInn should grow an agentic AI layer without weakening the PMS safety boundary.
+
+The first useful product milestone is a Telegram-based CEO secretary. It can chat in Vietnamese, answer hotel operations questions, run read-only operational reports, produce hourly digests, and summarize audit readiness and revenue snapshots for the owner.
+
+Later milestones can add observer-driven alerts, durable approval-gated writes, an online AI receptionist for guest messaging channels, and a voice receptionist channel at the physical front desk.
+
+The core rule is unchanged:
+
+- PMS SQLite state remains the source of truth.
+- Agent memory is never PMS truth.
+- Phase 1 agents may autonomously read and report.
+- PMS writes require a later durable approval and command execution path.
+
+## Relationship To Existing Specs
+
+This roadmap builds on, but does not replace, these existing designs:
+
+- `docs/superpowers/specs/2026-05-04-agentic-integration-guardrails-design.md`
+- `docs/superpowers/specs/2026-05-04-mcp-observer-stream-design.md`
+- `docs/superpowers/specs/2026-05-02-verification-gate-supervised-write-enablement-design.md`
+
+Those specs already define important foundations:
+
+- gateway loopback exposure by default
+- PMS truth versus observer facts versus agent memory
+- high-risk write policy behavior
+- outbox-backed observer stream
+- supervised write verification gates
+
+This roadmap adds the product and capability sequence for agentic AI on top of those foundations.
+
+## External Reference Boundary
+
+Agent platform reference research is internal project context, not public roadmap material.
+
+Public roadmap and implementation issues should describe only CapyInn-owned design decisions:
+
+- use CapyInn-owned provider, channel, and tool boundaries
+- keep tool registries static and role-scoped
+- keep Phase 1 read/report-only
+- keep agent memory non-authoritative
+- scrub credentials and sensitive tool output
+- require durable CapyInn approval ledgers for future writes
+
+Do not vendor, copy, or transplant source code from external agent platforms into CapyInn unless a future task performs a specific license, dependency, security, and architecture review for that exact code.
+
+## Roadmap Principles
+
+1. **YOLO is scoped to the toolset.**
+
+   The CEO secretary may operate autonomously inside its read-only/reporting tools. It must not receive PMS write tools in Phase 1.
+
+2. **Gateway permission is not business approval.**
+
+   An authenticated MCP client, Telegram channel, or future paired device is allowed to connect. That does not mean it can mutate PMS state.
+
+3. **Every PMS write remains command-boundary-first.**
+
+   Future writes must use durable idempotency, aggregate locks, SQL transactions, audit, and outbox events.
+
+4. **LLM output is advisory unless backed by trusted tool output.**
+
+   The agent may summarize and explain. It may not invent room state, revenue, availability, booking status, payment status, or audit status.
+
+5. **Memory is convenience, not truth.**
+
+   Agent memory may store preferences, summaries, and conversational context. It must not store canonical booking, room, folio, invoice, ledger, payment, housekeeping, or audit state.
+
+6. **Guest-facing agents are separate from CEO agents.**
+
+   Future receptionist agents must use separate roles, tools, sessions, and memory scopes.
+
+## Permission Model
+
+The roadmap separates four different permission layers.
+
+### Channel Permission
+
+Channel permission answers: is this Telegram sender allowed to talk to this agent?
+
+Phase 1 rules:
+
+- Telegram is the first channel.
+- The CEO identity is bound to numeric Telegram user ID.
+- Telegram display name and username are display metadata only.
+- Unknown or unpaired Telegram users receive no PMS data.
+- Public webhook ingress is out of scope for Phase 1; use a local outbound connector or polling model.
+
+### Agent Role Permission
+
+Agent role permission answers: what class of agent is this?
+
+Planned roles:
+
+- `CeoSecretary`
+- `GuestReceptionist`
+- `VoiceReceptionistChannel`
+- future integration-specific agents
+
+Phase 1 only implements the CEO secretary role.
+
+### Tool Risk Permission
+
+Tool risk permission answers: what tools can this role see?
+
+Risk classes:
+
+- `ReadOnly`: safe to auto-run in Phase 1.
+- `LowWrite`: future, still policy-controlled.
+- `HighWrite`: future draft-only before approval.
+
+`ReadOnly` only means "does not mutate PMS state." It does not automatically mean "safe for every channel or role." Read tools still need data-sensitivity classification.
+
+Data sensitivity classes:
+
+- `PublicHotelInfo`: safe for public guest answers.
+- `GuestScoped`: safe only after guest verification for that guest's booking or quote.
+- `StaffOperational`: safe for authenticated staff workflows.
+- `CeoSensitive`: safe only for the CEO or explicitly authorized owner/admin identities.
+
+Phase 1 `CeoSecretary` receives only static read-only/reporting tools, and those tools may include `CeoSensitive` data by explicit CEO opt-in. It does not receive shell, file, browser, generic HTTP, generic MCP discovery, or direct PMS write tools.
+
+Future guest receptionist tools must be both read-only and guest-safe. They must not inherit CEO read tools simply because those tools are non-mutating.
+
+### Business Write Approval
+
+Business write approval answers: did a human approve this exact mutation?
+
+This does not exist in Phase 1.
+
+Future approval-gated writes require:
+
+- durable pending action row
+- canonical payload hash
+- approval expiry
+- approving human identity
+- channel ID and message ID
+- replay-safe callback handling
+- execution through existing command idempotency, aggregate locks, transaction, audit, and outbox
+
+## Phase 1: CEO Telegram Read-Only Secretary
+
+### Goal
+
+Give the CEO a useful Telegram AI secretary for hotel operations without any PMS mutation path.
+
+### Capabilities
+
+The CEO secretary can:
+
+- chat in Vietnamese through Telegram
+- answer tool-gated natural language questions
+- show current room status
+- report arrivals and checkouts
+- report unpaid balances
+- report operational revenue snapshots
+- run audit readiness checks
+- summarize operational risks
+- send an hourly digest every hour, 24/7
+
+The CEO secretary cannot:
+
+- create a booking
+- modify a booking
+- cancel a booking
+- check in a guest
+- check out a guest
+- update room status
+- record payment
+- mutate folio or ledger records
+- close or post night audit
+- run arbitrary MCP tools
+- run shell, file, browser, or HTTP tools
+
+### Data And Privacy Posture
+
+Phase 1 uses OpenAI first.
+
+The CEO explicitly allows cloud LLM processing of detailed CEO-level PMS data, including guest, booking, room, folio, balance, and revenue details needed to answer the CEO's question.
+
+This opt-in does not allow careless persistence:
+
+- bot tokens must not appear in logs, memory, audit, tool output, or model feedback
+- OpenAI API keys must not appear in logs, memory, audit, tool output, or Telegram responses
+- raw sensitive tool outputs should not be stored in long-term memory
+- audit should store metadata and sanitized summaries, not become a second raw PII database
+- product settings must make the cloud data processing posture explicit before enabling the agent
+- the opt-in must be persisted and revocable
+- disabling the opt-in must stop cloud LLM calls that include CEO-sensitive PMS data
+- prompts, responses, tool outputs, and session history must have an explicit retention policy
+- data sent to OpenAI should be limited to fields needed for the requested answer or digest
+- provider configuration must document the selected provider's data-use and retention posture
+- sanitized audit/session records must be enough to explain what happened without storing full raw PMS extracts by default
+
+### Architecture
+
+Phase 1 flow:
+
+```text
+CEO Telegram
+  -> Telegram adapter
+  -> owner identity check
+  -> CEO secretary runtime
+  -> static read-only PMS tool registry
+  -> PMS query/services
+  -> SQLite PMS truth
+  -> OpenAI reasoning/summarization
+  -> Telegram response
+```
+
+Core components:
+
+- `AiProvider`: CapyInn-owned OpenAI wrapper for chat and tool calls.
+- `AiChannel`: CapyInn-owned channel abstraction, initially Telegram only.
+- `AiTool`: CapyInn-owned typed read-only tool boundary.
+- `CeoSecretaryRuntime`: message loop, tool authorization, tool execution, model call, response delivery.
+- `CeoReadToolRegistry`: static Phase 1 tool list.
+- `AgentSessionStore`: durable session/message metadata.
+- `AgentMemoryStore`: optional non-authoritative preferences and summaries.
+- `AgentAuditStore`: sanitized tool-call and delivery metadata.
+- `AgentDigestScheduler`: hourly digest job with fixed allowed tools and `uses_memory=false`.
+
+### Tool-Gated Natural Chat
+
+Natural chat is allowed, but it must be grounded in tool output.
+
+Rules:
+
+- The runtime exposes only read-only tool specs to OpenAI.
+- The runtime uses a small maximum tool-iteration limit.
+- Identical repeated tool calls in the same turn are deduplicated or stopped.
+- Tool results are returned as explicit structured envelopes.
+- If no suitable tool exists for a PMS data question, the assistant says it does not have enough data.
+- The model never receives a SQL handle, repository handle, transaction, or raw database access.
+- The model never writes SQL.
+
+### Phase 1 Read Tools
+
+The Phase 1 tool catalog should include:
+
+- `get_hotel_status`
+- `list_room_status`
+- `list_today_arrivals`
+- `list_today_checkouts`
+- `list_unpaid_balances`
+- `get_revenue_snapshot`
+- `get_audit_readiness`
+- `summarize_operational_risks`
+
+`get_audit_readiness` is a report/check tool. It does not close the day, post ledger records, mutate room state, or perform night-audit writes.
+
+`get_revenue_snapshot` is an operational snapshot for the current day/month and unpaid/deposit/balance state. Deeper CEO analytics such as ADR, RevPAR, historical trend comparisons, channel mix, and anomaly analytics are future work.
+
+### Hourly Digest
+
+The hourly digest runs every hour, 24/7.
+
+Digest requirements:
+
+- use only Phase 1 read-only tools
+- not depend on agent memory for PMS facts
+- record last-run status and delivery metadata
+- avoid infinite retry spam on delivery failure
+- make clear when data is unavailable
+
+The digest should cover:
+
+- current occupancy and room status
+- arrivals and checkouts
+- unpaid balances
+- revenue snapshot
+- audit readiness
+- operational risks needing CEO attention
+
+## Phase 2: Observer Alerts And Digest Hardening
+
+### Goal
+
+Add near-real-time operational awareness without adding write capability.
+
+### Capabilities
+
+Phase 2 uses CapyInn's outbox-backed observer stream to trigger alerts and stronger digests.
+
+Examples:
+
+- new booking observed
+- checkout completed
+- unpaid checkout risk
+- dirty room assigned soon
+- room readiness mismatch
+- payment or folio event requiring attention
+
+### Rules
+
+- Phase 2 remains read-only.
+- Observer events are committed facts, not detail data APIs.
+- Alerts must refresh detail through PMS read tools when needed.
+- Alerts must dedupe by observer event ID or deterministic risk key.
+- Alerts must have rate limits to avoid Telegram spam.
+- Restart must not duplicate already acknowledged alerts.
+- Observer cursor state must be persisted.
+- Alert state must distinguish delivered, failed, suppressed, and explicitly acknowledged alerts.
+- Acknowledgement means an alert state row has been persisted, not merely that a Telegram send was attempted.
+- Cursor-expired recovery must rebuild the operational snapshot from PMS read tools before resuming alerts.
+
+## Phase 3: Approval-Gated CEO Writes
+
+### Goal
+
+Allow the CEO secretary to help prepare exact PMS actions while preserving human approval and the command boundary.
+
+Phase 3 cannot start until the supervised-write verification gate from `docs/superpowers/specs/2026-05-02-verification-gate-supervised-write-enablement-design.md` has passed for the relevant command families.
+
+### Capabilities
+
+The agent may draft actions such as:
+
+- mark room clean
+- mark room maintenance
+- cancel booking
+- modify booking
+- create booking
+- record payment
+- close night audit
+
+The agent does not execute these actions directly.
+
+### Required Write Flow
+
+```text
+CEO request
+  -> agent drafts normalized action
+  -> policy classifies risk
+  -> pending action persisted with canonical payload hash
+  -> CEO approves or denies exact action
+  -> approval callback verifies owner, expiry, and hash
+  -> command executes through existing command boundary
+  -> idempotency, locks, transaction, audit, and outbox commit atomically
+  -> CEO receives result
+```
+
+### Rules
+
+- Direct write tools are not exposed to the LLM.
+- The LLM can only create draft actions.
+- Approval applies to one exact normalized payload.
+- Approval expires.
+- Denied or expired actions cannot be reused.
+- Duplicate approval callbacks replay idempotently.
+- Business state is revalidated inside the transaction.
+- Existing `command_idempotency`, `aggregate_locks`, command audit, and `outbox_events` remain the write center of gravity.
+- MCP supervised mode must continue returning `APPROVAL_REQUIRED` for high-risk direct write attempts unless the durable approval path handles the exact action.
+- Full autonomous mode remains disabled for high-risk PMS writes until a separate launch decision.
+- Tool schemas must not accept self-declared approval fields such as `approved: true`, approval tokens, idempotency claim tokens, or raw command claim tokens from the LLM.
+
+## Phase 4: Online AI Receptionist
+
+### Goal
+
+Add guest-facing AI support on messaging platforms without exposing CEO tools or unsafe PMS writes.
+
+Target platforms:
+
+- Zalo
+- Facebook Messenger
+- WhatsApp
+
+### Capability Stages
+
+Stage 1:
+
+- answer hotel policy and service questions
+- check room price and availability through guest-safe read/quote tools
+- create a lead or draft booking request
+- escalate unsupported or sensitive requests to staff
+
+Stage 2:
+
+- create real bookings only after additional safety gates exist
+- recheck availability before final booking
+- verify guest identity or contact channel as required
+- enforce deposit/payment policy
+- prevent overbooking
+- record guest consent and source channel
+- use approval or strict business rules for high-risk actions
+
+### Rules
+
+- Guest receptionist uses a separate role, session scope, memory scope, and tool registry.
+- Guest receptionist cannot access CEO tools or CEO memory.
+- Guest-facing answers must not leak another guest's booking, folio, identity, payment, or audit data.
+- Price and availability answers must come from PMS tools, not memory.
+- A lead or draft is not a confirmed room hold unless the PMS creates a real booking through the approved business path.
+
+## Phase 5: Voice Receptionist Channel
+
+### Goal
+
+Extend the online receptionist into a voice channel for physical guest support at the front desk.
+
+### Initial Model
+
+Treat voice as a new channel for the guest receptionist, not as a separate agent.
+
+```text
+guest speech
+  -> speech-to-text
+  -> guest receptionist policy and tools
+  -> response text
+  -> text-to-speech
+```
+
+### Rules
+
+- Voice transcripts are conversation context, not PMS truth.
+- Voice uses guest-safe tools by default.
+- Identity-sensitive actions still require verification.
+- Staff handoff must be available for ambiguous, angry, payment, overbooking, or identity-sensitive cases.
+
+If front-desk kiosk behavior later requires different permissions, device controls, staff override, or local-only policies, voice can become a separate agent role in a later roadmap revision.
+
+## Acceptance Gates
+
+### Phase 1 Gates
+
+- Unknown Telegram users receive no PMS data.
+- Unpaired Telegram users cannot trigger LLM calls.
+- Unpaired Telegram users cannot cause prompt construction with PMS context.
+- Paired CEO can receive status, room, checkout, balance, revenue, and audit readiness answers.
+- The Phase 1 registry contains no write tools.
+- The Phase 1 registry contains no shell, file, browser, generic HTTP, or generic MCP discovery tools.
+- Every Phase 1 tool has both a mutation-risk class and a data-sensitivity class.
+- CEO-sensitive tools are available only to the paired CEO role.
+- Cloud LLM use for CEO-sensitive PMS data requires persisted explicit opt-in.
+- Revoking the cloud-data opt-in prevents cloud LLM calls containing CEO-sensitive PMS data.
+- Prompt, response, session, and tool-output retention is explicit.
+- Data sent to OpenAI is limited to fields needed for the requested answer or digest.
+- Provider data-use and retention posture is documented in settings or operator docs.
+- Sanitized audit/session records do not store full raw PMS extracts by default.
+- Natural chat is tool-gated; unsupported PMS questions receive a data-unavailable answer.
+- Hourly digest uses read-only tools and `uses_memory=false`.
+- Bot token and OpenAI key never appear in logs, memory, audit, tool output, or Telegram responses.
+- Telegram flow cannot mutate PMS tables.
+- Agent memory cannot affect PMS query results.
+
+### Phase 2 Gates
+
+- Observer events dedupe after reconnect.
+- Restart does not duplicate already acknowledged alerts.
+- Observer cursor state persists across restart.
+- Alert state persists delivered, failed, suppressed, and acknowledged states.
+- Cursor-expired recovery rebuilds the operational snapshot from PMS read tools.
+- Synthesized risk alerts use deterministic dedupe keys.
+- Alerts are traceable to an observer event or deterministic read query.
+- Alerts do not forward raw outbox payloads.
+- Alerts respect rate limits.
+- Phase 2 still has no PMS write path.
+
+### Phase 3 Gates
+
+- Approval is tied to exact canonical payload hash.
+- Approval with modified args is rejected.
+- Expired approval is rejected.
+- Denied approval cannot execute.
+- Duplicate callback replays idempotently.
+- Non-owner callback is rejected.
+- Command execution uses durable idempotency.
+- Command execution acquires aggregate locks.
+- Business state revalidates inside the SQL transaction.
+- Mutation, audit, command ledger, and outbox commit atomically.
+- Direct write tools are not visible to the LLM.
+- The supervised-write verification gate has passed for each command family exposed through draft actions.
+- Direct high-risk MCP write attempts still return policy outcomes such as `APPROVAL_REQUIRED` or `WRITE_TOOL_DISABLED`.
+- Full autonomous high-risk writes remain disabled.
+- Tool schemas reject self-declared approval fields.
+
+### Phase 4 Gates
+
+- Guest role cannot access CEO tools.
+- Guest role cannot access CEO memory.
+- Guest cannot see another guest's data without verification.
+- Quotes use PMS availability and pricing tools.
+- Lead/draft creation does not silently reserve inventory.
+- Booking creation, if added, rechecks availability at write time.
+
+### Phase 5 Gates
+
+- Voice transcripts do not become PMS truth.
+- Voice uses guest-safe tools by default.
+- Identity-sensitive requests require verification.
+- Staff handoff is available for unsupported or high-risk conversations.
+
+## Out Of Scope For This Roadmap Spec
+
+This spec does not:
+
+- implement Telegram
+- implement OpenAI calls
+- add an agent runtime
+- add DB migrations
+- change MCP gateway routes
+- change PMS command behavior
+- add approval UI
+- enable autonomous PMS writes
+- implement guest messaging integrations
+- implement voice transcription or text-to-speech
+- vendor or copy external agent-platform source code
+
+## Strategic Recommendation
+
+Start with Phase 1.
+
+The fastest safe path is to implement a small CapyInn-native CEO secretary with narrow provider/channel/tool interfaces, static read-only tools, tool-gated chat, Telegram numeric identity, digest scheduling, credential scrubbing, and strict memory separation.
+
+Only after Phase 1 is stable should the roadmap move to observer alerts, and only after durable approval exists should the CEO secretary be allowed to prepare write actions.

--- a/docs/superpowers/specs/2026-05-05-ceo-agent-safety-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-05-ceo-agent-safety-foundation-design.md
@@ -146,6 +146,33 @@ Sessions store conversation or run metadata. Audit events store sanitized facts 
 
 None of these tables should store raw prompts, raw responses, raw PMS extracts, canonical booking state, room availability truth, payment truth, folio truth, invoice truth, ledger truth, housekeeping truth, or audit truth by default.
 
+## Retention Policy
+
+This slice must make retention explicit even though it does not run the real agent runtime.
+
+Required retention constants:
+
+- `raw_prompt_retention`: `not_stored`
+- `raw_response_retention`: `not_stored`
+- `raw_tool_output_retention`: `not_stored`
+- `raw_provider_error_retention`: `not_stored`
+- `session_metadata_retention`: `local_metadata_until_operator_cleanup_v1`
+- `audit_metadata_retention`: `local_metadata_until_operator_cleanup_v1`
+- `memory_retention`: `local_non_authoritative_until_operator_cleanup_v1`
+
+Required behavior:
+
+- raw prompts are not persisted in this slice
+- raw responses are not persisted in this slice
+- raw tool outputs are not persisted in this slice
+- raw provider errors are not persisted in this slice
+- session rows store metadata only
+- audit rows store sanitized summaries only
+- memory rows store non-authoritative preferences, summaries, and notes only
+- future raw prompt, response, tool-output, or provider-error persistence requires a separate design, UI consent, and verification gate
+
+The `agent_sessions.retention_policy` value must use `metadata_only_v1` for this slice. Any other retention policy value should be rejected until a future issue defines it.
+
 ## Database Schema
 
 Add migration v18.
@@ -238,6 +265,8 @@ Backend commands:
 - `get_ceo_cloud_data_opt_in() -> bool`
 - `set_ceo_cloud_data_opt_in(enabled: bool)`
 
+The setter must enforce backend authorization before it starts the command transaction. Allowed actors are authenticated admins or explicitly modeled owner/CEO actors. A receptionist, unauthenticated actor, agent runtime, or integration key must not be able to enable or revoke CEO cloud-data opt-in.
+
 The setter must use an explicit low-risk command boundary, following the existing crash-reporting preference pattern. It should record actor, command name, idempotency, canonical payload hash, timestamp, and command ledger metadata through the existing command executor.
 
 The setter must also write a sanitized `agent_audit_events` row:
@@ -260,9 +289,10 @@ The UI should:
 - show current enabled/disabled state
 - let an admin enable or revoke opt-in
 - call the new Tauri commands
+- rely on backend authorization, not UI-only hiding, for privacy enforcement
 - show concise text that cloud LLM processing may receive CEO-sensitive PMS data only when enabled
 - state that revoking opt-in blocks cloud calls containing CEO-sensitive PMS data
-- mention retention posture at a high level: sanitized audit/session metadata by default, no raw PMS extracts by default
+- state retention explicitly: raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored in this slice; sanitized session/audit metadata is stored locally under `metadata_only_v1`
 
 The UI should not:
 
@@ -352,9 +382,13 @@ Backend tests:
 - migration v18 creates agent tables, columns, indexes, and latest schema version
 - opt-in defaults to false
 - opt-in setter persists enabled and revoked states through command boundary
+- opt-in setter rejects unauthenticated, receptionist, agent runtime, and integration-key actors
+- unauthorized opt-in attempts do not change the setting and do not write opt-in audit events
 - exact opt-in command retry replays idempotently
 - same idempotency key with different opt-in payload conflicts
 - opt-in setter writes sanitized agent audit event
+- retention constants are exposed and match `not_stored` for raw prompt, response, tool output, and provider error data
+- session creation rejects unknown retention policies and accepts `metadata_only_v1`
 - runtime skeleton is disabled by default
 - unpaired Telegram actor denial happens before prompt construction
 - CEO-sensitive provider request construction requires opt-in
@@ -409,9 +443,10 @@ Exact command names may change during implementation, but coverage must preserve
 
 - CEO-sensitive cloud provider request construction requires persisted opt-in.
 - Revoking opt-in blocks future cloud requests containing CEO-sensitive PMS data.
-- Retention posture is documented.
+- Retention posture is explicit: raw prompts, responses, tool outputs, and provider errors are `not_stored`; sanitized session/audit metadata uses `metadata_only_v1`.
 - Provider data-use and retention posture is documented at a high level.
 - Audit/session records avoid full raw PMS extracts by default.
+- Backend authorization prevents non-admin, non-owner, agent runtime, or integration actors from changing CEO cloud-data opt-in.
 
 #125 partial:
 

--- a/docs/superpowers/specs/2026-05-05-ceo-agent-safety-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-05-ceo-agent-safety-foundation-design.md
@@ -1,0 +1,448 @@
+# CEO Agent Safety Foundation
+
+Issues: #117, #118, #119, and part of #125
+
+Parent scope: #76 Agentic AI and outbox integration roadmap
+
+Date: 2026-05-05
+
+## Status
+
+Approved design direction, pending implementation plan.
+
+This spec implements the safety foundation for the Phase 1 CEO secretary. It creates CapyInn-owned agent boundaries, data-sensitivity policy, persisted CEO cloud-data opt-in, session/audit/memory storage, and verification checks.
+
+This spec does not enable Telegram, OpenAI calls, tool-gated chat, hourly digest delivery, or PMS writes through an agent.
+
+## Plain-Language Goal
+
+CapyInn needs a CEO agent foundation before it adds a real Telegram secretary runtime.
+
+The foundation must answer four questions before any cloud LLM sees PMS data:
+
+- Who is the agent acting as?
+- Which channel and actor is allowed to talk to it?
+- Which tools are visible, and what data sensitivity do those tools carry?
+- Has the CEO explicitly allowed cloud processing of CEO-sensitive PMS data?
+
+The foundation also records session, audit, and memory boundaries in the database so later runtime work does not invent a separate truth store.
+
+## Chosen Approach
+
+Use a contract-first runtime skeleton.
+
+The implementation will add runtime-shaped modules and database storage now, but all external execution remains disabled. This keeps the architecture ready for #120 through #123 without violating #117's acceptance criterion that no Telegram, OpenAI, or PMS write behavior is enabled by this slice.
+
+Rejected alternatives:
+
+- A policy-only slice would be faster, but would leave session, audit, and memory boundaries too vague for #117 and #119.
+- A real runtime slice would overlap #120, #121, #122, #123, and possibly #124.
+
+## Relationship To Existing Specs
+
+This spec builds on:
+
+- `docs/superpowers/specs/2026-05-04-agentic-integration-guardrails-design.md`
+- `docs/superpowers/specs/2026-05-05-agentic-ai-roadmap-design.md`
+- `docs/superpowers/specs/2026-05-02-verification-gate-supervised-write-enablement-design.md`
+
+Those specs already establish:
+
+- PMS SQLite state is the source of truth.
+- Agent memory is not PMS truth.
+- The gateway is loopback-only by default.
+- High-risk MCP writes remain policy-gated.
+- Phase 1 CEO secretary is read/report-only.
+
+This spec adds concrete agent contracts, persistence, opt-in controls, and verification checks for the first CEO secretary foundation.
+
+## Architecture
+
+Add a new backend `agent` module with narrow CapyInn-owned contracts.
+
+Core model types:
+
+- `AgentRole`: initially only `CeoSecretary`.
+- `AgentChannel`: initially represents `Telegram`, but Telegram execution is disabled.
+- `AgentProvider`: initially represents `OpenAI`, but provider execution is disabled.
+- `MutationRisk`: `ReadOnly`, `LowWrite`, `HighWrite`.
+- `DataSensitivity`: `PublicHotelInfo`, `GuestScoped`, `StaffOperational`, `CeoSensitive`.
+- `AgentToolMeta`: name, description, mutation risk, data sensitivity, role allowlist, and forbidden dynamic capability flags.
+- `AgentSession`: durable metadata for a conversation or scheduled run.
+- `AgentAuditEvent`: sanitized event metadata.
+- `AgentMemoryItem`: non-authoritative preferences, summaries, and notes.
+
+The runtime skeleton may expose internal functions such as `handle_agent_message(...)` or equivalent service methods. In this slice, those methods fail closed:
+
+- unknown or unpaired channel actors cannot create prompts
+- missing or revoked cloud opt-in blocks provider request construction for CEO-sensitive data
+- provider execution returns a disabled or not-configured policy result
+- channel delivery returns a disabled or not-configured policy result
+- no Telegram polling, webhook, or send path is started
+- no OpenAI HTTP request is made
+- no PMS mutation path is exposed
+
+## Component Boundaries
+
+### Agent Provider Boundary
+
+The provider boundary is a narrow interface for future cloud LLM calls.
+
+This slice defines:
+
+- provider identity, initially `OpenAI`
+- scrubbed provider error shape
+- policy checks that must pass before provider request construction
+- tests proving no provider call can be made when runtime is disabled or cloud opt-in is false
+
+This slice does not include:
+
+- OpenAI API client
+- API key loading
+- prompt sending
+- streaming responses
+- model tool-call loop
+
+### Agent Channel Boundary
+
+The channel boundary represents where a message came from and where a future response would go.
+
+This slice defines:
+
+- channel identity, initially `Telegram`
+- stable numeric channel actor ID requirement for Telegram CEO binding
+- display name and username as metadata only
+- unknown or unpaired actor denial before prompt construction
+
+This slice does not include:
+
+- Telegram bot token
+- polling
+- webhook ingress
+- message sending
+- public network ingress
+
+### Agent Tool Boundary
+
+The agent tool boundary is separate from dynamic MCP tool discovery.
+
+The CEO secretary will eventually use a static read-only/reporting catalog. This slice creates the metadata and verification boundary first. Runtime tool execution is not implemented here.
+
+The model must never receive:
+
+- SQL/database handles
+- shell tools
+- file tools
+- browser tools
+- generic HTTP tools
+- generic MCP discovery tools
+- PMS write tools
+
+### Session, Audit, And Memory Boundary
+
+Sessions, audit, and memory are durable, but they are not PMS truth.
+
+Sessions store conversation or run metadata. Audit events store sanitized facts about policy decisions and future tool/provider activity. Memory stores non-authoritative preferences, summaries, and notes.
+
+None of these tables should store raw prompts, raw responses, raw PMS extracts, canonical booking state, room availability truth, payment truth, folio truth, invoice truth, ledger truth, housekeeping truth, or audit truth by default.
+
+## Database Schema
+
+Add migration v18.
+
+The migration must create these tables.
+
+### `agent_sessions`
+
+Purpose: durable metadata for agent conversations and scheduled runs.
+
+Required columns:
+
+- `id TEXT PRIMARY KEY`
+- `role TEXT NOT NULL`
+- `channel TEXT NOT NULL`
+- `channel_actor_id TEXT`
+- `status TEXT NOT NULL`
+- `uses_memory INTEGER NOT NULL DEFAULT 0`
+- `retention_policy TEXT NOT NULL`
+- `metadata_json TEXT NOT NULL DEFAULT '{}'`
+- `started_at TEXT NOT NULL`
+- `last_seen_at TEXT`
+- `ended_at TEXT`
+
+Indexes:
+
+- role, channel, channel actor, last seen
+- status and started time
+
+### `agent_audit_events`
+
+Purpose: sanitized event stream for opt-in changes, policy denials, future tool calls, and future provider decisions.
+
+Required columns:
+
+- `id INTEGER PRIMARY KEY AUTOINCREMENT`
+- `session_id TEXT`
+- `event_type TEXT NOT NULL`
+- `actor_id TEXT`
+- `role TEXT`
+- `channel TEXT`
+- `tool_name TEXT`
+- `provider TEXT`
+- `policy_outcome TEXT NOT NULL`
+- `mutation_risk TEXT`
+- `data_sensitivity TEXT`
+- `summary_json TEXT NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+
+Indexes:
+
+- event type and created time
+- session and created time
+- role, channel, and created time
+
+### `agent_memory_items`
+
+Purpose: non-authoritative agent memory.
+
+Required columns:
+
+- `id TEXT PRIMARY KEY`
+- `role TEXT NOT NULL`
+- `scope TEXT NOT NULL`
+- `key TEXT NOT NULL`
+- `value_json TEXT NOT NULL`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+Constraints:
+
+- unique role, scope, key
+
+The memory service must reject forbidden PMS truth categories, including canonical booking, room availability, payment, folio, invoice, ledger, housekeeping, and night-audit truth.
+
+## CEO Cloud-Data Opt-In
+
+Add a persisted, revocable setting for CEO cloud-data processing.
+
+Setting key:
+
+- `ceo_cloud_data_opt_in`
+
+Default:
+
+- `false`
+
+Backend commands:
+
+- `get_ceo_cloud_data_opt_in() -> bool`
+- `set_ceo_cloud_data_opt_in(enabled: bool)`
+
+The setter must use an explicit low-risk command boundary, following the existing crash-reporting preference pattern. It should record actor, command name, idempotency, canonical payload hash, timestamp, and command ledger metadata through the existing command executor.
+
+The setter must also write a sanitized `agent_audit_events` row:
+
+- `ceo_cloud_data_opt_in.enabled`
+- `ceo_cloud_data_opt_in.revoked`
+
+The setting update and its agent audit event must be written in the same command transaction. If either write fails, both must roll back.
+
+Audit summary must not include raw PMS data, prompts, responses, provider keys, bot tokens, or API keys.
+
+Revoking opt-in must prevent construction of any cloud provider request containing CEO-sensitive PMS data.
+
+## Settings UI
+
+Add a minimal admin-facing Settings UI for CEO cloud-data opt-in.
+
+The UI should:
+
+- show current enabled/disabled state
+- let an admin enable or revoke opt-in
+- call the new Tauri commands
+- show concise text that cloud LLM processing may receive CEO-sensitive PMS data only when enabled
+- state that revoking opt-in blocks cloud calls containing CEO-sensitive PMS data
+- mention retention posture at a high level: sanitized audit/session metadata by default, no raw PMS extracts by default
+
+The UI should not:
+
+- collect OpenAI keys
+- collect Telegram bot tokens
+- start the CEO secretary
+- imply runtime chat is enabled
+- expose raw audit rows
+
+## Tool Sensitivity Model
+
+`MutationRisk` values:
+
+- `ReadOnly`: does not mutate PMS state
+- `LowWrite`: low-risk business or configuration write through command boundary
+- `HighWrite`: high-risk PMS business write through command boundary and approval policy
+
+`DataSensitivity` values:
+
+- `PublicHotelInfo`: safe for public hotel policy or descriptive answers
+- `GuestScoped`: safe only after verifying the guest and scope
+- `StaffOperational`: safe for authenticated staff operations
+- `CeoSensitive`: safe only for CEO or explicitly authorized owner/admin identities
+
+Important rule:
+
+`ReadOnly` does not mean guest-safe. A read-only tool can still reveal guest, revenue, balance, audit, or operational information and must carry the correct sensitivity class.
+
+## Static CEO Tool Metadata
+
+This slice should create static metadata for the CEO secretary tool catalog. It does not need to implement all #122 CEO reporting tools yet.
+
+The metadata must make these rules testable:
+
+- every tool has mutation risk
+- every tool has data sensitivity
+- CEO-sensitive tools are role-scoped to `CeoSecretary`
+- Phase A CEO registry has no write tools
+- Phase A CEO registry has no shell, file, browser, generic HTTP, or dynamic MCP discovery tools
+
+Existing MCP write tools such as `create_reservation`, `modify_reservation`, and `cancel_reservation` remain `HighWrite` in the MCP policy model and must not appear in the Phase A CEO registry.
+
+Existing MCP read tools should be classified conservatively. Tools that may reveal bookings, guest details, invoices, unpaid balances, revenue, audit readiness, or operational risk should not be `PublicHotelInfo`.
+
+## Verification Gate Scope
+
+This spec implements the static and policy portion of #125.
+
+Required checks:
+
+- CEO registry contains no write tools
+- CEO registry contains no shell/file/browser/generic HTTP/dynamic MCP discovery tools
+- every agent tool has mutation risk and data sensitivity
+- unknown or unpaired Telegram actors cannot create prompt/provider requests
+- cloud provider request construction is blocked when CEO-sensitive data is involved and opt-in is false
+- revoked opt-in blocks future CEO-sensitive cloud request construction
+- runtime skeleton is disabled by default
+- no OpenAI API key or Telegram bot token appears in logs, memory, audit, tool output, or UI text
+- agent memory cannot be used as PMS truth
+- session and audit records do not store raw PMS extracts by default
+
+Existing high-risk MCP policy behavior must remain unchanged:
+
+- supervised high-risk write attempts return `APPROVAL_REQUIRED`
+- read-only mode returns `WRITE_TOOL_DISABLED`
+- represented full autonomy still does not launch high-risk writes
+
+## Error Handling
+
+Agent policy failures should use stable, machine-readable errors.
+
+Required error codes, or exact equivalents mapped through the existing app error system:
+
+- `AGENT_RUNTIME_DISABLED`
+- `AGENT_CHANNEL_UNPAIRED`
+- `AGENT_PROVIDER_DISABLED`
+- `AGENT_CLOUD_DATA_OPT_IN_REQUIRED`
+- `AGENT_TOOL_NOT_ALLOWED`
+- `AGENT_MEMORY_FORBIDDEN_TRUTH`
+
+Errors must be scrubbed before storage or display. They must not include provider secrets, bot tokens, raw prompts, raw responses, raw PMS extracts, SQL errors with sensitive details, or stack traces.
+
+## Testing Strategy
+
+Backend tests:
+
+- migration v18 creates agent tables, columns, indexes, and latest schema version
+- opt-in defaults to false
+- opt-in setter persists enabled and revoked states through command boundary
+- exact opt-in command retry replays idempotently
+- same idempotency key with different opt-in payload conflicts
+- opt-in setter writes sanitized agent audit event
+- runtime skeleton is disabled by default
+- unpaired Telegram actor denial happens before prompt construction
+- CEO-sensitive provider request construction requires opt-in
+- revoked opt-in blocks provider request construction
+- memory service rejects forbidden PMS truth categories
+- CEO registry contains only read-only allowed tool metadata
+
+Frontend tests:
+
+- Settings UI renders disabled opt-in by default
+- admin can toggle opt-in on and off
+- failed toggle reverts UI state
+- explanatory copy does not imply runtime is enabled
+
+Docs and manifest tests:
+
+- skill, OpenAPI, or manifest document data sensitivity classes
+- docs state `ReadOnly` is not automatically guest-safe
+- docs state cloud-data opt-in is required and revocable
+- docs state audit/session records avoid raw PMS extracts by default
+
+Suggested verification commands after implementation:
+
+```bash
+cargo test --manifest-path mhm/src-tauri/Cargo.toml agent:: -- --nocapture
+cargo test --manifest-path mhm/src-tauri/Cargo.toml db::tests:: -- --nocapture
+cargo test --manifest-path mhm/src-tauri/Cargo.toml command_idempotency::tests::set_ceo_cloud_data_opt_in -- --nocapture
+npm test -- --run src/pages/settings
+npm test -- --run tests/agentic-guardrails.test.ts
+```
+
+Exact command names may change during implementation, but coverage must preserve the behaviors above.
+
+## Acceptance Mapping
+
+#117:
+
+- Provider, channel, and tool boundaries are explicit.
+- Session, audit, and memory tables exist with clear retention and truth boundaries.
+- Agent memory is non-authoritative and forbidden from PMS truth categories.
+- Telegram, OpenAI, and PMS write behavior remain disabled.
+
+#118:
+
+- Tool metadata includes mutation risk and data sensitivity.
+- `ReadOnly` is not treated as guest-safe.
+- Data classes include `PublicHotelInfo`, `GuestScoped`, `StaffOperational`, and `CeoSensitive`.
+- CEO-sensitive tools are CEO-role scoped.
+- Future guest tools cannot inherit CEO read tools by default.
+
+#119:
+
+- CEO-sensitive cloud provider request construction requires persisted opt-in.
+- Revoking opt-in blocks future cloud requests containing CEO-sensitive PMS data.
+- Retention posture is documented.
+- Provider data-use and retention posture is documented at a high level.
+- Audit/session records avoid full raw PMS extracts by default.
+
+#125 partial:
+
+- Telegram actor denial is tested before prompt construction.
+- CEO registry contains no write, shell, file, browser, generic HTTP, or dynamic discovery tools.
+- Secret markers are not persisted in audit/session/memory/UI text.
+- Agent memory cannot affect PMS query results because it is not connected to PMS query services and rejects PMS truth categories.
+
+## Out Of Scope
+
+This spec does not:
+
+- implement Telegram polling
+- implement Telegram webhooks
+- implement Telegram message delivery
+- implement OpenAI API calls
+- implement model tool calling
+- implement static CEO reporting tools from #122
+- implement tool-gated chat loop from #123
+- implement hourly digest from #124
+- add guest receptionist tools
+- add voice receptionist tools
+- expose agent PMS writes
+- add approval UI
+- loosen MCP high-risk write policy
+- add generic tool discovery
+
+## Implementation Notes
+
+Before editing existing functions, classes, or methods, run GitNexus impact analysis for the target symbol and report direct callers, affected processes, and risk level. If risk is HIGH or CRITICAL, warn before editing.
+
+Run GitNexus `detect_changes` before committing implementation changes.
+
+Keep edits targeted. This slice should create the foundation and tests without broad refactoring of the PMS command boundary, gateway server, or existing read/write business flows.

--- a/mhm/shared/error-codes.json
+++ b/mhm/shared/error-codes.json
@@ -160,6 +160,36 @@
     "defaultMessage": "Cần xử lý khôi phục lệnh trước khi tiếp tục."
   },
   {
+    "code": "AGENT_RUNTIME_DISABLED",
+    "kind": "user",
+    "defaultMessage": "Trợ lý AI hiện đang bị tắt."
+  },
+  {
+    "code": "AGENT_CHANNEL_UNPAIRED",
+    "kind": "user",
+    "defaultMessage": "Kênh trợ lý AI chưa được liên kết."
+  },
+  {
+    "code": "AGENT_PROVIDER_DISABLED",
+    "kind": "user",
+    "defaultMessage": "Nhà cung cấp AI hiện đang bị tắt."
+  },
+  {
+    "code": "AGENT_CLOUD_DATA_OPT_IN_REQUIRED",
+    "kind": "user",
+    "defaultMessage": "Cần bật cho phép xử lý dữ liệu trên đám mây trước khi dùng trợ lý AI."
+  },
+  {
+    "code": "AGENT_TOOL_NOT_ALLOWED",
+    "kind": "user",
+    "defaultMessage": "Trợ lý AI không được phép dùng công cụ này."
+  },
+  {
+    "code": "AGENT_MEMORY_FORBIDDEN_TRUTH",
+    "kind": "user",
+    "defaultMessage": "Bộ nhớ trợ lý AI không được dùng làm dữ liệu PMS chính thức."
+  },
+  {
     "code": "SYSTEM_INTERNAL_ERROR",
     "kind": "system",
     "defaultMessage": "Có lỗi hệ thống, vui lòng thử lại"

--- a/mhm/skills/hotel-manager.skill.md
+++ b/mhm/skills/hotel-manager.skill.md
@@ -12,6 +12,21 @@ Observer events are committed PMS facts that tell you what area to refresh. Afte
 
 The gateway is loopback-only by default at `127.0.0.1`. LAN or remote exposure requires a separate explicit configuration, auth or pairing, and policy gates. A paired or authenticated client still cannot bypass high-risk write policy.
 
+## CEO Agent Safety Boundary
+
+ReadOnly does not mean guest-safe. A read-only tool can still expose guest, revenue, balance, audit, or operational data and must carry a data sensitivity class.
+
+Data sensitivity classes:
+
+- `PublicHotelInfo`: public hotel policy or descriptive information
+- `GuestScoped`: only after verifying the guest and scope
+- `StaffOperational`: authenticated staff operations
+- `CeoSensitive`: CEO or explicitly authorized owner/admin only
+
+CEO cloud-data opt-in is required before any cloud LLM request may include CEO-sensitive PMS data. The opt-in is persisted, revocable, and audited.
+
+Retention: raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored by the CEO agent safety foundation. Session and audit records store sanitized local metadata only.
+
 ## ⚠️ CRITICAL: Call `get_hotel_context` FIRST
 
 **Before ANY other tool call**, always call `get_hotel_context` to get the current date, time, timezone, and hotel info. This prevents date hallucinations.

--- a/mhm/skills/mcp-manifest.json
+++ b/mhm/skills/mcp-manifest.json
@@ -74,6 +74,32 @@
             ]
         }
     },
+    "agent_safety": {
+        "read_only_not_guest_safe": true,
+        "data_sensitivity_classes": [
+            "PublicHotelInfo",
+            "GuestScoped",
+            "StaffOperational",
+            "CeoSensitive"
+        ],
+        "cloud_data_opt_in": {
+            "setting_key": "ceo_cloud_data_opt_in",
+            "default": false,
+            "required_for": [
+                "cloud_llm_requests_with_ceo_sensitive_pms_data"
+            ],
+            "revocable": true,
+            "audited": true
+        },
+        "retention": {
+            "raw_prompt_retention": "not_stored",
+            "raw_response_retention": "not_stored",
+            "raw_tool_output_retention": "not_stored",
+            "raw_provider_error_retention": "not_stored",
+            "session_policy": "metadata_only_v1",
+            "audit_policy": "metadata_only_v1"
+        }
+    },
     "tools": [
         {
             "name": "get_hotel_context",

--- a/mhm/skills/openapi.yaml
+++ b/mhm/skills/openapi.yaml
@@ -21,6 +21,24 @@ servers:
         default: '61234'
         description: Gateway port shown in the CapyInn settings UI
 
+x-agent-safety:
+  read_only_not_guest_safe: true
+  data_sensitivity_classes:
+    - PublicHotelInfo
+    - GuestScoped
+    - StaffOperational
+    - CeoSensitive
+  cloud_data_opt_in:
+    statement: CEO cloud-data opt-in is persisted and revocable before CEO-sensitive PMS data can be sent to a cloud LLM.
+    setting_key: ceo_cloud_data_opt_in
+    default: false
+  retention:
+    raw_prompt_retention: not_stored
+    raw_response_retention: not_stored
+    raw_tool_output_retention: not_stored
+    raw_provider_error_retention: not_stored
+    session_policy: metadata_only_v1
+
 paths:
   /mcp:
     post:

--- a/mhm/src-tauri/src/agent/mod.rs
+++ b/mhm/src-tauri/src/agent/mod.rs
@@ -1,2 +1,3 @@
 pub mod model;
 pub mod retention;
+pub mod store;

--- a/mhm/src-tauri/src/agent/mod.rs
+++ b/mhm/src-tauri/src/agent/mod.rs
@@ -1,0 +1,2 @@
+pub mod model;
+pub mod retention;

--- a/mhm/src-tauri/src/agent/mod.rs
+++ b/mhm/src-tauri/src/agent/mod.rs
@@ -1,3 +1,5 @@
 pub mod model;
+pub mod registry;
 pub mod retention;
+pub mod runtime;
 pub mod store;

--- a/mhm/src-tauri/src/agent/mod.rs
+++ b/mhm/src-tauri/src/agent/mod.rs
@@ -2,4 +2,5 @@ pub mod model;
 pub mod registry;
 pub mod retention;
 pub mod runtime;
+pub mod settings;
 pub mod store;

--- a/mhm/src-tauri/src/agent/model.rs
+++ b/mhm/src-tauri/src/agent/model.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRole {
+    CeoSecretary,
+    GuestReceptionist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentChannel {
+    Telegram,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentProvider {
+    OpenAi,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationRisk {
+    ReadOnly,
+    LowWrite,
+    HighWrite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DataSensitivity {
+    PublicHotelInfo,
+    GuestScoped,
+    StaffOperational,
+    CeoSensitive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentToolCapability {
+    PmsRead,
+    PmsWrite,
+    Shell,
+    File,
+    Browser,
+    GenericHttp,
+    DynamicMcpDiscovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct AgentToolMeta {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub mutation_risk: MutationRisk,
+    pub data_sensitivity: DataSensitivity,
+    pub allowed_roles: &'static [AgentRole],
+    pub capability: AgentToolCapability,
+}
+
+impl AgentToolMeta {
+    pub fn allowed_for(&self, role: AgentRole) -> bool {
+        self.allowed_roles.contains(&role)
+    }
+
+    pub fn is_safe_for_phase_one_ceo_registry(&self) -> bool {
+        self.allowed_for(AgentRole::CeoSecretary)
+            && self.mutation_risk == MutationRisk::ReadOnly
+            && matches!(self.capability, AgentToolCapability::PmsRead)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelActor {
+    pub channel: AgentChannel,
+    pub stable_actor_id: Option<String>,
+    pub display_name: Option<String>,
+    pub username: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentRuntimeRequest {
+    pub role: AgentRole,
+    pub channel_actor: ChannelActor,
+    pub contains_ceo_sensitive_data: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_is_not_public_by_default() {
+        let meta = AgentToolMeta {
+            name: "list_unpaid_balances",
+            description: "Unpaid balances",
+            mutation_risk: MutationRisk::ReadOnly,
+            data_sensitivity: DataSensitivity::CeoSensitive,
+            allowed_roles: &[AgentRole::CeoSecretary],
+            capability: AgentToolCapability::PmsRead,
+        };
+
+        assert_eq!(meta.mutation_risk, MutationRisk::ReadOnly);
+        assert_eq!(meta.data_sensitivity, DataSensitivity::CeoSensitive);
+        assert!(meta.allowed_for(AgentRole::CeoSecretary));
+        assert!(!meta.allowed_for(AgentRole::GuestReceptionist));
+    }
+}

--- a/mhm/src-tauri/src/agent/model.rs
+++ b/mhm/src-tauri/src/agent/model.rs
@@ -10,12 +10,14 @@ pub enum AgentRole {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentChannel {
+    Desktop,
     Telegram,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentProvider {
+    None,
     OpenAi,
 }
 

--- a/mhm/src-tauri/src/agent/registry.rs
+++ b/mhm/src-tauri/src/agent/registry.rs
@@ -1,0 +1,143 @@
+use crate::agent::model::{
+    AgentRole, AgentToolCapability, AgentToolMeta, DataSensitivity, MutationRisk,
+};
+
+const CEO_ONLY: &[AgentRole] = &[AgentRole::CeoSecretary];
+
+pub const CEO_PHASE_A_TOOLS: &[AgentToolMeta] = &[
+    AgentToolMeta {
+        name: "get_hotel_status",
+        description: "Read current CEO hotel operations status summary from PMS reporting data.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "list_room_status",
+        description: "Read room occupancy, availability, and housekeeping status for CEO review.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "list_today_arrivals",
+        description: "Read today's expected arrivals and related operational notes for CEO review.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "list_today_checkouts",
+        description: "Read today's expected checkouts and departure workload for CEO review.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "list_unpaid_balances",
+        description: "Read outstanding guest and folio balances for CEO financial oversight.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "get_revenue_snapshot",
+        description:
+            "Read revenue totals, booking value, and payment collection snapshot for CEO review.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "get_audit_readiness",
+        description: "Read night-audit readiness indicators and unresolved operational blockers.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+    AgentToolMeta {
+        name: "summarize_operational_risks",
+        description: "Read PMS-derived operational risk signals for CEO summary generation.",
+        mutation_risk: MutationRisk::ReadOnly,
+        data_sensitivity: DataSensitivity::CeoSensitive,
+        allowed_roles: CEO_ONLY,
+        capability: AgentToolCapability::PmsRead,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::model::{AgentRole, AgentToolCapability, DataSensitivity, MutationRisk};
+
+    #[test]
+    fn ceo_registry_contains_only_read_only_pms_read_tools() {
+        let expected_names = [
+            "get_hotel_status",
+            "list_room_status",
+            "list_today_arrivals",
+            "list_today_checkouts",
+            "list_unpaid_balances",
+            "get_revenue_snapshot",
+            "get_audit_readiness",
+            "summarize_operational_risks",
+        ];
+
+        assert_eq!(CEO_PHASE_A_TOOLS.len(), expected_names.len());
+        for expected_name in expected_names {
+            assert!(
+                CEO_PHASE_A_TOOLS
+                    .iter()
+                    .any(|tool| tool.name == expected_name),
+                "missing {expected_name}"
+            );
+        }
+
+        for tool in CEO_PHASE_A_TOOLS {
+            assert_eq!(tool.mutation_risk, MutationRisk::ReadOnly, "{}", tool.name);
+            assert_eq!(
+                tool.capability,
+                AgentToolCapability::PmsRead,
+                "{}",
+                tool.name
+            );
+            assert!(tool.allowed_for(AgentRole::CeoSecretary), "{}", tool.name);
+            assert!(
+                !tool.allowed_for(AgentRole::GuestReceptionist),
+                "{}",
+                tool.name
+            );
+            assert_eq!(
+                tool.data_sensitivity,
+                DataSensitivity::CeoSensitive,
+                "{}",
+                tool.name
+            );
+            assert!(tool.is_safe_for_phase_one_ceo_registry(), "{}", tool.name);
+        }
+    }
+
+    #[test]
+    fn ceo_registry_contains_no_guest_public_sensitive_mismatch() {
+        for tool in CEO_PHASE_A_TOOLS {
+            if matches!(tool.data_sensitivity, DataSensitivity::PublicHotelInfo) {
+                assert!(
+                    !tool.name.contains("booking")
+                        && !tool.name.contains("invoice")
+                        && !tool.name.contains("revenue")
+                        && !tool.name.contains("balance")
+                        && !tool.name.contains("audit"),
+                    "{} must not be public hotel info",
+                    tool.name
+                );
+            }
+        }
+    }
+}

--- a/mhm/src-tauri/src/agent/retention.rs
+++ b/mhm/src-tauri/src/agent/retention.rs
@@ -1,0 +1,42 @@
+use crate::app_error::{codes, CommandError, CommandResult};
+
+pub const RETENTION_NOT_STORED: &str = "not_stored";
+pub const RAW_PROMPT_RETENTION: &str = RETENTION_NOT_STORED;
+pub const RAW_RESPONSE_RETENTION: &str = RETENTION_NOT_STORED;
+pub const RAW_TOOL_OUTPUT_RETENTION: &str = RETENTION_NOT_STORED;
+pub const RAW_PROVIDER_ERROR_RETENTION: &str = RETENTION_NOT_STORED;
+
+pub const SESSION_RETENTION_METADATA_ONLY: &str = "metadata_only_v1";
+pub const SESSION_METADATA_RETENTION: &str = "local_metadata_until_operator_cleanup_v1";
+pub const AUDIT_METADATA_RETENTION: &str = "local_metadata_until_operator_cleanup_v1";
+pub const MEMORY_RETENTION: &str = "local_non_authoritative_until_operator_cleanup_v1";
+
+pub fn validate_session_retention_policy(value: &str) -> CommandResult<()> {
+    if value == SESSION_RETENTION_METADATA_ONLY {
+        Ok(())
+    } else {
+        Err(CommandError::user(
+            codes::VALIDATION_INVALID_INPUT,
+            "Unknown agent session retention policy",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_agent_data_retention_is_not_stored() {
+        assert_eq!(RAW_PROMPT_RETENTION, RETENTION_NOT_STORED);
+        assert_eq!(RAW_RESPONSE_RETENTION, RETENTION_NOT_STORED);
+        assert_eq!(RAW_TOOL_OUTPUT_RETENTION, RETENTION_NOT_STORED);
+        assert_eq!(RAW_PROVIDER_ERROR_RETENTION, RETENTION_NOT_STORED);
+    }
+
+    #[test]
+    fn only_metadata_policy_is_accepted_for_sessions() {
+        assert!(validate_session_retention_policy(SESSION_RETENTION_METADATA_ONLY).is_ok());
+        assert!(validate_session_retention_policy("raw_prompt_30_days").is_err());
+    }
+}

--- a/mhm/src-tauri/src/agent/runtime.rs
+++ b/mhm/src-tauri/src/agent/runtime.rs
@@ -27,10 +27,7 @@ fn ensure_paired_actor(input: &AgentRuntimePolicyInput) -> CommandResult<()> {
 }
 
 fn ensure_cloud_opt_in(input: &AgentRuntimePolicyInput) -> CommandResult<()> {
-    if input.role == AgentRole::CeoSecretary
-        && input.contains_ceo_sensitive_data
-        && !input.ceo_cloud_data_opt_in
-    {
+    if input.contains_ceo_sensitive_data && !input.ceo_cloud_data_opt_in {
         return Err(CommandError::user(
             codes::AGENT_CLOUD_DATA_OPT_IN_REQUIRED,
             "CEO cloud-data opt-in is required",
@@ -96,6 +93,28 @@ mod tests {
         })
         .await
         .expect_err("missing opt-in must block provider construction");
+
+        assert_eq!(
+            result.code,
+            crate::app_error::codes::AGENT_CLOUD_DATA_OPT_IN_REQUIRED
+        );
+    }
+
+    #[tokio::test]
+    async fn ceo_sensitive_guest_request_requires_opt_in() {
+        let result = build_provider_request_disabled(AgentRuntimePolicyInput {
+            role: AgentRole::GuestReceptionist,
+            channel_actor: ChannelActor {
+                channel: AgentChannel::Telegram,
+                stable_actor_id: Some("12345".to_string()),
+                display_name: None,
+                username: None,
+            },
+            ceo_cloud_data_opt_in: false,
+            contains_ceo_sensitive_data: true,
+        })
+        .await
+        .expect_err("CEO-sensitive data must require opt-in for every role");
 
         assert_eq!(
             result.code,

--- a/mhm/src-tauri/src/agent/runtime.rs
+++ b/mhm/src-tauri/src/agent/runtime.rs
@@ -1,0 +1,124 @@
+use crate::{
+    agent::model::{AgentRole, ChannelActor},
+    app_error::{codes, CommandError, CommandResult},
+};
+
+#[derive(Debug, Clone)]
+pub struct AgentRuntimePolicyInput {
+    pub role: AgentRole,
+    pub channel_actor: ChannelActor,
+    pub ceo_cloud_data_opt_in: bool,
+    pub contains_ceo_sensitive_data: bool,
+}
+
+fn ensure_paired_actor(input: &AgentRuntimePolicyInput) -> CommandResult<()> {
+    if input
+        .channel_actor
+        .stable_actor_id
+        .as_deref()
+        .map_or(true, str::is_empty)
+    {
+        return Err(CommandError::user(
+            codes::AGENT_CHANNEL_UNPAIRED,
+            "Agent channel actor is not paired",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_cloud_opt_in(input: &AgentRuntimePolicyInput) -> CommandResult<()> {
+    if input.role == AgentRole::CeoSecretary
+        && input.contains_ceo_sensitive_data
+        && !input.ceo_cloud_data_opt_in
+    {
+        return Err(CommandError::user(
+            codes::AGENT_CLOUD_DATA_OPT_IN_REQUIRED,
+            "CEO cloud-data opt-in is required",
+        ));
+    }
+    Ok(())
+}
+
+pub async fn build_provider_request_disabled(input: AgentRuntimePolicyInput) -> CommandResult<()> {
+    ensure_paired_actor(&input)?;
+    ensure_cloud_opt_in(&input)?;
+    Err(CommandError::user(
+        codes::AGENT_PROVIDER_DISABLED,
+        "Agent provider execution is disabled",
+    ))
+}
+
+pub async fn handle_agent_message_disabled(input: AgentRuntimePolicyInput) -> CommandResult<()> {
+    ensure_paired_actor(&input)?;
+    ensure_cloud_opt_in(&input)?;
+    Err(CommandError::user(
+        codes::AGENT_RUNTIME_DISABLED,
+        "Agent runtime is disabled",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::model::{AgentChannel, AgentRole, ChannelActor};
+
+    #[tokio::test]
+    async fn unpaired_actor_is_denied_before_prompt_construction() {
+        let result = handle_agent_message_disabled(AgentRuntimePolicyInput {
+            role: AgentRole::CeoSecretary,
+            channel_actor: ChannelActor {
+                channel: AgentChannel::Telegram,
+                stable_actor_id: None,
+                display_name: Some("Unknown".to_string()),
+                username: Some("unknown".to_string()),
+            },
+            ceo_cloud_data_opt_in: true,
+            contains_ceo_sensitive_data: true,
+        })
+        .await
+        .expect_err("unpaired actor must be denied");
+
+        assert_eq!(result.code, crate::app_error::codes::AGENT_CHANNEL_UNPAIRED);
+    }
+
+    #[tokio::test]
+    async fn ceo_sensitive_provider_request_requires_opt_in() {
+        let result = build_provider_request_disabled(AgentRuntimePolicyInput {
+            role: AgentRole::CeoSecretary,
+            channel_actor: ChannelActor {
+                channel: AgentChannel::Telegram,
+                stable_actor_id: Some("12345".to_string()),
+                display_name: None,
+                username: None,
+            },
+            ceo_cloud_data_opt_in: false,
+            contains_ceo_sensitive_data: true,
+        })
+        .await
+        .expect_err("missing opt-in must block provider construction");
+
+        assert_eq!(
+            result.code,
+            crate::app_error::codes::AGENT_CLOUD_DATA_OPT_IN_REQUIRED
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_is_disabled_even_after_policy_checks() {
+        let result = handle_agent_message_disabled(AgentRuntimePolicyInput {
+            role: AgentRole::CeoSecretary,
+            channel_actor: ChannelActor {
+                channel: AgentChannel::Telegram,
+                stable_actor_id: Some("12345".to_string()),
+                display_name: None,
+                username: None,
+            },
+            ceo_cloud_data_opt_in: true,
+            contains_ceo_sensitive_data: true,
+        })
+        .await
+        .expect_err("runtime remains disabled");
+
+        assert_eq!(result.code, crate::app_error::codes::AGENT_RUNTIME_DISABLED);
+    }
+}

--- a/mhm/src-tauri/src/agent/runtime.rs
+++ b/mhm/src-tauri/src/agent/runtime.rs
@@ -16,7 +16,7 @@ fn ensure_paired_actor(input: &AgentRuntimePolicyInput) -> CommandResult<()> {
         .channel_actor
         .stable_actor_id
         .as_deref()
-        .map_or(true, str::is_empty)
+        .is_none_or(str::is_empty)
     {
         return Err(CommandError::user(
             codes::AGENT_CHANNEL_UNPAIRED,

--- a/mhm/src-tauri/src/agent/runtime.rs
+++ b/mhm/src-tauri/src/agent/runtime.rs
@@ -16,7 +16,7 @@ fn ensure_paired_actor(input: &AgentRuntimePolicyInput) -> CommandResult<()> {
         .channel_actor
         .stable_actor_id
         .as_deref()
-        .is_none_or(str::is_empty)
+        .is_none_or(|actor_id| actor_id.trim().is_empty())
     {
         return Err(CommandError::user(
             codes::AGENT_CHANNEL_UNPAIRED,
@@ -74,6 +74,25 @@ mod tests {
         })
         .await
         .expect_err("unpaired actor must be denied");
+
+        assert_eq!(result.code, crate::app_error::codes::AGENT_CHANNEL_UNPAIRED);
+    }
+
+    #[tokio::test]
+    async fn whitespace_only_actor_id_is_denied_before_prompt_construction() {
+        let result = handle_agent_message_disabled(AgentRuntimePolicyInput {
+            role: AgentRole::CeoSecretary,
+            channel_actor: ChannelActor {
+                channel: AgentChannel::Telegram,
+                stable_actor_id: Some("   ".to_string()),
+                display_name: Some("Unknown".to_string()),
+                username: Some("unknown".to_string()),
+            },
+            ceo_cloud_data_opt_in: true,
+            contains_ceo_sensitive_data: true,
+        })
+        .await
+        .expect_err("whitespace-only actor id must be denied");
 
         assert_eq!(result.code, crate::app_error::codes::AGENT_CHANNEL_UNPAIRED);
     }

--- a/mhm/src-tauri/src/agent/settings.rs
+++ b/mhm/src-tauri/src/agent/settings.rs
@@ -34,14 +34,19 @@ pub async fn get_ceo_cloud_data_opt_in(pool: &Pool<Sqlite>) -> CommandResult<boo
                 )
             })?;
 
-    Ok(matches!(value.as_deref(), Some("true" | "TRUE" | "True")))
+    Ok(value
+        .as_deref()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            normalized == "true" || normalized == "1"
+        })
+        .unwrap_or(false))
 }
 
 pub async fn set_ceo_cloud_data_opt_in_idempotent(
     pool: &Pool<Sqlite>,
     ctx: &WriteCommandContext,
     enabled: bool,
-    _request_context: Value,
 ) -> CommandResult<IdempotentCommandResult<Value>> {
     let request = WriteCommandRequest::new_low_risk(
         serde_json::json!({ "enabled": enabled }),
@@ -147,6 +152,15 @@ mod tests {
             .expect("query settings")
     }
 
+    async fn save_setting_value(pool: &Pool<Sqlite>, value: &str) {
+        sqlx::query("INSERT INTO settings (key, value) VALUES (?, ?)")
+            .bind(CEO_CLOUD_DATA_OPT_IN_SETTING)
+            .bind(value)
+            .execute(pool)
+            .await
+            .expect("seed setting");
+    }
+
     async fn audit_rows(pool: &Pool<Sqlite>) -> Vec<(String, String)> {
         // (event_type, summary_json)
         sqlx::query_as::<_, (String, String)>(
@@ -178,22 +192,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enabling_persists_setting_and_writes_one_sanitized_audit_event() {
+    async fn stored_numeric_true_setting_returns_true() {
+        let pool = test_pool().await;
+        save_setting_value(&pool, "1").await;
+        let value = get_ceo_cloud_data_opt_in(&pool)
+            .await
+            .expect("read helper succeeds");
+        assert!(value);
+    }
+
+    #[tokio::test]
+    async fn enabling_persists_setting_and_writes_one_metadata_only_audit_event() {
         let pool = test_pool().await;
         let ctx = write_ctx("req-1", "idem-1");
-        let request_context = serde_json::json!({
-            "surface": "settings",
-            "openai_api_key": "sk-test-leak",
-            "telegram_bot_token": "123:abc",
-            "prompt": "raw prompt leak",
-            "response": "raw response leak",
-            "tool_output": "raw tool output leak",
-            "providerKey": "provider-key-leak",
-            "secret": "super-secret",
-            "token": "bearer token leak",
-        });
 
-        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, request_context)
+        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true)
             .await
             .expect("set should succeed");
 
@@ -205,6 +218,13 @@ mod tests {
 
         let summary: serde_json::Value =
             serde_json::from_str(&rows[0].1).expect("summary json parses");
+        let top_level_keys = summary
+            .as_object()
+            .expect("summary must be an object")
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(top_level_keys, vec!["enabled", "retention", "setting"]);
         assert_eq!(summary["enabled"], serde_json::json!(true));
         assert_eq!(
             summary["retention"]["raw_items"],
@@ -221,26 +241,13 @@ mod tests {
         );
         assert_eq!(summary["retention"]["audit_meta"], AUDIT_METADATA_RETENTION);
         assert_eq!(summary["retention"]["memory"], MEMORY_RETENTION);
-
-        // Ensure raw values are not present.
-        assert!(!rows[0].1.contains("sk-test-leak"));
-        assert!(!rows[0].1.contains("123:abc"));
-        assert!(!rows[0].1.contains("super-secret"));
-        assert!(!rows[0].1.contains("openai_api_key"));
-        assert!(!rows[0].1.contains("telegram_bot_token"));
-        assert!(!rows[0].1.contains("providerKey"));
-        assert!(!rows[0].1.contains("\"prompt\""));
-        assert!(!rows[0].1.contains("\"response\""));
-        assert!(!rows[0].1.contains("tool_output leak"));
-        assert!(!rows[0].1.contains("\"secret\""));
-        assert!(!rows[0].1.contains("\"token\""));
     }
 
     #[tokio::test]
     async fn revoking_persists_setting_and_writes_revoked_audit_event() {
         let pool = test_pool().await;
         let ctx = write_ctx("req-2", "idem-2");
-        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, false, serde_json::json!({}))
+        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, false)
             .await
             .expect("revoke should succeed");
 
@@ -254,12 +261,12 @@ mod tests {
     async fn retry_same_idempotency_key_same_payload_replays_without_duplicate_audit_event() {
         let pool = test_pool().await;
         let ctx = write_ctx("req-3", "idem-3");
-        let first = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, serde_json::json!({}))
+        let first = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true)
             .await
             .expect("first succeeds");
         assert!(!first.replayed);
 
-        let second = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, serde_json::json!({}))
+        let second = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true)
             .await
             .expect("second replays");
         assert!(second.replayed);
@@ -273,11 +280,11 @@ mod tests {
         let pool = test_pool().await;
         let ctx = write_ctx("req-4", "idem-4");
 
-        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, serde_json::json!({}))
+        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true)
             .await
             .expect("first succeeds");
 
-        let error = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, false, serde_json::json!({}))
+        let error = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, false)
             .await
             .expect_err("hash mismatch must be rejected");
 

--- a/mhm/src-tauri/src/agent/settings.rs
+++ b/mhm/src-tauri/src/agent/settings.rs
@@ -1,0 +1,286 @@
+use crate::{
+    agent::{
+        model::{AgentChannel, AgentProvider, AgentRole, DataSensitivity, MutationRisk},
+        retention::{
+            AUDIT_METADATA_RETENTION, MEMORY_RETENTION, RAW_PROMPT_RETENTION,
+            RAW_PROVIDER_ERROR_RETENTION, RAW_RESPONSE_RETENTION, RAW_TOOL_OUTPUT_RETENTION,
+            SESSION_METADATA_RETENTION,
+        },
+        store::{insert_agent_audit_event_tx, NewAgentAuditEvent},
+    },
+    app_error::{codes, CommandError, CommandResult},
+    command_idempotency::{
+        system_error, IdempotentCommandResult, WriteCommandContext, WriteCommandExecutor,
+        WriteCommandRequest,
+    },
+    services::settings_store,
+};
+use serde_json::Value;
+use sqlx::{Pool, Sqlite};
+
+pub const CEO_CLOUD_DATA_OPT_IN_SETTING: &str = "ceo_cloud_data_opt_in";
+pub const SET_CEO_CLOUD_DATA_OPT_IN_COMMAND: &str = "agent.set_ceo_cloud_data_opt_in";
+
+pub async fn get_ceo_cloud_data_opt_in(pool: &Pool<Sqlite>) -> CommandResult<bool> {
+    let value: Option<String> =
+        sqlx::query_scalar("SELECT value FROM settings WHERE key = ? LIMIT 1")
+            .bind(CEO_CLOUD_DATA_OPT_IN_SETTING)
+            .fetch_optional(pool)
+            .await
+            .map_err(|error| {
+                CommandError::system(
+                    codes::SYSTEM_INTERNAL_ERROR,
+                    format!("Failed to read ceo_cloud_data_opt_in setting: {error}"),
+                )
+            })?;
+
+    Ok(matches!(value.as_deref(), Some("true" | "TRUE" | "True")))
+}
+
+pub async fn set_ceo_cloud_data_opt_in_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    enabled: bool,
+    _request_context: Value,
+) -> CommandResult<IdempotentCommandResult<Value>> {
+    let request = WriteCommandRequest::new_low_risk(
+        serde_json::json!({ "enabled": enabled }),
+        "Set CEO cloud-data opt-in",
+    )?
+    .with_primary_aggregate_key(format!("settings:{CEO_CLOUD_DATA_OPT_IN_SETTING}"))
+    .with_lock_key_deriver(|_intent| Ok(vec![format!("settings:{CEO_CLOUD_DATA_OPT_IN_SETTING}")]));
+
+    let event_type = if enabled {
+        "ceo_cloud_data_opt_in.enabled"
+    } else {
+        "ceo_cloud_data_opt_in.revoked"
+    }
+    .to_string();
+
+    let actor_id = ctx.actor_id.clone();
+    WriteCommandExecutor::new(pool.clone())
+        .execute_atomic(ctx, request, move |tx| {
+            Box::pin(async move {
+                settings_store::save_setting_tx(
+                    tx,
+                    CEO_CLOUD_DATA_OPT_IN_SETTING,
+                    if enabled { "true" } else { "false" },
+                )
+                .await
+                .map_err(system_error)?;
+
+                let summary = serde_json::json!({
+                    "enabled": enabled,
+                    "setting": CEO_CLOUD_DATA_OPT_IN_SETTING,
+                    "retention": {
+                        "raw_items": [
+                            { "category": "raw_prompt", "retention": RAW_PROMPT_RETENTION },
+                            { "category": "raw_response", "retention": RAW_RESPONSE_RETENTION },
+                            { "category": "raw_tool_output", "retention": RAW_TOOL_OUTPUT_RETENTION },
+                            { "category": "raw_provider_error", "retention": RAW_PROVIDER_ERROR_RETENTION },
+                        ],
+                        "session_meta": SESSION_METADATA_RETENTION,
+                        "audit_meta": AUDIT_METADATA_RETENTION,
+                        "memory": MEMORY_RETENTION,
+                    },
+                });
+
+                insert_agent_audit_event_tx(
+                    tx,
+                    NewAgentAuditEvent {
+                        session_id: None,
+                        event_type,
+                        actor_id,
+                        role: Some(AgentRole::CeoSecretary),
+                        channel: Some(AgentChannel::Desktop),
+                        tool_name: None,
+                        provider: Some(AgentProvider::None),
+                        policy_outcome: "allowed".to_string(),
+                        mutation_risk: Some(MutationRisk::LowWrite),
+                        data_sensitivity: Some(DataSensitivity::CeoSensitive),
+                        summary,
+                    },
+                )
+                .await?;
+
+                Ok(serde_json::json!({ "enabled": enabled }))
+            })
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_idempotency::ActorType;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let database_url = format!(
+            "sqlite://file:{}?mode=memory&cache=shared",
+            uuid::Uuid::new_v4()
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("failed to open sqlite test pool");
+
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .expect("failed to enable foreign keys");
+
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("failed to run migrations");
+
+        pool
+    }
+
+    async fn get_setting_value(pool: &Pool<Sqlite>) -> Option<String> {
+        sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+            .bind(CEO_CLOUD_DATA_OPT_IN_SETTING)
+            .fetch_optional(pool)
+            .await
+            .expect("query settings")
+    }
+
+    async fn audit_rows(pool: &Pool<Sqlite>) -> Vec<(String, String)> {
+        // (event_type, summary_json)
+        sqlx::query_as::<_, (String, String)>(
+            "SELECT event_type, summary_json FROM agent_audit_events ORDER BY id ASC",
+        )
+        .fetch_all(pool)
+        .await
+        .expect("read audit rows")
+    }
+
+    fn write_ctx(request_id: &str, idempotency_key: &str) -> WriteCommandContext {
+        let mut ctx = WriteCommandContext::for_internal_test(
+            request_id,
+            idempotency_key,
+            SET_CEO_CLOUD_DATA_OPT_IN_COMMAND,
+        );
+        ctx.actor_type = ActorType::Human;
+        ctx.actor_id = Some("admin-1".to_string());
+        ctx
+    }
+
+    #[tokio::test]
+    async fn default_missing_setting_returns_false() {
+        let pool = test_pool().await;
+        let value = get_ceo_cloud_data_opt_in(&pool)
+            .await
+            .expect("read helper succeeds");
+        assert!(!value);
+    }
+
+    #[tokio::test]
+    async fn enabling_persists_setting_and_writes_one_sanitized_audit_event() {
+        let pool = test_pool().await;
+        let ctx = write_ctx("req-1", "idem-1");
+        let request_context = serde_json::json!({
+            "surface": "settings",
+            "openai_api_key": "sk-test-leak",
+            "telegram_bot_token": "123:abc",
+            "prompt": "raw prompt leak",
+            "response": "raw response leak",
+            "tool_output": "raw tool output leak",
+            "providerKey": "provider-key-leak",
+            "secret": "super-secret",
+            "token": "bearer token leak",
+        });
+
+        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, request_context)
+            .await
+            .expect("set should succeed");
+
+        assert_eq!(get_setting_value(&pool).await.as_deref(), Some("true"));
+
+        let rows = audit_rows(&pool).await;
+        assert_eq!(rows.len(), 1, "exactly one audit event must be written");
+        assert_eq!(rows[0].0, "ceo_cloud_data_opt_in.enabled");
+
+        let summary: serde_json::Value =
+            serde_json::from_str(&rows[0].1).expect("summary json parses");
+        assert_eq!(summary["enabled"], serde_json::json!(true));
+        assert_eq!(
+            summary["retention"]["raw_items"],
+            serde_json::json!([
+                { "category": "raw_prompt", "retention": RAW_PROMPT_RETENTION },
+                { "category": "raw_response", "retention": RAW_RESPONSE_RETENTION },
+                { "category": "raw_tool_output", "retention": RAW_TOOL_OUTPUT_RETENTION },
+                { "category": "raw_provider_error", "retention": RAW_PROVIDER_ERROR_RETENTION },
+            ])
+        );
+        assert_eq!(
+            summary["retention"]["session_meta"],
+            SESSION_METADATA_RETENTION
+        );
+        assert_eq!(summary["retention"]["audit_meta"], AUDIT_METADATA_RETENTION);
+        assert_eq!(summary["retention"]["memory"], MEMORY_RETENTION);
+
+        // Ensure raw values are not present.
+        assert!(!rows[0].1.contains("sk-test-leak"));
+        assert!(!rows[0].1.contains("123:abc"));
+        assert!(!rows[0].1.contains("super-secret"));
+        assert!(!rows[0].1.contains("openai_api_key"));
+        assert!(!rows[0].1.contains("telegram_bot_token"));
+        assert!(!rows[0].1.contains("providerKey"));
+        assert!(!rows[0].1.contains("\"prompt\""));
+        assert!(!rows[0].1.contains("\"response\""));
+        assert!(!rows[0].1.contains("tool_output leak"));
+        assert!(!rows[0].1.contains("\"secret\""));
+        assert!(!rows[0].1.contains("\"token\""));
+    }
+
+    #[tokio::test]
+    async fn revoking_persists_setting_and_writes_revoked_audit_event() {
+        let pool = test_pool().await;
+        let ctx = write_ctx("req-2", "idem-2");
+        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, false, serde_json::json!({}))
+            .await
+            .expect("revoke should succeed");
+
+        assert_eq!(get_setting_value(&pool).await.as_deref(), Some("false"));
+        let rows = audit_rows(&pool).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "ceo_cloud_data_opt_in.revoked");
+    }
+
+    #[tokio::test]
+    async fn retry_same_idempotency_key_same_payload_replays_without_duplicate_audit_event() {
+        let pool = test_pool().await;
+        let ctx = write_ctx("req-3", "idem-3");
+        let first = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, serde_json::json!({}))
+            .await
+            .expect("first succeeds");
+        assert!(!first.replayed);
+
+        let second = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, serde_json::json!({}))
+            .await
+            .expect("second replays");
+        assert!(second.replayed);
+
+        let rows = audit_rows(&pool).await;
+        assert_eq!(rows.len(), 1, "replay must not duplicate audit events");
+    }
+
+    #[tokio::test]
+    async fn same_idempotency_key_different_payload_is_rejected() {
+        let pool = test_pool().await;
+        let ctx = write_ctx("req-4", "idem-4");
+
+        set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, true, serde_json::json!({}))
+            .await
+            .expect("first succeeds");
+
+        let error = set_ceo_cloud_data_opt_in_idempotent(&pool, &ctx, false, serde_json::json!({}))
+            .await
+            .expect_err("hash mismatch must be rejected");
+
+        assert_eq!(error.code, codes::CONFLICT_IDEMPOTENCY_HASH_MISMATCH);
+    }
+}

--- a/mhm/src-tauri/src/agent/store.rs
+++ b/mhm/src-tauri/src/agent/store.rs
@@ -1,0 +1,434 @@
+use crate::{
+    agent::{
+        model::{AgentChannel, AgentProvider, AgentRole, DataSensitivity, MutationRisk},
+        retention::validate_session_retention_policy,
+    },
+    app_error::{codes, CommandError, CommandResult},
+    command_idempotency::system_error,
+};
+use serde_json::{Map, Value};
+use sqlx::{Pool, Sqlite, Transaction};
+
+#[derive(Debug, Clone)]
+pub struct NewAgentSession {
+    pub id: String,
+    pub role: AgentRole,
+    pub channel: AgentChannel,
+    pub channel_actor_id: Option<String>,
+    pub uses_memory: bool,
+    pub retention_policy: String,
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewAgentAuditEvent {
+    pub session_id: Option<String>,
+    pub event_type: String,
+    pub actor_id: Option<String>,
+    pub role: Option<AgentRole>,
+    pub channel: Option<AgentChannel>,
+    pub tool_name: Option<String>,
+    pub provider: Option<AgentProvider>,
+    pub policy_outcome: String,
+    pub mutation_risk: Option<MutationRisk>,
+    pub data_sensitivity: Option<DataSensitivity>,
+    pub summary: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewAgentMemoryItem {
+    pub id: String,
+    pub role: AgentRole,
+    pub scope: String,
+    pub key: String,
+    pub value: Value,
+}
+
+fn role_as_str(role: AgentRole) -> &'static str {
+    match role {
+        AgentRole::CeoSecretary => "ceo_secretary",
+        AgentRole::GuestReceptionist => "guest_receptionist",
+    }
+}
+
+fn channel_as_str(channel: AgentChannel) -> &'static str {
+    match channel {
+        AgentChannel::Telegram => "telegram",
+    }
+}
+
+fn provider_as_str(provider: AgentProvider) -> &'static str {
+    match provider {
+        AgentProvider::OpenAi => "open_ai",
+    }
+}
+
+fn mutation_risk_as_str(value: MutationRisk) -> &'static str {
+    match value {
+        MutationRisk::ReadOnly => "read_only",
+        MutationRisk::LowWrite => "low_write",
+        MutationRisk::HighWrite => "high_write",
+    }
+}
+
+fn data_sensitivity_as_str(value: DataSensitivity) -> &'static str {
+    match value {
+        DataSensitivity::PublicHotelInfo => "public_hotel_info",
+        DataSensitivity::GuestScoped => "guest_scoped",
+        DataSensitivity::StaffOperational => "staff_operational",
+        DataSensitivity::CeoSensitive => "ceo_sensitive",
+    }
+}
+
+fn stable_json(value: &Value) -> CommandResult<String> {
+    serde_json::to_string(value).map_err(system_error)
+}
+
+fn sanitize_metadata(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let sanitized = map
+                .iter()
+                .map(|(key, child)| {
+                    if is_sensitive_metadata_key(key) {
+                        (key.clone(), Value::String("[redacted]".to_string()))
+                    } else {
+                        (key.clone(), sanitize_metadata(child))
+                    }
+                })
+                .collect::<Map<String, Value>>();
+            Value::Object(sanitized)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(sanitize_metadata).collect()),
+        Value::String(text) if contains_obvious_secret_marker(text) => {
+            Value::String("[redacted]".to_string())
+        }
+        _ => value.clone(),
+    }
+}
+
+fn is_sensitive_metadata_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    [
+        "raw_prompt",
+        "prompt",
+        "provider_key",
+        "api_key",
+        "openai_api_key",
+        "bot_token",
+        "telegram_bot_token",
+        "token",
+        "secret",
+        "password",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn contains_obvious_secret_marker(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    [
+        "capyinn_sk_",
+        "openai_api_key",
+        "sk-",
+        "bot_token",
+        "telegram_bot_token",
+        "provider_key",
+        "bearer ",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn contains_forbidden_memory_truth(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    [
+        "canonical_booking",
+        "canonical booking",
+        "canonical_booking_state",
+        "booking_truth",
+        "booking truth",
+        "room_availability_truth",
+        "room availability truth",
+        "payment_truth",
+        "payment truth",
+        "folio_truth",
+        "folio truth",
+        "invoice_truth",
+        "invoice truth",
+        "ledger_truth",
+        "ledger truth",
+        "housekeeping_truth",
+        "housekeeping truth",
+        "night_audit_truth",
+        "night audit truth",
+        "audit_truth",
+        "audit truth",
+    ]
+    .iter()
+    .any(|forbidden| normalized.contains(forbidden))
+}
+
+fn validate_memory_item(input: &NewAgentMemoryItem) -> CommandResult<()> {
+    let value_text = input.value.to_string();
+    if contains_forbidden_memory_truth(&input.scope)
+        || contains_forbidden_memory_truth(&input.key)
+        || contains_forbidden_memory_truth(&value_text)
+    {
+        return Err(CommandError::user(
+            codes::AGENT_MEMORY_FORBIDDEN_TRUTH,
+            "Agent memory cannot store PMS truth",
+        ));
+    }
+    Ok(())
+}
+
+pub async fn create_agent_session(
+    pool: &Pool<Sqlite>,
+    input: NewAgentSession,
+) -> CommandResult<()> {
+    validate_session_retention_policy(&input.retention_policy)?;
+    let now = chrono::Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (
+            id, role, channel, channel_actor_id, status, uses_memory,
+            retention_policy, metadata_json, started_at, last_seen_at, ended_at
+         ) VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, NULL)",
+    )
+    .bind(&input.id)
+    .bind(role_as_str(input.role))
+    .bind(channel_as_str(input.channel))
+    .bind(&input.channel_actor_id)
+    .bind(if input.uses_memory { 1_i64 } else { 0_i64 })
+    .bind(&input.retention_policy)
+    .bind(stable_json(&input.metadata)?)
+    .bind(&now)
+    .bind(&now)
+    .execute(pool)
+    .await
+    .map_err(system_error)?;
+
+    Ok(())
+}
+
+pub async fn insert_agent_audit_event(
+    pool: &Pool<Sqlite>,
+    input: NewAgentAuditEvent,
+) -> CommandResult<()> {
+    let mut tx = pool.begin().await.map_err(system_error)?;
+    insert_agent_audit_event_tx(&mut tx, input).await?;
+    tx.commit().await.map_err(system_error)?;
+    Ok(())
+}
+
+pub async fn insert_agent_audit_event_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    input: NewAgentAuditEvent,
+) -> CommandResult<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let summary = sanitize_metadata(&input.summary);
+
+    sqlx::query(
+        "INSERT INTO agent_audit_events (
+            session_id, event_type, actor_id, role, channel, tool_name, provider,
+            policy_outcome, mutation_risk, data_sensitivity, summary_json, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&input.session_id)
+    .bind(&input.event_type)
+    .bind(&input.actor_id)
+    .bind(input.role.map(role_as_str))
+    .bind(input.channel.map(channel_as_str))
+    .bind(&input.tool_name)
+    .bind(input.provider.map(provider_as_str))
+    .bind(&input.policy_outcome)
+    .bind(input.mutation_risk.map(mutation_risk_as_str))
+    .bind(input.data_sensitivity.map(data_sensitivity_as_str))
+    .bind(stable_json(&summary)?)
+    .bind(&now)
+    .execute(&mut **tx)
+    .await
+    .map_err(system_error)?;
+
+    Ok(())
+}
+
+pub async fn upsert_agent_memory_item(
+    pool: &Pool<Sqlite>,
+    input: NewAgentMemoryItem,
+) -> CommandResult<()> {
+    validate_memory_item(&input)?;
+    let now = chrono::Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "INSERT INTO agent_memory_items (
+            id, role, scope, key, value_json, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(role, scope, key) DO UPDATE SET
+            value_json = excluded.value_json,
+            updated_at = excluded.updated_at",
+    )
+    .bind(&input.id)
+    .bind(role_as_str(input.role))
+    .bind(&input.scope)
+    .bind(&input.key)
+    .bind(stable_json(&input.value)?)
+    .bind(&now)
+    .bind(&now)
+    .execute(pool)
+    .await
+    .map_err(system_error)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::{
+        model::{AgentChannel, AgentRole, DataSensitivity, MutationRisk},
+        retention::SESSION_RETENTION_METADATA_ONLY,
+    };
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite};
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connects");
+        crate::db::run_migrations(&pool).await.expect("migrations");
+        pool
+    }
+
+    #[tokio::test]
+    async fn create_session_rejects_unknown_retention_policy() {
+        let pool = test_pool().await;
+
+        let error = create_agent_session(
+            &pool,
+            NewAgentSession {
+                id: "session-bad-retention".to_string(),
+                role: AgentRole::CeoSecretary,
+                channel: AgentChannel::Telegram,
+                channel_actor_id: Some("12345".to_string()),
+                uses_memory: false,
+                retention_policy: "raw_prompt_30_days".to_string(),
+                metadata: serde_json::json!({}),
+            },
+        )
+        .await
+        .expect_err("unknown retention must fail");
+
+        assert_eq!(
+            error.code,
+            crate::app_error::codes::VALIDATION_INVALID_INPUT
+        );
+    }
+
+    #[tokio::test]
+    async fn create_session_stores_metadata_only_policy() {
+        let pool = test_pool().await;
+
+        create_agent_session(
+            &pool,
+            NewAgentSession {
+                id: "session-ok".to_string(),
+                role: AgentRole::CeoSecretary,
+                channel: AgentChannel::Telegram,
+                channel_actor_id: Some("12345".to_string()),
+                uses_memory: false,
+                retention_policy: SESSION_RETENTION_METADATA_ONLY.to_string(),
+                metadata: serde_json::json!({ "source": "test" }),
+            },
+        )
+        .await
+        .expect("session stored");
+
+        let row =
+            sqlx::query("SELECT retention_policy, metadata_json FROM agent_sessions WHERE id = ?")
+                .bind("session-ok")
+                .fetch_one(&pool)
+                .await
+                .expect("reads session");
+
+        assert_eq!(
+            row.get::<String, _>("retention_policy"),
+            SESSION_RETENTION_METADATA_ONLY
+        );
+        assert_eq!(
+            row.get::<String, _>("metadata_json"),
+            "{\"source\":\"test\"}"
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_event_stores_sanitized_metadata() {
+        let pool = test_pool().await;
+
+        insert_agent_audit_event(
+            &pool,
+            NewAgentAuditEvent {
+                session_id: None,
+                event_type: "runtime.disabled".to_string(),
+                actor_id: Some("admin-1".to_string()),
+                role: Some(AgentRole::CeoSecretary),
+                channel: Some(AgentChannel::Telegram),
+                tool_name: None,
+                provider: None,
+                policy_outcome: "denied".to_string(),
+                mutation_risk: Some(MutationRisk::ReadOnly),
+                data_sensitivity: Some(DataSensitivity::CeoSensitive),
+                summary: serde_json::json!({
+                    "reason": "runtime_disabled",
+                    "raw_prompt": "show yesterday revenue",
+                    "provider_key": "capyinn_sk_test",
+                    "nested": {
+                        "bot_token": "OPENAI_TOKEN_TEST"
+                    }
+                }),
+            },
+        )
+        .await
+        .expect("audit event stored");
+
+        let summary: String = sqlx::query_scalar(
+            "SELECT summary_json FROM agent_audit_events WHERE event_type = 'runtime.disabled'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("reads summary");
+        assert!(summary.contains("\"reason\":\"runtime_disabled\""));
+        assert!(summary.contains("\"raw_prompt\":\"[redacted]\""));
+        assert!(summary.contains("\"provider_key\":\"[redacted]\""));
+        assert!(summary.contains("\"bot_token\":\"[redacted]\""));
+        assert!(!summary.contains(' '));
+        assert!(!summary.contains("show yesterday revenue"));
+        assert!(!summary.contains("capyinn_sk_"));
+        assert!(!summary.contains("OPENAI"));
+    }
+
+    #[tokio::test]
+    async fn memory_rejects_pms_truth_categories() {
+        let pool = test_pool().await;
+
+        let error = upsert_agent_memory_item(
+            &pool,
+            NewAgentMemoryItem {
+                id: "memory-truth".to_string(),
+                role: AgentRole::CeoSecretary,
+                scope: "canonical_booking_state".to_string(),
+                key: "booking-1".to_string(),
+                value: serde_json::json!({ "status": "active" }),
+            },
+        )
+        .await
+        .expect_err("PMS truth must not be stored in memory");
+
+        assert_eq!(
+            error.code,
+            crate::app_error::codes::AGENT_MEMORY_FORBIDDEN_TRUTH
+        );
+    }
+}

--- a/mhm/src-tauri/src/agent/store.rs
+++ b/mhm/src-tauri/src/agent/store.rs
@@ -53,12 +53,14 @@ fn role_as_str(role: AgentRole) -> &'static str {
 
 fn channel_as_str(channel: AgentChannel) -> &'static str {
     match channel {
+        AgentChannel::Desktop => "desktop",
         AgentChannel::Telegram => "telegram",
     }
 }
 
 fn provider_as_str(provider: AgentProvider) -> &'static str {
     match provider {
+        AgentProvider::None => "none",
         AgentProvider::OpenAi => "open_ai",
     }
 }
@@ -112,6 +114,10 @@ fn is_sensitive_metadata_key(key: &str) -> bool {
     [
         "raw_prompt",
         "prompt",
+        "raw_response",
+        "response",
+        "raw_tool_output",
+        "tool_output",
         "provider_key",
         "api_key",
         "openai_api_key",

--- a/mhm/src-tauri/src/agent/store.rs
+++ b/mhm/src-tauri/src/agent/store.rs
@@ -108,7 +108,7 @@ fn sanitize_metadata(value: &Value) -> Value {
 }
 
 fn is_sensitive_metadata_key(key: &str) -> bool {
-    let normalized = key.to_ascii_lowercase();
+    let normalized = normalized_category(key);
     [
         "raw_prompt",
         "prompt",
@@ -123,7 +123,8 @@ fn is_sensitive_metadata_key(key: &str) -> bool {
         "authorization",
     ]
     .iter()
-    .any(|marker| normalized.contains(marker))
+    .map(|marker| normalized_category(marker))
+    .any(|marker| normalized.contains(&marker))
 }
 
 fn contains_obvious_secret_marker(value: &str) -> bool {
@@ -380,10 +381,13 @@ mod tests {
                 metadata: serde_json::json!({
                     "source": "test",
                     "raw_prompt": "show private details",
+                    "apiKey": "abc123",
                     "provider_key": "capyinn_sk_secret",
+                    "providerKey": "plain-provider-key",
                     "authorization": "Bearer abc",
                     "nested": {
                         "OPENAI_API_KEY": "sk-secret",
+                        "openaiApiKey": "plain-openai-key",
                         "telegram_bot_token": "telegram-token"
                     }
                 }),
@@ -401,15 +405,21 @@ mod tests {
 
         assert!(metadata.contains("\"source\":\"test\""));
         assert!(metadata.contains("\"raw_prompt\":\"[redacted]\""));
+        assert!(metadata.contains("\"apiKey\":\"[redacted]\""));
         assert!(metadata.contains("\"provider_key\":\"[redacted]\""));
+        assert!(metadata.contains("\"providerKey\":\"[redacted]\""));
         assert!(metadata.contains("\"authorization\":\"[redacted]\""));
         assert!(metadata.contains("\"OPENAI_API_KEY\":\"[redacted]\""));
+        assert!(metadata.contains("\"openaiApiKey\":\"[redacted]\""));
         assert!(metadata.contains("\"telegram_bot_token\":\"[redacted]\""));
         assert!(!metadata.contains(' '));
         assert!(!metadata.contains("show private details"));
+        assert!(!metadata.contains("abc123"));
         assert!(!metadata.contains("capyinn_sk_secret"));
+        assert!(!metadata.contains("plain-provider-key"));
         assert!(!metadata.contains("Bearer abc"));
         assert!(!metadata.contains("sk-secret"));
+        assert!(!metadata.contains("plain-openai-key"));
         assert!(!metadata.contains("telegram-token"));
     }
 

--- a/mhm/src-tauri/src/agent/store.rs
+++ b/mhm/src-tauri/src/agent/store.rs
@@ -120,6 +120,7 @@ fn is_sensitive_metadata_key(key: &str) -> bool {
         "token",
         "secret",
         "password",
+        "authorization",
     ]
     .iter()
     .any(|marker| normalized.contains(marker))
@@ -141,32 +142,32 @@ fn contains_obvious_secret_marker(value: &str) -> bool {
 }
 
 fn contains_forbidden_memory_truth(value: &str) -> bool {
-    let normalized = value.to_ascii_lowercase();
+    let normalized = normalized_category(value);
     [
         "canonical_booking",
-        "canonical booking",
         "canonical_booking_state",
         "booking_truth",
-        "booking truth",
         "room_availability_truth",
-        "room availability truth",
         "payment_truth",
-        "payment truth",
         "folio_truth",
-        "folio truth",
         "invoice_truth",
-        "invoice truth",
         "ledger_truth",
-        "ledger truth",
         "housekeeping_truth",
-        "housekeeping truth",
         "night_audit_truth",
-        "night audit truth",
         "audit_truth",
-        "audit truth",
+        "auto_mutating_recovery_commands",
     ]
     .iter()
-    .any(|forbidden| normalized.contains(forbidden))
+    .map(|forbidden| normalized_category(forbidden))
+    .any(|forbidden| normalized.contains(&forbidden))
+}
+
+fn normalized_category(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(char::to_lowercase)
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect()
 }
 
 fn validate_memory_item(input: &NewAgentMemoryItem) -> CommandResult<()> {
@@ -202,7 +203,7 @@ pub async fn create_agent_session(
     .bind(&input.channel_actor_id)
     .bind(if input.uses_memory { 1_i64 } else { 0_i64 })
     .bind(&input.retention_policy)
-    .bind(stable_json(&input.metadata)?)
+    .bind(stable_json(&sanitize_metadata(&input.metadata))?)
     .bind(&now)
     .bind(&now)
     .execute(pool)
@@ -364,6 +365,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_session_stores_sanitized_metadata() {
+        let pool = test_pool().await;
+
+        create_agent_session(
+            &pool,
+            NewAgentSession {
+                id: "session-sanitized".to_string(),
+                role: AgentRole::CeoSecretary,
+                channel: AgentChannel::Telegram,
+                channel_actor_id: Some("12345".to_string()),
+                uses_memory: false,
+                retention_policy: SESSION_RETENTION_METADATA_ONLY.to_string(),
+                metadata: serde_json::json!({
+                    "source": "test",
+                    "raw_prompt": "show private details",
+                    "provider_key": "capyinn_sk_secret",
+                    "authorization": "Bearer abc",
+                    "nested": {
+                        "OPENAI_API_KEY": "sk-secret",
+                        "telegram_bot_token": "telegram-token"
+                    }
+                }),
+            },
+        )
+        .await
+        .expect("session stored");
+
+        let metadata: String =
+            sqlx::query_scalar("SELECT metadata_json FROM agent_sessions WHERE id = ?")
+                .bind("session-sanitized")
+                .fetch_one(&pool)
+                .await
+                .expect("reads metadata");
+
+        assert!(metadata.contains("\"source\":\"test\""));
+        assert!(metadata.contains("\"raw_prompt\":\"[redacted]\""));
+        assert!(metadata.contains("\"provider_key\":\"[redacted]\""));
+        assert!(metadata.contains("\"authorization\":\"[redacted]\""));
+        assert!(metadata.contains("\"OPENAI_API_KEY\":\"[redacted]\""));
+        assert!(metadata.contains("\"telegram_bot_token\":\"[redacted]\""));
+        assert!(!metadata.contains(' '));
+        assert!(!metadata.contains("show private details"));
+        assert!(!metadata.contains("capyinn_sk_secret"));
+        assert!(!metadata.contains("Bearer abc"));
+        assert!(!metadata.contains("sk-secret"));
+        assert!(!metadata.contains("telegram-token"));
+    }
+
+    #[tokio::test]
     async fn audit_event_stores_sanitized_metadata() {
         let pool = test_pool().await;
 
@@ -430,5 +480,67 @@ mod tests {
             error.code,
             crate::app_error::codes::AGENT_MEMORY_FORBIDDEN_TRUTH
         );
+    }
+
+    #[tokio::test]
+    async fn memory_rejects_normalized_pms_truth_categories() {
+        let pool = test_pool().await;
+
+        for (id, scope, key, value) in [
+            (
+                "memory-auto-scope",
+                "auto_mutating_recovery_commands",
+                "preference",
+                serde_json::json!({ "summary": "ok" }),
+            ),
+            (
+                "memory-auto-key",
+                "preference",
+                "auto_mutating_recovery_commands",
+                serde_json::json!({ "summary": "ok" }),
+            ),
+            (
+                "memory-auto-value",
+                "preference",
+                "summary",
+                serde_json::json!({ "category": "auto_mutating_recovery_commands" }),
+            ),
+            (
+                "memory-camel",
+                "canonicalBookingState",
+                "booking-1",
+                serde_json::json!({ "summary": "ok" }),
+            ),
+            (
+                "memory-hyphen",
+                "room-availability truth",
+                "room-1",
+                serde_json::json!({ "summary": "ok" }),
+            ),
+            (
+                "memory-space",
+                "preference",
+                "payment truth",
+                serde_json::json!({ "summary": "ok" }),
+            ),
+        ] {
+            let error = upsert_agent_memory_item(
+                &pool,
+                NewAgentMemoryItem {
+                    id: id.to_string(),
+                    role: AgentRole::CeoSecretary,
+                    scope: scope.to_string(),
+                    key: key.to_string(),
+                    value,
+                },
+            )
+            .await
+            .expect_err("normalized PMS truth must not be stored in memory");
+
+            assert_eq!(
+                error.code,
+                crate::app_error::codes::AGENT_MEMORY_FORBIDDEN_TRUTH
+            );
+        }
     }
 }

--- a/mhm/src-tauri/src/app_error.rs
+++ b/mhm/src-tauri/src/app_error.rs
@@ -42,6 +42,12 @@ pub mod codes {
         "Dữ liệu đã thay đổi, vui lòng tải lại trước khi thao tác.";
     pub const COMMAND_LEDGER_ROW_NOT_FOUND: &str = "COMMAND_LEDGER_ROW_NOT_FOUND";
     pub const RECOVERY_REQUIRED: &str = "RECOVERY_REQUIRED";
+    pub const AGENT_RUNTIME_DISABLED: &str = "AGENT_RUNTIME_DISABLED";
+    pub const AGENT_CHANNEL_UNPAIRED: &str = "AGENT_CHANNEL_UNPAIRED";
+    pub const AGENT_PROVIDER_DISABLED: &str = "AGENT_PROVIDER_DISABLED";
+    pub const AGENT_CLOUD_DATA_OPT_IN_REQUIRED: &str = "AGENT_CLOUD_DATA_OPT_IN_REQUIRED";
+    pub const AGENT_TOOL_NOT_ALLOWED: &str = "AGENT_TOOL_NOT_ALLOWED";
+    pub const AGENT_MEMORY_FORBIDDEN_TRUTH: &str = "AGENT_MEMORY_FORBIDDEN_TRUTH";
     pub const SYSTEM_INTERNAL_ERROR: &str = "SYSTEM_INTERNAL_ERROR";
 
     pub const ALL: &[&str] = &[
@@ -77,6 +83,12 @@ pub mod codes {
         CONFLICT_INVALID_STATE_TRANSITION,
         COMMAND_LEDGER_ROW_NOT_FOUND,
         RECOVERY_REQUIRED,
+        AGENT_RUNTIME_DISABLED,
+        AGENT_CHANNEL_UNPAIRED,
+        AGENT_PROVIDER_DISABLED,
+        AGENT_CLOUD_DATA_OPT_IN_REQUIRED,
+        AGENT_TOOL_NOT_ALLOWED,
+        AGENT_MEMORY_FORBIDDEN_TRUTH,
         SYSTEM_INTERNAL_ERROR,
     ];
 }
@@ -389,6 +401,22 @@ mod tests {
     #[should_panic(expected = "unregistered command error code")]
     fn rejects_unregistered_command_error_code() {
         let _ = CommandError::user("NOT_REGISTERED", "boom");
+    }
+
+    #[test]
+    fn agent_error_codes_are_registered() {
+        for code in [
+            codes::AGENT_RUNTIME_DISABLED,
+            codes::AGENT_CHANNEL_UNPAIRED,
+            codes::AGENT_PROVIDER_DISABLED,
+            codes::AGENT_CLOUD_DATA_OPT_IN_REQUIRED,
+            codes::AGENT_TOOL_NOT_ALLOWED,
+            codes::AGENT_MEMORY_FORBIDDEN_TRUTH,
+        ] {
+            let error = CommandError::user(code, "agent policy denied");
+            assert_eq!(error.code, code);
+            assert_eq!(error.kind, AppErrorKind::User);
+        }
     }
 
     #[test]

--- a/mhm/src-tauri/src/app_error.rs
+++ b/mhm/src-tauri/src/app_error.rs
@@ -624,12 +624,44 @@ mod tests {
                 "Cần xử lý khôi phục lệnh trước khi tiếp tục.",
             ),
             (
+                codes::AGENT_RUNTIME_DISABLED,
+                AppErrorKind::User,
+                "Trợ lý AI hiện đang bị tắt.",
+            ),
+            (
+                codes::AGENT_CHANNEL_UNPAIRED,
+                AppErrorKind::User,
+                "Kênh trợ lý AI chưa được liên kết.",
+            ),
+            (
+                codes::AGENT_PROVIDER_DISABLED,
+                AppErrorKind::User,
+                "Nhà cung cấp AI hiện đang bị tắt.",
+            ),
+            (
+                codes::AGENT_CLOUD_DATA_OPT_IN_REQUIRED,
+                AppErrorKind::User,
+                "Cần bật cho phép xử lý dữ liệu trên đám mây trước khi dùng trợ lý AI.",
+            ),
+            (
+                codes::AGENT_TOOL_NOT_ALLOWED,
+                AppErrorKind::User,
+                "Trợ lý AI không được phép dùng công cụ này.",
+            ),
+            (
+                codes::AGENT_MEMORY_FORBIDDEN_TRUTH,
+                AppErrorKind::User,
+                "Bộ nhớ trợ lý AI không được dùng làm dữ liệu PMS chính thức.",
+            ),
+            (
                 codes::SYSTEM_INTERNAL_ERROR,
                 AppErrorKind::System,
                 GENERIC_SYSTEM_ERROR_MESSAGE,
             ),
         ];
 
+        let expected_codes: Vec<&str> = expected.iter().map(|(code, _, _)| *code).collect();
+        assert_eq!(expected_codes, codes::ALL);
         assert_eq!(registry.len(), expected.len());
         for (entry, (code, kind, default_message)) in registry.iter().zip(expected.iter()) {
             assert_eq!(entry.code, *code);

--- a/mhm/src-tauri/src/commands/agent_settings.rs
+++ b/mhm/src-tauri/src/commands/agent_settings.rs
@@ -34,14 +34,9 @@ pub async fn set_ceo_cloud_data_opt_in(
     )?;
     ctx.actor_id = Some(user.id.clone());
 
-    set_ceo_cloud_data_opt_in_idempotent(
-        &state.db,
-        &ctx,
-        enabled,
-        serde_json::json!({ "surface": "tauri" }),
-    )
-    .await
-    .map(|_| ())
+    set_ceo_cloud_data_opt_in_idempotent(&state.db, &ctx, enabled)
+        .await
+        .map(|_| ())
 }
 
 #[cfg(test)]

--- a/mhm/src-tauri/src/commands/agent_settings.rs
+++ b/mhm/src-tauri/src/commands/agent_settings.rs
@@ -1,0 +1,84 @@
+use super::{get_user, require_admin_user, AppState};
+use crate::{
+    agent::settings::{
+        get_ceo_cloud_data_opt_in as read_ceo_cloud_data_opt_in,
+        set_ceo_cloud_data_opt_in_idempotent, SET_CEO_CLOUD_DATA_OPT_IN_COMMAND,
+    },
+    app_error::CommandResult,
+    command_idempotency::WriteCommandContext,
+    models::User,
+};
+use tauri::State;
+
+pub(crate) fn require_ceo_cloud_opt_in_admin(user: Option<User>) -> CommandResult<User> {
+    require_admin_user(user)
+}
+
+#[tauri::command]
+pub async fn get_ceo_cloud_data_opt_in(state: State<'_, AppState>) -> CommandResult<bool> {
+    let _user = require_ceo_cloud_opt_in_admin(get_user(&state))?;
+    read_ceo_cloud_data_opt_in(&state.db).await
+}
+
+#[tauri::command]
+pub async fn set_ceo_cloud_data_opt_in(
+    state: State<'_, AppState>,
+    enabled: bool,
+    idempotency_key: String,
+) -> CommandResult<()> {
+    let user = require_ceo_cloud_opt_in_admin(get_user(&state))?;
+    let mut ctx = WriteCommandContext::for_scoped_command(
+        uuid::Uuid::new_v4().to_string(),
+        idempotency_key,
+        SET_CEO_CLOUD_DATA_OPT_IN_COMMAND,
+    )?;
+    ctx.actor_id = Some(user.id.clone());
+
+    set_ceo_cloud_data_opt_in_idempotent(
+        &state.db,
+        &ctx,
+        enabled,
+        serde_json::json!({ "surface": "tauri" }),
+    )
+    .await
+    .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_error::{codes, AppErrorKind};
+
+    fn mock_user(role: &str) -> User {
+        User {
+            id: "u1".to_string(),
+            name: "Test".to_string(),
+            role: role.to_string(),
+            active: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn admin_user_allowed_by_auth_helper() {
+        let user =
+            require_ceo_cloud_opt_in_admin(Some(mock_user("admin"))).expect("admin must pass");
+        assert_eq!(user.role, "admin");
+    }
+
+    #[test]
+    fn receptionist_user_rejected() {
+        let error = require_ceo_cloud_opt_in_admin(Some(mock_user("receptionist")))
+            .expect_err("non-admin must fail");
+        assert_eq!(error.code, codes::AUTH_FORBIDDEN);
+        assert_eq!(error.kind, AppErrorKind::User);
+    }
+
+    #[test]
+    fn unauthenticated_user_rejected() {
+        let error =
+            require_ceo_cloud_opt_in_admin(None).expect_err("missing user must be rejected");
+        assert_eq!(error.code, codes::AUTH_NOT_AUTHENTICATED);
+        assert_eq!(error.kind, AppErrorKind::User);
+    }
+}

--- a/mhm/src-tauri/src/commands/mod.rs
+++ b/mhm/src-tauri/src/commands/mod.rs
@@ -80,6 +80,7 @@ pub(crate) fn emit_db_update(app: &tauri::AppHandle, entity: &str) {
     let _ = app.emit("db-updated", serde_json::json!({ "entity": entity }));
 }
 
+pub mod agent_settings;
 pub mod analytics;
 pub mod audit;
 pub mod auth;

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -26,6 +26,7 @@ pub async fn init_db() -> Result<Pool<Sqlite>, sqlx::Error> {
     run_migrations(&pool).await?;
     ensure_setting_default(&pool, "setup_completed", "false").await?;
     ensure_setting_default(&pool, "send_crash_reports", "false").await?;
+    ensure_setting_default(&pool, "ceo_cloud_data_opt_in", "false").await?;
 
     Ok(pool)
 }
@@ -994,6 +995,102 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         set_schema_version(&mut tx, 17).await?;
         tx.commit().await?;
     }
+
+    // -- V18: Agent safety session, audit, and memory schema --
+    if current < 18 {
+        let mut tx = pool.begin().await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS agent_sessions (
+                id TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                channel TEXT NOT NULL,
+                channel_actor_id TEXT,
+                status TEXT NOT NULL,
+                uses_memory INTEGER NOT NULL DEFAULT 0,
+                retention_policy TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                started_at TEXT NOT NULL,
+                last_seen_at TEXT,
+                ended_at TEXT
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS agent_sessions_actor_idx
+             ON agent_sessions(role, channel, channel_actor_id, last_seen_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS agent_sessions_status_idx
+             ON agent_sessions(status, started_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS agent_audit_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT REFERENCES agent_sessions(id),
+                event_type TEXT NOT NULL,
+                actor_id TEXT,
+                role TEXT,
+                channel TEXT,
+                tool_name TEXT,
+                provider TEXT,
+                policy_outcome TEXT NOT NULL,
+                mutation_risk TEXT,
+                data_sensitivity TEXT,
+                summary_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS agent_audit_events_type_idx
+             ON agent_audit_events(event_type, created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS agent_audit_events_session_idx
+             ON agent_audit_events(session_id, created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS agent_audit_events_role_channel_idx
+             ON agent_audit_events(role, channel, created_at)",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS agent_memory_items (
+                id TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(role, scope, key)
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        set_schema_version(&mut tx, 18).await?;
+        tx.commit().await?;
+    }
     Ok(())
 }
 
@@ -1149,6 +1246,93 @@ mod tests {
         .fetch_one(pool)
         .await
         .expect("checks sqlite table")
+    }
+
+    async fn table_exists(pool: &SqlitePool, table: &str) -> bool {
+        sqlite_table_count(pool, table).await == 1
+    }
+
+    async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> bool {
+        let sql = match table {
+            "agent_sessions" => {
+                "SELECT COUNT(*) FROM pragma_table_info('agent_sessions') WHERE name = ?"
+            }
+            "agent_audit_events" => {
+                "SELECT COUNT(*) FROM pragma_table_info('agent_audit_events') WHERE name = ?"
+            }
+            "agent_memory_items" => {
+                "SELECT COUNT(*) FROM pragma_table_info('agent_memory_items') WHERE name = ?"
+            }
+            _ => panic!("unsupported table {table}"),
+        };
+
+        let count: i64 = sqlx::query_scalar(sql)
+            .bind(column)
+            .fetch_one(pool)
+            .await
+            .expect("reads table info");
+        count == 1
+    }
+
+    async fn assert_agent_safety_shape(pool: &SqlitePool) {
+        for table in ["agent_sessions", "agent_audit_events", "agent_memory_items"] {
+            assert!(table_exists(pool, table).await, "{table} table exists");
+        }
+
+        for column in [
+            "id",
+            "role",
+            "channel",
+            "channel_actor_id",
+            "status",
+            "uses_memory",
+            "retention_policy",
+            "metadata_json",
+            "started_at",
+            "last_seen_at",
+            "ended_at",
+        ] {
+            assert!(
+                column_exists(pool, "agent_sessions", column).await,
+                "agent_sessions.{column} exists"
+            );
+        }
+
+        for column in [
+            "id",
+            "session_id",
+            "event_type",
+            "actor_id",
+            "role",
+            "channel",
+            "tool_name",
+            "provider",
+            "policy_outcome",
+            "mutation_risk",
+            "data_sensitivity",
+            "summary_json",
+            "created_at",
+        ] {
+            assert!(
+                column_exists(pool, "agent_audit_events", column).await,
+                "agent_audit_events.{column} exists"
+            );
+        }
+
+        for column in [
+            "id",
+            "role",
+            "scope",
+            "key",
+            "value_json",
+            "created_at",
+            "updated_at",
+        ] {
+            assert!(
+                column_exists(pool, "agent_memory_items", column).await,
+                "agent_memory_items.{column} exists"
+            );
+        }
     }
 
     async fn outbox_column_count(pool: &SqlitePool, name: &str) -> i64 {
@@ -1337,7 +1521,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]
@@ -1353,7 +1537,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1641,7 +1825,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]
@@ -1708,7 +1892,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]
@@ -1788,7 +1972,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]
@@ -1828,7 +2012,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]
@@ -1846,7 +2030,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]
@@ -1876,7 +2060,44 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 17);
+        assert_eq!(version, 18);
+    }
+
+    #[tokio::test]
+    async fn migration_v18_adds_agent_safety_tables() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+
+        run_migrations(&pool).await.expect("runs migrations");
+
+        assert_agent_safety_shape(&pool).await;
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 18);
+    }
+
+    #[tokio::test]
+    async fn migration_v18_upgrades_existing_v17_database() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("initial migrations run");
+        sqlx::query("UPDATE schema_version SET version = 17")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version");
+        for table in ["agent_audit_events", "agent_memory_items", "agent_sessions"] {
+            sqlx::query(&format!("DROP TABLE IF EXISTS {table}"))
+                .execute(&pool)
+                .await
+                .expect("removes v18 table");
+        }
+
+        run_migrations(&pool).await.expect("v18 migration reruns");
+
+        assert_agent_safety_shape(&pool).await;
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 18);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 use log::{error, info};
 use tauri::Manager;
 
-pub mod aggregate_locks;
 pub mod agent;
+pub mod aggregate_locks;
 pub mod app_error;
 pub mod app_identity;
 mod backup;
@@ -261,6 +261,8 @@ pub fn run() {
             commands::settings::get_settings,
             commands::settings::get_crash_reporting_preference,
             commands::settings::set_crash_reporting_preference,
+            commands::agent_settings::get_ceo_cloud_data_opt_in,
+            commands::agent_settings::set_ceo_cloud_data_opt_in,
             commands::diagnostics::record_js_crash,
             commands::diagnostics::get_pending_crash_report,
             commands::diagnostics::mark_crash_report_submitted,

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use log::{error, info};
 use tauri::Manager;
 
 pub mod aggregate_locks;
+pub mod agent;
 pub mod app_error;
 pub mod app_identity;
 mod backup;

--- a/mhm/src/__mocks__/tauri-core.ts
+++ b/mhm/src/__mocks__/tauri-core.ts
@@ -45,6 +45,8 @@ export const invoke = vi.fn(async (command: string, args?: Record<string, unknow
         },
         get_crash_reporting_preference: false,
         set_crash_reporting_preference: undefined,
+        get_ceo_cloud_data_opt_in: false,
+        set_ceo_cloud_data_opt_in: undefined,
         complete_onboarding: {
             setup_completed: true,
             app_lock_enabled: false,

--- a/mhm/src/pages/settings/CeoAgentSection.test.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SettingsPage from "./index";
+import CeoAgentSection from "./CeoAgentSection";
+import { clearMockResponses, invoke, setMockResponses } from "@/__mocks__/tauri-core";
+import { useAuthStore } from "@/stores/useAuthStore";
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    error: toastError,
+  },
+}));
+
+describe("CeoAgentSection", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+
+    useAuthStore.setState({
+      user: { id: "u1", name: "Admin", role: "admin", active: true, created_at: "" },
+      isAuthenticated: true,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("renders the disabled opt-in state and required copy", async () => {
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => false,
+      set_ceo_cloud_data_opt_in: () => undefined,
+    });
+
+    render(<CeoAgentSection />);
+
+    expect(
+      screen.getByText(/opt-in is required before future CEO-sensitive cloud LLM processing/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/opt-in is revocable/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/revoking blocks cloud calls containing CEO-sensitive PMS data/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/runtime remains disabled in this foundation slice/i)).toBeInTheDocument();
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Allow CEO cloud-data processing",
+    });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("allows an admin to toggle opt-in on via an idempotent write command", async () => {
+    const user = userEvent.setup();
+
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => false,
+      set_ceo_cloud_data_opt_in: () => undefined,
+    });
+
+    render(<CeoAgentSection />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Allow CEO cloud-data processing",
+    });
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "set_ceo_cloud_data_opt_in",
+        expect.objectContaining({
+          enabled: true,
+          idempotencyKey: expect.stringMatching(/^set_ceo_cloud_data_opt_in:/),
+        }),
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("CEO cloud-data opt-in enabled");
+  });
+
+  it("allows an admin to revoke opt-in and calls the backend with enabled=false", async () => {
+    const user = userEvent.setup();
+
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => true,
+      set_ceo_cloud_data_opt_in: () => undefined,
+    });
+
+    render(<CeoAgentSection />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Allow CEO cloud-data processing",
+    });
+    expect(checkbox).toBeChecked();
+
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "set_ceo_cloud_data_opt_in",
+        expect.objectContaining({
+          enabled: false,
+          idempotencyKey: expect.stringMatching(/^set_ceo_cloud_data_opt_in:/),
+        }),
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("CEO cloud-data opt-in revoked");
+  });
+
+  it("reverts the checkbox and shows an error toast when the update fails", async () => {
+    const user = userEvent.setup();
+
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => false,
+      set_ceo_cloud_data_opt_in: () => {
+        throw new Error("boom");
+      },
+    });
+
+    render(<CeoAgentSection />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Allow CEO cloud-data processing",
+    });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Unable to update CEO cloud-data opt-in"));
+    expect(checkbox).not.toBeChecked();
+  });
+});
+
+describe("SettingsPage CEO Agent nav", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+  });
+
+  it("shows CEO Agent in settings nav for admins and renders the section", async () => {
+    const user = userEvent.setup();
+    useAuthStore.setState({
+      user: { id: "u1", name: "Admin", role: "admin", active: true, created_at: "" },
+      isAuthenticated: true,
+      loading: false,
+      error: null,
+    });
+
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => false,
+      set_ceo_cloud_data_opt_in: () => undefined,
+    });
+
+    render(<SettingsPage />);
+
+    const navButton = screen.getByRole("button", { name: "CEO Agent" });
+    await user.click(navButton);
+
+    expect(await screen.findByRole("checkbox", { name: "Allow CEO cloud-data processing" })).toBeInTheDocument();
+  });
+
+  it("does not show CEO Agent in settings nav for receptionist users", () => {
+    useAuthStore.setState({
+      user: { id: "u2", name: "Reception", role: "receptionist", active: true, created_at: "" },
+      isAuthenticated: true,
+      loading: false,
+      error: null,
+    });
+
+    render(<SettingsPage />);
+
+    expect(screen.queryByRole("button", { name: "CEO Agent" })).not.toBeInTheDocument();
+  });
+});
+

--- a/mhm/src/pages/settings/CeoAgentSection.test.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.test.tsx
@@ -54,7 +54,7 @@ describe("CeoAgentSection", () => {
         /raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored/i,
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/runtime remains disabled in this foundation slice/i)).toBeInTheDocument();
+    expect(screen.getByText(/runtime remains disabled in this build/i)).toBeInTheDocument();
 
     const checkbox = await screen.findByRole("checkbox", {
       name: "Allow CEO cloud-data processing",
@@ -140,6 +140,57 @@ describe("CeoAgentSection", () => {
     await waitFor(() => expect(toastError).toHaveBeenCalledWith("Unable to update CEO cloud-data opt-in"));
     expect(checkbox).not.toBeChecked();
   });
+
+  it("keeps the toggle disabled when loading opt-in state fails", async () => {
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => {
+        throw new Error("unavailable");
+      },
+      set_ceo_cloud_data_opt_in: () => undefined,
+    });
+
+    render(<CeoAgentSection />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Allow CEO cloud-data processing",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to load CEO cloud-data opt-in")).toBeInTheDocument();
+    });
+    expect(checkbox).toBeDisabled();
+  });
+
+  it("disables the toggle while saving to prevent duplicate writes", async () => {
+    const user = userEvent.setup();
+    let resolveWrite: (() => void) | undefined;
+    const setHandler = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    );
+
+    setMockResponses({
+      get_ceo_cloud_data_opt_in: () => false,
+      set_ceo_cloud_data_opt_in: setHandler,
+    });
+
+    render(<CeoAgentSection />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Allow CEO cloud-data processing",
+    });
+
+    await user.click(checkbox);
+    expect(checkbox).toBeDisabled();
+
+    await user.click(checkbox);
+    expect(setHandler).toHaveBeenCalledTimes(1);
+
+    resolveWrite?.();
+    await waitFor(() => expect(checkbox).not.toBeDisabled());
+  });
 });
 
 describe("SettingsPage CEO Agent nav", () => {
@@ -183,4 +234,3 @@ describe("SettingsPage CEO Agent nav", () => {
     expect(screen.queryByRole("button", { name: "CEO Agent" })).not.toBeInTheDocument();
   });
 });
-

--- a/mhm/src/pages/settings/CeoAgentSection.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { invokeCommand, invokeWriteCommand } from "@/lib/invokeCommand";
+
+export default function CeoAgentSection() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    invokeCommand<boolean>("get_ceo_cloud_data_opt_in")
+      .then(setEnabled)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleToggle = async (nextValue: boolean) => {
+    setEnabled(nextValue);
+    setStatusMessage(null);
+
+    try {
+      await invokeWriteCommand("set_ceo_cloud_data_opt_in", { enabled: nextValue });
+      const message = nextValue
+        ? "CEO cloud-data opt-in enabled"
+        : "CEO cloud-data opt-in revoked";
+      setStatusMessage(message);
+      toast.success(message);
+    } catch {
+      setEnabled(!nextValue);
+      setStatusMessage("Unable to update CEO cloud-data opt-in");
+      toast.error("Unable to update CEO cloud-data opt-in");
+    }
+  };
+
+  return (
+    <div className="max-w-lg space-y-6">
+      <div>
+        <h3 className="mb-1 text-lg font-bold">CEO Agent</h3>
+        <p className="text-sm text-brand-muted">
+          Opt-in is required before future CEO-sensitive cloud LLM processing.
+        </p>
+      </div>
+
+      <label className="flex items-center justify-between rounded-xl border border-slate-200 p-4">
+        <div className="pr-4 space-y-1">
+          <p className="text-sm font-medium">Allow CEO cloud-data processing</p>
+          <div className="text-xs text-brand-muted space-y-1">
+            <p>Opt-in is revocable.</p>
+            <p>Revoking blocks cloud calls containing CEO-sensitive PMS data.</p>
+            <p>
+              Raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored.
+            </p>
+            <p>Runtime remains disabled in this foundation slice.</p>
+          </div>
+        </div>
+        <input
+          type="checkbox"
+          aria-label="Allow CEO cloud-data processing"
+          checked={enabled}
+          disabled={loading}
+          onChange={(event) => void handleToggle(event.target.checked)}
+        />
+      </label>
+
+      {statusMessage && <p className="text-sm text-brand-text">{statusMessage}</p>}
+    </div>
+  );
+}

--- a/mhm/src/pages/settings/CeoAgentSection.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.tsx
@@ -6,15 +6,25 @@ import { invokeCommand, invokeWriteCommand } from "@/lib/invokeCommand";
 export default function CeoAgentSection() {
   const [enabled, setEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
   useEffect(() => {
     invokeCommand<boolean>("get_ceo_cloud_data_opt_in")
-      .then(setEnabled)
+      .then((value) => {
+        setEnabled(value);
+        setLoadError(null);
+      })
+      .catch(() => {
+        setLoadError("Unable to load CEO cloud-data opt-in");
+      })
       .finally(() => setLoading(false));
   }, []);
 
   const handleToggle = async (nextValue: boolean) => {
+    const previous = enabled;
+    setSaving(true);
     setEnabled(nextValue);
     setStatusMessage(null);
 
@@ -26,9 +36,11 @@ export default function CeoAgentSection() {
       setStatusMessage(message);
       toast.success(message);
     } catch {
-      setEnabled(!nextValue);
+      setEnabled(previous);
       setStatusMessage("Unable to update CEO cloud-data opt-in");
       toast.error("Unable to update CEO cloud-data opt-in");
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -50,18 +62,19 @@ export default function CeoAgentSection() {
             <p>
               Raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored.
             </p>
-            <p>Runtime remains disabled in this foundation slice.</p>
+            <p>Runtime remains disabled in this build.</p>
           </div>
         </div>
         <input
           type="checkbox"
           aria-label="Allow CEO cloud-data processing"
           checked={enabled}
-          disabled={loading}
+          disabled={loading || saving || Boolean(loadError)}
           onChange={(event) => void handleToggle(event.target.checked)}
         />
       </label>
 
+      {loadError && <p className="text-sm text-red-500">{loadError}</p>}
       {statusMessage && <p className="text-sm text-brand-text">{statusMessage}</p>}
     </div>
   );

--- a/mhm/src/pages/settings/index.tsx
+++ b/mhm/src/pages/settings/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   BedDouble,
+  Bot,
   Building2,
   Camera,
   Clock,
@@ -17,6 +18,7 @@ import { useAuthStore } from "@/stores/useAuthStore";
 
 import AppearanceSection from "./AppearanceSection";
 import CheckinRulesSection from "./CheckinRulesSection";
+import CeoAgentSection from "./CeoAgentSection";
 import DataSection from "./DataSection";
 import DiagnosticsSection from "./DiagnosticsSection";
 import GatewaySection from "./GatewaySection";
@@ -36,6 +38,7 @@ type SettingsSectionKey =
   | "diagnostics"
   | "data"
   | "gateway"
+  | "ceo-agent"
   | "updates"
   | "pricing"
   | "users";
@@ -56,6 +59,7 @@ export default function SettingsPage() {
     { key: "updates" as const, label: "Software Update", icon: RefreshCcw },
     ...(isAdmin()
       ? [
+        { key: "ceo-agent" as const, label: "CEO Agent", icon: Bot },
         { key: "pricing" as const, label: "Pricing", icon: DollarSign },
         { key: "users" as const, label: "Users", icon: Users },
       ]
@@ -94,6 +98,7 @@ export default function SettingsPage() {
         {activeSection === "data" && <DataSection />}
         {activeSection === "gateway" && <GatewaySection />}
         {activeSection === "updates" && <SoftwareUpdateSection />}
+        {activeSection === "ceo-agent" && isAdmin() && <CeoAgentSection />}
         {activeSection === "pricing" && isAdmin() && <PricingSection />}
         {activeSection === "users" && isAdmin() && <UserManagement />}
       </Card>

--- a/mhm/tests/agentic-guardrails.test.ts
+++ b/mhm/tests/agentic-guardrails.test.ts
@@ -70,4 +70,48 @@ describe("agentic integration guardrails", () => {
             "LAN or remote exposure requires explicit configuration, auth or pairing, and policy gates",
         );
     });
+
+    it("documents CEO agent data sensitivity and cloud opt-in boundaries", () => {
+        const skill = readWorkspaceFile("skills/hotel-manager.skill.md");
+        const openapi = readWorkspaceFile("skills/openapi.yaml");
+        const manifest = JSON.parse(readWorkspaceFile("skills/mcp-manifest.json"));
+
+        expect(skill).toContain("ReadOnly does not mean guest-safe");
+        expect(skill).toContain("CEO cloud-data opt-in is required");
+        expect(skill).toContain(
+            "raw prompts, raw responses, raw tool outputs, and raw provider errors are not stored",
+        );
+
+        expect(openapi).toContain("PublicHotelInfo");
+        expect(openapi).toContain("GuestScoped");
+        expect(openapi).toContain("StaffOperational");
+        expect(openapi).toContain("CeoSensitive");
+        expect(openapi).toContain(
+            "CEO cloud-data opt-in is persisted and revocable",
+        );
+
+        expect(manifest.agent_safety.data_sensitivity_classes).toEqual([
+            "PublicHotelInfo",
+            "GuestScoped",
+            "StaffOperational",
+            "CeoSensitive",
+        ]);
+        expect(manifest.agent_safety.read_only_not_guest_safe).toBe(true);
+        expect(manifest.agent_safety.cloud_data_opt_in.setting_key).toBe(
+            "ceo_cloud_data_opt_in",
+        );
+        expect(manifest.agent_safety.cloud_data_opt_in.default).toBe(false);
+        expect(manifest.agent_safety.retention.raw_prompt_retention).toBe(
+            "not_stored",
+        );
+        expect(manifest.agent_safety.retention.raw_response_retention).toBe(
+            "not_stored",
+        );
+        expect(manifest.agent_safety.retention.raw_tool_output_retention).toBe(
+            "not_stored",
+        );
+        expect(
+            manifest.agent_safety.retention.raw_provider_error_retention,
+        ).toBe("not_stored");
+    });
 });


### PR DESCRIPTION
## Summary
- add CEO agent safety model, sensitivity classes, retention constants, and disabled runtime skeleton
- add v18 agent safety tables plus audited/admin-only CEO cloud-data opt-in command
- add minimal Settings UI and docs/manifest guardrails

## Safety
- no Telegram/OpenAI/provider calls are enabled
- runtime remains disabled and unpaired actors fail before prompt/provider construction
- CEO-sensitive cloud request construction requires persisted opt-in
- raw prompts/responses/tool outputs/provider errors are not stored; audit/session metadata is sanitized
- no PMS business writes introduced

## Verification
- `cargo clippy --manifest-path mhm/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `npm run verify:full`