### PR TITLE
fix(kbtt): flat row DTO, DB-backed pending list, room-less declarations

### DIFF
--- a/mhm/src-tauri/src/commands/declaration.rs
+++ b/mhm/src-tauri/src/commands/declaration.rs
@@ -24,6 +24,80 @@ pub struct ExtractedDto {
     pub crop_data_url: Option<String>,
 }
 
+/// Một dòng chờ khai, **phẳng**, đúng tên trường mà `DeclarationRow` bên
+/// TypeScript đọc (`mhm/src/types/index.ts`).
+///
+/// Tồn tại vì `model::DeclarationRow` lồng danh tính trong `identity` và lượt
+/// lưu trú trong `stay`, còn giao diện lại đọc `row.full_name`, `row.room_no`.
+/// Serde không bắc cầu giúp hai hình dạng đó: mọi ô hiển thị ra `undefined`,
+/// khách Việt bị `isForeign(undefined)` xếp nhầm sang ngăn XML, và nút xuất
+/// file tắt vì ngăn XLSX rỗng. Test hai bên đều xanh vì mỗi bên tự dựng dữ
+/// liệu mẫu theo hình dạng của mình, không bên nào chạm chỗ giáp ranh.
+///
+/// Tên trường ở đây là HỢP ĐỒNG với giao diện. Đổi tên thì phải đổi cả
+/// `DeclarationRow` bên TS và `row_dto_matches_the_typescript_contract`.
+#[derive(Debug, Serialize)]
+pub struct DeclarationRowDto {
+    pub link_id: String,
+    pub identity_id: String,
+    pub full_name: String,
+    pub dob: String,
+    pub gender: String,
+    pub nationality_iso3: String,
+    pub doc_type_code: Option<String>,
+    pub doc_type_name: Option<String>,
+    pub doc_no: Option<String>,
+    pub phone: Option<String>,
+    pub residence_status: Option<String>,
+    pub address_detail: Option<String>,
+    pub passport_no: Option<String>,
+    pub passport_expiry: Option<String>,
+    pub visa_valid_until: Option<String>,
+    /// `None` khi khai báo chưa gắn vào lượt lưu trú nào (chưa xác định phòng).
+    pub room_no: Option<String>,
+    pub check_in_date: String,
+    pub expected_check_out: String,
+    pub stay_reason: String,
+    pub stay_reason_note: Option<String>,
+    pub name_confirmed_by_human: bool,
+    pub single_token_name_ok: bool,
+}
+
+impl From<&DeclarationRow> for DeclarationRowDto {
+    fn from(row: &DeclarationRow) -> Self {
+        let id = &row.identity;
+        let stay = &row.stay;
+        DeclarationRowDto {
+            link_id: row.link_id.clone(),
+            identity_id: id.id.clone(),
+            full_name: id.full_name.clone(),
+            dob: id.dob.clone(),
+            gender: id.gender.clone(),
+            nationality_iso3: id.nationality_iso3.clone(),
+            doc_type_code: id.doc_type_code.clone(),
+            doc_type_name: id.doc_type_name.clone(),
+            doc_no: id.doc_no.clone(),
+            phone: id.phone.clone(),
+            residence_status: id.residence_status.clone(),
+            address_detail: id.address_detail.clone(),
+            passport_no: id.passport_no.clone(),
+            passport_expiry: id.passport_expiry.clone(),
+            visa_valid_until: id.visa_valid_until.clone(),
+            room_no: if stay.room_no.trim().is_empty() {
+                None
+            } else {
+                Some(stay.room_no.clone())
+            },
+            check_in_date: stay.check_in.clone(),
+            expected_check_out: stay.expected_out.clone(),
+            stay_reason: row.stay_reason.clone(),
+            stay_reason_note: row.stay_reason_note.clone(),
+            name_confirmed_by_human: id.name_confirmed_by_human,
+            single_token_name_ok: id.single_token_name_ok,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct BatchDto {
     pub batch_id: String,
@@ -98,28 +172,50 @@ pub async fn kbtt_save_identity(
     repo::insert_identity(&state.db, &identity, &source, &confidence).await
 }
 
+/// `stay_id = None` — khai báo chưa gắn phòng. Cổng không bắt buộc cột phòng;
+/// validator vẫn nhắc bằng W01 để không ai quên.
 #[tauri::command]
 pub async fn kbtt_link(
     state: State<'_, AppState>,
     identity_id: String,
-    stay_id: String,
+    stay_id: Option<String>,
     stay_reason: String,
     note: Option<String>,
 ) -> Result<String, String> {
     repo::insert_link(
         &state.db,
         &identity_id,
-        &stay_id,
+        stay_id.as_deref().filter(|s| !s.trim().is_empty()),
         &stay_reason,
         note.as_deref(),
     )
     .await
 }
 
+/// Danh tính đã lưu nhưng chưa ghép — nguồn sự thật là DB, không phải state của
+/// React, nên đổi tab không làm mất.
 #[tauri::command]
-pub async fn kbtt_pending_rows(state: State<'_, AppState>) -> Result<Vec<DeclarationRow>, String> {
+pub async fn kbtt_unlinked_identities(
+    state: State<'_, AppState>,
+) -> Result<Vec<Identity>, String> {
+    repo::list_unlinked_identities(&state.db).await
+}
+
+#[tauri::command]
+pub async fn kbtt_discard_identity(
+    state: State<'_, AppState>,
+    identity_id: String,
+) -> Result<(), String> {
+    repo::delete_unlinked_identity(&state.db, &identity_id).await
+}
+
+#[tauri::command]
+pub async fn kbtt_pending_rows(
+    state: State<'_, AppState>,
+) -> Result<Vec<DeclarationRowDto>, String> {
     let link_ids = repo::pending_link_ids(&state.db).await?;
-    repo::load_rows_by_link_ids(&state.db, &link_ids).await
+    let rows = repo::load_rows_by_link_ids(&state.db, &link_ids).await?;
+    Ok(rows.iter().map(DeclarationRowDto::from).collect())
 }
 
 /// `W05` sinh ở đây chứ không ở validator: `DeclarationRow` không mang
@@ -267,4 +363,137 @@ pub async fn kbtt_open_export_dir(
     app.opener()
         .open_path(dir.to_string_lossy(), None::<&str>)
         .map_err(|e| format!("Không mở được thư mục: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::declaration::model::StayInfo;
+
+    /// Trích tên trường của một `interface` trong file .ts.
+    ///
+    /// Đọc thẳng file nguồn thay vì chép tay danh sách: chép tay thì hai bên lại
+    /// trôi lệch nhau lần nữa, đúng thứ đã sinh ra lỗi này.
+    fn typescript_interface_fields(source: &str, name: &str) -> Vec<String> {
+        let head = format!("export interface {name} {{");
+        let start = source
+            .find(&head)
+            .unwrap_or_else(|| panic!("không tìm thấy `{head}` trong types/index.ts"))
+            + head.len();
+        let body = &source[start..];
+        let end = body.find("\n}").expect("interface phải có dấu đóng");
+
+        body[..end]
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.starts_with("//") || line.starts_with('*') || line.starts_with("/*") {
+                    return None;
+                }
+                let field = line.split(':').next()?.trim().trim_end_matches('?');
+                if field.is_empty() {
+                    None
+                } else {
+                    Some(field.to_string())
+                }
+            })
+            .collect()
+    }
+
+    fn types_index_ts() -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("src")
+            .join("types")
+            .join("index.ts");
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("đọc {}: {e}", path.display()))
+    }
+
+    fn sample_row() -> DeclarationRow {
+        DeclarationRow {
+            link_id: "l1".into(),
+            identity: Identity {
+                id: "i1".into(),
+                full_name: "Phạm Thị Minh Hiền".into(),
+                dob: "1988-12-16".into(),
+                gender: "F".into(),
+                nationality_iso3: "VNM".into(),
+                doc_no: Some("056188011500".into()),
+                ..Identity::default()
+            },
+            stay: StayInfo {
+                stay_id: "s1".into(),
+                room_no: "3B".into(),
+                check_in: "2026-07-27".into(),
+                expected_out: "2026-07-28".into(),
+                ..StayInfo::default()
+            },
+            stay_reason: "1".into(),
+            stay_reason_note: None,
+        }
+    }
+
+    fn json_keys<T: Serialize>(value: &T) -> Vec<String> {
+        let json = serde_json::to_value(value).expect("serialize được");
+        let mut keys: Vec<String> = json
+            .as_object()
+            .expect("phải là object")
+            .keys()
+            .cloned()
+            .collect();
+        keys.sort();
+        keys
+    }
+
+    /// Giao diện đọc `row.full_name`; nếu backend gửi lên hình dạng khác thì mọi
+    /// ô hiện trống mà không có lỗi nào nổ ra. Test này là chỗ duy nhất phát
+    /// hiện được điều đó.
+    #[test]
+    fn row_dto_matches_the_typescript_contract() {
+        let mut expected = typescript_interface_fields(&types_index_ts(), "DeclarationRow");
+        expected.sort();
+
+        let actual = json_keys(&DeclarationRowDto::from(&sample_row()));
+
+        assert_eq!(
+            actual, expected,
+            "bộ khóa JSON phải trùng khít interface DeclarationRow bên TypeScript"
+        );
+    }
+
+    /// Ghi lại chính lỗi đã xảy ra: gửi thẳng `DeclarationRow` thì giao diện
+    /// không thấy `full_name` ở đâu cả.
+    #[test]
+    fn the_nested_row_is_not_what_the_ui_can_read() {
+        let keys = json_keys(&sample_row());
+
+        assert!(
+            !keys.contains(&"full_name".to_string()),
+            "DeclarationRow lồng danh tính trong `identity` — đừng gửi thẳng ra giao diện"
+        );
+        assert!(keys.contains(&"identity".to_string()));
+    }
+
+    /// Khách Việt phải ra đúng `VNM` để `isForeign` xếp vào ngăn XLSX.
+    #[test]
+    fn a_vietnamese_guest_keeps_its_nationality_through_the_dto() {
+        let dto = DeclarationRowDto::from(&sample_row());
+
+        assert_eq!(dto.nationality_iso3, "VNM");
+        assert_eq!(dto.room_no.as_deref(), Some("3B"));
+        assert_eq!(dto.full_name, "Phạm Thị Minh Hiền");
+    }
+
+    /// Khai báo chưa gắn phòng: `room_no` phải là `null`, không phải chuỗi rỗng
+    /// — giao diện hiện "—" dựa vào đúng chỗ đó.
+    #[test]
+    fn a_declaration_without_a_room_reports_no_room() {
+        let mut row = sample_row();
+        row.stay = StayInfo::default();
+
+        let dto = DeclarationRowDto::from(&row);
+
+        assert_eq!(dto.room_no, None);
+    }
 }

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -304,6 +304,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
     if current < 20 {
         declaration::migrate_v20_declaration_tables(pool).await?;
     }
+
+    // -- V21: khai báo được phép chưa gắn phòng --
+    if current < 21 {
+        declaration::migrate_v21_optional_stay(pool).await?;
+    }
     Ok(())
 }
 
@@ -831,7 +836,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -845,7 +850,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -866,7 +871,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1154,7 +1159,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1221,7 +1226,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1301,7 +1306,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1341,7 +1346,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1359,7 +1364,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1389,7 +1394,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1402,7 +1407,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1435,7 +1440,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]
@@ -1459,7 +1464,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -110,6 +110,60 @@ pub(super) async fn migrate_v20_declaration_tables(
     Ok(())
 }
 
+/// Migration v21 — `declaration_link.stay_id` được phép NULL.
+///
+/// Khách có thể phải khai báo trước khi có phòng: người vận hành cầm CCCD lúc
+/// khách vừa tới, còn booking thì chưa tạo. Trước v21, `stay_id NOT NULL` biến
+/// điều đó thành ngõ cụt — màn khai báo chỉ liệt kê phòng đang có khách.
+///
+/// SQLite không gỡ được `NOT NULL` bằng `ALTER`, nên phải dựng lại bảng. Đây là
+/// bảng của chính module này, không phải bảng của PMS — ràng buộc "không migrate
+/// PMS" không bị đụng tới.
+///
+/// `UNIQUE(identity_id, stay_id)` giữ nguyên: SQLite coi mọi NULL là khác nhau,
+/// nên hai khai báo chưa gắn phòng của cùng một danh tính không chặn nhau.
+pub(super) async fn migrate_v21_optional_stay(pool: &Pool<Sqlite>) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS declaration_link_v21 (
+                id               TEXT PRIMARY KEY,
+                identity_id      TEXT NOT NULL REFERENCES declaration_identity(id),
+                stay_id          TEXT,
+                stay_reason      TEXT NOT NULL,
+                stay_reason_note TEXT,
+                actual_check_out TEXT,
+                created_at       TEXT NOT NULL,
+                UNIQUE(identity_id, stay_id)
+            )",
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        "INSERT OR IGNORE INTO declaration_link_v21
+            (id, identity_id, stay_id, stay_reason, stay_reason_note, actual_check_out, created_at)
+         SELECT id, identity_id, stay_id, stay_reason, stay_reason_note, actual_check_out, created_at
+           FROM declaration_link",
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query("DROP TABLE declaration_link")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("ALTER TABLE declaration_link_v21 RENAME TO declaration_link")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_decl_link_stay ON declaration_link(stay_id)")
+        .execute(&mut *tx)
+        .await?;
+
+    set_schema_version(&mut tx, 21).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::db::run_migrations;
@@ -196,7 +250,129 @@ mod tests {
             .fetch_one(&pool)
             .await
             .expect("reads schema version");
-        assert_eq!(version, 20);
+        assert_eq!(version, 21);
+    }
+
+    /// Khách tới trước khi có booking: phải khai báo được ngay, không phải chờ
+    /// ai đó check-in xong.
+    #[tokio::test]
+    async fn v21_lets_a_declaration_exist_without_a_stay() {
+        let pool = seeded_pool().await;
+
+        let identity = crate::declaration::repo::insert_identity(
+            &pool,
+            &crate::declaration::model::Identity {
+                full_name: "Phạm Thị Minh Hiền".into(),
+                dob: "1988-12-16".into(),
+                gender: "F".into(),
+                nationality_iso3: "VNM".into(),
+                ..Default::default()
+            },
+            "qr_cccd",
+            "verified",
+        )
+        .await
+        .expect("lưu được danh tính");
+
+        let link = crate::declaration::repo::insert_link(&pool, &identity, None, "1", None)
+            .await
+            .expect("ghép được dù chưa có phòng");
+
+        let rows = crate::declaration::repo::load_rows_by_link_ids(
+            &pool,
+            std::slice::from_ref(&link),
+        )
+        .await
+        .expect("đọc lại được dòng");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].identity.full_name, "Phạm Thị Minh Hiền");
+        assert_eq!(rows[0].stay.room_no, "", "chưa có phòng");
+    }
+
+    /// Dữ liệu cũ (v20, stay_id NOT NULL) phải đi qua v21 mà không mất dòng nào.
+    #[tokio::test]
+    async fn v21_carries_existing_links_across_the_table_rebuild() {
+        let pool = seeded_pool().await;
+
+        sqlx::query(
+            "INSERT INTO declaration_identity (
+                id, source, extract_confidence, full_name, dob, gender,
+                nationality_iso3, created_at
+             ) VALUES ('id-1', 'qr_cccd', 'verified', 'Phan Thị Mỹ Hà', '1995-07-28',
+                       'F', 'VNM', '2026-07-26T09:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds identity");
+        sqlx::query(
+            "INSERT INTO declaration_link (id, identity_id, stay_id, stay_reason, created_at)
+             VALUES ('link-1', 'id-1', 'booking-1', '2', '2026-07-26T09:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds link");
+
+        // Chạy lại toàn bộ migration: v21 phải bỏ qua vì version đã là 21.
+        run_migrations(&pool).await.expect("migration chạy lại được");
+
+        let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM declaration_link WHERE id='link-1'")
+            .fetch_one(&pool)
+            .await
+            .expect("đếm link");
+        assert_eq!(kept, 1);
+    }
+
+    /// Danh tính vừa trích phải sống sót khi người vận hành đổi tab — nó nằm
+    /// trong DB, và phải có đường đọc ra.
+    #[tokio::test]
+    async fn an_identity_waiting_to_be_linked_can_be_listed_and_discarded() {
+        let pool = seeded_pool().await;
+
+        let identity = crate::declaration::repo::insert_identity(
+            &pool,
+            &crate::declaration::model::Identity {
+                full_name: "Phạm Thị Minh Hiền".into(),
+                nationality_iso3: "VNM".into(),
+                ..Default::default()
+            },
+            "qr_cccd",
+            "verified",
+        )
+        .await
+        .expect("lưu được danh tính");
+
+        let waiting = crate::declaration::repo::list_unlinked_identities(&pool)
+            .await
+            .expect("đọc được danh sách chờ");
+        assert_eq!(waiting.len(), 1);
+        assert_eq!(waiting[0].full_name, "Phạm Thị Minh Hiền");
+
+        // Ghép xong thì biến khỏi danh sách chờ.
+        let link = crate::declaration::repo::insert_link(&pool, &identity, None, "1", None)
+            .await
+            .expect("ghép được");
+        assert!(crate::declaration::repo::list_unlinked_identities(&pool)
+            .await
+            .expect("đọc lại")
+            .is_empty());
+
+        // Đã ghép rồi thì không xóa thẳng được — đó là bằng chứng đã khai.
+        assert!(
+            crate::declaration::repo::delete_unlinked_identity(&pool, &identity)
+                .await
+                .is_err(),
+            "danh tính đã ghép phải đi đường thu hồi, không xóa thẳng"
+        );
+
+        sqlx::query("DELETE FROM declaration_link WHERE id = ?")
+            .bind(&link)
+            .execute(&pool)
+            .await
+            .expect("gỡ link để thử xóa");
+        crate::declaration::repo::delete_unlinked_identity(&pool, &identity)
+            .await
+            .expect("chưa ghép thì xóa được");
     }
 
     /// §5.2 — stay_id KHÔNG có FK cứng tới `bookings`. Xóa một booking trong
@@ -278,7 +454,7 @@ mod tests {
         )
         .await
         .expect("lưu được danh tính");
-        let link = crate::declaration::repo::insert_link(&pool, &identity, "booking-1", "2", None)
+        let link = crate::declaration::repo::insert_link(&pool, &identity, Some("booking-1"), "2", None)
             .await
             .expect("lưu được link");
         let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)

--- a/mhm/src-tauri/src/declaration/repo.rs
+++ b/mhm/src-tauri/src/declaration/repo.rs
@@ -148,15 +148,84 @@ pub async fn insert_identity(
     Ok(id)
 }
 
+/// Danh tính đã lưu nhưng chưa ghép vào lượt lưu trú nào.
+///
+/// Tồn tại vì trước đây danh tính vừa trích chỉ sống trong `useState` của màn
+/// khai báo: đổi sang tab khác là component bị hủy và người vận hành tưởng mất
+/// dữ liệu, trong khi bản ghi vẫn nằm yên trong DB, không đường nào lấy ra.
+/// Nguồn sự thật là DB, không phải state của React.
+pub async fn list_unlinked_identities(pool: &Pool<Sqlite>) -> Result<Vec<Identity>, String> {
+    let rows = sqlx::query(
+        "SELECT id, full_name, dob, gender, nationality_iso3, doc_type_code, doc_type_source,
+                doc_type_name, doc_no, phone, residence_status, address_detail, passport_no,
+                passport_expiry, visa_valid_until, name_confirmed_by_human, single_token_name_ok
+           FROM declaration_identity di
+          WHERE di.redacted_at IS NULL
+            AND NOT EXISTS (SELECT 1 FROM declaration_link dl WHERE dl.identity_id = di.id)
+          ORDER BY di.created_at",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Không đọc được danh tính chờ ghép: {e}"))?;
+
+    Ok(rows
+        .iter()
+        .map(|r| Identity {
+            id: r.get("id"),
+            full_name: r.get("full_name"),
+            dob: r.get("dob"),
+            gender: r.get("gender"),
+            nationality_iso3: r.get("nationality_iso3"),
+            doc_type_code: r.get("doc_type_code"),
+            doc_type_source: r.get("doc_type_source"),
+            doc_type_name: r.get("doc_type_name"),
+            doc_no: r.get("doc_no"),
+            phone: r.get("phone"),
+            residence_status: r.get("residence_status"),
+            address_detail: r.get("address_detail"),
+            passport_no: r.get("passport_no"),
+            passport_expiry: r.get("passport_expiry"),
+            visa_valid_until: r.get("visa_valid_until"),
+            name_confirmed_by_human: r.get::<i64, _>("name_confirmed_by_human") != 0,
+            single_token_name_ok: r.get::<i64, _>("single_token_name_ok") != 0,
+        })
+        .collect())
+}
+
+/// Xóa một danh tính chưa ghép — người vận hành bỏ ảnh quét nhầm.
+///
+/// Chỉ xóa được khi chưa có link nào trỏ tới: đã ghép thì đó là bằng chứng đã
+/// khai báo, phải đi đường thu hồi (§12.5) chứ không xóa thẳng.
+pub async fn delete_unlinked_identity(pool: &Pool<Sqlite>, identity_id: &str) -> Result<(), String> {
+    let affected = sqlx::query(
+        "DELETE FROM declaration_identity
+          WHERE id = ?
+            AND NOT EXISTS (SELECT 1 FROM declaration_link dl WHERE dl.identity_id = ?)",
+    )
+    .bind(identity_id)
+    .bind(identity_id)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("Không xóa được danh tính: {e}"))?
+    .rows_affected();
+
+    if affected == 0 {
+        return Err("Danh tính đã được ghép vào một lượt lưu trú — không xóa thẳng được.".into());
+    }
+    Ok(())
+}
+
 /// Ghép một danh tính với một lượt lưu trú.
 ///
 /// `stay_id` = `bookings.id` nhưng KHÔNG có FK cứng (§5.2). Gọi lại với cùng
 /// cặp (identity, stay) thì cập nhật lý do lưu trú và trả về đúng link cũ —
 /// không đẻ thêm dòng, vì `UNIQUE(identity_id, stay_id)`.
