### PR TITLE
[codex] add local receptionist demo

### DIFF
--- a/mhm/src-tauri/src/agent/mod.rs
+++ b/mhm/src-tauri/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod digest;
 pub mod model;
 pub mod provider;
+pub mod receptionist_demo;
 pub mod registry;
 pub mod retention;
 pub mod runtime;

--- a/mhm/src-tauri/src/agent/receptionist_demo.rs
+++ b/mhm/src-tauri/src/agent/receptionist_demo.rs
@@ -3,12 +3,15 @@ use crate::services::settings_store;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::{Pool, Row, Sqlite};
+use std::time::Duration;
 
 pub const DEFAULT_LOCAL_RECEPTIONIST_ENDPOINT: &str = "http://127.0.0.1:8080/v1/chat/completions";
 pub const DEFAULT_LOCAL_RECEPTIONIST_MODEL: &str = "capyinn-gemma4-e2b-q5km";
 const MAX_MESSAGE_CHARS: usize = 2_000;
 const MAX_MODEL_CHARS: usize = 128;
 const MAX_ENDPOINT_CHARS: usize = 2_048;
+const LOCAL_PROVIDER_TIMEOUT_SECONDS: u64 = 60;
+const MAX_PROVIDER_RESPONSE_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct LocalReceptionistChatRequest {
@@ -22,6 +25,36 @@ pub struct LocalReceptionistChatResponse {
     pub answer: String,
     pub provider: String,
     pub model: String,
+}
+
+#[derive(Debug, Serialize)]
+struct LocalChatCompletionRequest {
+    model: String,
+    messages: Vec<LocalChatMessage>,
+    temperature: f32,
+    max_tokens: u16,
+    stream: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct LocalChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalChatCompletionResponse {
+    choices: Vec<LocalChatChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalChatChoice {
+    message: LocalChatChoiceMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalChatChoiceMessage {
+    content: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,6 +112,69 @@ pub(crate) async fn build_guest_facing_context(
     })
 }
 
+pub(crate) fn build_local_provider_client() -> CommandResult<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(LOCAL_PROVIDER_TIMEOUT_SECONDS))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|_| internal_error("Cannot create local provider client."))
+}
+
+pub(crate) async fn call_local_provider(
+    client: &reqwest::Client,
+    endpoint: &str,
+    model: &str,
+    system_prompt: &str,
+    user_message: &str,
+) -> CommandResult<String> {
+    validate_local_http_endpoint(endpoint)?;
+
+    let body = LocalChatCompletionRequest {
+        model: model.to_string(),
+        messages: vec![
+            LocalChatMessage {
+                role: "system".to_string(),
+                content: system_prompt.to_string(),
+            },
+            LocalChatMessage {
+                role: "user".to_string(),
+                content: user_message.to_string(),
+            },
+        ],
+        temperature: 0.2,
+        max_tokens: 512,
+        stream: false,
+    };
+
+    let response = client
+        .post(endpoint)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| {
+            if error.is_timeout() {
+                provider_timeout_error()
+            } else {
+                provider_unreachable_error()
+            }
+        })?;
+
+    let status = response.status();
+    if status.is_redirection() || !status.is_success() {
+        return Err(provider_rejected_error());
+    }
+
+    let bytes = read_limited_provider_response(response).await?;
+    let parsed: LocalChatCompletionResponse =
+        serde_json::from_slice(&bytes).map_err(|_| provider_unsupported_error())?;
+    parsed
+        .choices
+        .first()
+        .map(|choice| choice.message.content.trim().to_string())
+        .filter(|content| !content.is_empty())
+        .ok_or_else(provider_unsupported_error)
+}
+
 pub(crate) fn validate_request(
     request: LocalReceptionistChatRequest,
 ) -> CommandResult<ValidatedLocalReceptionistRequest> {
@@ -133,6 +229,70 @@ fn validate_local_http_endpoint(endpoint: &str) -> CommandResult<()> {
 
 fn validation_error(message: &'static str) -> CommandError {
     CommandError::user(codes::VALIDATION_INVALID_INPUT, message)
+}
+
+async fn read_limited_provider_response(response: reqwest::Response) -> CommandResult<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_PROVIDER_RESPONSE_BYTES as u64)
+    {
+        return Err(provider_too_large_error());
+    }
+
+    let mut response = response;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        if error.is_timeout() {
+            provider_timeout_error()
+        } else {
+            provider_unreachable_error()
+        }
+    })? {
+        if bytes.len().saturating_add(chunk.len()) > MAX_PROVIDER_RESPONSE_BYTES {
+            return Err(provider_too_large_error());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn provider_unreachable_error() -> CommandError {
+    CommandError::system(
+        codes::AGENT_PROVIDER_REQUEST_FAILED,
+        "Local provider is not reachable. Start llama-server and try again.",
+    )
+}
+
+fn provider_timeout_error() -> CommandError {
+    CommandError::system(
+        codes::AGENT_PROVIDER_REQUEST_FAILED,
+        "Local provider timed out. Try a shorter question or restart llama-server.",
+    )
+}
+
+fn provider_rejected_error() -> CommandError {
+    CommandError::system(
+        codes::AGENT_PROVIDER_REQUEST_FAILED,
+        "Local provider rejected the request. Check the endpoint and model name.",
+    )
+}
+
+fn provider_too_large_error() -> CommandError {
+    CommandError::system(
+        codes::AGENT_PROVIDER_REQUEST_FAILED,
+        "Local provider response was too large. Try a shorter answer.",
+    )
+}
+
+fn provider_unsupported_error() -> CommandError {
+    CommandError::system(
+        codes::AGENT_PROVIDER_REQUEST_FAILED,
+        "Local provider returned an unsupported response.",
+    )
+}
+
+fn internal_error(message: &'static str) -> CommandError {
+    CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
 }
 
 async fn load_hotel_context(pool: &Pool<Sqlite>) -> CommandResult<HotelContext> {
@@ -247,7 +407,16 @@ fn system_error(message: String) -> CommandError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Redirect},
+        routing::post,
+        Json, Router,
+    };
     use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
 
     fn valid_request() -> LocalReceptionistChatRequest {
         LocalReceptionistChatRequest {
@@ -294,6 +463,187 @@ mod tests {
             .execute(pool)
             .await
             .expect("failed to save setting");
+    }
+
+    async fn spawn_chat_server(router: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind test chat server");
+        let addr = listener
+            .local_addr()
+            .expect("failed to read test chat server address");
+
+        tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("test chat server failed");
+        });
+
+        format!("http://{addr}/v1/chat/completions")
+    }
+
+    #[tokio::test]
+    async fn local_provider_parses_openai_compatible_response() {
+        let captured_body = Arc::new(Mutex::new(None::<Value>));
+        let endpoint = spawn_chat_server(
+            Router::new()
+                .route(
+                    "/v1/chat/completions",
+                    post(
+                        |State(captured_body): State<Arc<Mutex<Option<Value>>>>,
+                         Json(body): Json<Value>| async move {
+                            *captured_body.lock().expect("capture body lock") = Some(body);
+                            Json(serde_json::json!({
+                                "choices": [
+                                    {
+                                        "message": {
+                                            "content": "Hello from local Gemma."
+                                        }
+                                    }
+                                ]
+                            }))
+                        },
+                    ),
+                )
+                .with_state(captured_body.clone()),
+        )
+        .await;
+        let client = build_local_provider_client().expect("client should build");
+
+        let answer = call_local_provider(
+            &client,
+            &endpoint,
+            "gemma",
+            "system prompt",
+            "guest question",
+        )
+        .await
+        .expect("provider response should parse");
+
+        assert_eq!(answer, "Hello from local Gemma.");
+        let body = captured_body
+            .lock()
+            .expect("capture body lock")
+            .clone()
+            .expect("request body should be captured");
+        assert_eq!(body["model"], "gemma");
+        assert_eq!(body["temperature"], 0.2);
+        assert_eq!(body["max_tokens"], 512);
+        assert_eq!(body["stream"], false);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"], "system prompt");
+        assert_eq!(body["messages"][1]["role"], "user");
+        assert_eq!(body["messages"][1]["content"], "guest question");
+    }
+
+    #[tokio::test]
+    async fn local_provider_rejects_remote_endpoint_before_sending() {
+        let client = build_local_provider_client().expect("client should build");
+
+        let error = call_local_provider(
+            &client,
+            "http://example.com/v1/chat/completions",
+            "gemma",
+            "system prompt",
+            "guest question",
+        )
+        .await
+        .expect_err("remote endpoint should be rejected before provider call");
+
+        assert_eq!(error.code, codes::VALIDATION_INVALID_INPUT);
+        assert!(error.support_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn local_provider_rejects_too_large_content_length() {
+        let endpoint = spawn_chat_server(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async { "x".repeat(MAX_PROVIDER_RESPONSE_BYTES + 1) }),
+        ))
+        .await;
+        let client = build_local_provider_client().expect("client should build");
+
+        let error = call_local_provider(
+            &client,
+            &endpoint,
+            "gemma",
+            "system prompt",
+            "guest question",
+        )
+        .await
+        .expect_err("oversized response should fail");
+
+        assert_eq!(error.code, codes::AGENT_PROVIDER_REQUEST_FAILED);
+        assert!(error.message.contains("too large"));
+    }
+
+    #[tokio::test]
+    async fn local_provider_rejects_redirects_without_following() {
+        let endpoint = spawn_chat_server(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async { Redirect::temporary("https://example.com/leak") }),
+        ))
+        .await;
+        let client = build_local_provider_client().expect("client should build");
+
+        let error = call_local_provider(
+            &client,
+            &endpoint,
+            "gemma",
+            "system prompt",
+            "guest question",
+        )
+        .await
+        .expect_err("redirect should be rejected");
+
+        assert_eq!(error.code, codes::AGENT_PROVIDER_REQUEST_FAILED);
+        assert!(error.message.contains("rejected"));
+    }
+
+    #[tokio::test]
+    async fn local_provider_rejects_malformed_response() {
+        let endpoint = spawn_chat_server(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async { Json(serde_json::json!({ "choices": [] })) }),
+        ))
+        .await;
+        let client = build_local_provider_client().expect("client should build");
+
+        let error = call_local_provider(
+            &client,
+            &endpoint,
+            "gemma",
+            "system prompt",
+            "guest question",
+        )
+        .await
+        .expect_err("malformed response should be rejected");
+
+        assert_eq!(error.code, codes::AGENT_PROVIDER_REQUEST_FAILED);
+        assert!(error.message.contains("unsupported"));
+    }
+
+    #[tokio::test]
+    async fn local_provider_rejects_non_success_status() {
+        let endpoint = spawn_chat_server(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async { StatusCode::BAD_REQUEST.into_response() }),
+        ))
+        .await;
+        let client = build_local_provider_client().expect("client should build");
+
+        let error = call_local_provider(
+            &client,
+            &endpoint,
+            "gemma",
+            "system prompt",
+            "guest question",
+        )
+        .await
+        .expect_err("non-success status should be rejected");
+
+        assert_eq!(error.code, codes::AGENT_PROVIDER_REQUEST_FAILED);
+        assert!(error.message.contains("rejected"));
     }
 
     #[test]

