### PR TITLE
[codex] Record baseline CI test guard

### DIFF
--- a/docs/cleanup/2026-05-09-baseline-ci-test-guard.md
+++ b/docs/cleanup/2026-05-09-baseline-ci-test-guard.md
@@ -1,0 +1,58 @@
+# Cleanup Baseline Report: Baseline CI Test Guard
+
+- Date: 2026-05-09
+- Issue: #134
+- Parent issue: #133
+- Scope: baseline CI/test guard evidence for cleanup work
+
+## Purpose
+
+This report records the known-good local baseline for issue #134 before cleanup work continues under parent issue #133. The baseline is intended to prevent cleanup changes from weakening the existing CI/test gate or introducing undocumented failing commands.
+
+## Command Results
+
+| Command | Working directory | Status | Evidence | Transient local log |
+| --- | --- | --- | --- | --- |
+| `npm test` | `mhm` | PASS | `Test Files 52 passed (52); Tests 255 passed (255)` | `/tmp/capyinn-134-baseline/npm-test.log` |
+| `npm run build` | `mhm` | PASS | Vite built successfully in 3.81s; large chunk warning only | `/tmp/capyinn-134-baseline/npm-build.log` |
+| `cargo check` | `mhm/src-tauri` | PASS | `Finished dev profile ... in 15.14s` | `/tmp/capyinn-134-baseline/cargo-check.log` |
+| `cargo test` | `mhm/src-tauri` | PASS | `test result: ok. 701 passed; 0 failed`; bin and doc tests also passed | `/tmp/capyinn-134-baseline/cargo-test.log` |
+| `cargo clippy --all-targets -- -D warnings` | `mhm/src-tauri` | PASS | `Finished dev profile ... in 14.31s` | `/tmp/capyinn-134-baseline/cargo-clippy.log` |
+
+The `/tmp/capyinn-134-baseline/*` logs were transient local capture artifacts used to record the baseline evidence above. They are not committed.
+
+## Known Failing Baseline
+
+There are no known failing baseline commands as of 2026-05-09. All baseline commands listed above passed.
+
+## CI Parity
+
+The main baseline gate for issue #134 is the `build-test` job in `.github/workflows/ci.yml`, which runs on `macos-latest`.
+
+Exact baseline command mapping:
+
+| Local command | Local working directory | CI job | CI step | CI working directory |
+| --- | --- | --- | --- | --- |
+| `npm test` | `mhm` | `build-test` | `Run frontend tests` | `mhm` |
+| `npm run build` | `mhm` | `build-test` | `Build frontend` | `mhm` |
+| `cargo check` | `mhm/src-tauri` | `build-test` | `Run cargo check` | `mhm/src-tauri` |
+| `cargo test` | `mhm/src-tauri` | `build-test` | `Run cargo test` | `mhm/src-tauri` |
+| `cargo clippy --all-targets -- -D warnings` | `mhm/src-tauri` | `build-test` | `Run clippy` | `mhm/src-tauri` |
+
+`cargo check` is included for CI parity even though the issue #134 minimum baseline names frontend tests, frontend build, Rust tests, and clippy.
+
+`.github/workflows/ci.yml` also includes `verify-wave1`, which runs `npm run verify:full` from `mhm` after `build-test`. That job is additional isolated Wave 1 verification, not the main #134 baseline gate.
+
+README.md and CONTRIBUTING.md both mention the baseline command family.
+
+## Experimental Service Requirement
+
+The #134 CI workflow in `.github/workflows/ci.yml` consists of `build-test` and `verify-wave1`. Neither job requires Telegram, OpenAI, MCP, gateway, live-network credentials, or experimental service configuration.
+
+`verify-wave1` only adds the isolated Wave 1 verification job: it sets `CAPYINN_ARTIFACT_ROOT=$HOME/CapyInn-TestSuite` and runs `npm run verify:full` from `mhm`. The verification runner uses the isolated runtime root and disables gateway and watcher processes through `CAPYINN_DISABLE_GATEWAY=true` and `CAPYINN_DISABLE_WATCHER=true`.
+
+This statement is scoped to the #134 CI workflow only. It is not a claim about release workflows.
+
+## Cleanup Rule
+
+Cleanup work under parent issue #133 must preserve this baseline gate. If a cleanup change causes any listed command, mapped `build-test` CI step, or `verify-wave1` step to fail, the cleanup change must be fixed or reverted before proceeding. Only failures reproduced on the unchanged baseline may be documented as pre-existing, and they must include concrete evidence and owner follow-up.