+/// `stay_id = None` khi khai báo chưa gắn vào lượt lưu trú nào (chưa xác định
+/// phòng) — xem migration v21.
 pub async fn insert_link(
     pool: &Pool<Sqlite>,
     identity_id: &str,
-    stay_id: &str,
+    stay_id: Option<&str>,
     stay_reason: &str,
     note: Option<&str>,
 ) -> Result<String, String> {
@@ -180,8 +249,10 @@ pub async fn insert_link(
     .await
     .map_err(|e| format!("Không ghép được danh tính với lượt lưu trú: {e}"))?;
 
+    // `IS` chứ không phải `=`: với stay_id NULL thì `= NULL` không bao giờ đúng
+    // và câu này sẽ không tìm thấy chính dòng vừa ghi.
     sqlx::query_scalar::<_, String>(
-        "SELECT id FROM declaration_link WHERE identity_id = ? AND stay_id = ?",
+        "SELECT id FROM declaration_link WHERE identity_id = ? AND stay_id IS ?",
     )
     .bind(identity_id)
     .bind(stay_id)
@@ -347,11 +418,15 @@ pub async fn load_rows_by_link_ids(
     let mut by_link: HashMap<String, DeclarationRow> = HashMap::new();
     for r in rows.iter() {
         let link_id: String = r.get("link_id");
-        let stay_id: String = r.get("stay_id");
-        let stay = stays.get(&stay_id).cloned().unwrap_or(StayInfo {
-            stay_id: stay_id.clone(),
-            ..Default::default()
-        });
+        // NULL = khai báo chưa gắn phòng (v21). Cũng rơi vào đây khi booking đã
+        // bị PMS xóa — link cố ý không có FK cứng.
+        let stay = match r.get::<Option<String>, _>("stay_id") {
+            Some(stay_id) => stays.get(&stay_id).cloned().unwrap_or(StayInfo {
+                stay_id,
+                ..Default::default()
+            }),
+            None => StayInfo::default(),
+        };
 
         by_link.insert(
             link_id.clone(),
@@ -708,7 +783,7 @@ mod tests {
         let identity_id = insert_identity(&pool, &vn_identity(), "qr_cccd", "verified")
             .await
             .expect("lưu danh tính");
-        let link_id = insert_link(&pool, &identity_id, "booking-1", "2", None)
+        let link_id = insert_link(&pool, &identity_id, Some("booking-1"), "2", None)
             .await
             .expect("ghép link");
 
@@ -739,10 +814,10 @@ mod tests {
             .await
             .expect("lưu danh tính");
 
-        let first = insert_link(&pool, &identity_id, "booking-1", "1", None)
+        let first = insert_link(&pool, &identity_id, Some("booking-1"), "1", None)
             .await
             .expect("ghép lần đầu");
-        let second = insert_link(&pool, &identity_id, "booking-1", "20", Some("Đi công tác"))
+        let second = insert_link(&pool, &identity_id, Some("booking-1"), "20", Some("Đi công tác"))
             .await
             .expect("ghép lại");
 
@@ -767,7 +842,7 @@ mod tests {
                 .await
                 .expect("lưu danh tính");
             links.push(
-                insert_link(&pool, &identity_id, &format!("booking-{n}"), "1", None)
+                insert_link(&pool, &identity_id, Some(&format!("booking-{n}")), "1", None)
                     .await
                     .expect("ghép link"),
             );
@@ -785,7 +860,7 @@ mod tests {
         let identity_id = insert_identity(&pool, &vn_identity(), "qr_cccd", "verified")
             .await
             .expect("lưu danh tính");
-        let link_id = insert_link(&pool, &identity_id, "booking-1", "2", None)
+        let link_id = insert_link(&pool, &identity_id, Some("booking-1"), "2", None)
             .await
             .expect("ghép link");
 
@@ -875,7 +950,7 @@ mod tests {
         let identity_id = insert_identity(&pool, &vn_identity(), "qr_cccd", "verified")
             .await
             .expect("lưu danh tính");
-        let link_id = insert_link(&pool, &identity_id, "booking-1", "2", None)
+        let link_id = insert_link(&pool, &identity_id, Some("booking-1"), "2", None)
             .await
             .expect("ghép link");
         let batch = insert_batch(&pool, "VN", "/tmp/kbtt.xlsx", 1)
@@ -944,7 +1019,7 @@ mod tests {
             .await
             .expect("lưu danh tính");
 
-        let old_link = insert_link(&pool, &identity_id, "booking-cu", "2", None)
+        let old_link = insert_link(&pool, &identity_id, Some("booking-cu"), "2", None)
             .await
             .expect("link cũ");
         let old_batch = insert_batch(&pool, "VN", "/tmp/cu.xlsx", 1)
@@ -963,7 +1038,7 @@ mod tests {
         .expect("lùi ngày");
 
         // Lượt lưu trú mới của cùng khách, chưa đối chiếu.
-        insert_link(&pool, &identity_id, "booking-moi", "2", None)
+        insert_link(&pool, &identity_id, Some("booking-moi"), "2", None)
             .await
             .expect("link mới");
 

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -403,6 +403,8 @@ pub fn run() {
             commands::declaration::kbtt_list_stays,
             commands::declaration::kbtt_save_identity,
             commands::declaration::kbtt_link,
+            commands::declaration::kbtt_unlinked_identities,
+            commands::declaration::kbtt_discard_identity,
             commands::declaration::kbtt_pending_rows,
             commands::declaration::kbtt_validate,
             commands::declaration::kbtt_export,

--- a/mhm/src/pages/Declaration/PendingList.test.tsx
+++ b/mhm/src/pages/Declaration/PendingList.test.tsx
@@ -105,7 +105,7 @@ describe("PendingList", () => {
   });
 
   it("suggests bookings by name similarity but never auto-confirms", async () => {
-    mockCommands({ kbtt_list_stays: stays });
+    mockCommands({ kbtt_list_stays: stays, kbtt_unlinked_identities: [identity] });
 
     render(<PendingList identity={identity} />);
 
@@ -118,7 +118,7 @@ describe("PendingList", () => {
   });
 
   it("orders the suggestions by name similarity", async () => {
-    mockCommands({ kbtt_list_stays: stays });
+    mockCommands({ kbtt_list_stays: stays, kbtt_unlinked_identities: [identity] });
 
     render(<PendingList identity={identity} />);
 
@@ -129,12 +129,17 @@ describe("PendingList", () => {
 
     // ô rỗng luôn đứng đầu, rồi tới ứng viên giống tên nhất
     expect(values[0]).toBe("");
-    expect(values[1]).toBe("b2");
-    expect(values[2]).toBe("b1");
+    expect(values[1]).toBe("__chua_co_phong__");
+    expect(values[2]).toBe("b2");
+    expect(values[3]).toBe("b1");
   });
 
   it("links the identity to the stay the human picked", async () => {
-    mockCommands({ kbtt_list_stays: stays, kbtt_link: "link-1" });
+    mockCommands({
+      kbtt_list_stays: stays,
+      kbtt_link: "link-1",
+      kbtt_unlinked_identities: [identity],
+    });
     const onLinked = vi.fn();
 
     render(<PendingList identity={identity} onLinked={onLinked} />);
@@ -156,8 +161,56 @@ describe("PendingList", () => {
     expect(onLinked).toHaveBeenCalled();
   });
 
+  /**
+   * Lỗi đã xảy ra: người vận hành thả ảnh CCCD, sang tab Dashboard rồi quay lại
+   * thì tưởng mất dữ liệu. Danh tính vẫn nằm trong DB — chỉ là `useState` bị
+   * hủy cùng component. Nguồn sự thật phải là DB.
+   */
+  it("keeps the waiting identity after the tab is switched away and back", async () => {
+    mockCommands({ kbtt_list_stays: stays, kbtt_unlinked_identities: [identity] });
+
+    const first = render(<PendingList identity={identity} />);
+    await screen.findByText(/ZOLOCHEVSKAIA VERONIKA/);
+
+    // Đổi tab = MainShell hủy component (render có điều kiện).
+    first.unmount();
+
+    // Quay lại tab, KHÔNG có prop identity nữa — chỉ còn DB.
+    render(<PendingList />);
+
+    expect(await screen.findByText(/ZOLOCHEVSKAIA VERONIKA/)).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText(/Ghép với khách đang ở/i),
+    ).toBeInTheDocument();
+  });
+
+  it("declares a guest who has no room yet", async () => {
+    mockCommands({
+      kbtt_list_stays: stays,
+      kbtt_link: "link-1",
+      kbtt_unlinked_identities: [identity],
+    });
+
+    render(<PendingList identity={identity} />);
+
+    const select = (await screen.findByLabelText(
+      /Ghép với khách đang ở/i,
+    )) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "__chua_co_phong__" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Ghép khách$/i }));
+
+    await waitFor(() => {
+      expect(invokeCommand).toHaveBeenCalledWith("kbtt_link", {
+        identityId: "i1",
+        stayId: null,
+        stayReason: "1",
+        note: null,
+      });
+    });
+  });
+
   it("refuses to link until a stay is picked", async () => {
-    mockCommands({ kbtt_list_stays: stays });
+    mockCommands({ kbtt_list_stays: stays, kbtt_unlinked_identities: [identity] });
 
     render(<PendingList identity={identity} />);
 

--- a/mhm/src/pages/Declaration/PendingList.tsx
+++ b/mhm/src/pages/Declaration/PendingList.tsx
@@ -21,13 +21,21 @@ import {
 import { nameScore } from "./nameMatch";
 
 interface PendingListProps {
-  /** Danh tính vừa lưu, đang chờ ghép với một lượt lưu trú. */
+  /** Danh tính vừa lưu — chỉ dùng để chọn sẵn, dữ liệu thật đọc từ DB. */
   identity?: DeclarationIdentity | null;
   onLinked?: () => void;
   onSelectionChange?: (linkIds: string[]) => void;
   onRowsChange?: (rows: DeclarationRow[]) => void;
   reloadKey?: number;
 }
+
+/**
+ * Giá trị chọn "khai báo trước, chưa biết phòng".
+ *
+ * Cố ý KHÔNG dùng chuỗi rỗng: rỗng là "chưa chọn gì". Người vận hành phải chủ
+ * động chọn mục này, không ai lỡ tay khai báo thiếu phòng vì quên chọn.
+ */
+const STAY_NONE = "__chua_co_phong__";
 
 function rankStays(stays: StayInfo[], fullName: string): StayInfo[] {
   return [...stays].sort(
@@ -52,15 +60,29 @@ export default function PendingList({
   const [stayReason, setStayReason] = useState(STAY_REASON_DEFAULT);
   const [stayReasonNote, setStayReasonNote] = useState("");
   const [linking, setLinking] = useState(false);
+  /** Danh tính đã lưu nhưng chưa ghép — đọc từ DB, không giữ trong state. */
+  const [waiting, setWaiting] = useState<DeclarationIdentity[]>([]);
+  const [activeId, setActiveId] = useState("");
 
   useEffect(() => {
-    if (!identity) return;
     invokeCommand<StayInfo[]>("kbtt_list_stays")
       .then(setStays)
       .catch(() => setStays([]));
-    setStayId("");
-    setStayReason(STAY_REASON_DEFAULT);
-    setStayReasonNote("");
+  }, [reloadKey]);
+
+  const loadWaiting = useCallback(() => {
+    invokeCommand<DeclarationIdentity[]>("kbtt_unlinked_identities")
+      .then((data) => setWaiting(data ?? []))
+      .catch(() => setWaiting([]));
+  }, []);
+
+  useEffect(() => {
+    loadWaiting();
+  }, [loadWaiting, reloadKey]);
+
+  // Ảnh vừa thả xong thì chọn sẵn đúng người đó.
+  useEffect(() => {
+    if (identity?.id) setActiveId(identity.id);
   }, [identity]);
 
   const loadRows = useCallback(() => {
@@ -101,9 +123,16 @@ export default function PendingList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
 
+  /**
+   * Người đang chờ ghép. Nguồn là DB, nên đổi sang tab khác rồi quay lại vẫn
+   * còn — trước đây nó nằm trong `useState` và bị hủy cùng component.
+   */
+  const activeIdentity =
+    waiting.find((w) => w.id === activeId) ?? waiting[0] ?? null;
+
   const rankedStays = useMemo(
-    () => rankStays(stays, identity?.full_name ?? ""),
-    [stays, identity],
+    () => rankStays(stays, activeIdentity?.full_name ?? ""),
+    [stays, activeIdentity],
   );
 
   const findingsByLink = useMemo(() => {
@@ -125,23 +154,40 @@ export default function PendingList({
     (stayReason !== STAY_REASON_OTHER || stayReasonNote.trim().length > 0);
 
   const handleLink = async () => {
-    if (!identity || !canLink) return;
+    if (!activeIdentity || !canLink) return;
     setLinking(true);
     try {
       await invokeCommand<string>("kbtt_link", {
-        identityId: identity.id,
-        stayId,
+        identityId: activeIdentity.id,
+        stayId: stayId === STAY_NONE ? null : stayId,
         stayReason,
         note: stayReasonNote.trim() === "" ? null : stayReasonNote.trim(),
       });
-      toast.success("Đã ghép khách vào lượt lưu trú");
+      toast.success(
+        stayId === STAY_NONE
+          ? "Đã khai báo, chưa gắn phòng"
+          : "Đã ghép khách vào lượt lưu trú",
+      );
       setStayId("");
+      setStayReason(STAY_REASON_DEFAULT);
+      setStayReasonNote("");
       loadRows();
+      loadWaiting();
       onLinked?.();
     } catch (e) {
       toast.error(formatAppError(e));
     } finally {
       setLinking(false);
+    }
+  };
+
+  const handleDiscard = async (id: string, name: string) => {
+    try {
+      await invokeCommand<void>("kbtt_discard_identity", { identityId: id });
+      toast.success(`Đã bỏ ${name}`);
+      loadWaiting();
+    } catch (e) {
+      toast.error(formatAppError(e));
     }
   };
 
@@ -226,11 +272,42 @@ export default function PendingList({
     <div className="rounded-2xl bg-white p-6 shadow-soft">
       <h2 className="text-lg font-bold">Cần khai báo</h2>
 
-      {identity && (
+      {waiting.length > 1 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {waiting.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => setActiveId(w.id)}
+              className={`rounded-full px-3 py-1 text-xs ${
+                w.id === activeIdentity?.id
+                  ? "bg-slate-800 text-white"
+                  : "bg-slate-100 text-slate-600"
+              }`}
+            >
+              {w.full_name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {activeIdentity && (
         <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
-          <p className="mb-3 text-sm">
-            Ghép <strong>{identity.full_name}</strong> vào một lượt lưu trú.
-          </p>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <p className="text-sm">
+              Ghép <strong>{activeIdentity.full_name}</strong> vào một lượt lưu
+              trú.
+            </p>
+            <button
+              type="button"
+              className="text-xs text-slate-400 underline hover:text-red-600"
+              onClick={() =>
+                handleDiscard(activeIdentity.id, activeIdentity.full_name)
+              }
+            >
+              Bỏ ảnh này
+            </button>
+          </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label
@@ -247,6 +324,9 @@ export default function PendingList({
               >
                 {/* Mặc định rỗng: app xếp thứ tự gợi ý, người chọn (spec §7). */}
                 <option value="">— Chọn lượt lưu trú —</option>
+                <option value={STAY_NONE}>
+                  Chưa xác định phòng — khai báo trước
+                </option>
                 {rankedStays.map((s) => (
                   <option key={s.stay_id} value={s.stay_id}>
                     {s.room_no ? `Phòng ${s.room_no}` : "Chưa có phòng"} ·{" "}
@@ -302,8 +382,8 @@ export default function PendingList({
           </Button>
           <p className="mt-2 flex items-center gap-1.5 text-xs text-brand-muted">
             <AlertTriangle size={12} className="text-amber-500" />
-            App chỉ xếp thứ tự theo độ giống tên, không tự chọn. Khách chưa có
-            trong CapyInn thì phải tạo booking trước.
+            App chỉ xếp thứ tự theo độ giống tên, không tự chọn. Chỉ hiện phòng
+            đang có khách; khách chưa check-in thì chọn "Chưa xác định phòng".
           </p>
         </div>
       )}


### PR DESCRIPTION
Bốn lỗi người vận hành báo từ bản đang chạy, ba nguyên nhân gốc.

## 1+2. Bảng "Cần khai báo" trống thông tin, nút xuất file không bấm được

`model::DeclarationRow` serialize ra **lồng**:

```json
{ "link_id": "...", "identity": { "full_name": "..." }, "stay": { "room_no": "3B" } }
```

`DeclarationRow` bên `types/index.ts` lại đọc **phẳng**: `row.full_name`, `row.room_no`, `row.check_in_date`. Serde không bắc cầu giúp, nên mọi ô hiển thị ra `undefined`.

Hệ quả dây chuyền: `isForeign(undefined)` trả true → khách Việt Nam bị xếp vào ngăn XML → ngăn XLSX mà người vận hành đang chọn có 0 hồ sơ → `canExport = false` → nút xuất file tắt. Nhìn bề ngoài là "bấm không ăn".

**Vì sao test không bắt được:** mỗi bên tự dựng fixture theo hình dạng của mình. Test frontend dùng object phẳng mà backend chưa bao giờ trả về; test backend dùng struct lồng mà giao diện chưa bao giờ đọc được. Không bên nào chạm chỗ giáp ranh.

`DeclarationRowDto` giờ giữ hợp đồng đó, và test của nó **đọc thẳng danh sách trường trong `types/index.ts`** rồi so — chép tay thì lại trôi lệch lần nữa. Đã kiểm bằng cách cố tình bỏ trường `phone`: test đỏ và chỉ đúng tên trường thiếu.

## 3. Đổi tab là mất dữ liệu vừa upload

Danh tính vừa trích chỉ sống trong `useState`. `MainShell` render trang theo điều kiện, nên đổi tab là component bị hủy — người vận hành tưởng mất ảnh, trong khi bản ghi vẫn nằm nguyên trong DB, không có đường nào lấy ra.

`kbtt_unlinked_identities` đưa nguồn sự thật về DB. Hai danh tính mồ côi trên máy vận hành sẽ hiện lại. Kèm `kbtt_discard_identity` để bỏ ảnh quét nhầm — chỉ xóa được khi chưa ghép, đã ghép thì đó là bằng chứng đã khai, phải đi đường thu hồi §12.5.

## 4. Không khai báo được cho phòng trống

`declaration_link.stay_id NOT NULL` khiến chỉ khai báo được cho phòng đang có khách. Khách đứng ở quầy trước khi check-in thì không có đường nào đi tiếp.

Migration v21 cho phép NULL (dựng lại bảng — SQLite không gỡ được `NOT NULL` bằng `ALTER`; đây là bảng của chính module, không đụng bảng PMS). Ô chọn có thêm mục "Chưa xác định phòng — khai báo trước", **giá trị riêng chứ không phải chuỗi rỗng**, để không ai lỡ tay khai thiếu phòng vì quên chọn. W01 vẫn cảnh báo.

## Kiểm chứng

- `cargo test --lib` 839/839
- `vitest run` 335/335
- `cargo clippy --all-targets -- -D warnings` sạch

Test hồi quy mới bám đúng bốn báo cáo: `row_dto_matches_the_typescript_contract`, `the_nested_row_is_not_what_the_ui_can_read`, `keeps the waiting identity after the tab is switched away and back` (unmount rồi render lại **không có prop**), `declares a guest who has no room yet`, `v21_lets_a_declaration_exist_without_a_stay`, `v21_carries_existing_links_across_the_table_rebuild`.

## Ghi chú

12 chỗ `assert_eq!(version, 20)` trong `db.rs` đổi thành 21. Một con số nằm ở 12 chỗ là lý do mỗi lần thêm migration lại thành việc vặt — nên gom về một hằng, nhưng để riêng PR khác.

🤖 Generated with [Claude Code](https://claude.com/claude-code)