### PR TITLE
fix(kbtt): merge repeat scans of one card, allow removing a declaration

### DIFF
--- a/mhm/src-tauri/src/commands/declaration.rs
+++ b/mhm/src-tauri/src/commands/declaration.rs
@@ -209,6 +209,13 @@ pub async fn kbtt_discard_identity(
     repo::delete_unlinked_identity(&state.db, &identity_id).await
 }
 
+/// Gỡ một khai báo đã ghép — ghép nhầm phòng, hoặc ghép trùng. Từ chối nếu nó
+/// đã nằm trong lô đã đối soát.
+#[tauri::command]
+pub async fn kbtt_unlink(state: State<'_, AppState>, link_id: String) -> Result<(), String> {
+    repo::delete_link(&state.db, &link_id).await
+}
+
 #[tauri::command]
 pub async fn kbtt_pending_rows(
     state: State<'_, AppState>,

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -223,6 +223,189 @@ mod tests {
         pool
     }
 
+    /// Đúng tình huống đã kẹt trên máy vận hành: thả cùng một tấm CCCD nhiều
+    /// lần rồi ghép cả hai → hai khai báo cùng số giấy tờ cùng ngày đến → E14
+    /// chặn xuất file, và không có đường nào đi tiếp.
+    #[tokio::test]
+    async fn dropping_the_same_card_twice_reuses_the_identity() {
+        let pool = seeded_pool().await;
+
+        let card = crate::declaration::model::Identity {
+            full_name: "Phạm Thị Minh Hiền".into(),
+            dob: "1988-12-16".into(),
+            gender: "F".into(),
+            nationality_iso3: "VNM".into(),
+            doc_no: Some("056188011500".into()),
+            ..Default::default()
+        };
+
+        let first = crate::declaration::repo::insert_identity(&pool, &card, "qr_cccd", "verified")
+            .await
+            .expect("lần thả thứ nhất");
+        let second = crate::declaration::repo::insert_identity(&pool, &card, "qr_cccd", "verified")
+            .await
+            .expect("lần thả thứ hai");
+
+        assert_eq!(first, second, "cùng số giấy tờ phải là cùng một danh tính");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM declaration_identity")
+            .fetch_one(&pool)
+            .await
+            .expect("đếm danh tính");
+        assert_eq!(count, 1, "không được đẻ thêm dòng");
+    }
+
+    /// Không có số giấy tờ thì không có gì để nhận ra người trùng — nhập tay
+    /// thiếu số vẫn phải lưu được, mỗi lần một dòng.
+    #[tokio::test]
+    async fn an_identity_without_a_document_number_is_never_merged() {
+        let pool = seeded_pool().await;
+
+        let no_doc = crate::declaration::model::Identity {
+            full_name: "Khách nhập tay".into(),
+            dob: "1990-01-01".into(),
+            nationality_iso3: "VNM".into(),
+            ..Default::default()
+        };
+
+        let a = crate::declaration::repo::insert_identity(&pool, &no_doc, "manual", "needs_review")
+            .await
+            .expect("lưu lần 1");
+        let b = crate::declaration::repo::insert_identity(&pool, &no_doc, "manual", "needs_review")
+            .await
+            .expect("lưu lần 2");
+
+        assert_ne!(a, b);
+    }
+
+    /// Đã nộp cho công an rồi thì bản ghi là bằng chứng của cái đã nộp — lần
+    /// thả sau không được sửa nó sau lưng.
+    #[tokio::test]
+    async fn a_declared_identity_is_not_rewritten_by_a_later_scan() {
+        let pool = seeded_pool().await;
+
+        let card = crate::declaration::model::Identity {
+            full_name: "Phạm Thị Minh Hiền".into(),
+            dob: "1988-12-16".into(),
+            gender: "F".into(),
+            nationality_iso3: "VNM".into(),
+            doc_no: Some("056188011500".into()),
+            ..Default::default()
+        };
+        let id = crate::declaration::repo::insert_identity(&pool, &card, "qr_cccd", "verified")
+            .await
+            .expect("lưu danh tính");
+        let link =
+            crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
+                .await
+                .expect("ghép");
+        let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
+            .await
+            .expect("lô");
+        crate::declaration::repo::insert_entries(&pool, &batch, std::slice::from_ref(&link))
+            .await
+            .expect("dòng của lô");
+        crate::declaration::repo::set_batch_verified(&pool, &batch, 1)
+            .await
+            .expect("đối soát xong");
+
+        let mut misread = card.clone();
+        misread.full_name = "TÊN ĐỌC SAI".into();
+        let again = crate::declaration::repo::insert_identity(&pool, &misread, "qr_cccd", "verified")
+            .await
+            .expect("thả lại");
+
+        assert_eq!(again, id, "vẫn là cùng một người");
+        let name: String =
+            sqlx::query_scalar("SELECT full_name FROM declaration_identity WHERE id = ?")
+                .bind(&id)
+                .fetch_one(&pool)
+                .await
+                .expect("đọc tên");
+        assert_eq!(name, "Phạm Thị Minh Hiền", "tên đã khai không được ghi đè");
+    }
+
+    /// Ghép nhầm thì phải gỡ được — nếu không, một dòng thừa chặn cả lô.
+    #[tokio::test]
+    async fn a_declaration_can_be_unlinked_until_it_has_been_reconciled() {
+        let pool = seeded_pool().await;
+
+        let id = crate::declaration::repo::insert_identity(
+            &pool,
+            &crate::declaration::model::Identity {
+                full_name: "Phạm Thị Minh Hiền".into(),
+                nationality_iso3: "VNM".into(),
+                doc_no: Some("056188011500".into()),
+                ..Default::default()
+            },
+            "qr_cccd",
+            "verified",
+        )
+        .await
+        .expect("danh tính");
+        let link =
+            crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
+                .await
+                .expect("ghép");
+
+        // Đã xuất file nhưng chưa đối soát: vẫn gỡ được.
+        let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
+            .await
+            .expect("lô");
+        crate::declaration::repo::insert_entries(&pool, &batch, std::slice::from_ref(&link))
+            .await
+            .expect("dòng của lô");
+        crate::declaration::repo::delete_link(&pool, &link)
+            .await
+            .expect("lô chưa đối soát thì gỡ được");
+
+        let left: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM declaration_link")
+            .fetch_one(&pool)
+            .await
+            .expect("đếm");
+        assert_eq!(left, 0);
+    }
+
+    /// Đã đối soát = đã khai lên cổng. Xóa đi là mất dấu vết.
+    #[tokio::test]
+    async fn a_reconciled_declaration_refuses_to_be_unlinked() {
+        let pool = seeded_pool().await;
+
+        let id = crate::declaration::repo::insert_identity(
+            &pool,
+            &crate::declaration::model::Identity {
+                full_name: "Phạm Thị Minh Hiền".into(),
+                nationality_iso3: "VNM".into(),
+                doc_no: Some("056188011500".into()),
+                ..Default::default()
+            },
+            "qr_cccd",
+            "verified",
+        )
+        .await
+        .expect("danh tính");
+        let link =
+            crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
+                .await
+                .expect("ghép");
+        let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
+            .await
+            .expect("lô");
+        crate::declaration::repo::insert_entries(&pool, &batch, std::slice::from_ref(&link))
+            .await
+            .expect("dòng của lô");
+        crate::declaration::repo::set_batch_verified(&pool, &batch, 1)
+            .await
+            .expect("đối soát");
+
+        assert!(
+            crate::declaration::repo::delete_link(&pool, &link)
+                .await
+                .is_err(),
+            "đã đối soát thì không gỡ được"
+        );
+    }
+
     #[tokio::test]
     async fn v20_creates_four_declaration_tables_and_sets_version() {
         let pool = SqlitePool::connect("sqlite::memory:")

--- a/mhm/src-tauri/src/declaration/repo.rs
+++ b/mhm/src-tauri/src/declaration/repo.rs
@@ -98,7 +98,30 @@ pub async fn count_undeclared_within_48h(pool: &Pool<Sqlite>) -> Result<i64, Str
 
 // ─── Ghi — chỉ bốn bảng declaration_* ───────────────────────────────────────
 
-/// Lưu một danh tính đã trích. Trả về id (uuid TEXT) vừa lưu.
+/// Số giấy tờ định danh một con người. CCCD trước, hộ chiếu sau.
+///
+/// Trả `None` khi cả hai đều trống — nhập tay thiếu số giấy tờ thì không có gì
+/// để nhận ra người trùng, đành để mỗi lần lưu là một dòng.
+fn document_key(identity: &Identity) -> Option<String> {
+    [&identity.doc_no, &identity.passport_no]
+        .into_iter()
+        .flatten()
+        .map(|v| v.trim())
+        .find(|v| !v.is_empty())
+        .map(str::to_string)
+}
+
+/// Lưu một danh tính đã trích. Trả về id (uuid TEXT).
+///
+/// **Thả trùng một tấm giấy tờ thì dùng lại dòng cũ, không đẻ dòng mới.** Mỗi
+/// lần thả ảnh sinh một danh tính riêng sẽ dẫn tới hai khai báo cùng số giấy tờ
+/// cùng ngày đến, và validator chặn bằng E14 — đúng, vì nộp trùng lên cổng là
+/// sai — nhưng người vận hành không còn đường nào đi tiếp. Chặn ngay từ đây rẻ
+/// hơn dọn ở cuối.
+///
+/// Dữ liệu mới chỉ được ghi đè khi danh tính CHƯA nằm trong lô nào đã đối soát.
+/// Đã nộp cho công an rồi thì bản ghi đó là bằng chứng của cái đã nộp, không
+/// được sửa sau lưng.
 ///
 /// KHÔNG có cột ảnh và KHÔNG có cột payload thô — xem §12.
 pub async fn insert_identity(
@@ -107,6 +130,36 @@ pub async fn insert_identity(
     source: &str,
     confidence: &str,
 ) -> Result<String, String> {
+    if let Some(key) = document_key(identity) {
+        let existing = sqlx::query(
+            "SELECT id,
+                    EXISTS (SELECT 1
+                              FROM declaration_link dl
+                              JOIN declaration_entry de  ON de.link_id = dl.id
+                              JOIN declaration_batch dbt ON dbt.id     = de.batch_id
+                             WHERE dl.identity_id = di.id
+                               AND dbt.status = 'verified') AS already_declared
+               FROM declaration_identity di
+              WHERE redacted_at IS NULL
+                AND (doc_no = ? OR passport_no = ?)
+              ORDER BY created_at
+              LIMIT 1",
+        )
+        .bind(&key)
+        .bind(&key)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| format!("Không tra được danh tính đã có: {e}"))?;
+
+        if let Some(row) = existing {
+            let existing_id: String = row.get("id");
+            if row.get::<i64, _>("already_declared") == 0 {
+                update_identity_fields(pool, &existing_id, identity, source, confidence).await?;
+            }
+            return Ok(existing_id);
+        }
+    }
+
     let id = if identity.id.trim().is_empty() {
         uuid::Uuid::new_v4().to_string()
     } else {
@@ -146,6 +199,108 @@ pub async fn insert_identity(
     .map_err(|e| format!("Không lưu được danh tính: {e}"))?;
 
     Ok(id)
+}
+
+/// Cập nhật một danh tính đã có bằng lần trích mới nhất.
+///
+/// Giữ nguyên `id` và `created_at`: link đang trỏ vào id đó, và `created_at` là
+/// lúc người này lần đầu được đưa vào hệ thống.
+async fn update_identity_fields(
+    pool: &Pool<Sqlite>,
+    id: &str,
+    identity: &Identity,
+    source: &str,
+    confidence: &str,
+) -> Result<(), String> {
+    sqlx::query(
+        "UPDATE declaration_identity SET
+            source = ?, extract_confidence = ?, full_name = ?, dob = ?, gender = ?,
+            nationality_iso3 = ?, doc_type_code = ?, doc_type_source = ?, doc_type_name = ?,
+            doc_no = ?, phone = ?, residence_status = ?, address_detail = ?,
+            passport_no = ?, passport_expiry = ?, visa_valid_until = ?,
+            name_confirmed_by_human = ?, single_token_name_ok = ?
+          WHERE id = ?",
+    )
+    .bind(source)
+    .bind(confidence)
+    .bind(&identity.full_name)
+    .bind(&identity.dob)
+    .bind(&identity.gender)
+    .bind(&identity.nationality_iso3)
+    .bind(&identity.doc_type_code)
+    .bind(&identity.doc_type_source)
+    .bind(&identity.doc_type_name)
+    .bind(&identity.doc_no)
+    .bind(&identity.phone)
+    .bind(&identity.residence_status)
+    .bind(&identity.address_detail)
+    .bind(&identity.passport_no)
+    .bind(&identity.passport_expiry)
+    .bind(&identity.visa_valid_until)
+    .bind(i64::from(identity.name_confirmed_by_human))
+    .bind(i64::from(identity.single_token_name_ok))
+    .bind(id)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("Không cập nhật được danh tính: {e}"))?;
+
+    Ok(())
+}
+
+/// Gỡ một khai báo khỏi danh sách chờ.
+///
+/// Người vận hành ghép nhầm phòng, hoặc ghép trùng, thì phải có đường lùi —
+/// không có nó, một dòng thừa chặn E14 vĩnh viễn và cả lô không xuất được.
+///
+/// Đã nằm trong lô ĐÃ ĐỐI SOÁT thì từ chối: đó là bằng chứng khách này đã được
+/// khai lên cổng, xóa đi là mất dấu vết. Lô chưa đối soát (`exported`) thì gỡ
+/// được — file xuất ra vẫn còn trên đĩa, và lô sẽ tự lệch số khi đối soát.
+pub async fn delete_link(pool: &Pool<Sqlite>, link_id: &str) -> Result<(), String> {
+    let declared: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+           FROM declaration_entry de
+           JOIN declaration_batch dbt ON dbt.id = de.batch_id
+          WHERE de.link_id = ? AND dbt.status = 'verified'",
+    )
+    .bind(link_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| format!("Không kiểm được lô của khai báo: {e}"))?;
+
+    if declared > 0 {
+        return Err(
+            "Khai báo này đã nằm trong một lô đã đối soát — không gỡ được, vì đó là bằng chứng đã khai."
+                .into(),
+        );
+    }
+
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| format!("Không mở được giao dịch: {e}"))?;
+
+    // Entry của lô chưa đối soát phải đi trước — declaration_entry.link_id có FK.
+    sqlx::query("DELETE FROM declaration_entry WHERE link_id = ?")
+        .bind(link_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| format!("Không gỡ được dòng khỏi lô: {e}"))?;
+
+    let affected = sqlx::query("DELETE FROM declaration_link WHERE id = ?")
+        .bind(link_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| format!("Không gỡ được khai báo: {e}"))?
+        .rows_affected();
+
+    tx.commit()
+        .await
+        .map_err(|e| format!("Không lưu được thay đổi: {e}"))?;
+
+    if affected == 0 {
+        return Err("Không tìm thấy khai báo cần gỡ.".into());
+    }
+    Ok(())
 }
 
 /// Danh tính đã lưu nhưng chưa ghép vào lượt lưu trú nào.

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -405,6 +405,7 @@ pub fn run() {
             commands::declaration::kbtt_link,
             commands::declaration::kbtt_unlinked_identities,
             commands::declaration::kbtt_discard_identity,
+            commands::declaration::kbtt_unlink,
             commands::declaration::kbtt_pending_rows,
             commands::declaration::kbtt_validate,
             commands::declaration::kbtt_export,

--- a/mhm/src/pages/Declaration/PendingList.test.tsx
+++ b/mhm/src/pages/Declaration/PendingList.test.tsx
@@ -260,6 +260,28 @@ describe("PendingList", () => {
     expect(screen.getByTitle(/Chưa ai xác nhận tên/i)).toBeInTheDocument();
   });
 
+  /// Ghép nhầm phòng hoặc ghép trùng thì phải gỡ được ngay trên dòng đó —
+  /// không có nó, một dòng thừa chặn E14 và cả lô không xuất được.
+  it("removes a wrong declaration straight from its row", async () => {
+    mockCommands({
+      kbtt_pending_rows: [row({ link_id: "l1", full_name: "Phạm Thị Minh Hiền" })],
+      kbtt_unlink: null,
+    });
+
+    render(<PendingList />);
+
+    const remove = await screen.findByLabelText(
+      /Gỡ khai báo của Phạm Thị Minh Hiền/i,
+    );
+    fireEvent.click(remove);
+
+    await waitFor(() => {
+      expect(invokeCommand).toHaveBeenCalledWith("kbtt_unlink", {
+        linkId: "l1",
+      });
+    });
+  });
+
   it("reports the selected link ids upward", async () => {
     mockCommands({
       kbtt_pending_rows: [row({ link_id: "l1", nationality_iso3: "VNM" })],

--- a/mhm/src/pages/Declaration/PendingList.tsx
+++ b/mhm/src/pages/Declaration/PendingList.tsx
@@ -181,6 +181,17 @@ export default function PendingList({
     }
   };
 
+  const handleUnlink = async (linkId: string, name: string) => {
+    try {
+      await invokeCommand<void>("kbtt_unlink", { linkId });
+      toast.success(`Đã gỡ khai báo của ${name}`);
+      loadRows();
+      loadWaiting();
+    } catch (e) {
+      toast.error(formatAppError(e));
+    }
+  };
+
   const handleDiscard = async (id: string, name: string) => {
     try {
       await invokeCommand<void>("kbtt_discard_identity", { identityId: id });
@@ -216,6 +227,7 @@ export default function PendingList({
                 <th className="px-3 py-2">Phòng</th>
                 <th className="px-3 py-2">Ngày đến</th>
                 <th className="px-3 py-2">Kiểm tra</th>
+                <th className="w-16 px-3 py-2" />
               </tr>
             </thead>
             <tbody>
@@ -257,6 +269,16 @@ export default function PendingList({
                           ))}
                         </span>
                       )}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        aria-label={`Gỡ khai báo của ${r.full_name}`}
+                        className="text-xs text-slate-400 underline hover:text-red-600"
+                        onClick={() => handleUnlink(r.link_id, r.full_name)}
+                      >
+                        Gỡ
+                      </button>
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
Tiếp theo [#178](https://github.com/chuanman2707/CapyInn/pull/178). QA bằng computer use trên bản đang chạy cho thấy 6/7 điểm đã đạt, nhưng **vẫn không xuất được file** — lần này vì `E14 — Trùng hồ sơ trong cùng lô: cùng số giấy tờ và cùng ngày đến`.

## Validator đúng, thiết kế sai

Nộp trùng một người lên cổng công an là sai, nên E14 chặn là đúng. Vấn đề là người vận hành **không có đường nào đi tiếp**.

Mỗi lần thả ảnh sinh một `declaration_identity` mới. Thả cùng một tấm CCCD hai lần rồi ghép cả hai → hai khai báo cùng số giấy tờ, cùng ngày đến. `UNIQUE(identity_id, stay_id)` không đỡ được vì hai `identity_id` khác nhau. Và giao diện không có nút nào gỡ một khai báo **đã ghép** — `kbtt_discard_identity` chỉ xóa được ảnh chưa ghép.

Kết quả: một dòng thừa chặn cả lô, vĩnh viễn. Trên máy vận hành đang có đúng hai dòng như vậy:

```
b3fd2083…  Phạm Thị Minh Hiền  056188011500  phòng 3B  09:56
49c3b62f…  Phạm Thị Minh Hiền  056188011500  phòng 3B  10:35
```

## Hai thay đổi — thiếu một cái là vẫn kẹt

**1. Gộp danh tính trùng.** `insert_identity` dùng lại dòng cũ khi số giấy tờ khớp (CCCD trước, hộ chiếu sau). Chặn từ gốc rẻ hơn dọn ở cuối.

Một ranh giới quan trọng: danh tính **đã nằm trong lô đã đối soát** thì lần thả sau **không được ghi đè**. Dòng đó là bằng chứng của cái đã nộp cho công an; sửa sau lưng là làm sai lệch hồ sơ. Có test riêng (`a_declared_identity_is_not_rewritten_by_a_later_scan`).

Khách nhập tay không có số giấy tờ thì không gộp — không có gì để nhận ra người trùng.

**2. `kbtt_unlink` + nút "Gỡ" trên từng dòng.** Gỡ được khi lô chưa đối soát, xóa kèm `declaration_entry` của lô đó trước (bảng entry có FK trỏ vào link). Đã đối soát thì từ chối, cùng lý do trên.

Cái thứ nhất ngăn lỗi mới, cái thứ hai dọn lỗi đã có. Chỉ làm một trong hai thì hai dòng đang kẹt vẫn kẹt.

## Kiểm chứng

- `cargo clippy --all-targets -- -D warnings` sạch
- `cargo test --lib` 844/844
- `vitest run` 336/336

Test mới: `dropping_the_same_card_twice_reuses_the_identity`, `an_identity_without_a_document_number_is_never_merged`, `a_declared_identity_is_not_rewritten_by_a_later_scan`, `a_declaration_can_be_unlinked_until_it_has_been_reconciled`, `a_reconciled_declaration_refuses_to_be_unlinked`, `removes a wrong declaration straight from its row`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)