### PR TITLE
[codex] Address CEO digest review feedback

### DIFF
--- a/mhm/src-tauri/src/agent/digest/scheduler.rs
+++ b/mhm/src-tauri/src/agent/digest/scheduler.rs
@@ -41,7 +41,7 @@ pub async fn ensure_startup_digest_due_run(
     config: &CeoDigestConfig,
     now: DateTime<Utc>,
 ) -> CommandResult<bool> {
-    if last_delivery_is_recent(pool, now).await? {
+    if last_delivery_is_recent(pool, config, now).await? {
         return Ok(false);
     }
     let due_at = truncate_to_utc_second(now)?;
@@ -279,7 +279,7 @@ async fn ensure_hourly_digest_due_run(
     config: &CeoDigestConfig,
     now: DateTime<Utc>,
 ) -> CommandResult<bool> {
-    if last_delivery_is_recent(pool, now).await? {
+    if last_delivery_is_recent(pool, config, now).await? {
         return Ok(false);
     }
 
@@ -402,12 +402,25 @@ async fn existing_digest_run_matches(
     ))
 }
 
-async fn last_delivery_is_recent(pool: &Pool<Sqlite>, now: DateTime<Utc>) -> CommandResult<bool> {
+async fn last_delivery_is_recent(
+    pool: &Pool<Sqlite>,
+    config: &CeoDigestConfig,
+    now: DateTime<Utc>,
+) -> CommandResult<bool> {
+    let delivery_chat_id = config
+        .telegram_delivery_chat_id
+        .map(|value| value.to_string());
     let row = sqlx::query(
         "SELECT delivered_at FROM agent_digest_runs
          WHERE status = 'delivered'
+           AND ((? IS NULL AND channel_actor_id IS NULL) OR channel_actor_id = ?)
+           AND ((? IS NULL AND delivery_chat_id IS NULL) OR delivery_chat_id = ?)
          ORDER BY delivered_at DESC LIMIT 1",
     )
+    .bind(&config.telegram_user_id)
+    .bind(&config.telegram_user_id)
+    .bind(&delivery_chat_id)
+    .bind(&delivery_chat_id)
     .fetch_optional(pool)
     .await
     .map_err(system_error)?;
@@ -652,6 +665,39 @@ mod tests {
             .expect("claimed");
     }
 
+    async fn seed_delivered_digest_run(
+        pool: &Pool<Sqlite>,
+        id: &str,
+        telegram_user_id: &str,
+        telegram_delivery_chat_id: i64,
+        due_at: &str,
+        delivered_at: &str,
+    ) {
+        create_digest_run_if_absent(
+            pool,
+            NewDigestRun {
+                id: id.to_string(),
+                channel_actor_id: Some(telegram_user_id.to_string()),
+                delivery_chat_id: Some(telegram_delivery_chat_id),
+                due_at: due_at.to_string(),
+                max_attempts: CEO_DIGEST_MAX_ATTEMPTS,
+            },
+        )
+        .await
+        .expect("create delivered digest run");
+        sqlx::query(
+            "UPDATE agent_digest_runs
+             SET status = 'delivered', delivered_at = ?, updated_at = ?
+             WHERE id = ?",
+        )
+        .bind(delivered_at)
+        .bind(delivered_at)
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("mark delivered digest run");
+    }
+
     async fn make_claim_stale(pool: &Pool<Sqlite>, id: &str) {
         sqlx::query("UPDATE agent_digest_runs SET claimed_at = ? WHERE id = ?")
             .bind("2026-05-07T00:00:00Z")
@@ -812,6 +858,52 @@ mod tests {
             chat_ids,
             vec![Some("55".to_string()), Some("66".to_string())]
         );
+    }
+
+    #[tokio::test]
+    async fn startup_due_run_ignores_recent_delivery_for_stale_target() {
+        let pool = test_pool().await;
+        let now = "2026-05-07T02:10:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("now");
+        seed_delivered_digest_run(
+            &pool,
+            "old-delivered-target",
+            "123",
+            55,
+            "2026-05-07T01:00:00Z",
+            "2026-05-07T01:55:00Z",
+        )
+        .await;
+
+        let created =
+            ensure_startup_digest_due_run(&pool, &digest_config_for_target("123", 66), now)
+                .await
+                .expect("startup due run");
+        assert!(created);
+    }
+
+    #[tokio::test]
+    async fn hourly_due_run_ignores_recent_delivery_for_stale_target() {
+        let pool = test_pool().await;
+        let now = "2026-05-07T02:10:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("now");
+        seed_delivered_digest_run(
+            &pool,
+            "old-delivered-target",
+            "123",
+            55,
+            "2026-05-07T01:00:00Z",
+            "2026-05-07T01:55:00Z",
+        )
+        .await;
+
+        let created =
+            ensure_hourly_digest_due_run(&pool, &digest_config_for_target("123", 66), now)
+                .await
+                .expect("hourly due run");
+        assert!(created);
     }
 
     #[tokio::test]

--- a/mhm/src/pages/settings/CeoAgentSection.test.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.test.tsx
@@ -274,6 +274,26 @@ describe("CeoAgentSection", () => {
     });
   });
 
+  it("saves signed digest delivery chat ids for Telegram groups", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+    render(<CeoAgentSection />);
+
+    await user.type(await screen.findByLabelText("Telegram delivery chat ID"), "-10055");
+    await user.click(screen.getByRole("button", { name: "Save digest config" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "set_ceo_digest_config",
+        expect.objectContaining({
+          telegramDeliveryChatId: -10055,
+          idempotencyKey: expect.stringMatching(/^set_ceo_digest_config:/),
+        }),
+      );
+    });
+    expect(screen.getByLabelText("Telegram delivery chat ID")).toHaveValue("-10055");
+  });
+
   it("keeps saved digest config when post-save gate refresh fails", async () => {
     const user = userEvent.setup();
     let digestGateCalls = 0;

--- a/mhm/src/pages/settings/CeoAgentSection.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.tsx
@@ -469,10 +469,12 @@ export default function CeoAgentSection() {
           <input
             aria-label="Telegram delivery chat ID"
             inputMode="numeric"
-            pattern="[0-9]*"
+            pattern="-?[0-9]*"
             value={telegramDeliveryChatId}
             disabled={disabled}
-            onChange={(event) => setTelegramDeliveryChatId(event.target.value.replace(/\D/g, ""))}
+            onChange={(event) =>
+              setTelegramDeliveryChatId(event.target.value.replace(/[^\d-]/g, "").replace(/(?!^)-/g, ""))
+            }
             className="h-10 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
           />
         </label>


### PR DESCRIPTION
## Summary

Follow-up for review comments left on merged PR #130.

- Scopes recent-delivery suppression to the current digest target actor/chat so stale Telegram targets no longer block startup/hourly runs for the new target.
- Allows signed Telegram delivery chat IDs in CEO Digest settings so group and supergroup chat IDs keep their leading `-`.
- Adds regression coverage for stale-target recent deliveries and signed delivery chat IDs.

## Validation

- `cargo test --manifest-path mhm/src-tauri/Cargo.toml agent::digest::scheduler:: -- --nocapture` passed: 9/9.
- `npm test -- --run src/pages/settings/CeoAgentSection.test.tsx` passed: 15/15.
- `npm run verify:agent` passed: Rust agent 105/105, settings 13/13, UI 15/15, guardrails 9/9.
- `cargo clippy --all-targets -- -D warnings` passed.
- `npm run verify:quick` passed: frontend 74/74 and Rust quick filters.

## Notes

GitNexus pre-edit impacts were low for the scheduler functions and `CeoAgentSection`. Staged detect reported high because `CeoAgentSection` participates in multiple frontend flows, so `verify:quick` was run after the targeted and agent checks.