### PR TITLE
[codex] define core PMS guardrails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
-# Contributing to MHM
+# Contributing to CapyInn
 
 Thanks for contributing.
 
 ## Project Layout
 
-- `mhm/` is the core PMS application.
-- `docs/plans/` contains public implementation plans and release prep notes.
+- `mhm/` is the current implementation path for the CapyInn PMS application. It is rename debt, not the product name.
+- `docs/architecture/core-pms-boundaries.md` is the canonical guardrail for core PMS, experimental runtime, command safety, and the postponed `mhm/` rename.
+- `docs/plans/` contains public implementation plans and release prep notes when present.
 
 ## Prerequisites
 
@@ -55,6 +56,18 @@ cargo clippy --all-targets -- -D warnings
 - TypeScript should stay strict and type-safe.
 - Rust should compile cleanly and pass clippy.
 - Avoid committing secrets, local paths, exported browser cookies, or internal agent files.
+
+## PMS Architecture Guardrails
+
+- Core PMS includes rooms, stays, reservations, guests, housekeeping, billing, invoices, groups, night audit, settings, and auth.
+- Experimental runtime includes gateway, MCP, agent runtime, observer streams, digest, Telegram, CEO, and OpenAI surfaces.
+- Experimental disabled means normal PMS operation has no experimental background tasks, no required external API keys, no Telegram/OpenAI/MCP/gateway config, no agent direct PMS table mutation, and no experimental UI in the normal profile.
+- Business writes must enter through Tauri commands and continue through service/lifecycle modules.
+- Reads should use Tauri commands and query modules when read SQL is shared, growing, or part of a review hotspot.
+- The intended orchestration is `UI -> command -> service/lifecycle` for writes and `UI -> command -> query` for reads.
+- Command safety is core PMS infrastructure: preserve actor, command name, idempotency key, canonical payload hash, timestamp, request context, stable lock keys, audit writes, command ledger metadata, and transactional outbox writes.
+- UI, bots, agents, and integrations must not mutate PMS tables directly.
+- Do not rename `mhm/` until canonical docs, CI, smoke tests, and normal-profile runtime boundaries are stable.
 
 ## Commits
 

