### PR TITLE
[codex] Frontend invoke wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           workspaces: |
             mhm/src-tauri -> target
+          cache-bin: false
 
       - name: Install frontend dependencies
         working-directory: mhm
@@ -77,6 +78,7 @@ jobs:
         with:
           workspaces: |
             mhm/src-tauri -> target
+          cache-bin: false
 
       - name: Install frontend dependencies
         working-directory: mhm

--- a/mhm/src/pages/settings/CheckinRulesSection.tsx
+++ b/mhm/src/pages/settings/CheckinRulesSection.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
 
 function readSavedTime(
   value: Record<string, unknown>,
@@ -55,7 +56,7 @@ export default function CheckinRulesSection() {
 
   const handleSave = () => {
     const value = JSON.stringify({ checkin: checkinTime, checkout: checkoutTime });
-    invoke("save_settings", { key: "checkin_rules", value })
+    invokeWriteCommand("save_settings", { key: "checkin_rules", value })
       .then(() => toast.success("Đã lưu quy tắc check-in!"))
       .catch(() => toast.error("Lỗi khi lưu!"));
   };

--- a/mhm/src/pages/settings/HotelInfoSection.tsx
+++ b/mhm/src/pages/settings/HotelInfoSection.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { APP_NAME } from "@/lib/appIdentity";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
 
 export default function HotelInfoSection() {
   const [hotelName, setHotelName] = useState(APP_NAME);
@@ -32,7 +33,7 @@ export default function HotelInfoSection() {
 
   const handleSave = () => {
     const value = JSON.stringify({ name: hotelName, address, phone, rating });
-    invoke("save_settings", { key: "hotel_info", value })
+    invokeWriteCommand("save_settings", { key: "hotel_info", value })
       .then(() => toast.success("Đã lưu thông tin khách sạn!"))
       .catch(() => toast.error("Lỗi khi lưu!"));
   };

--- a/mhm/src/pages/settings/PricingSection.test.tsx
+++ b/mhm/src/pages/settings/PricingSection.test.tsx
@@ -4,11 +4,16 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const invoke = vi.hoisted(() => vi.fn());
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
 const toastError = vi.hoisted(() => vi.fn());
 const toastSuccess = vi.hoisted(() => vi.fn());
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke,
+}));
+
+vi.mock("@/lib/invokeCommand", () => ({
+  invokeWriteCommand,
 }));
 
 vi.mock("sonner", () => ({
@@ -60,12 +65,10 @@ import PricingSection from "./PricingSection";
 describe("PricingSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    invokeWriteCommand.mockResolvedValue(undefined);
     invoke.mockImplementation(async (command: string) => {
       if (command === "get_pricing_rules") {
         return [];
-      }
-      if (command === "save_pricing_rule") {
-        return undefined;
       }
       throw new Error(`Unexpected command: ${command}`);
     });
@@ -93,9 +96,45 @@ describe("PricingSection", () => {
       "save_pricing_rule",
       expect.anything(),
     );
+    expect(invokeWriteCommand).not.toHaveBeenCalledWith(
+      "save_pricing_rule",
+      expect.anything(),
+    );
     expect(toastError).toHaveBeenCalledWith(
       "hourly_rate must be a safe integer VND value",
     );
     expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("saves pricing rules through invokeWriteCommand", async () => {
+    const user = userEvent.setup();
+    render(<PricingSection />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("get_pricing_rules");
+    });
+
+    fireEvent.change(screen.getByLabelText("Loại phòng"), {
+      target: { value: "standard" },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Thêm" }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith("save_pricing_rule", {
+        roomType: "standard",
+        hourlyRate: 80000,
+        overnightRate: 300000,
+        dailyRate: 400000,
+        earlyPct: 30,
+        latePct: 30,
+        weekendPct: 20,
+      });
+    });
+    expect(invoke).not.toHaveBeenCalledWith(
+      "save_pricing_rule",
+      expect.anything(),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("Đã lưu bảng giá!");
   });
 });

--- a/mhm/src/pages/settings/PricingSection.tsx
+++ b/mhm/src/pages/settings/PricingSection.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { assertNonNegativeMoneyVnd } from "@/lib/money";
 import type { PricingRuleData } from "@/types";
 
@@ -43,7 +44,7 @@ export default function PricingSection() {
       const hourlyRate = assertNonNegativeMoneyVnd(form.hourly_rate, "hourly_rate");
       const overnightRate = assertNonNegativeMoneyVnd(form.overnight_rate, "overnight_rate");
       const dailyRate = assertNonNegativeMoneyVnd(form.daily_rate, "daily_rate");
-      await invoke("save_pricing_rule", {
+      await invokeWriteCommand("save_pricing_rule", {
         roomType: form.room_type,
         hourlyRate,
         overnightRate,

--- a/mhm/src/pages/settings/SettingsWriteSections.test.tsx
+++ b/mhm/src/pages/settings/SettingsWriteSections.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.hoisted(() => vi.fn());
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+}));
+
+vi.mock("@/lib/invokeCommand", () => ({
+  invokeWriteCommand,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: toastSuccess,
+  },
+}));
+
+import CheckinRulesSection from "./CheckinRulesSection";
+import HotelInfoSection from "./HotelInfoSection";
+
+describe("settings write sections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeWriteCommand.mockResolvedValue(undefined);
+    invoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command !== "get_settings") {
+        throw new Error(`Unexpected raw invoke ${command}`);
+      }
+
+      if (args?.key === "hotel_info") {
+        return JSON.stringify({
+          name: "Grand Hotel",
+          address: "123 Main St",
+          phone: "0901234567",
+          rating: "4.8",
+        });
+      }
+
+      if (args?.key === "checkin_rules") {
+        return JSON.stringify({
+          checkin: "15:30",
+          checkout: "11:15",
+        });
+      }
+
+      return null;
+    });
+  });
+
+  it("saves hotel info through invokeWriteCommand", async () => {
+    const user = userEvent.setup();
+    render(<HotelInfoSection />);
+
+    const hotelNameInput = await screen.findByDisplayValue("Grand Hotel");
+    await user.clear(hotelNameInput);
+    await user.type(hotelNameInput, "New Hotel");
+
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith("save_settings", {
+        key: "hotel_info",
+        value: JSON.stringify({
+          name: "New Hotel",
+          address: "123 Main St",
+          phone: "0901234567",
+          rating: "4.8",
+        }),
+      });
+    });
+    expect(invoke).not.toHaveBeenCalledWith("save_settings", expect.anything());
+    expect(toastSuccess).toHaveBeenCalledWith("Đã lưu thông tin khách sạn!");
+  });
+
+  it("saves check-in rules through invokeWriteCommand", async () => {
+    const user = userEvent.setup();
+    render(<CheckinRulesSection />);
+
+    const checkinInput = await screen.findByDisplayValue("15:30");
+    const checkoutInput = await screen.findByDisplayValue("11:15");
+
+    fireEvent.change(checkinInput, { target: { value: "16:00" } });
+    fireEvent.change(checkoutInput, { target: { value: "10:45" } });
+
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith("save_settings", {
+        key: "checkin_rules",
+        value: JSON.stringify({ checkin: "16:00", checkout: "10:45" }),
+      });
+    });
+    expect(invoke).not.toHaveBeenCalledWith("save_settings", expect.anything());
+    expect(toastSuccess).toHaveBeenCalledWith("Đã lưu quy tắc check-in!");
+  });
+});

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -35,6 +35,10 @@ describe("useHotelStore monitoring context", () => {
         return [];
       }
 
+      if (command === "get_housekeeping_tasks") {
+        return [];
+      }
+
       if (command === "get_dashboard_stats") {
         return {
           total_rooms: 10,
@@ -273,6 +277,20 @@ describe("useHotelStore monitoring context", () => {
     });
     expect(invoke).not.toHaveBeenCalledWith(
       "remove_group_service",
+      expect.anything(),
+    );
+  });
+
+  it("routes updateHousekeeping through invokeWriteCommand", async () => {
+    await useHotelStore.getState().updateHousekeeping("task-1", "cleaning", "Started");
+
+    expect(invokeWriteCommand).toHaveBeenCalledWith("update_housekeeping", {
+      taskId: "task-1",
+      newStatus: "cleaning",
+      note: "Started",
+    });
+    expect(invoke).not.toHaveBeenCalledWith(
+      "update_housekeeping",
       expect.anything(),
     );
   });

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -213,7 +213,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     },
 
     updateHousekeeping: async (taskId, status, note) => {
-      await invoke("update_housekeeping", { taskId, newStatus: status, note });
+      await invokeWriteCommand("update_housekeeping", { taskId, newStatus: status, note });
       await get().fetchHousekeeping();
       await get().fetchRooms();
     },

