### PR TITLE
docs: realign public docs with the shipped implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,12 @@ Thanks for contributing.
 
 - `mhm/` is the current implementation path for the CapyInn PMS application. It is rename debt, not the product name.
 - `docs/architecture/core-pms-boundaries.md` is the canonical guardrail for core PMS, experimental runtime, command safety, and the postponed `mhm/` rename.
-- `docs/plans/` contains public implementation plans and release prep notes when present.
+- `docs/superpowers/specs/` contains published design specs, and `docs/superpowers/plans/` contains the matching implementation plans, when present.
+- `docs/release-checklist.md` and `docs/release-signing.md` cover the release preflight, signing, and updater manifest details.
 
 ## Prerequisites
 
-- macOS 12 or newer
+- macOS 12 or newer for local development; Windows and Linux bundles are produced by the release workflow, not by the documented local setup
 - Node.js 20 or newer
 - Rust stable via `rustup`
 - Xcode Command Line Tools
@@ -47,6 +48,12 @@ If you changed Rust code, also run:
 
 ```bash
 cargo clippy --all-targets -- -D warnings
+```
+
+If you touched a core PMS lifecycle — reservations, stays, groups, or backup — run the smoke gate from `mhm/`:
+
+```bash
+npm run verify:full
 ```
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ CapyInn is built for a narrow but practical use case: small hotels that need a s
 - Maintenance notes per room
 - Night-audit flow for daily reconciliation
 
+### Temporary residence declaration (Khai báo tạm trú)
+
+- Dedicated workspace that turns guest ID images into upload-ready files for the Ministry of Public Security portal at `tbltkbtt.bocongan.gov.vn`
+- Identity capture reads the CCCD QR code first and falls back to passport MRZ through `ocr-rs`, with a manual form for anything neither can read
+- Extracted identities are linked to an existing stay, then exported as XLSX for Vietnamese guests and XML for foreign guests
+- Batch history and a reconciliation checklist exist because the portal reports "import successful" even when it accepts zero records
+- The module reads PMS tables only; it adds its own tables and never mutates rooms, bookings, or guests
+
+### Auto-update
+
+- Release builds check the GitHub Releases `latest.json` feed through the Tauri updater plugin
+- Update artifacts are signed, and the signing and manifest details are documented in [docs/release-signing.md](docs/release-signing.md)
+
 ### MCP and automation integrations
 
 - CapyInn can be extended through MCP-friendly workflows for operator tooling and agent-driven automations
@@ -168,10 +181,12 @@ CapyInn is built for a narrow but practical use case: small hotels that need a s
 | macOS | 12+ |
 | Node.js | 20+ |
 | Rust | stable via `rustup` |
-| Xcode CLT | recent version |
+| Xcode CLT | recent version (macOS builds) |
 | Disk footprint | roughly 25MB before operational data |
 
-The project is currently verified most heavily on macOS and Apple Silicon.
+The install steps below describe a macOS development machine. The project is verified most heavily on macOS and Apple Silicon, which is the only macOS architecture the release workflow builds.
+
+Tagged releases also publish a Windows NSIS installer and a Linux AppImage. Those bundles are produced by CI on `windows-latest` and `ubuntu-22.04` but receive far less hands-on testing than the macOS build.
 
 ## Local development
 
@@ -213,6 +228,14 @@ cargo test --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 ```
 
+The repository also ships scripted verification gates. `verify:full` is the smoke gate the release checklist expects to pass before a tag is pushed; it runs the quick wave, the frontend suite, booking and backup scenario tests, and a native Tauri startup smoke against an isolated runtime root.
+
+```bash
+cd CapyInn/mhm
+npm run verify:quick
+npm run verify:full
+```
+
 If you only need the web UI during frontend work:
 
 ```bash
@@ -225,29 +248,36 @@ npm run dev
 ```text
 CapyInn/
 ├── Public/                 # README demo screenshots
+├── docs/                   # Architecture guardrails, release docs, plans and specs
 ├── mhm/
 │   ├── src/                # React UI, stores, pages, components
-│   ├── src-tauri/          # Rust backend, IPC commands, DB, gateway, OCR
+│   ├── src-tauri/          # Rust backend, IPC commands, DB, gateway, OCR, declaration
 │   ├── tests/              # Vitest suites and mocked desktop flows
+│   ├── scripts/            # Verification and release helper scripts
+│   ├── shared/             # Types shared between the frontend and helper scripts
+│   ├── skills/             # Agent skill definition for the MCP gateway
 │   ├── public/             # Static assets
 │   └── models/             # OCR models
-├── PRD.md                  # Product requirements
+├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── SECURITY.md
 └── README.md
 ```
 
+`mhm/` is the current implementation path, not the product name. Renaming it is deliberately postponed; see [docs/architecture/core-pms-boundaries.md](docs/architecture/core-pms-boundaries.md).
+
 ## Known limitations
 
-- OCR is currently optimized for Vietnamese national ID cards; passports and international documents are not complete yet
-- Windows and Linux are not first-class targets yet
+- Check-in OCR is optimized for Vietnamese national ID cards; the passport MRZ reader currently lives in the temporary residence declaration workspace rather than the check-in scan flow
+- macOS Apple Silicon is the primary target; Windows and Linux bundles are published by CI but are not verified as thoroughly
 - The project is designed for mini-hotel scale, not large chain operations
 
 ## Additional docs
 