--- a/mhm/src-tauri/src/agent/receptionist_demo.rs
+++ b/mhm/src-tauri/src/agent/receptionist_demo.rs
@@ -12,6 +12,7 @@ const MAX_MODEL_CHARS: usize = 128;
 const MAX_ENDPOINT_CHARS: usize = 2_048;
 const LOCAL_PROVIDER_TIMEOUT_SECONDS: u64 = 60;
 const MAX_PROVIDER_RESPONSE_BYTES: usize = 1024 * 1024;
+const MAX_CONTEXT_BYTES: usize = 24 * 1024;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct LocalReceptionistChatRequest {
@@ -110,6 +111,51 @@ pub(crate) async fn build_guest_facing_context(
         room_types: load_room_type_names(pool).await?,
         pricing_rules: load_receptionist_pricing_rules(pool).await?,
     })
+}
+
+pub async fn run_local_receptionist_chat(
+    pool: &Pool<Sqlite>,
+    request: LocalReceptionistChatRequest,
+) -> CommandResult<LocalReceptionistChatResponse> {
+    let request = validate_request(request)?;
+    let context = build_guest_facing_context(pool).await?;
+    let context_json = serde_json::to_string_pretty(&context)
+        .map_err(|_| internal_error("Cannot serialize receptionist context."))?;
+    if context_json.len() > MAX_CONTEXT_BYTES {
+        return Err(CommandError::system(
+            codes::AGENT_PROVIDER_REQUEST_FAILED,
+            "Local receptionist context is too large.",
+        ));
+    }
+
+    let system_prompt = build_system_prompt(&context_json);
+    let client = build_local_provider_client()?;
+    let answer = call_local_provider(
+        &client,
+        &request.endpoint,
+        &request.model,
+        &system_prompt,
+        &request.message,
+    )
+    .await?;
+
+    Ok(LocalReceptionistChatResponse {
+        answer,
+        provider: "local".to_string(),
+        model: request.model,
+    })
+}
+
+fn build_system_prompt(context_json: &str) -> String {
+    format!(
+        "You are CapyInn Local Receptionist Demo, a front-desk assistant for a small hotel PMS.\n\
+Answer in the same language as the user.\n\
+Use only the provided hotel context.\n\
+Do not invent prices, policies, availability, bookings, payments, or guest data.\n\
+Do not confirm or create reservations.\n\
+If information is missing, say that staff should confirm it in CapyInn.\n\n\
+HOTEL CONTEXT:\n{context_json}"
+    )
 }
 
 pub(crate) fn build_local_provider_client() -> CommandResult<reqwest::Client> {
@@ -465,6 +511,34 @@ mod tests {
             .expect("failed to save setting");
     }
 
+    async fn protected_table_counts(pool: &Pool<Sqlite>) -> Vec<(String, i64)> {
+        let seeded_read_tables = ["settings", "room_types", "pricing_rules"];
+        let tables: Vec<String> = sqlx::query_scalar(
+            "SELECT name
+             FROM sqlite_master
+             WHERE type = 'table'
+               AND name NOT LIKE 'sqlite_%'
+               AND name != 'schema_version'
+             ORDER BY name",
+        )
+        .fetch_all(pool)
+        .await
+        .expect("list sqlite tables");
+        let mut counts = Vec::new();
+        for table in tables {
+            if seeded_read_tables.contains(&table.as_str()) {
+                continue;
+            }
+            let sql = format!("SELECT COUNT(*) FROM \"{}\"", table.replace('"', "\"\""));
+            let count = sqlx::query_scalar::<_, i64>(&sql)
+                .fetch_one(pool)
+                .await
+                .unwrap_or_else(|error| panic!("count table {table}: {error}"));
+            counts.push((table, count));
+        }
+        counts
+    }
+
     async fn spawn_chat_server(router: Router) -> String {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -644,6 +718,69 @@ mod tests {
 
         assert_eq!(error.code, codes::AGENT_PROVIDER_REQUEST_FAILED);
         assert!(error.message.contains("rejected"));
+    }
+
+    #[tokio::test]
+    async fn run_local_receptionist_chat_returns_answer_and_does_not_write_pms_tables() {
+        let pool = test_pool().await;
+        save_setting_for_test(
+            &pool,
+            "hotel_info",
+            r#"{"name":"CapyInn Test","address":"Da Nang","phone":"0900","rating":"4.7"}"#,
+        )
+        .await;
+        sqlx::query("INSERT INTO room_types (id, name, created_at) VALUES ('standard', 'Standard', '2026-05-11T00:00:00+07:00')")
+            .execute(&pool)
+            .await
+            .expect("seed room type");
+        sqlx::query(
+            "INSERT INTO pricing_rules (
+                id, room_type, hourly_rate, overnight_rate, daily_rate,
+                overnight_start, overnight_end, daily_checkin, daily_checkout,
+                early_checkin_surcharge_pct, late_checkout_surcharge_pct, weekend_uplift_pct,
+                created_at, updated_at
+            ) VALUES (
+                'price-standard', 'standard', 80000, 300000, 400000,
+                '22:00', '11:00', '14:00', '12:00',
+                30.0, 30.0, 0.0,
+                '2026-05-11T00:00:00+07:00', '2026-05-11T00:00:00+07:00'
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed pricing");
+        let endpoint = spawn_chat_server(Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                Json(serde_json::json!({
+                    "choices": [
+                        { "message": { "content": "Hourly rooms are listed in CapyInn pricing." } }
+                    ]
+                }))
+            }),
+        ))
+        .await;
+        let before = protected_table_counts(&pool).await;
+
+        let response = run_local_receptionist_chat(
+            &pool,
+            LocalReceptionistChatRequest {
+                endpoint,
+                model: DEFAULT_LOCAL_RECEPTIONIST_MODEL.to_string(),
+                message: "Do you have hourly rooms?".to_string(),
+            },
+        )
+        .await
+        .expect("chat succeeds");
+
+        let after = protected_table_counts(&pool).await;
+        assert_eq!(
+            response.answer,
+            "Hourly rooms are listed in CapyInn pricing."
+        );
+        assert_eq!(response.provider, "local");
+        assert_eq!(response.model, DEFAULT_LOCAL_RECEPTIONIST_MODEL);
+        assert_eq!(after, before);
     }
 
     #[test]