--- a/mhm/tests/e2e/06-housekeeping.test.tsx
+++ b/mhm/tests/e2e/06-housekeeping.test.tsx
@@ -50,6 +50,7 @@ describe("06 — Housekeeping", () => {
             taskId: "hk-1",
             newStatus: "cleaning",
             note: "Started cleaning",
+            idempotencyKey: expect.stringMatching(/^update_housekeeping:/),
         });
     });
 

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -4,7 +4,7 @@ import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 type RawInvokeOccurrence = {
-  command: string;
+  command: string | undefined;
   file: string;
   line: number;
 };
@@ -55,6 +55,10 @@ const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
   record_js_crash: "diagnostics crash recording path",
   search_guest_by_phone: "read-only guest search lookup",
   set_crash_reporting_preference: "diagnostics preference action excluded from PMS wrapper scope",
+};
+
+const RAW_INVOKE_ALLOWED_NON_LITERAL_SITES: Record<string, string> = {
+  "src/lib/invokeCommand.ts": "central invoke wrapper dispatch boundary",
 };
 
 let rawInvokeOccurrencesCache: RawInvokeOccurrence[] | undefined;
@@ -171,13 +175,11 @@ function findRawInvokeOccurrencesInSource(
         ? stringCommandFromExpression(node.arguments[0])
         : undefined;
 
-      if (command) {
-        occurrences.push({
-          command,
-          file: relative(process.cwd(), file),
-          line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
-        });
-      }
+      occurrences.push({
+        command,
+        file: relative(process.cwd(), file),
+        line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+      });
     }
 
     ts.forEachChild(node, visit);