--- a/docs/superpowers/specs/2026-05-09-baseline-ci-test-guard-design.md
+++ b/docs/superpowers/specs/2026-05-09-baseline-ci-test-guard-design.md
@@ -1,0 +1,126 @@
+# Baseline CI Test Guard Design
+
+Issue: #134 ARCH-02 Batch 0: Establish baseline validation and baseline CI gates
+
+Parent roadmap: #133 Core PMS Architecture Stabilization V2.1
+
+Date: 2026-05-09
+Status: Approved for implementation planning
+
+## Purpose
+
+Record the current validation truth before architecture cleanup begins, and confirm that CI blocks obvious broken cleanup changes without requiring experimental service configuration.
+
+This slice is intentionally a baseline and guardrail pass. It should not refactor code, rename folders, fix unrelated test failures, or expand CI into slow or flaky gates.
+
+## Scope
+
+- Create a baseline report under `docs/cleanup/`.
+- Run and record the current result of the baseline validation commands.
+- Confirm `.github/workflows/ci.yml` runs, or clearly documents, the same frontend and Rust gates.
+- Record any current failure as a known failing baseline with a short summary.
+- Keep experimental services out of the CI requirement set.
+
+## Non-Goals
+
+- Do not fix unrelated failures unless the failure is tiny, isolated, and clearly part of making the baseline guard trustworthy.
+- Do not refactor application code.
+- Do not add slow, flaky, live-network, or secret-dependent gates.
+- Do not require Telegram, OpenAI, MCP, gateway, or other experimental runtime configuration.
+- Do not rename `mhm/` or move source files.
+
+## Chosen Approach
+
+Use a docs-first baseline plus CI parity check.
+
+The main artifact will be a new report in `docs/cleanup/` named:
+
+```text
+docs/cleanup/2026-05-09-baseline-ci-test-guard.md
+```
+
+The report will capture the result of the required issue #134 commands plus one CI-parity command:
+
+```bash
+cd mhm && npm test
+cd mhm && npm run build
+cd mhm/src-tauri && cargo check
+cd mhm/src-tauri && cargo test
+cd mhm/src-tauri && cargo clippy --all-targets -- -D warnings
+```
+
+The four commands named in #134 are the minimum baseline. `cargo check` is included because the existing CI workflow and contributor docs already run it, so the baseline should match the real gate contributors see.
+
+Rejected alternatives:
+
+- Split the existing CI into separate frontend and Rust jobs. This could improve diagnosis, but it is more workflow churn than #134 needs.
+- Add a script that generates or refreshes the baseline report. That is repeatable, but it adds maintenance surface for a baseline that should be updated deliberately, not regenerated casually.
+
+## Baseline Report
+
+The report will include:
+
+- issue and roadmap references;
+- command matrix with command, working directory, status, and concise evidence;
+- known-failing section only if one or more commands fail;
+- CI parity mapping from each baseline command to the corresponding `.github/workflows/ci.yml` step;
+- explicit note that experimental services are not required;
+- short guidance that future cleanup issues must not claim green verification for a command that is still documented as known failing.
+
+If all commands pass, the known-failing section will say there are no known failing baseline commands as of the report date.
+
+If a command fails, the report will record only the useful failure signal: failing suite or compiler phase, representative error line, and whether the failure appears pre-existing. Full terminal logs should not be pasted into the report.
+
+## CI Guard
+
+The existing CI workflow already has a `build-test` job that installs Node dependencies, sets up Rust with clippy, and runs frontend tests, frontend build, cargo check, cargo test, and clippy.
+
+Implementation must leave CI unchanged if that remains true after inspection. A workflow edit is justified only if the current file is missing a required baseline command or makes experimental service configuration necessary.
+
+The `verify-wave1` job is related but not the main #134 baseline gate. It can remain in place as an additional verification job.
+
+## Validation Flow
+
+Run the baseline commands locally and record the result:
+
+```bash
+cd mhm && npm test
+cd mhm && npm run build
+cd mhm/src-tauri && cargo check
+cd mhm/src-tauri && cargo test
+cd mhm/src-tauri && cargo clippy --all-targets -- -D warnings
+```
+
+Then verify documentation and CI references:
+
+```bash
+rg -n "npm test|npm run build|cargo check|cargo test|clippy" .github/workflows docs/cleanup CONTRIBUTING.md README.md
+```
+
+Before committing implementation changes, run GitNexus change detection:
+
+```text
+gitnexus_detect_changes(scope: "all", repo: "HotelManager")
+```
+
+## Error Handling Policy
+
+Failure discovery should be handled conservatively:
+
+- If a baseline command passes, record pass and concise evidence.
+- If a baseline command fails for an unrelated reason, record it as known failing and do not fix it in #134.
+- If the failure is a tiny CI/doc mismatch directly blocking #134, make the narrowest correction.
+- If the failure implies a larger product or architecture problem, stop and split a follow-up issue.
+
+Warnings and noisy logs are not failures unless they make the command exit non-zero or materially reduce cleanup confidence.
+
+## Risks
+
+The implementation risk is low because the expected change is documentation-only. The main risks are:
+
+- accidentally turning the baseline issue into unrelated test repair;
+- omitting `cargo check` from the report even though CI runs it;
+- making CI depend on experimental services;
+- over-recording logs instead of writing a useful baseline summary.
+
+Keep the implementation scoped to the cleanup baseline report and a narrow CI/doc edit only if inspection proves one is needed.


### PR DESCRIPTION
## Summary
- Add the #134 cleanup baseline report under `docs/cleanup/`.
- Record pass status for frontend tests/build, Rust check/tests, and clippy.
- Document CI parity for `build-test` and clarify `verify-wave1` as additional isolated verification.

## Validation
- `cd mhm && npm test` -> 52 files / 255 tests passed
- `cd mhm && npm run build` -> passed
- `cd mhm/src-tauri && cargo check` -> passed
- `cd mhm/src-tauri && cargo test` -> 701 tests passed
- `cd mhm/src-tauri && cargo clippy --all-targets -- -D warnings` -> passed
- GitNexus detect_changes(all): low risk, 0 changed symbols, 0 affected processes

## Notes
- No CI workflow edits were needed; current `ci.yml` already covers the baseline gates.
- No experimental service credentials are required for the #134 CI workflow.