--- a/mhm/src-tauri/src/agent/receptionist_demo.rs
+++ b/mhm/src-tauri/src/agent/receptionist_demo.rs
@@ -1,5 +1,8 @@
 use crate::app_error::{codes, CommandError, CommandResult};
+use crate::services::settings_store;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::{Pool, Row, Sqlite};
 
 pub const DEFAULT_LOCAL_RECEPTIONIST_ENDPOINT: &str = "http://127.0.0.1:8080/v1/chat/completions";
 pub const DEFAULT_LOCAL_RECEPTIONIST_MODEL: &str = "capyinn-gemma4-e2b-q5km";
@@ -26,6 +29,54 @@ pub(crate) struct ValidatedLocalReceptionistRequest {
     pub(crate) endpoint: String,
     pub(crate) model: String,
     pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct GuestFacingContext {
+    pub hotel: HotelContext,
+    pub checkin_rules: CheckinRulesContext,
+    pub room_types: Vec<String>,
+    pub pricing_rules: Vec<ReceptionistPricingRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct HotelContext {
+    pub name: String,
+    pub address: String,
+    pub phone: String,
+    pub rating: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct CheckinRulesContext {
+    pub checkin: String,
+    pub checkout: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ReceptionistPricingRule {
+    pub room_type: String,
+    pub hourly_rate: i64,
+    pub overnight_rate: i64,
+    pub daily_rate: i64,
+    pub overnight_start: String,
+    pub overnight_end: String,
+    pub daily_checkin: String,
+    pub daily_checkout: String,
+    pub early_checkin_surcharge_pct: f64,
+    pub late_checkout_surcharge_pct: f64,
+    pub weekend_uplift_pct: f64,
+}
+
+pub(crate) async fn build_guest_facing_context(
+    pool: &Pool<Sqlite>,
+) -> CommandResult<GuestFacingContext> {
+    Ok(GuestFacingContext {
+        hotel: load_hotel_context(pool).await?,
+        checkin_rules: load_checkin_rules_context(pool).await?,
+        room_types: load_room_type_names(pool).await?,
+        pricing_rules: load_receptionist_pricing_rules(pool).await?,
+    })
 }
 
 pub(crate) fn validate_request(
@@ -84,9 +135,119 @@ fn validation_error(message: &'static str) -> CommandError {
     CommandError::user(codes::VALIDATION_INVALID_INPUT, message)
 }
 
+async fn load_hotel_context(pool: &Pool<Sqlite>) -> CommandResult<HotelContext> {
+    let value = settings_store::get_setting(pool, "hotel_info")
+        .await
+        .map(parse_json_object)
+        .map_err(|error| system_error(format!("failed to load hotel info: {error}")))?;
+
+    Ok(HotelContext {
+        name: string_field(&value, "name").unwrap_or_else(|| crate::app_identity::APP_NAME.into()),
+        address: string_field(&value, "address").unwrap_or_default(),
+        phone: string_field(&value, "phone").unwrap_or_default(),
+        rating: string_field(&value, "rating").unwrap_or_default(),
+    })
+}
+
+async fn load_checkin_rules_context(pool: &Pool<Sqlite>) -> CommandResult<CheckinRulesContext> {
+    let value = settings_store::get_setting(pool, "checkin_rules")
+        .await
+        .map(parse_json_object)
+        .map_err(|error| system_error(format!("failed to load check-in rules: {error}")))?;
+
+    Ok(CheckinRulesContext {
+        checkin: string_field(&value, "checkin")
+            .or_else(|| string_field(&value, "default_checkin_time"))
+            .unwrap_or_else(|| "14:00".to_string()),
+        checkout: string_field(&value, "checkout")
+            .or_else(|| string_field(&value, "default_checkout_time"))
+            .unwrap_or_else(|| "12:00".to_string()),
+    })
+}
+
+async fn load_room_type_names(pool: &Pool<Sqlite>) -> CommandResult<Vec<String>> {
+    let rows = sqlx::query("SELECT name FROM room_types ORDER BY name")
+        .fetch_all(pool)
+        .await
+        .map_err(|error| system_error(format!("failed to load room types: {error}")))?;
+
+    Ok(rows
+        .iter()
+        .map(|row| row.get::<String, _>("name"))
+        .collect())
+}
+
+async fn load_receptionist_pricing_rules(
+    pool: &Pool<Sqlite>,
+) -> CommandResult<Vec<ReceptionistPricingRule>> {
+    let rows = sqlx::query(
+        "SELECT room_type, hourly_rate, overnight_rate, daily_rate,
+                overnight_start, overnight_end, daily_checkin, daily_checkout,
+                early_checkin_surcharge_pct, late_checkout_surcharge_pct,
+                weekend_uplift_pct
+         FROM pricing_rules ORDER BY room_type",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| system_error(format!("failed to load pricing rules: {error}")))?;
+
+    Ok(rows
+        .iter()
+        .map(|row| ReceptionistPricingRule {
+            room_type: row.get::<String, _>("room_type"),
+            hourly_rate: money_i64(row, "hourly_rate"),
+            overnight_rate: money_i64(row, "overnight_rate"),
+            daily_rate: money_i64(row, "daily_rate"),
+            overnight_start: row.get::<String, _>("overnight_start"),
+            overnight_end: row.get::<String, _>("overnight_end"),
+            daily_checkin: row.get::<String, _>("daily_checkin"),
+            daily_checkout: row.get::<String, _>("daily_checkout"),
+            early_checkin_surcharge_pct: number_f64(row, "early_checkin_surcharge_pct"),
+            late_checkout_surcharge_pct: number_f64(row, "late_checkout_surcharge_pct"),
+            weekend_uplift_pct: number_f64(row, "weekend_uplift_pct"),
+        })
+        .collect())
+}
+
+fn parse_json_object(raw: Option<String>) -> Value {
+    raw.and_then(|value| serde_json::from_str::<Value>(&value).ok())
+        .filter(Value::is_object)
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()))
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn money_i64(row: &sqlx::sqlite::SqliteRow, column: &str) -> i64 {
+    row.try_get::<i64, _>(column).unwrap_or_else(|_| {
+        let value = row.get::<f64, _>(column);
+        assert!(
+            value.is_finite() && value.fract() == 0.0,
+            "money column {column} must be a whole minor-unit amount"
+        );
+        value as i64
+    })
+}
+
+fn number_f64(row: &sqlx::sqlite::SqliteRow, column: &str) -> f64 {
+    row.try_get::<f64, _>(column)
+        .unwrap_or_else(|_| row.get::<i64, _>(column) as f64)
+}
+
+fn system_error(message: String) -> CommandError {
+    CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
 
     fn valid_request() -> LocalReceptionistChatRequest {
         LocalReceptionistChatRequest {
@@ -100,6 +261,39 @@ mod tests {
         let error = validate_request(request).expect_err("request must fail validation");
         assert_eq!(error.code, codes::VALIDATION_INVALID_INPUT);
         assert!(error.support_id.is_none());
+    }
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let database_url = format!(
+            "sqlite://file:{}?mode=memory&cache=shared",
+            uuid::Uuid::new_v4()
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("failed to open sqlite test pool");
+
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .expect("failed to enable foreign keys");
+
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("failed to run migrations");
+
+        pool
+    }
+
+    async fn save_setting_for_test(pool: &Pool<Sqlite>, key: &str, value: &str) {
+        sqlx::query("INSERT INTO settings (key, value) VALUES (?, ?)")
+            .bind(key)
+            .bind(value)
+            .execute(pool)
+            .await
+            .expect("failed to save setting");
     }
 
     #[test]
@@ -161,5 +355,103 @@ mod tests {
         request.endpoint = format!("http://127.0.0.1:8080/{}", "a".repeat(MAX_ENDPOINT_CHARS));
 
         assert_validation_error(request);
+    }
+
+    #[tokio::test]
+    async fn guest_context_uses_only_guest_facing_settings_room_types_and_pricing() {
+        let pool = test_pool().await;
+
+        save_setting_for_test(
+            &pool,
+            "hotel_info",
+            r#"{
+                "name": "CapyInn Test",
+                "address": "Da Nang",
+                "phone": "0900",
+                "rating": "4.7",
+                "internal": "secret"
+            }"#,
+        )
+        .await;
+        save_setting_for_test(
+            &pool,
+            "checkin_rules",
+            r#"{
+                "checkin": "14:00",
+                "checkout": "12:00",
+                "private_note": "staff only"
+            }"#,
+        )
+        .await;
+
+        sqlx::query("INSERT INTO room_types (id, name, created_at) VALUES (?, ?, ?)")
+            .bind("standard")
+            .bind("Standard")
+            .bind("2026-05-11T00:00:00+07:00")
+            .execute(&pool)
+            .await
+            .expect("failed to insert room type");
+
+        sqlx::query(
+            "INSERT INTO pricing_rules
+             (id, room_type, hourly_rate, overnight_rate, daily_rate,
+              overnight_start, overnight_end, daily_checkin, daily_checkout,
+              early_checkin_surcharge_pct, late_checkout_surcharge_pct,
+              weekend_uplift_pct, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("price-standard")
+        .bind("standard")
+        .bind(80_000_i64)
+        .bind(300_000_i64)
+        .bind(400_000_i64)
+        .bind("22:00")
+        .bind("11:00")
+        .bind("14:00")
+        .bind("12:00")
+        .bind(30.0_f64)
+        .bind(30.0_f64)
+        .bind(0.0_f64)
+        .bind("2026-05-11T00:00:00+07:00")
+        .bind("2026-05-11T00:00:00+07:00")
+        .execute(&pool)
+        .await
+        .expect("failed to insert pricing rule");
+
+        let context = build_guest_facing_context(&pool)
+            .await
+            .expect("guest context should build");
+        let value = serde_json::to_value(context).expect("context should serialize");
+
+        assert_eq!(value["hotel"]["name"], "CapyInn Test");
+        assert_eq!(value["hotel"]["address"], "Da Nang");
+        assert_eq!(value["hotel"]["phone"], "0900");
+        assert_eq!(value["hotel"]["rating"], "4.7");
+        assert_eq!(value["checkin_rules"]["checkin"], "14:00");
+        assert_eq!(value["checkin_rules"]["checkout"], "12:00");
+        assert_eq!(value["room_types"], serde_json::json!(["Standard"]));
+        assert_eq!(value["pricing_rules"][0]["room_type"], "standard");
+        assert_eq!(value["pricing_rules"][0]["hourly_rate"], 80_000);
+        assert_eq!(value["pricing_rules"][0]["overnight_rate"], 300_000);
+        assert_eq!(value["pricing_rules"][0]["daily_rate"], 400_000);
+        assert_eq!(value["pricing_rules"][0]["overnight_start"], "22:00");
+        assert_eq!(value["pricing_rules"][0]["overnight_end"], "11:00");
+        assert_eq!(value["pricing_rules"][0]["daily_checkin"], "14:00");
+        assert_eq!(value["pricing_rules"][0]["daily_checkout"], "12:00");
+        assert_eq!(
+            value["pricing_rules"][0]["early_checkin_surcharge_pct"],
+            30.0
+        );
+        assert_eq!(
+            value["pricing_rules"][0]["late_checkout_surcharge_pct"],
+            30.0
+        );
+        assert_eq!(value["pricing_rules"][0]["weekend_uplift_pct"], 0.0);
+
+        let serialized = serde_json::to_string(&value).expect("value should serialize");
+        assert!(!serialized.contains("internal"));
+        assert!(!serialized.contains("private_note"));
+        assert!(!serialized.contains("price-standard"));
+        assert!(!serialized.contains("created_at"));
     }
 }

--- a/mhm/src-tauri/src/agent/receptionist_demo.rs
+++ b/mhm/src-tauri/src/agent/receptionist_demo.rs
@@ -1,0 +1,165 @@
+use crate::app_error::{codes, CommandError, CommandResult};
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_LOCAL_RECEPTIONIST_ENDPOINT: &str = "http://127.0.0.1:8080/v1/chat/completions";
+pub const DEFAULT_LOCAL_RECEPTIONIST_MODEL: &str = "capyinn-gemma4-e2b-q5km";
+const MAX_MESSAGE_CHARS: usize = 2_000;
+const MAX_MODEL_CHARS: usize = 128;
+const MAX_ENDPOINT_CHARS: usize = 2_048;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct LocalReceptionistChatRequest {
+    pub endpoint: String,
+    pub model: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct LocalReceptionistChatResponse {
+    pub answer: String,
+    pub provider: String,
+    pub model: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidatedLocalReceptionistRequest {
+    pub(crate) endpoint: String,
+    pub(crate) model: String,
+    pub(crate) message: String,
+}
+
+pub(crate) fn validate_request(
+    request: LocalReceptionistChatRequest,
+) -> CommandResult<ValidatedLocalReceptionistRequest> {
+    let endpoint = request.endpoint.trim();
+    let model = request.model.trim();
+    let message = request.message.trim();
+
+    validate_local_http_endpoint(endpoint)?;
+
+    if model.is_empty() {
+        return Err(validation_error("Model is required"));
+    }
+    if model.chars().count() > MAX_MODEL_CHARS {
+        return Err(validation_error("Model is too long"));
+    }
+    if model.chars().any(char::is_control) {
+        return Err(validation_error("Model contains invalid characters"));
+    }
+
+    if message.is_empty() {
+        return Err(validation_error("Message is required"));
+    }
+    if message.chars().count() > MAX_MESSAGE_CHARS {
+        return Err(validation_error("Message is too long"));
+    }
+
+    Ok(ValidatedLocalReceptionistRequest {
+        endpoint: endpoint.to_string(),
+        model: model.to_string(),
+        message: message.to_string(),
+    })
+}
+
+fn validate_local_http_endpoint(endpoint: &str) -> CommandResult<()> {
+    if endpoint.is_empty() {
+        return Err(validation_error("Endpoint is required"));
+    }
+    if endpoint.chars().count() > MAX_ENDPOINT_CHARS {
+        return Err(validation_error("Endpoint is too long"));
+    }
+
+    let url = reqwest::Url::parse(endpoint).map_err(|_| validation_error("Endpoint is invalid"))?;
+    if url.scheme() != "http" {
+        return Err(validation_error("Endpoint must use local HTTP"));
+    }
+
+    match url.host_str() {
+        Some("127.0.0.1" | "localhost") => Ok(()),
+        _ => Err(validation_error("Endpoint must be local")),
+    }
+}
+
+fn validation_error(message: &'static str) -> CommandError {
+    CommandError::user(codes::VALIDATION_INVALID_INPUT, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_request() -> LocalReceptionistChatRequest {
+        LocalReceptionistChatRequest {
+            endpoint: DEFAULT_LOCAL_RECEPTIONIST_ENDPOINT.to_string(),
+            model: DEFAULT_LOCAL_RECEPTIONIST_MODEL.to_string(),
+            message: "Do you have hourly rooms?".to_string(),
+        }
+    }
+
+    fn assert_validation_error(request: LocalReceptionistChatRequest) {
+        let error = validate_request(request).expect_err("request must fail validation");
+        assert_eq!(error.code, codes::VALIDATION_INVALID_INPUT);
+        assert!(error.support_id.is_none());
+    }
+
+    #[test]
+    fn validate_request_accepts_localhost_http_endpoint() {
+        let mut request = valid_request();
+        request.endpoint = "http://localhost:8080/v1/chat/completions".to_string();
+
+        let validated = validate_request(request).expect("request should pass validation");
+
+        assert_eq!(
+            validated.endpoint,
+            "http://localhost:8080/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn validate_request_rejects_remote_endpoint() {
+        let mut request = valid_request();
+        request.endpoint = "https://example.com/v1/chat/completions".to_string();
+
+        assert_validation_error(request);
+    }
+
+    #[test]
+    fn validate_request_rejects_empty_message() {
+        let mut request = valid_request();
+        request.message = "   ".to_string();
+
+        assert_validation_error(request);
+    }
+
+    #[test]
+    fn validate_request_rejects_too_long_message() {
+        let mut request = valid_request();
+        request.message = "a".repeat(MAX_MESSAGE_CHARS + 1);
+
+        assert_validation_error(request);
+    }
+
+    #[test]
+    fn validate_request_rejects_empty_model() {
+        let mut request = valid_request();
+        request.model = "   ".to_string();
+
+        assert_validation_error(request);
+    }
+
+    #[test]
+    fn validate_request_rejects_control_characters_in_model() {
+        let mut request = valid_request();
+        request.model = "capyinn\nmodel".to_string();
+
+        assert_validation_error(request);
+    }
+
+    #[test]
+    fn validate_request_rejects_too_long_endpoint() {
+        let mut request = valid_request();
+        request.endpoint = format!("http://127.0.0.1:8080/{}", "a".repeat(MAX_ENDPOINT_CHARS));
+
+        assert_validation_error(request);
+    }
+}

--- a/mhm/src-tauri/src/commands/local_receptionist.rs
+++ b/mhm/src-tauri/src/commands/local_receptionist.rs
@@ -1,0 +1,26 @@
+use super::AppState;
+use crate::{
+    agent::receptionist_demo::{
+        run_local_receptionist_chat, LocalReceptionistChatRequest, LocalReceptionistChatResponse,
+    },
+    app_error::CommandResult,
+};
+use tauri::State;
+
+#[tauri::command]
+pub async fn local_receptionist_chat(
+    state: State<'_, AppState>,
+    endpoint: String,
+    model: String,
+    message: String,
+) -> CommandResult<LocalReceptionistChatResponse> {
+    run_local_receptionist_chat(
+        &state.db,
+        LocalReceptionistChatRequest {
+            endpoint,
+            model,
+            message,
+        },
+    )
+    .await
+}

--- a/mhm/src-tauri/src/commands/mod.rs
+++ b/mhm/src-tauri/src/commands/mod.rs
@@ -92,6 +92,7 @@ pub mod diagnostics;
 pub mod groups;
 pub mod guests;
 pub mod invoices;
+pub mod local_receptionist;
 pub mod onboarding;
 pub mod pricing;
 pub mod reservations;

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -290,6 +290,7 @@ pub fn run() {
             commands::agent_settings::get_ceo_digest_config,
             commands::agent_settings::get_ceo_digest_gate_status,
             commands::agent_settings::set_ceo_digest_config,
+            commands::local_receptionist::local_receptionist_chat,
             commands::diagnostics::record_js_crash,
             commands::diagnostics::get_pending_crash_report,
             commands::diagnostics::mark_crash_report_submitted,

--- a/mhm/src/__mocks__/tauri-core.ts
+++ b/mhm/src/__mocks__/tauri-core.ts
@@ -78,6 +78,11 @@ export const invoke = vi.fn(async (command: string, args?: Record<string, unknow
         clear_ceo_openai_api_key: undefined,
         get_ceo_telegram_gate_status: { ready: false, missing: ["runtime_enabled"] },
         get_ceo_digest_gate_status: { ready: false, missing: ["digest_enabled"] },
+        local_receptionist_chat: {
+            answer: "Local Gemma can answer with hotel pricing context.",
+            provider: "local",
+            model: "capyinn-gemma4-e2b-q5km",
+        },
         complete_onboarding: {
             setup_completed: true,
             app_lock_enabled: false,

--- a/mhm/src/pages/settings/CeoAgentSection.test.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -46,6 +46,16 @@ type CeoDigestGateFixture = {
   ready: boolean;
   missing: string[];
 };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
 
 const disabledConfig: CeoTelegramConfigFixture = {
   runtime_enabled: false,
@@ -121,6 +131,7 @@ describe("CeoAgentSection", () => {
     invoke.mockClear();
     toastSuccess.mockReset();
     toastError.mockReset();
+    window.localStorage.clear();
 
     useAuthStore.setState({
       user: { id: "u1", name: "Admin", role: "admin", active: true, created_at: "" },
@@ -482,6 +493,237 @@ describe("CeoAgentSection", () => {
       expect(screen.getByText("Unable to load CEO Telegram Chat settings")).toBeInTheDocument();
     });
     expect(checkbox).toBeDisabled();
+  });
+
+  it("renders the local receptionist demo and persists endpoint and model", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+
+    render(<CeoAgentSection />);
+
+    expect(await screen.findByText("Local Receptionist Demo")).toBeInTheDocument();
+    const endpoint = screen.getByLabelText("Local provider endpoint");
+    const model = screen.getByLabelText("Local model name");
+
+    await user.clear(endpoint);
+    await user.type(endpoint, "http://localhost:8081/v1/chat/completions");
+    await user.clear(model);
+    await user.type(model, "capyinn-local-test");
+
+    expect(window.localStorage.getItem("capyinn.localReceptionist.endpoint")).toBe(
+      "http://localhost:8081/v1/chat/completions",
+    );
+    expect(window.localStorage.getItem("capyinn.localReceptionist.model")).toBe(
+      "capyinn-local-test",
+    );
+  });
+
+  it("calls local_receptionist_chat and shows the answer", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+    setMockResponses({
+      local_receptionist_chat: (args) => ({
+        answer: `Answer for ${(args?.message as string) ?? ""}`,
+        provider: "local",
+        model: (args?.model as string) ?? "capyinn-gemma4-e2b-q5km",
+      }),
+    });
+
+    render(<CeoAgentSection />);
+
+    await user.type(
+      await screen.findByLabelText("Receptionist message"),
+      "Do you have hourly rooms?",
+    );
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "local_receptionist_chat",
+        expect.objectContaining({
+          endpoint: "http://127.0.0.1:8080/v1/chat/completions",
+          model: "capyinn-gemma4-e2b-q5km",
+          message: "Do you have hourly rooms?",
+        }),
+      );
+    });
+    expect(await screen.findByText("Answer for Do you have hourly rooms?")).toBeInTheDocument();
+  });
+
+  it("disables local receptionist submit for blank messages", async () => {
+    mockInitialState();
+
+    render(<CeoAgentSection />);
+
+    expect(await screen.findByRole("button", { name: "Ask local Gemma" })).toBeDisabled();
+  });
+
+  it("shows field validation and does not invoke for remote endpoints", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+
+    render(<CeoAgentSection />);
+
+    await user.clear(await screen.findByLabelText("Local provider endpoint"));
+    await user.type(
+      screen.getByLabelText("Local provider endpoint"),
+      "https://example.com/v1/chat/completions",
+    );
+    await user.type(await screen.findByLabelText("Receptionist message"), "Hello");
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(
+      await screen.findByText("Endpoint must be http://127.0.0.1 or http://localhost."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Local provider endpoint")).toHaveAttribute(
+      "aria-describedby",
+      "local-receptionist-endpoint-error",
+    );
+    expect(screen.getByLabelText("Local provider endpoint")).toHaveAttribute("aria-invalid", "true");
+    expect(invoke).not.toHaveBeenCalledWith("local_receptionist_chat", expect.anything());
+  });
+
+  it("shows endpoint length validation on the endpoint field", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+
+    render(<CeoAgentSection />);
+
+    const endpoint = await screen.findByLabelText("Local provider endpoint");
+    fireEvent.change(endpoint, {
+      target: { value: `http://127.0.0.1/${"a".repeat(2048)}` },
+    });
+    await user.type(await screen.findByLabelText("Receptionist message"), "Hello");
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(await screen.findByText("Endpoint is too long.")).toBeInTheDocument();
+    expect(endpoint).toHaveAttribute("aria-describedby", "local-receptionist-endpoint-error");
+    expect(endpoint).toHaveAttribute("aria-invalid", "true");
+    expect(invoke).not.toHaveBeenCalledWith("local_receptionist_chat", expect.anything());
+  });
+
+  it("shows field validation and does not invoke for blank model names", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+
+    render(<CeoAgentSection />);
+
+    await user.clear(await screen.findByLabelText("Local model name"));
+    await user.type(await screen.findByLabelText("Receptionist message"), "Hello");
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(await screen.findByText("Model name is required.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Local model name")).toHaveAttribute(
+      "aria-describedby",
+      "local-receptionist-model-error",
+    );
+    expect(screen.getByLabelText("Local model name")).toHaveAttribute("aria-invalid", "true");
+    expect(invoke).not.toHaveBeenCalledWith("local_receptionist_chat", expect.anything());
+  });
+
+  it("shows message validation on the message field", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+
+    render(<CeoAgentSection />);
+
+    const message = await screen.findByLabelText("Receptionist message");
+    fireEvent.change(message, { target: { value: "x".repeat(2001) } });
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(await screen.findByText("Message is too long.")).toBeInTheDocument();
+    expect(message).toHaveAttribute("aria-describedby", "local-receptionist-message-error");
+    expect(message).toHaveAttribute("aria-invalid", "true");
+    expect(invoke).not.toHaveBeenCalledWith("local_receptionist_chat", expect.anything());
+  });
+
+  it("disables local receptionist fields while a request is in flight", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<{ answer: string; provider: "local"; model: string }>();
+    mockInitialState();
+    setMockResponses({
+      local_receptionist_chat: () => pending.promise,
+    });
+
+    render(<CeoAgentSection />);
+
+    const endpoint = await screen.findByLabelText("Local provider endpoint");
+    const model = screen.getByLabelText("Local model name");
+    const message = screen.getByLabelText("Receptionist message");
+    await user.type(message, "Hello");
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(await screen.findByRole("button", { name: "Asking local Gemma..." })).toBeDisabled();
+    expect(endpoint).toBeDisabled();
+    expect(model).toBeDisabled();
+    expect(message).toBeDisabled();
+
+    pending.resolve({
+      answer: "Local answer",
+      provider: "local",
+      model: "capyinn-gemma4-e2b-q5km",
+    });
+
+    expect(await screen.findByText("Local answer")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "request timed out after 60 seconds with raw endpoint details",
+      "Local provider timed out. Try a shorter question or restart llama-server.",
+    ],
+    [
+      "provider rejected request with raw status 500",
+      "Local provider rejected the request. Check the endpoint and model name.",
+    ],
+    [
+      "provider response too large with raw byte count",
+      "Local provider response was too large. Try a shorter answer.",
+    ],
+    [
+      "unsupported provider response with raw schema details",
+      "Local provider returned an unsupported response.",
+    ],
+    [
+      "invalid request with raw validation details",
+      "Please check the local endpoint, model name, and message.",
+    ],
+  ])("shows a short local provider error for %s", async (rawError, expectedMessage) => {
+    const user = userEvent.setup();
+    mockInitialState();
+    setMockResponses({
+      local_receptionist_chat: () => {
+        throw new Error(rawError);
+      },
+    });
+
+    render(<CeoAgentSection />);
+
+    await user.type(await screen.findByLabelText("Receptionist message"), "Hello");
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(await screen.findByText(expectedMessage)).toBeInTheDocument();
+    expect(screen.queryByText(/raw/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a short local provider error without raw details", async () => {
+    const user = userEvent.setup();
+    mockInitialState();
+    setMockResponses({
+      local_receptionist_chat: () => {
+        throw new Error("raw tcp connect ECONNREFUSED with internal details");
+      },
+    });
+
+    render(<CeoAgentSection />);
+
+    await user.type(await screen.findByLabelText("Receptionist message"), "Hello");
+    await user.click(screen.getByRole("button", { name: "Ask local Gemma" }));
+
+    expect(
+      await screen.findByText("Local provider is not reachable. Start llama-server and try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/ECONNREFUSED/)).not.toBeInTheDocument();
   });
 });
 

--- a/mhm/src/pages/settings/CeoAgentSection.tsx
+++ b/mhm/src/pages/settings/CeoAgentSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { invokeCommand, invokeWriteCommand } from "@/lib/invokeCommand";
+import LocalReceptionistDemo from "./LocalReceptionistDemo";
 
 type CeoTelegramConfig = {
   runtime_enabled: boolean;
@@ -389,6 +390,8 @@ export default function CeoAgentSection() {
           Owner-bound Telegram access to read-only PMS answers.
         </p>
       </div>
+
+      <LocalReceptionistDemo />
 
       <section className="space-y-3 rounded-xl border border-slate-200 p-4">
         <div className="flex items-center justify-between gap-4">

--- a/mhm/src/pages/settings/LocalReceptionistDemo.tsx
+++ b/mhm/src/pages/settings/LocalReceptionistDemo.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useState } from "react";
+
+import { invokeCommand } from "@/lib/invokeCommand";
+
+const DEFAULT_ENDPOINT = "http://127.0.0.1:8080/v1/chat/completions";
+const DEFAULT_MODEL = "capyinn-gemma4-e2b-q5km";
+const ENDPOINT_STORAGE_KEY = "capyinn.localReceptionist.endpoint";
+const MODEL_STORAGE_KEY = "capyinn.localReceptionist.model";
+const UNREACHABLE_MESSAGE = "Local provider is not reachable. Start llama-server and try again.";
+const MAX_ENDPOINT_CHARS = 2048;
+const MAX_MODEL_CHARS = 128;
+const MAX_MESSAGE_CHARS = 2000;
+
+type LocalReceptionistChatResponse = {
+  answer: string;
+  provider: "local";
+  model: string;
+};
+
+type LocalFieldErrors = {
+  endpoint?: string;
+  model?: string;
+  message?: string;
+};
+
+function readLocalStorage(key: string, fallback: string) {
+  try {
+    return window.localStorage.getItem(key) || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeLocalStorage(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Ignore storage failures; the demo can still run with component state.
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function collectErrorMessages(error: unknown, messages: string[] = []): string[] {
+  if (typeof error === "string") {
+    messages.push(error);
+    return messages;
+  }
+
+  if (error instanceof Error) {
+    messages.push(error.message);
+    if ("cause" in error) {
+      collectErrorMessages((error as Error & { cause?: unknown }).cause, messages);
+    }
+    return messages;
+  }
+
+  if (isRecord(error)) {
+    if (typeof error.message === "string") {
+      messages.push(error.message);
+    }
+    if ("cause" in error) {
+      collectErrorMessages(error.cause, messages);
+    }
+  }
+
+  return messages;
+}
+
+function localErrorMessage(error: unknown) {
+  const message = collectErrorMessages(error).join(" ").toLowerCase();
+  if (message.includes("timed out") || message.includes("timeout")) {
+    return "Local provider timed out. Try a shorter question or restart llama-server.";
+  }
+  if (message.includes("rejected")) {
+    return "Local provider rejected the request. Check the endpoint and model name.";
+  }
+  if (message.includes("too large")) {
+    return "Local provider response was too large. Try a shorter answer.";
+  }
+  if (message.includes("unsupported")) {
+    return "Local provider returned an unsupported response.";
+  }
+  if (message.includes("invalid")) {
+    return "Please check the local endpoint, model name, and message.";
+  }
+  return UNREACHABLE_MESSAGE;
+}
+
+function validateLocalEndpoint(value: string) {
+  const endpoint = value.trim();
+  if (!endpoint) {
+    return "Endpoint is required.";
+  }
+  if (endpoint.length > MAX_ENDPOINT_CHARS) {
+    return "Endpoint is too long.";
+  }
+  try {
+    const parsed = new URL(endpoint);
+    if (
+      parsed.protocol !== "http:" ||
+      (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost")
+    ) {
+      return "Endpoint must be http://127.0.0.1 or http://localhost.";
+    }
+  } catch {
+    return "Endpoint must be a valid local HTTP URL.";
+  }
+  return "";
+}
+
+function validateModelName(value: string) {
+  const model = value.trim();
+  if (!model) {
+    return "Model name is required.";
+  }
+  if (model.length > MAX_MODEL_CHARS || /[\u0000-\u001f\u007f]/.test(model)) {
+    return "Model name is invalid.";
+  }
+  return "";
+}
+
+function validateMessage(value: string) {
+  const text = value.trim();
+  if (!text) {
+    return "Message is required.";
+  }
+  if (text.length > MAX_MESSAGE_CHARS) {
+    return "Message is too long.";
+  }
+  return "";
+}
+
+export default function LocalReceptionistDemo() {
+  const [endpoint, setEndpoint] = useState(() =>
+    readLocalStorage(ENDPOINT_STORAGE_KEY, DEFAULT_ENDPOINT),
+  );
+  const [model, setModel] = useState(() => readLocalStorage(MODEL_STORAGE_KEY, DEFAULT_MODEL));
+  const [message, setMessage] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<LocalFieldErrors>({});
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    writeLocalStorage(ENDPOINT_STORAGE_KEY, endpoint);
+  }, [endpoint]);
+
+  useEffect(() => {
+    writeLocalStorage(MODEL_STORAGE_KEY, model);
+  }, [model]);
+
+  const canSubmit = message.trim().length > 0 && !loading;
+
+  const clearFieldError = (field: keyof LocalFieldErrors) => {
+    setFieldErrors((current) =>
+      current[field] === undefined ? current : { ...current, [field]: undefined },
+    );
+  };
+
+  const handleAsk = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
+    const nextFieldErrors: LocalFieldErrors = {
+      endpoint: validateLocalEndpoint(endpoint) || undefined,
+      model: validateModelName(model) || undefined,
+      message: validateMessage(message) || undefined,
+    };
+    if (nextFieldErrors.endpoint || nextFieldErrors.model || nextFieldErrors.message) {
+      setAnswer("");
+      setError("");
+      setFieldErrors(nextFieldErrors);
+      return;
+    }
+
+    setLoading(true);
+    setAnswer("");
+    setError("");
+    setFieldErrors({});
+    try {
+      const result = await invokeCommand<LocalReceptionistChatResponse>(
+        "local_receptionist_chat",
+        {
+          endpoint: endpoint.trim(),
+          model: model.trim(),
+          message: message.trim(),
+        },
+      );
+      setAnswer(result.answer);
+    } catch (caught) {
+      setError(localErrorMessage(caught));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="space-y-4 rounded-xl border border-slate-200 p-4">
+      <div>
+        <h3 className="text-sm font-semibold">Local Receptionist Demo</h3>
+        <p className="text-xs text-brand-muted">
+          Runs locally through a provider on 127.0.0.1 or localhost. Uses hotel info and pricing
+          context only. No PMS writes.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="space-y-1 text-sm font-medium">
+          <span>Local provider endpoint</span>
+          <input
+            aria-label="Local provider endpoint"
+            aria-describedby={
+              fieldErrors.endpoint ? "local-receptionist-endpoint-error" : undefined
+            }
+            aria-invalid={Boolean(fieldErrors.endpoint)}
+            value={endpoint}
+            disabled={loading}
+            onChange={(event) => {
+              setEndpoint(event.target.value);
+              clearFieldError("endpoint");
+            }}
+            className="h-10 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
+          />
+          {fieldErrors.endpoint && (
+            <p id="local-receptionist-endpoint-error" className="text-xs text-red-500">
+              {fieldErrors.endpoint}
+            </p>
+          )}
+        </label>
+
+        <label className="space-y-1 text-sm font-medium">
+          <span>Local model name</span>
+          <input
+            aria-label="Local model name"
+            aria-describedby={fieldErrors.model ? "local-receptionist-model-error" : undefined}
+            aria-invalid={Boolean(fieldErrors.model)}
+            value={model}
+            disabled={loading}
+            onChange={(event) => {
+              setModel(event.target.value);
+              clearFieldError("model");
+            }}
+            className="h-10 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
+          />
+          {fieldErrors.model && (
+            <p id="local-receptionist-model-error" className="text-xs text-red-500">
+              {fieldErrors.model}
+            </p>
+          )}
+        </label>
+      </div>
+
+      <label className="block space-y-1 text-sm font-medium">
+        <span>Receptionist message</span>
+        <textarea
+          aria-label="Receptionist message"
+          aria-describedby={fieldErrors.message ? "local-receptionist-message-error" : undefined}
+          aria-invalid={Boolean(fieldErrors.message)}
+          value={message}
+          disabled={loading}
+          rows={3}
+          onChange={(event) => {
+            setMessage(event.target.value);
+            clearFieldError("message");
+          }}
+          className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
+        />
+        {fieldErrors.message && (
+          <p id="local-receptionist-message-error" className="text-xs text-red-500">
+            {fieldErrors.message}
+          </p>
+        )}
+      </label>
+
+      <button
+        type="button"
+        disabled={!canSubmit}
+        onClick={() => void handleAsk()}
+        className="rounded-xl bg-brand-primary px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+      >
+        {loading ? "Asking local Gemma..." : "Ask local Gemma"}
+      </button>
+
+      {answer && (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+          {answer}
+        </div>
+      )}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a read-only local receptionist demo powered by a localhost OpenAI-compatible provider.
- Build a guest-facing hotel context from allowed settings, room types, and pricing fields only.
- Add an Agent settings UI to configure the local endpoint/model and test receptionist questions.

## Why
This supports the Gemma 4 demo: CapyInn can call a local quantized Gemma 4 model for front-desk assistant flows without relying on cloud AI APIs.

## Safety Notes
- Local provider endpoints are restricted to `http://127.0.0.1` or `http://localhost`.
- The receptionist command does not write PMS tables and includes a no-write test.
- The prompt tells the assistant not to invent prices, policies, availability, bookings, payments, or guest data.
- Provider errors are sanitized before display in the UI.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml receptionist_demo::tests -- --nocapture`
- `npm test -- --run src/pages/settings/CeoAgentSection.test.tsx`
- `npm run build`

## Demo Runbook
Start local Gemma server:

```bash
/Users/capyinn-q5km/llama.cpp/build/bin/llama-server \
  -m /Users/capyinn-q5km/capyinn-gemma-4-Q5_K_M.gguf \
  --host 127.0.0.1 \
  --port 8080 \
  --ctx-size 4096 \
  -ngl 99 \
  --no-webui \
  --reasoning off \
  --top-k 1 \
  --repeat-penalty 1.08 \
  --repeat-last-n 128
```

Then run the app:

```bash
cd /Users/HotelManager/mhm
npm run tauri -- dev
```