-- [PRD](PRD.md)
+- [Core PMS boundaries](docs/architecture/core-pms-boundaries.md)
 - [Contributing guide](CONTRIBUTING.md)
 - [Release checklist](docs/release-checklist.md)
+- [Release signing and updater](docs/release-signing.md)
 - [Security policy](SECURITY.md)
 - [Changelog](CHANGELOG.md)
 

--- a/mhm/skills/hotel-manager.skill.md
+++ b/mhm/skills/hotel-manager.skill.md
@@ -49,6 +49,11 @@ Retention: raw prompts, raw responses, raw tool outputs, and raw provider errors
 | `get_hotel_info` | Hotel settings by key | Guest asks hotel name/address/rules |
 | `calculate_price` | Price estimate | Guest asks "how much for X nights?" |
 | `get_invoice` | Latest issued invoice | Guest asks for an existing invoice summary |
+| `list_command_recovery_queue` | Command recovery rows needing operator attention | Operator asks what is stuck |
+| `inspect_command_recovery` | One recovery row and its safe recovery history | Operator drills into a single stuck command |
+
+The two command recovery tools are read-only. They do not retry, dismiss, or mark a
+row terminal; recovery actions stay with a human operator in the desktop app.
 
 ### Action Tools (Write)
 

--- a/mhm/skills/mcp-manifest.json
+++ b/mhm/skills/mcp-manifest.json
@@ -281,6 +281,30 @@
             }
         },
         {
+            "name": "list_command_recovery_queue",
+            "description": "List command recovery rows needing operator attention. Read-only: this does not retry, dismiss, or mark terminal.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        },
+        {
+            "name": "inspect_command_recovery",
+            "description": "Inspect one command recovery row and its safe recovery history. Read-only: this does not retry, dismiss, or mark terminal.",
+            "inputSchema": {
+                "type": "object",
+                "required": [
+                    "command_idempotency_id"
+                ],
+                "properties": {
+                    "command_idempotency_id": {
+                        "type": "integer",
+                        "description": "Command ledger row id to inspect."
+                    }
+                }
+            }
+        },
+        {
             "name": "create_reservation",
             "description": "Create a new reservation (booking with status 'booked'). The reservation must be confirmed by hotel staff before check-in.",
             "inputSchema": {


### PR DESCRIPTION
A documentation pass over the tracked docs. Every item below is a statement that no longer matched the code, verified against `origin/main`.

## README

| Was | Now |
| --- | --- |
| `[PRD](PRD.md)` in Additional docs | `docs/PRD.md` is not tracked in this repo, so the link 404'd for every reader. Replaced with [Core PMS boundaries](docs/architecture/core-pms-boundaries.md) and [Release signing](docs/release-signing.md), which do ship. |
| Repository layout listed `PRD.md` | Tree now matches the tracked tree: adds `docs/`, `mhm/scripts/`, `mhm/shared/`, `mhm/skills/`. |
| No mention of Khai báo tạm trú | The temporary residence declaration workspace ships as an ungated nav entry with its own backend module (`src-tauri/src/declaration/`), CCCD QR + passport MRZ extraction, XLSX/XML export for the Bộ Công An portal, and a reconciliation loop. Now documented. |
| No mention of auto-update | The Tauri updater plugin points at the GitHub Releases `latest.json` feed in `tauri.conf.json`. Now documented. |
| "Windows and Linux are not first-class targets yet" | `.github/workflows/release.yml` publishes a Windows NSIS installer and a Linux AppImage. Reworded to say those bundles ship but get less hands-on testing, and that macOS is built for Apple Silicon only. |
| "passports and international documents are not complete yet" | An MRZ reader ships in the declaration workspace. Narrowed the limitation to the check-in scan flow, which is still CCCD-only. |
| Verification listed only the raw cargo/npm commands | Added `verify:quick` and `verify:full`, the gates `docs/release-checklist.md` already depends on. |

## CONTRIBUTING

- `docs/plans/` does not exist. Specs and plans live under `docs/superpowers/specs/` and `docs/superpowers/plans/`.
- Added the `verify:full` smoke gate for core PMS lifecycle changes.

## Agent skill and MCP manifest

The gateway serves 17 tools. Both `mhm/skills/hotel-manager.skill.md` and `mhm/skills/mcp-manifest.json` listed 15, missing `list_command_recovery_queue` and `inspect_command_recovery`. Added to both, with a note that they are read-only and do not retry, dismiss, or mark a row terminal.

## Verification

- Every relative link and HTML `img src` across all 43 tracked markdown files resolves on disk (scripted check, 0 broken).
- Gateway tool names parsed from `tools.rs` now match `mcp-manifest.json` and `hotel-manager.skill.md` exactly, checked in both directions: 17 / 17 / 17, no diff either way.
- `npx vitest run tests/agentic-guardrails.test.ts` — 13 passed. This suite asserts on the skill doc and manifest, so it is the gate that matters for this change.
- Docs-only diff; no source files touched.

## Known gap, not addressed here

`CHANGELOG.md` still has only an `Unreleased` section while v0.1.0 through v0.1.6 are tagged and four are published as GitHub Releases. Writing accurate retroactive entries means summarizing ~146 commits and belongs in its own PR rather than being guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)