--- a/docs/architecture/core-pms-boundaries.md
+++ b/docs/architecture/core-pms-boundaries.md
@@ -1,0 +1,130 @@
+# Core PMS Boundaries
+
+Date: 2026-05-08
+Status: Canonical guardrail
+
+## Purpose
+
+CapyInn is an offline-first PMS for mini hotels. This document defines the boundary between stable PMS core, command safety infrastructure, and experimental runtime surfaces so contributors can keep cleanup and feature work reviewable.
+
+Normal PMS operation must not require gateway, MCP, OpenAI, Telegram, CEO-agent, digest, or other experimental runtime configuration.
+
+## Core PMS
+
+Core PMS is the stable product surface required for day-to-day hotel operations:
+
+- rooms and room status;
+- stays, check-in, extend-stay, and check-out;
+- reservations and reservation lifecycle;
+- guests and guest registration data;
+- housekeeping and maintenance state;
+- billing, folios, payments, invoices, and financial reporting;
+- group booking and group invoices;
+- night audit and end-of-day reconciliation;
+- settings, authentication, and app lock;
+- SQLite schema, migrations, and queries required for normal PMS workflows.
+
+Core PMS work should be understandable, testable, and able to run without experimental runtime enabled.
+
+## Experimental Runtime
+
+Experimental runtime is not part of the stable PMS product surface unless a later issue explicitly promotes it:
+
+- gateway runtime and gateway consumers;
+- MCP surfaces;
+- agent runtime, tools, providers, supervisors, and memory;
+- observer streams and external consumers;
+- digest jobs and digest delivery;
+- Telegram surfaces;
+- CEO and OpenAI surfaces;
+- experimental UI badges, panels, toasts, or background tasks.
+
+Experimental runtime code may exist in the repository, but it must not be required by the normal PMS profile.
+
+## Command Safety Core
+
+Command safety is PMS core infrastructure, not experimental platform work. Every business write must cross an explicit command boundary and preserve the command metadata needed for idempotency, authorization, auditability, and recovery:
+
+- actor;
+- command name;
+- idempotency key;
+- canonical payload hash;
+- timestamp;
+- request context;
+- stable lock keys for high-risk aggregates such as booking, room/date, folio, invoice, ledger, or audit date;
+- command ledger metadata;
+- audit writes;
+- transactional outbox writes when outbox records are part of the same business mutation.
+
+Retryable commands must be idempotent. The same idempotency key with the same canonical payload hash replays the prior result; the same key with a different payload hash must fail closed. High-risk writes must be serialized by stable lock keys. Financial records must remain append-only where the domain requires reversals or adjustments.
+
+The important distinction is that transactional outbox writes can be core safety, while outbox dispatchers, observers, gateway consumers, and external delivery workers are experimental runtime.
+
+## Experimental Disabled
+
+Experimental disabled means:
+
+- no experimental background task starts by default;
+- no external API key is required;
+- no Telegram, OpenAI, MCP, or gateway config is required;
+- no agent, bot, UI surface, or integration mutates PMS tables directly;
+- no experimental UI entry appears in the normal app profile;
+- core PMS smoke flows can run with experimental flags and config absent.
+
+Any external effect from a business mutation must go through a durable outbox record written in the same transaction as the mutation. Dispatching that event is a separate runtime concern.
+
+## Command Orchestration Convention
+
+Tauri commands are the boundary between UI/integrations and the backend. They should orchestrate work instead of becoming the permanent home for large business rules or shared SQL.
+
+Write flow:
+
+```text
+UI
+  -> command
+  -> service / lifecycle
+  -> repository / transaction
+  -> audit + idempotency + lock + transactional outbox write
+  -> SQLite
+```
+
+Read flow:
+
+```text
+UI
+  -> command
+  -> query
+  -> SQLite
+```
+
+New write behavior should have a clear service or lifecycle home. New read behavior should have a query-module home when the SQL is shared, growing, or part of a command module that is already a review hotspot.
+
+Small command-local read helpers are acceptable when they are genuinely narrow, private, and unlikely to grow. Do not create abstractions just to move a few lines.
+
+## SQL Placement
+
+Use these defaults when adding or moving SQL:
+
+- mutation SQL belongs behind service, lifecycle, repository, or transaction boundaries;
+- reusable read SQL belongs in query modules;
+- command modules may adapt request/response shapes, validate command-level inputs, call services or queries, and map errors;
+- command modules should not accumulate unrelated read SQL, write SQL, and business state-machine logic in the same function;
+- direct PMS table writes from UI, bots, agents, or integrations are forbidden.
+
+## Implementation Path And Rename Debt
+
+`mhm/` is the current implementation path. It is not the product name.
+
+The product and repository story should use CapyInn. Renaming `mhm/` remains postponed cleanup until canonical docs, CI, smoke tests, and normal-profile runtime boundaries are stable. Do not combine an `mhm/` folder rename with command, migration, frontend shell, or experimental-runtime changes.
+
+## Review Checklist
+
+Before approving a cleanup or feature PR, check:
+
+- Does the change affect core PMS, experimental runtime, or both?
+- If it writes business data, does it cross the command boundary with actor, command name, idempotency key, canonical payload hash, timestamp, and request context?
+- Are high-risk writes serialized by stable lock keys?
+- Are audit and command ledger records preserved where required?
+- Are transactional outbox writes kept with the business mutation when they are part of the safety contract?
+- Are outbox dispatchers, observers, gateway, MCP, agent, digest, Telegram, CEO, and OpenAI surfaces disabled from the normal PMS profile?
+- Does the PR avoid mixing folder rename debt with runtime or command-safety changes?

