### PR TITLE
[codex] Fix backup concurrency CI test

### DIFF
--- a/mhm/src-tauri/src/backup/runner.rs
+++ b/mhm/src-tauri/src/backup/runner.rs
@@ -1,6 +1,6 @@
 use crate::backup::{
-    storage::{prune_old_backups, sqlite_string_literal, sync_directory, BackupReservation},
     BackupError, BackupOutcome, BackupReason,
+    storage::{BackupReservation, prune_old_backups, sqlite_string_literal, sync_directory},
 };
 use chrono::{NaiveDateTime, Utc};
 use std::{fs, path::Path, time::Duration};
@@ -72,9 +72,9 @@ mod tests {
     use super::*;
     use crate::backup::{
         build_backup_filename, is_managed_backup_file,
-        test_support::{backup_file_name, BackupFixture},
+        test_support::{BackupFixture, backup_file_name},
     };
-    use chrono::{Duration as ChronoDuration, NaiveDate};
+    use chrono::Duration as ChronoDuration;
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::fs;
 
@@ -129,10 +129,11 @@ mod tests {
         let fixture = BackupFixture::new().await;
         fixture.insert_demo_row("guest-001").await;
 
-        let timestamp = NaiveDate::from_ymd_opt(2026, 4, 18)
+        let timestamp = retention_timestamp_now();
+        let expected_stem = build_backup_filename(BackupReason::Manual, timestamp)
+            .strip_suffix(".db")
             .unwrap()
-            .and_hms_opt(23, 15, 0)
-            .unwrap();
+            .to_owned();
 
         let first = run_backup_once_at(
             &fixture.db_path,
@@ -171,8 +172,8 @@ mod tests {
             backup_file_name(&first.path),
             backup_file_name(&second.path)
         );
-        assert!(backup_file_name(&first.path).starts_with("capyinn_backup_manual_20260418_231500"));
-        assert!(backup_file_name(&second.path).starts_with("capyinn_backup_manual_20260418_231500"));
+        assert!(backup_file_name(&first.path).starts_with(&expected_stem));
+        assert!(backup_file_name(&second.path).starts_with(&expected_stem));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- keep the backup concurrency/collision test timestamp inside the active retention window
- compute the expected backup filename stem from the runtime timestamp instead of a stale fixed date

## Why
CI failed on main after #169 because the test used 2026-04-18; on 2026-05-19 that manual backup is older than the 30-day retention window, so pruning correctly removed the base file and kept only the collision-suffix safety-floor file.

## Validation
- cargo test --manifest-path mhm/src-tauri/Cargo.toml backup::runner::tests::run_backup_once_serializes_concurrent_backups -- --nocapture
- cargo test --manifest-path mhm/src-tauri/Cargo.toml
- cargo check (mhm/src-tauri)
- cargo clippy --all-targets -- -D warnings (mhm/src-tauri)
- rustfmt --edition 2024 --check mhm/src-tauri/src/backup/runner.rs