@@ -201,7 +203,10 @@ function getRawInvokeOccurrences(): RawInvokeOccurrence[] {
 
 function formatOccurrences(occurrences: RawInvokeOccurrence[]): string {
   return occurrences
-    .map(({ command, file, line }) => `${command} at ${file}:${line}`)
+    .map(
+      ({ command, file, line }) =>
+        `${command ?? "<non-literal command>"} at ${file}:${line}`,
+    )
     .join("\n");
 }
 
@@ -227,9 +232,24 @@ describe("frontend invoke wrapper guardrails", () => {
     ]);
   });
 
+  it("flags raw Tauri invoke calls without literal command names", () => {
+    const source = `
+      import { invoke } from "@tauri-apps/api/core";
+
+      const command = "save_settings";
+      invoke(command);
+    `;
+
+    expect(
+      findRawInvokeOccurrencesInSource("src/example.ts", source).map(
+        ({ command }) => command ?? "<non-literal command>",
+      ),
+    ).toEqual(["<non-literal command>"]);
+  });
+
   it("keeps Batch 1 PMS writes out of raw Tauri invoke calls", () => {
     const forbidden = getRawInvokeOccurrences().filter(({ command }) =>
-      PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command),
+      command ? PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command) : false,
     );
 
     expect(formatOccurrences(forbidden)).toBe("");