--- a/docs/superpowers/specs/2026-05-08-docs-guardrails-135-155-design.md
+++ b/docs/superpowers/specs/2026-05-08-docs-guardrails-135-155-design.md
@@ -1,0 +1,57 @@
+# Docs Guardrails For Issues 135 And 155 Design
+
+Date: 2026-05-08
+Status: Approved for implementation planning
+
+## Purpose
+
+Implement GitHub issues #135 and #155 as a docs-only architecture guardrail pass. The work should define CapyInn's stable PMS core, separate experimental runtime surfaces from normal PMS operation, document the command safety contract, and establish the command/service/query convention without changing runtime behavior.
+
+## Scope
+
+- Create `docs/architecture/core-pms-boundaries.md` as the canonical architecture boundary document.
+- Update `CONTRIBUTING.md` to use CapyInn naming, explain that `mhm/` is the current implementation path and rename debt, and summarize the contributor rules from the canonical doc.
+- Do not edit `README.md` in this pass.
+- Do not move files, rename `mhm/`, delete agent/gateway code, or change runtime behavior.
+
+The repository ignores `/docs/`, so the new canonical architecture document must be force-added as part of implementation:
+
+```bash
+git add -f docs/architecture/core-pms-boundaries.md
+```
+
+## Canonical Boundary Document
+
+`docs/architecture/core-pms-boundaries.md` will define:
+
+- stable core PMS areas: rooms, stays, reservations, guests, housekeeping, billing, invoices, groups, night audit, settings, and auth;
+- experimental runtime areas: gateway, MCP, agent runtime, observer streams, digest, Telegram, CEO, and OpenAI surfaces;
+- command safety core: explicit command boundary, actor, command name, idempotency key, canonical payload hash, timestamp, request context, stable lock keys, audit writes, command ledger metadata, and transactional outbox writes;
+- experimental disabled meaning: no experimental background tasks, no required external API keys, no Telegram/OpenAI/MCP/gateway config, no direct agent PMS table mutation, and no experimental UI in the normal profile;
+- command orchestration convention: writes follow `UI -> command -> service/lifecycle`, reads follow `UI -> command -> query`;
+- SQL placement convention: mutation SQL belongs behind service/lifecycle/repository boundaries, while reusable or growing read SQL belongs in query modules;
+- `mhm/` as the current implementation path and postponed rename debt, not the product name.
+
+## Contributor Guidance
+
+`CONTRIBUTING.md` will stay concise and link or point contributors to the canonical boundary document. It should make the command boundary explicit enough for day-to-day review:
+
+- business writes go through commands and service/lifecycle modules;
+- reads go through commands and query modules when the logic is shared or the command module is growing;
+- agents, bots, UI, and integrations must not mutate PMS tables directly;
+- experimental runtime work must remain disabled from the normal profile unless a later issue explicitly promotes it.
+
+## Validation
+
+Run adapted validation searches. The original issue validation commands include `README.md`, but the user explicitly removed `README.md` from this pass, so validation should cover `CONTRIBUTING.md` and `docs` only:
+
+```bash
+rg -n "core PMS|experimental|MCP|agent|gateway|Telegram|OpenAI|idempotency|lock key|audit|outbox|experimental disabled" CONTRIBUTING.md docs
+rg -n "command.*service|command.*query|orchestration|mhm" docs CONTRIBUTING.md
+```
+
+Also check the diff to confirm the implementation is docs-only and does not touch `README.md` or runtime files.
+
+## Risks
+
+The implementation risk is low because the change is documentation-only. The main review risk is accidental scope creep into README, runtime behavior, or broad cleanup docs. Keep the implementation edit set limited to the canonical architecture doc and `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary
- Add canonical core PMS boundary documentation for issues #135 and #155.
- Update CONTRIBUTING with CapyInn naming, mhm rename debt, experimental-disabled rules, command safety, and command/service/query convention.
- Keep README and runtime code out of the PR scope per user override.

## Validation
- rg -n "core PMS|experimental|MCP|agent|gateway|Telegram|OpenAI|idempotency|lock key|audit|outbox|experimental disabled" CONTRIBUTING.md docs
- rg -n "command.*service|command.*query|orchestration|mhm" docs CONTRIBUTING.md
- git diff --check origin/main...HEAD
- GitNexus detect_changes on the staged docs diff before the implementation commit: low risk, 0 changed symbols/flows

## Notes
- docs/ is ignored locally, so docs/architecture/core-pms-boundaries.md was force-added intentionally.
- README.md is intentionally unchanged.