@@ -237,7 +257,9 @@ describe("frontend invoke wrapper guardrails", () => {
 
   it("keeps every remaining raw Tauri invoke explicitly categorized", () => {
     const rawCommands = new Set(
-      getRawInvokeOccurrences().map(({ command }) => command),
+      getRawInvokeOccurrences()
+        .map(({ command }) => command)
+        .filter((command): command is string => command !== undefined),
     );
 
     for (const [command, reason] of Object.entries(RAW_INVOKE_ALLOWED_COMMANDS)) {
@@ -245,10 +267,23 @@ describe("frontend invoke wrapper guardrails", () => {
       expect(rawCommands.has(command), `${command} is not a remaining raw invoke`).toBe(true);
     }
 
-    const unknown = getRawInvokeOccurrences().filter(
-      ({ command }) =>
-        !PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command) &&
-        !(command in RAW_INVOKE_ALLOWED_COMMANDS),
+    const nonLiteralSites = new Set(
+      getRawInvokeOccurrences()
+        .filter(({ command }) => command === undefined)
+        .map(({ file }) => file),
+    );
+    for (const [file, reason] of Object.entries(RAW_INVOKE_ALLOWED_NON_LITERAL_SITES)) {
+      expect(reason, `${file} needs an allowlist reason`).toMatch(/\S.{10,}/);
+      expect(nonLiteralSites.has(file), `${file} is not a remaining non-literal raw invoke`).toBe(
+        true,
+      );
+    }
+
+    const unknown = getRawInvokeOccurrences().filter(({ command, file }) =>
+      command === undefined
+        ? !(file in RAW_INVOKE_ALLOWED_NON_LITERAL_SITES)
+        : !PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command) &&
+          !(command in RAW_INVOKE_ALLOWED_COMMANDS),
     );
 
     expect(formatOccurrences(unknown)).toBe("");

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -1,0 +1,126 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+type RawInvokeOccurrence = {
+  command: string;
+  file: string;
+  line: number;
+};
+
+const FRONTEND_SRC_ROOT = join(process.cwd(), "src");
+
+const PMS_WRITE_COMMANDS_REQUIRING_WRAPPER = new Set([
+  "save_pricing_rule",
+  "save_settings",
+  "update_housekeeping",
+]);
+
+const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
+  auto_assign_rooms: "read-style room assignment preview; no PMS mutation is committed",
+  backup_database: "system backup/export action, not a PMS business write wrapper target",
+  calculate_price_preview: "read-only pricing preview",
+  check_availability: "read-only reservation availability lookup",
+  complete_onboarding: "bootstrap setup command excluded from Batch 1 PMS wrapper scope",
+  export_bookings_csv: "system export action, not a PMS business write wrapper target",
+  export_crash_report: "diagnostics export action",
+  gateway_generate_key: "gateway runtime administration excluded from PMS write wrapper scope",
+  gateway_get_status: "gateway runtime status read",
+  generate_group_invoice: "read-only group invoice data generation; no invoice record is persisted",
+  get_all_bookings: "read-only booking list lookup",
+  get_all_groups: "read-only group list lookup",
+  get_all_guests: "read-only guest list lookup",
+  get_analytics: "read-only analytics lookup",
+  get_audit_logs: "read-only audit lookup",
+  get_bootstrap_status: "bootstrap runtime read",
+  get_crash_reporting_preference: "diagnostics preference read",
+  get_current_user: "auth session read",
+  get_dashboard_stats: "read-only dashboard stats lookup",
+  get_expenses: "read-only expense lookup",
+  get_guest_history: "read-only guest history lookup",
+  get_housekeeping_tasks: "read-only housekeeping task lookup",
+  get_pending_crash_report: "diagnostics recovery read",
+  get_pricing_rules: "read-only pricing rules lookup",
+  get_recent_activity: "read-only activity feed lookup",
+  get_room_detail: "read-only room detail lookup",
+  get_room_types: "read-only room type lookup",
+  get_rooms: "read-only room list lookup",
+  get_rooms_availability: "read-only room availability lookup",
+  get_settings: "read-only settings lookup",
+  get_stay_info_text: "read-only stay info lookup",
+  logout: "auth runtime action excluded from PMS write wrapper scope",
+  mark_crash_report_dismissed: "diagnostics lifecycle action",
+  mark_crash_report_send_failed: "diagnostics lifecycle action",
+  mark_crash_report_submitted: "diagnostics lifecycle action",
+  preview_checkout_settlement: "read-only checkout settlement preview",
+  record_js_crash: "diagnostics crash recording path",
+  search_guest_by_phone: "read-only guest search lookup",
+  set_crash_reporting_preference: "diagnostics preference action excluded from PMS wrapper scope",
+};
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    const stats = statSync(path);
+
+    if (stats.isDirectory()) {
+      if (entry === "__mocks__") {
+        return [];
+      }
+      return listSourceFiles(path);
+    }
+
+    if (!/\.(ts|tsx)$/.test(entry) || /\.test\.(ts|tsx)$/.test(entry)) {
+      return [];
+    }
+
+    return [path];
+  });
+}
+
+function lineNumberForIndex(source: string, index: number): number {
+  return source.slice(0, index).split("\n").length;
+}
+
+function findRawInvokeOccurrences(): RawInvokeOccurrence[] {
+  const invokePattern = /\binvoke(?:<[^>]+>)?\(\s*["']([^"']+)["']/g;
+
+  return listSourceFiles(FRONTEND_SRC_ROOT).flatMap((file) => {
+    const source = readFileSync(file, "utf8");
+    return Array.from(source.matchAll(invokePattern), (match) => ({
+      command: match[1],
+      file: relative(process.cwd(), file),
+      line: lineNumberForIndex(source, match.index ?? 0),
+    }));
+  });
+}
+
+function formatOccurrences(occurrences: RawInvokeOccurrence[]): string {
+  return occurrences
+    .map(({ command, file, line }) => `${command} at ${file}:${line}`)
+    .join("\n");
+}
+
+describe("frontend invoke wrapper guardrails", () => {
+  it("keeps Batch 1 PMS writes out of raw Tauri invoke calls", () => {
+    const forbidden = findRawInvokeOccurrences().filter(({ command }) =>
+      PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command),
+    );
+
+    expect(formatOccurrences(forbidden)).toBe("");
+  });
+
+  it("keeps every remaining raw Tauri invoke explicitly categorized", () => {
+    for (const [command, reason] of Object.entries(RAW_INVOKE_ALLOWED_COMMANDS)) {
+      expect(reason, `${command} needs an allowlist reason`).toMatch(/\S.{10,}/);
+    }
+
+    const unknown = findRawInvokeOccurrences().filter(
+      ({ command }) =>
+        !PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command) &&
+        !(command in RAW_INVOKE_ALLOWED_COMMANDS),
+    );
+
+    expect(formatOccurrences(unknown)).toBe("");
+  });
+});

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -17,9 +17,7 @@ const PMS_WRITE_COMMANDS_REQUIRING_WRAPPER = new Set([
 ]);
 
 const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
-  auto_assign_rooms: "read-style room assignment preview; no PMS mutation is committed",
   backup_database: "system backup/export action, not a PMS business write wrapper target",
-  calculate_price_preview: "read-only pricing preview",
   check_availability: "read-only reservation availability lookup",
   complete_onboarding: "bootstrap setup command excluded from Batch 1 PMS wrapper scope",
   export_bookings_csv: "system export action, not a PMS business write wrapper target",
@@ -111,8 +109,13 @@ describe("frontend invoke wrapper guardrails", () => {
   });
 
   it("keeps every remaining raw Tauri invoke explicitly categorized", () => {
+    const rawCommands = new Set(
+      findRawInvokeOccurrences().map(({ command }) => command),
+    );
+
     for (const [command, reason] of Object.entries(RAW_INVOKE_ALLOWED_COMMANDS)) {
       expect(reason, `${command} needs an allowlist reason`).toMatch(/\S.{10,}/);
+      expect(rawCommands.has(command), `${command} is not a remaining raw invoke`).toBe(true);
     }
 
     const unknown = findRawInvokeOccurrences().filter(

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 type RawInvokeOccurrence = {
@@ -56,6 +57,8 @@ const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
   set_crash_reporting_preference: "diagnostics preference action excluded from PMS wrapper scope",
 };
 
+let rawInvokeOccurrencesCache: RawInvokeOccurrence[] | undefined;
+
 function listSourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
     const path = join(dir, entry);
@@ -76,21 +79,124 @@ function listSourceFiles(dir: string): string[] {
   });
 }
 
-function lineNumberForIndex(source: string, index: number): number {
-  return source.slice(0, index).split("\n").length;
+function sourceKindForFile(file: string): ts.ScriptKind {
+  return file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+}
+
+function findTauriInvokeImports(sourceFile: ts.SourceFile): {
+  invokeLocals: Set<string>;
+  namespaceLocals: Set<string>;
+} {
+  const invokeLocals = new Set<string>();
+  const namespaceLocals = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    if (
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== "@tauri-apps/api/core"
+    ) {
+      continue;
+    }
+
+    const importClause = statement.importClause;
+    const namedBindings = importClause?.namedBindings;
+    if (!namedBindings) {
+      continue;
+    }
+
+    if (ts.isNamespaceImport(namedBindings)) {
+      namespaceLocals.add(namedBindings.name.text);
+      continue;
+    }
+
+    for (const element of namedBindings.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      if (importedName === "invoke") {
+        invokeLocals.add(element.name.text);
+      }
+    }
+  }
+
+  return { invokeLocals, namespaceLocals };
+}
+
+function isImportedInvokeCall(
+  expression: ts.Expression,
+  invokeLocals: Set<string>,
+  namespaceLocals: Set<string>,
+): boolean {
+  if (ts.isIdentifier(expression)) {
+    return invokeLocals.has(expression.text);
+  }
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === "invoke" &&
+    ts.isIdentifier(expression.expression) &&
+    namespaceLocals.has(expression.expression.text)
+  );
+}
+
+function stringCommandFromExpression(expression: ts.Expression): string | undefined {
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text;
+  }
+
+  return undefined;
+}
+
+function findRawInvokeOccurrencesInSource(
+  file: string,
+  source: string,
+): RawInvokeOccurrence[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    sourceKindForFile(file),
+  );
+  const { invokeLocals, namespaceLocals } = findTauriInvokeImports(sourceFile);
+  const occurrences: RawInvokeOccurrence[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      isImportedInvokeCall(node.expression, invokeLocals, namespaceLocals)
+    ) {
+      const command = node.arguments[0]
+        ? stringCommandFromExpression(node.arguments[0])
+        : undefined;
+
+      if (command) {
+        occurrences.push({
+          command,
+          file: relative(process.cwd(), file),
+          line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return occurrences;
 }
 
 function findRawInvokeOccurrences(): RawInvokeOccurrence[] {
-  const invokePattern = /\binvoke(?:<[^>]+>)?\(\s*["']([^"']+)["']/g;
-
   return listSourceFiles(FRONTEND_SRC_ROOT).flatMap((file) => {
     const source = readFileSync(file, "utf8");
-    return Array.from(source.matchAll(invokePattern), (match) => ({
-      command: match[1],
-      file: relative(process.cwd(), file),
-      line: lineNumberForIndex(source, match.index ?? 0),
-    }));
+    return findRawInvokeOccurrencesInSource(file, source);
   });
+}
+
+function getRawInvokeOccurrences(): RawInvokeOccurrence[] {
+  rawInvokeOccurrencesCache ??= findRawInvokeOccurrences();
+  return rawInvokeOccurrencesCache;
 }
 
 function formatOccurrences(occurrences: RawInvokeOccurrence[]): string {
@@ -100,8 +206,29 @@ function formatOccurrences(occurrences: RawInvokeOccurrence[]): string {
 }
 
 describe("frontend invoke wrapper guardrails", () => {
+  it("detects aliased, namespaced, and typed raw Tauri invoke calls", () => {
+    const source = `
+      import { invoke, invoke as tauriInvoke } from "@tauri-apps/api/core";
+      import * as tauriCore from "@tauri-apps/api/core";
+
+      invoke<Result<Foo>>("save_pricing_rule");
+      tauriInvoke("save_settings");
+      tauriCore.invoke(\`update_housekeeping\`);
+    `;
+
+    expect(
+      findRawInvokeOccurrencesInSource("src/example.ts", source).map(
+        ({ command }) => command,
+      ),
+    ).toEqual([
+      "save_pricing_rule",
+      "save_settings",
+      "update_housekeeping",
+    ]);
+  });
+
   it("keeps Batch 1 PMS writes out of raw Tauri invoke calls", () => {
-    const forbidden = findRawInvokeOccurrences().filter(({ command }) =>
+    const forbidden = getRawInvokeOccurrences().filter(({ command }) =>
       PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command),
     );
 
@@ -110,7 +237,7 @@ describe("frontend invoke wrapper guardrails", () => {
 
   it("keeps every remaining raw Tauri invoke explicitly categorized", () => {
     const rawCommands = new Set(
-      findRawInvokeOccurrences().map(({ command }) => command),
+      getRawInvokeOccurrences().map(({ command }) => command),
     );
 
     for (const [command, reason] of Object.entries(RAW_INVOKE_ALLOWED_COMMANDS)) {
@@ -118,7 +245,7 @@ describe("frontend invoke wrapper guardrails", () => {
       expect(rawCommands.has(command), `${command} is not a remaining raw invoke`).toBe(true);
     }
 
-    const unknown = findRawInvokeOccurrences().filter(
+    const unknown = getRawInvokeOccurrences().filter(
       ({ command }) =>
         !PMS_WRITE_COMMANDS_REQUIRING_WRAPPER.has(command) &&
         !(command in RAW_INVOKE_ALLOWED_COMMANDS),


### PR DESCRIPTION
## Summary
- Route selected frontend PMS writes through `invokeWriteCommand` for pricing rules, settings saves, and housekeeping updates.
- Add focused coverage for those write paths and housekeeping metadata expectations.
- Add AST-based guardrails so raw Tauri invoke calls for Batch 1 write commands, aliases, namespace calls, typed calls, and non-literal command expressions are caught.
- Keep Rust CI from restoring cached Cargo binaries so `cargo` cannot resolve to a stale `rustup-init` binary on PR checks.

## Validation
- Rebuilt the PR branch cleanly on top of `origin/main` at `a9d57e0`
- `npm run build`
- `npm test` (55 files, 280 tests)
- `cargo check`
- `npm test -- tests/frontend-invoke-wrapper-guardrails.test.ts`
- `rg -n "invoke<|invoke\(" src --glob "!**/*.test.*" --glob "!src/__mocks__/**"` confirmed no raw `save_pricing_rule`, `save_settings`, or `update_housekeeping` call sites

## Notes
- The local working tree at `/Users/binhan/HotelManager` still has unrelated dirty files outside this PR: `mhm/src-tauri/src/agent/supervisor.rs`, `mhm/src-tauri/src/runtime_config.rs`, and `mhm/src/stores/useHotelStore.test.ts`. They were not included in this PR.
- PR branch was force-updated with lease earlier to remove stale history and align with current `origin/main`.