### PR TITLE
refactor: get SQL out of the command layer, and hold the boundary with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -54,6 +54,10 @@ jobs:
       - name: Run clippy
         working-directory: mhm/src-tauri
         run: cargo clippy --all-targets -- -D warnings
+
+      - name: Check formatting
+        working-directory: mhm/src-tauri
+        run: cargo fmt -- --check
 
   verify-wave1:
     runs-on: macos-latest

--- a/mhm/src-tauri/src/agent/test_support.rs
+++ b/mhm/src-tauri/src/agent/test_support.rs
@@ -1,5 +1,5 @@
 use serde_json::{Map, Number, Value};
-use sqlx::{Pool, Row, Sqlite, TypeInfo as _, ValueRef as _, sqlite::SqliteRow};
+use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, TypeInfo as _, ValueRef as _};
 
 const ALLOWED_PHASE_ONE_AGENT_MUTATION_TABLES: &[&str] =
     &["agent_sessions", "agent_audit_events", "agent_digest_runs"];
@@ -105,7 +105,7 @@ fn quote_identifier(identifier: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
 
     async fn test_pool() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()

--- a/mhm/src-tauri/src/agent/tools/ceo_read.rs
+++ b/mhm/src-tauri/src/agent/tools/ceo_read.rs
@@ -245,6 +245,9 @@ mod tests {
         )
         .await
         .expect_err("allowed no-arg tool must reject args");
-        assert_eq!(error.code, crate::app_error::codes::VALIDATION_INVALID_INPUT);
+        assert_eq!(
+            error.code,
+            crate::app_error::codes::VALIDATION_INVALID_INPUT
+        );
     }
 }

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -235,10 +235,8 @@ fn production_source(source: &str) -> String {
 /// about emptying it. The test fails both when an unlisted command module grows
 /// SQL *and* when a listed one is cleaned up without being struck off, so the
 /// list cannot quietly rot.
-const COMMANDS_STILL_HOLDING_SQL: [&str; 5] = [
-    "commands/analytics.rs",
+const COMMANDS_STILL_HOLDING_SQL: [&str; 3] = [
     "commands/auth.rs",
-    "commands/bookings.rs",
     "commands/groups.rs",
     "commands/guests.rs",
 ];

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -235,13 +235,12 @@ fn production_source(source: &str) -> String {
 /// about emptying it. The test fails both when an unlisted command module grows
 /// SQL *and* when a listed one is cleaned up without being struck off, so the
 /// list cannot quietly rot.
-const COMMANDS_STILL_HOLDING_SQL: [&str; 6] = [
+const COMMANDS_STILL_HOLDING_SQL: [&str; 5] = [
     "commands/analytics.rs",
     "commands/auth.rs",
     "commands/bookings.rs",
     "commands/groups.rs",
     "commands/guests.rs",
-    "commands/pricing.rs",
 ];
 
 #[test]

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -200,6 +200,12 @@ fn command_layer_imports_sees_through_a_nested_use_block() {
 ///
 /// Relies on rustfmt: a file-level `mod` and its closing brace both sit at column
 /// zero, so the block ends at the next line that is exactly `}`.
+///
+/// That dependency is the weak point: an unformatted file whose closing brace is
+/// indented would make this swallow to end-of-file and report a *false clean* —
+/// the dangerous direction for a guard. CI runs `cargo fmt -- --check`, which is
+/// what keeps the assumption true; do not remove that check without revisiting
+/// this function.
 fn production_source(source: &str) -> String {
     let lines: Vec<&str> = source.lines().collect();
     let mut kept = Vec::with_capacity(lines.len());

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -186,19 +186,61 @@ fn command_layer_imports_sees_through_a_nested_use_block() {
     }
 }
 
-/// Command modules that still issue SQL directly, in descending size. This is a
-/// ratchet, not a permission list: `docs/cleanup/` items E1–E3 are about
-/// emptying it. The test fails both when an unlisted command module grows SQL
-/// *and* when a listed one is cleaned up without being struck off, so the list
-/// cannot quietly rot.
-const COMMANDS_STILL_HOLDING_SQL: [&str; 8] = [
-    "commands/agent_settings.rs",
+/// The source with the bodies of inline `#[cfg(test)] mod … { … }` blocks removed.
+///
+/// Test fixtures seed tables with raw SQL; that is not the command layer owning
+/// SQL, and counting it made this guard report roughly twice the real number. It
+/// named `commands/invoices.rs` (10 test-only calls, zero in production) as the
+/// largest remaining offender when that file was already correct.
+///
+/// Removes each block rather than truncating at the first one: `commands/pricing.rs`
+/// has its test module in the *middle* of the file, with five more production
+/// queries after it. Truncating there would have under-reported — a false clean,
+/// which is the worse failure for a guard.
+///
+/// Relies on rustfmt: a file-level `mod` and its closing brace both sit at column
+/// zero, so the block ends at the next line that is exactly `}`.
+fn production_source(source: &str) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut kept = Vec::with_capacity(lines.len());
+    let mut index = 0;
+
+    while index < lines.len() {
+        if lines[index] == "#[cfg(test)]" {
+            let mut probe = index + 1;
+            while probe < lines.len() && lines[probe].trim().is_empty() {
+                probe += 1;
+            }
+            let opens_a_module = probe < lines.len()
+                && lines[probe].starts_with("mod ")
+                && lines[probe].ends_with('{');
+            if opens_a_module {
+                index = probe + 1;
+                while index < lines.len() && lines[index] != "}" {
+                    index += 1;
+                }
+                index += 1; // step past the closing brace
+                continue;
+            }
+        }
+        kept.push(lines[index]);
+        index += 1;
+    }
+
+    kept.join("\n")
+}
+
+/// Command modules that still issue SQL in *production* code, largest first.
+/// This is a ratchet, not a permission list: `docs/cleanup/` items E1–E3 are
+/// about emptying it. The test fails both when an unlisted command module grows
+/// SQL *and* when a listed one is cleaned up without being struck off, so the
+/// list cannot quietly rot.
+const COMMANDS_STILL_HOLDING_SQL: [&str; 6] = [
     "commands/analytics.rs",
     "commands/auth.rs",
     "commands/bookings.rs",
     "commands/groups.rs",
     "commands/guests.rs",
-    "commands/invoices.rs",
     "commands/pricing.rs",
 ];
 
@@ -213,7 +255,7 @@ fn command_modules_only_hold_sql_where_the_cleanup_ratchet_still_allows_it() {
             continue;
         }
         let source = fs::read_to_string(&file).expect("read source file");
-        let holds_sql = source.contains("sqlx::query");
+        let holds_sql = production_source(&source).contains("sqlx::query");
         let listed = COMMANDS_STILL_HOLDING_SQL.contains(&name.as_str());
 
         match (holds_sql, listed) {
@@ -235,6 +277,38 @@ fn command_modules_only_hold_sql_where_the_cleanup_ratchet_still_allows_it() {
          COMMANDS_STILL_HOLDING_SQL so the ratchet keeps tightening.\n\n{}",
         already_clean.join("\n")
     );
+}
+
+#[test]
+fn production_source_removes_inline_test_modules_wherever_they_sit() {
+    let with_tests =
+        "use sqlx::Pool;\n\nfn real() {}\n\n#[cfg(test)]\nmod tests {\n    sqlx::query(\"seed\");\n}\n";
+    let production = production_source(with_tests);
+    assert!(production.contains("fn real()"));
+    assert!(!production.contains("sqlx::query"));
+
+    // The `commands/pricing.rs` shape: production code *after* the test module.
+    // Truncating at the first `#[cfg(test)]` reports this file as clean, which is
+    // the worse failure for a guard. An earlier version of this helper did.
+    let tests_in_the_middle = "fn early() {}\n\n#[cfg(test)]\nmod tests {\n    fn seed() {\n        let _ = 1;\n    }\n}\n\nfn late() {\n    sqlx::query(\"real\");\n}\n";
+    let production = production_source(tests_in_the_middle);
+    assert!(production.contains("fn early()"));
+    assert!(production.contains("fn late()"));
+    assert!(production.contains("sqlx::query"));
+
+    // A blank line between the attribute and the module is the same shape.
+    let spaced = "fn real() {}\n\n#[cfg(test)]\n\nmod tests {\n    sqlx::query(\"seed\");\n}\n";
+    assert!(!production_source(spaced).contains("sqlx::query"));
+
+    // `#[cfg(test)]` on a plain item must not swallow anything.
+    let cfg_on_item =
+        "#[cfg(test)]\npub fn helper() {}\n\nfn real() {\n    sqlx::query(\"real\");\n}\n";
+    assert!(production_source(cfg_on_item).contains("sqlx::query"));
+    assert!(production_source(cfg_on_item).contains("pub fn helper()"));
+
+    // No test module at all: nothing is removed.
+    let plain = "fn real() {\n    sqlx::query(\"real\");\n}";
+    assert_eq!(production_source(plain), plain);
 }
 
 /// Markers for *holding a connection or issuing SQL*, as opposed to merely

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -235,7 +235,7 @@ fn production_source(source: &str) -> String {
 /// about emptying it. The test fails both when an unlisted command module grows
 /// SQL *and* when a listed one is cleaned up without being struck off, so the
 /// list cannot quietly rot.
-const COMMANDS_STILL_HOLDING_SQL: [&str; 1] = ["commands/groups.rs"];
+const COMMANDS_STILL_HOLDING_SQL: [&str; 0] = [];
 
 #[test]
 fn command_modules_only_hold_sql_where_the_cleanup_ratchet_still_allows_it() {

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -235,11 +235,7 @@ fn production_source(source: &str) -> String {
 /// about emptying it. The test fails both when an unlisted command module grows
 /// SQL *and* when a listed one is cleaned up without being struck off, so the
 /// list cannot quietly rot.
-const COMMANDS_STILL_HOLDING_SQL: [&str; 3] = [
-    "commands/auth.rs",
-    "commands/groups.rs",
-    "commands/guests.rs",
-];
+const COMMANDS_STILL_HOLDING_SQL: [&str; 1] = ["commands/groups.rs"];
 
 #[test]
 fn command_modules_only_hold_sql_where_the_cleanup_ratchet_still_allows_it() {

--- a/mhm/src-tauri/src/architecture_guard.rs
+++ b/mhm/src-tauri/src/architecture_guard.rs
@@ -191,7 +191,7 @@ fn command_layer_imports_sees_through_a_nested_use_block() {
 /// emptying it. The test fails both when an unlisted command module grows SQL
 /// *and* when a listed one is cleaned up without being struck off, so the list
 /// cannot quietly rot.
-const COMMANDS_STILL_HOLDING_SQL: [&str; 9] = [
+const COMMANDS_STILL_HOLDING_SQL: [&str; 8] = [
     "commands/agent_settings.rs",
     "commands/analytics.rs",
     "commands/auth.rs",
@@ -200,7 +200,6 @@ const COMMANDS_STILL_HOLDING_SQL: [&str; 9] = [
     "commands/guests.rs",
     "commands/invoices.rs",
     "commands/pricing.rs",
-    "commands/rooms.rs",
 ];
 
 #[test]

--- a/mhm/src-tauri/src/backup/runner.rs
+++ b/mhm/src-tauri/src/backup/runner.rs
@@ -1,6 +1,6 @@
 use crate::backup::{
+    storage::{prune_old_backups, sqlite_string_literal, sync_directory, BackupReservation},
     BackupError, BackupOutcome, BackupReason,
-    storage::{BackupReservation, prune_old_backups, sqlite_string_literal, sync_directory},
 };
 use chrono::{NaiveDateTime, Utc};
 use std::{fs, path::Path, time::Duration};
@@ -72,7 +72,7 @@ mod tests {
     use super::*;
     use crate::backup::{
         build_backup_filename, is_managed_backup_file,
-        test_support::{BackupFixture, backup_file_name},
+        test_support::{backup_file_name, BackupFixture},
     };
     use chrono::Duration as ChronoDuration;
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};

--- a/mhm/src-tauri/src/bin/test_ocr.rs
+++ b/mhm/src-tauri/src/bin/test_ocr.rs
@@ -7,9 +7,18 @@ fn main() {
         .expect("src-tauri should live inside the app directory");
     let models_dir = app_dir.join("models");
     println!("Models dir: {}", models_dir.display());
-    println!("Det exists: {}", models_dir.join("PP-OCRv5_mobile_det.mnn").exists());
-    println!("Rec exists: {}", models_dir.join("PP-OCRv5_mobile_rec.mnn").exists());
-    println!("Keys exists: {}", models_dir.join("ppocr_keys_v5.txt").exists());
+    println!(
+        "Det exists: {}",
+        models_dir.join("PP-OCRv5_mobile_det.mnn").exists()
+    );
+    println!(
+        "Rec exists: {}",
+        models_dir.join("PP-OCRv5_mobile_rec.mnn").exists()
+    );
+    println!(
+        "Keys exists: {}",
+        models_dir.join("ppocr_keys_v5.txt").exists()
+    );
 
     println!("\nCreating OCR engine...");
     let engine = ocr_rs::OcrEngine::new(
@@ -17,7 +26,8 @@ fn main() {
         models_dir.join("PP-OCRv5_mobile_rec.mnn").to_str().unwrap(),
         models_dir.join("ppocr_keys_v5.txt").to_str().unwrap(),
         None,
-    ).expect("Failed to create OCR engine");
+    )
+    .expect("Failed to create OCR engine");
     println!("OCR engine ready!");
 
     let re_doc = regex::Regex::new(r"\b(\d{12})\b").unwrap();
@@ -32,7 +42,11 @@ fn main() {
     for entry in std::fs::read_dir(scans_dir).expect("Can't read Scans dir") {
         let entry = entry.unwrap();
         let path = entry.path();
-        if path.extension().map(|e| e == "png" || e == "jpg" || e == "jpeg").unwrap_or(false) {
+        if path
+            .extension()
+            .map(|e| e == "png" || e == "jpg" || e == "jpeg")
+            .unwrap_or(false)
+        {
             println!("\n--- OCR on: {} ---", path.display());
             let img = image::open(&path).expect("Failed to open image");
 
@@ -60,8 +74,11 @@ fn main() {
                 println!("Ngày sinh: {}", m.as_str());
             }
 
-            if full_text.contains("Nam") { println!("Giới tính: Nam"); }
-            else if full_text.contains("Nữ") { println!("Giới tính: Nữ"); }
+            if full_text.contains("Nam") {
+                println!("Giới tính: Nam");
+            } else if full_text.contains("Nữ") {
+                println!("Giới tính: Nữ");
+            }
         }
     }
 }

--- a/mhm/src-tauri/src/commands/analytics.rs
+++ b/mhm/src-tauri/src/commands/analytics.rs
@@ -1,6 +1,8 @@
 use super::AppState;
+use crate::queries::booking::activity_queries::{
+    self, RecentCheckIn, RecentCheckOut, RecentHousekeeping,
+};
 use crate::{models::*, queries::booking::revenue_queries};
-use sqlx::Row;
 use tauri::State;
 
 // ─── A3: Get Analytics ───
@@ -33,105 +35,89 @@ pub async fn get_recent_activity(
     state: State<'_, AppState>,
     limit: i32,
 ) -> Result<Vec<ActivityItem>, String> {
-    let mut activities: Vec<ActivityItem> = vec![];
+    let check_ins = activity_queries::load_recent_check_ins(&state.db, limit)
+        .await
+        .map_err(|e| e.to_string())?;
+    let check_outs = activity_queries::load_recent_check_outs(&state.db, limit)
+        .await
+        .map_err(|e| e.to_string())?;
+    let housekeeping = activity_queries::load_recent_housekeeping(&state.db, limit)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    // Recent check-ins
-    let checkins = sqlx::query(
-        "SELECT b.room_id, g.full_name, b.check_in_at
-         FROM bookings b JOIN guests g ON g.id = b.primary_guest_id
-         ORDER BY b.check_in_at DESC LIMIT ?",
-    )
-    .bind(limit)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
+    Ok(build_activity_feed(
+        check_ins,
+        check_outs,
+        housekeeping,
+        limit,
+    ))
+}
 
-    for r in &checkins {
-        let room_id: String = r.get("room_id");
-        let name: String = r.get("full_name");
-        let time_str: String = r.get("check_in_at");
-        let time = extract_time(&time_str);
+/// Turns the three activity reads into the dashboard feed.
+///
+/// Pure on purpose: everything below here is presentation — the icon, the
+/// Tailwind class, and the Vietnamese status label the dashboard renders — so
+/// it can be tested without a database.
+fn build_activity_feed(
+    check_ins: Vec<RecentCheckIn>,
+    check_outs: Vec<RecentCheckOut>,
+    housekeeping: Vec<RecentHousekeeping>,
+    limit: i32,
+) -> Vec<ActivityItem> {
+    let mut activities: Vec<ActivityItem> = Vec::new();
+
+    for row in check_ins {
         activities.push(ActivityItem {
             icon: "🟢".to_string(),
-            text: format!("Check-in {} → {}", name, room_id),
-            time,
+            text: format!("Check-in {} → {}", row.guest_name, row.room_id),
+            time: extract_time(&row.check_in_at),
             color: "bg-emerald-50".to_string(),
             kind: "check_in".to_string(),
-            room_id: Some(room_id),
-            guest_name: Some(name),
-            occurred_at: time_str,
+            room_id: Some(row.room_id),
+            guest_name: Some(row.guest_name),
+            occurred_at: row.check_in_at,
             status_label: "Đã check-in".to_string(),
         });
     }
 
-    // Recent check-outs
-    let checkouts = sqlx::query(
-        "SELECT b.room_id, g.full_name, b.actual_checkout
-         FROM bookings b JOIN guests g ON g.id = b.primary_guest_id
-         WHERE b.actual_checkout IS NOT NULL
-         ORDER BY b.actual_checkout DESC LIMIT ?",
-    )
-    .bind(limit)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    for r in &checkouts {
-        let room_id: String = r.get("room_id");
-        let name: String = r.get("full_name");
-        let time_str: String = r.get("actual_checkout");
-        let time = extract_time(&time_str);
+    for row in check_outs {
         activities.push(ActivityItem {
             icon: "🔴".to_string(),
-            text: format!("Check-out {} — Room {}", name, room_id),
-            time,
+            text: format!("Check-out {} — Room {}", row.guest_name, row.room_id),
+            time: extract_time(&row.actual_checkout),
             color: "bg-red-50".to_string(),
             kind: "check_out".to_string(),
-            room_id: Some(room_id),
-            guest_name: Some(name),
-            occurred_at: time_str,
+            room_id: Some(row.room_id),
+            guest_name: Some(row.guest_name),
+            occurred_at: row.actual_checkout,
             status_label: "Đã check-out".to_string(),
         });
     }
 
-    // Recent housekeeping
-    let hk = sqlx::query(
-        "SELECT room_id, status, triggered_at FROM housekeeping
-         ORDER BY triggered_at DESC LIMIT ?",
-    )
-    .bind(limit)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    for r in &hk {
-        let room_id: String = r.get("room_id");
-        let status: String = r.get("status");
-        let time_str: String = r.get("triggered_at");
-        let time = extract_time(&time_str);
-        let label = if status == "clean" {
+    for row in housekeeping {
+        let label = if row.status == "clean" {
             "Cleaned"
         } else {
             "Needs cleaning"
         };
         activities.push(ActivityItem {
             icon: "🧹".to_string(),
-            text: format!("{} — Room {}", label, room_id),
-            time,
+            text: format!("{} — Room {}", label, row.room_id),
+            time: extract_time(&row.triggered_at),
             color: "bg-amber-50".to_string(),
             kind: "housekeeping".to_string(),
-            room_id: Some(room_id),
+            room_id: Some(row.room_id),
             guest_name: None,
-            occurred_at: time_str,
+            occurred_at: row.triggered_at,
             status_label: label.to_string(),
         });
     }
 
     // Sort by full timestamp descending to keep cross-day ordering stable.
     activities.sort_by(|a, b| b.occurred_at.cmp(&a.occurred_at));
-    activities.truncate(limit as usize);
+    activities.truncate(limit.max(0) as usize);
 
-    Ok(activities)
+    activities
 }
 
 fn extract_time(datetime_str: &str) -> String {
@@ -149,4 +135,171 @@ fn extract_time(datetime_str: &str) -> String {
         }
     }
     datetime_str.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_activity_feed, extract_time};
+    use crate::queries::booking::activity_queries::{
+        RecentCheckIn, RecentCheckOut, RecentHousekeeping,
+    };
+
+    fn check_in(room_id: &str, guest: &str, at: &str) -> RecentCheckIn {
+        RecentCheckIn {
+            room_id: room_id.to_string(),
+            guest_name: guest.to_string(),
+            check_in_at: at.to_string(),
+        }
+    }
+
+    fn check_out(room_id: &str, guest: &str, at: &str) -> RecentCheckOut {
+        RecentCheckOut {
+            room_id: room_id.to_string(),
+            guest_name: guest.to_string(),
+            actual_checkout: at.to_string(),
+        }
+    }
+
+    fn housekeeping(room_id: &str, status: &str, at: &str) -> RecentHousekeeping {
+        RecentHousekeeping {
+            room_id: room_id.to_string(),
+            status: status.to_string(),
+            triggered_at: at.to_string(),
+        }
+    }
+
+    #[test]
+    fn the_three_sources_interleave_newest_first() {
+        let feed = build_activity_feed(
+            vec![check_in("101", "An", "2026-04-10T14:00:00+07:00")],
+            vec![check_out("102", "Binh", "2026-04-10T12:00:00+07:00")],
+            vec![housekeeping("103", "clean", "2026-04-10T16:00:00+07:00")],
+            10,
+        );
+
+        let kinds: Vec<&str> = feed.iter().map(|item| item.kind.as_str()).collect();
+        assert_eq!(
+            kinds,
+            vec!["housekeeping", "check_in", "check_out"],
+            "the feed is ordered by the full timestamp, not by source"
+        );
+    }
+
+    #[test]
+    fn the_limit_applies_to_the_merged_feed_not_to_each_source() {
+        let feed = build_activity_feed(
+            vec![
+                check_in("101", "An", "2026-04-10T09:00:00+07:00"),
+                check_in("102", "Binh", "2026-04-10T08:00:00+07:00"),
+            ],
+            vec![check_out("103", "Cuong", "2026-04-10T10:00:00+07:00")],
+            vec![housekeeping("104", "dirty", "2026-04-10T11:00:00+07:00")],
+            2,
+        );
+
+        assert_eq!(feed.len(), 2);
+        assert_eq!(feed[0].room_id.as_deref(), Some("104"));
+        assert_eq!(feed[1].room_id.as_deref(), Some("103"));
+    }
+
+    #[test]
+    fn a_check_in_carries_its_presentation() {
+        let feed = build_activity_feed(
+            vec![check_in("101", "An", "2026-04-10T14:30:00+07:00")],
+            vec![],
+            vec![],
+            10,
+        );
+
+        let item = &feed[0];
+        assert_eq!(item.icon, "🟢");
+        assert_eq!(item.text, "Check-in An → 101");
+        assert_eq!(item.time, "14:30");
+        assert_eq!(item.color, "bg-emerald-50");
+        assert_eq!(item.status_label, "Đã check-in");
+        assert_eq!(item.guest_name.as_deref(), Some("An"));
+    }
+
+    #[test]
+    fn a_check_out_carries_its_presentation() {
+        let feed = build_activity_feed(
+            vec![],
+            vec![check_out("102", "Binh", "2026-04-10T11:05:00+07:00")],
+            vec![],
+            10,
+        );
+
+        let item = &feed[0];
+        assert_eq!(item.icon, "🔴");
+        assert_eq!(item.text, "Check-out Binh — Room 102");
+        assert_eq!(item.time, "11:05");
+        assert_eq!(item.color, "bg-red-50");
+        assert_eq!(item.status_label, "Đã check-out");
+    }
+
+    #[test]
+    fn housekeeping_reads_clean_against_everything_else() {
+        let feed = build_activity_feed(
+            vec![],
+            vec![],
+            vec![
+                housekeeping("103", "clean", "2026-04-10T16:00:00+07:00"),
+                housekeeping("104", "dirty", "2026-04-10T15:00:00+07:00"),
+                housekeeping("105", "cleaning", "2026-04-10T14:00:00+07:00"),
+            ],
+            10,
+        );
+
+        let labels: Vec<&str> = feed.iter().map(|i| i.status_label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["Cleaned", "Needs cleaning", "Needs cleaning"],
+            "only the literal 'clean' status reads as done"
+        );
+        assert!(feed.iter().all(|i| i.guest_name.is_none()));
+        assert_eq!(feed[0].text, "Cleaned — Room 103");
+    }
+
+    #[test]
+    fn ties_keep_check_in_before_check_out_before_housekeeping() {
+        let same = "2026-04-10T10:00:00+07:00";
+        let feed = build_activity_feed(
+            vec![check_in("101", "An", same)],
+            vec![check_out("102", "Binh", same)],
+            vec![housekeeping("103", "clean", same)],
+            10,
+        );
+
+        let kinds: Vec<&str> = feed.iter().map(|item| item.kind.as_str()).collect();
+        assert_eq!(kinds, vec!["check_in", "check_out", "housekeeping"]);
+    }
+
+    #[test]
+    fn an_empty_feed_survives_a_zero_or_negative_limit() {
+        assert!(build_activity_feed(vec![], vec![], vec![], 0).is_empty());
+        assert!(build_activity_feed(
+            vec![check_in("101", "An", "2026-04-10T10:00:00+07:00")],
+            vec![],
+            vec![],
+            -1,
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn extract_time_reads_hh_mm_from_every_shape_it_meets() {
+        assert_eq!(extract_time("2026-04-10T14:30:00+07:00"), "14:30");
+        assert_eq!(extract_time("2026-04-10 14:30:00"), "14:30");
+        assert_eq!(
+            extract_time("2026-04-10"),
+            "2026-04-10",
+            "no time component falls back to the raw string"
+        );
+        assert_eq!(
+            extract_time("2026-04-10T14"),
+            "2026-04-10T14",
+            "a truncated time component falls back rather than panicking"
+        );
+        assert_eq!(extract_time(""), "");
+    }
 }

--- a/mhm/src-tauri/src/commands/auth.rs
+++ b/mhm/src-tauri/src/commands/auth.rs
@@ -1,48 +1,40 @@
 use super::{get_user, require_admin, AppState};
 use crate::app_error::{codes, log_system_error, CommandError, CommandResult};
-use crate::db::row::get_money_vnd;
+use crate::domain::auth::credentials::pin_hash;
 use crate::models::*;
+use crate::queries::auth::user_queries;
+use crate::queries::guests::guest_queries;
+use crate::repositories::auth::user_repository::{self, NewUser};
 use serde_json::json;
-use sqlx::Row;
 use tauri::State;
 
 // ═══════════════════════════════════════════════
 // Phase 1: Auth & RBAC Commands
 // ═══════════════════════════════════════════════
 
+/// Quick check-in searches on at least this many digits, so a stray keystroke
+/// does not pull the whole guest book back.
+const MIN_PHONE_SEARCH_LEN: usize = 3;
+
+/// Quick check-in shows a short pick-list, not a full result set.
+const PHONE_SEARCH_LIMIT: i32 = 5;
+
 #[tauri::command]
 pub async fn login(state: State<'_, AppState>, req: LoginRequest) -> CommandResult<LoginResponse> {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(req.pin.as_bytes());
-    let pin_hash = format!("{:x}", hasher.finalize());
+    let user = user_queries::load_active_user_by_pin_hash(&state.db, &pin_hash(&req.pin))
+        .await
+        .map_err(|error| {
+            log_system_error("login", error.to_string(), json!({ "step": "fetch_user" }))
+        })?;
 
-    let row = sqlx::query(
-        "SELECT id, name, role, active, created_at FROM users WHERE pin_hash = ? AND active = 1",
-    )
-    .bind(&pin_hash)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|error| {
-        log_system_error("login", error.to_string(), json!({ "step": "fetch_user" }))
-    })?;
-
-    let row = match row {
-        Some(row) => row,
+    let user = match user {
+        Some(user) => user,
         None => {
             return Err(CommandError::user(
                 codes::AUTH_INVALID_PIN,
                 "Mã PIN không đúng",
             ))
         }
-    };
-
-    let user = User {
-        id: row.get("id"),
-        name: row.get("name"),
-        role: row.get("role"),
-        active: row.get::<i32, _>("active") == 1,
-        created_at: row.get("created_at"),
     };
 
     // Store in AppState
@@ -75,28 +67,13 @@ pub async fn get_current_user(state: State<'_, AppState>) -> Result<Option<User>
 pub async fn list_users(state: State<'_, AppState>) -> CommandResult<Vec<User>> {
     require_admin(&state)?;
 
-    let rows =
-        sqlx::query("SELECT id, name, role, active, created_at FROM users ORDER BY created_at")
-            .fetch_all(&state.db)
-            .await
-            .map_err(|error| {
-                log_system_error(
-                    "list_users",
-                    error.to_string(),
-                    json!({ "step": "fetch_users" }),
-                )
-            })?;
-
-    Ok(rows
-        .iter()
-        .map(|r| User {
-            id: r.get("id"),
-            name: r.get("name"),
-            role: r.get("role"),
-            active: r.get::<i32, _>("active") == 1,
-            created_at: r.get("created_at"),
-        })
-        .collect())
+    user_queries::load_users(&state.db).await.map_err(|error| {
+        log_system_error(
+            "list_users",
+            error.to_string(),
+            json!({ "step": "fetch_users" }),
+        )
+    })
 }
 
 #[tauri::command]
@@ -107,24 +84,19 @@ pub async fn create_user(
     require_admin(&state)?;
 
     let CreateUserRequest { name, pin, role } = req;
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(pin.as_bytes());
-    let pin_hash = format!("{:x}", hasher.finalize());
-
     let id = uuid::Uuid::new_v4().to_string();
     let now = chrono::Local::now().to_rfc3339();
 
-    sqlx::query(
-        "INSERT INTO users (id, name, pin_hash, role, active, created_at)
-         VALUES (?, ?, ?, ?, 1, ?)",
+    user_repository::insert_user(
+        &state.db,
+        NewUser {
+            id: &id,
+            name: &name,
+            pin_hash: &pin_hash(&pin),
+            role: &role,
+            created_at: &now,
+        },
     )
-    .bind(&id)
-    .bind(&name)
-    .bind(&pin_hash)
-    .bind(&role)
-    .bind(&now)
-    .execute(&state.db)
     .await
     .map_err(|error| {
         log_system_error(
@@ -150,39 +122,11 @@ pub async fn search_guest_by_phone(
     state: State<'_, AppState>,
     phone: String,
 ) -> Result<Vec<GuestSummary>, String> {
-    if phone.len() < 3 {
+    if phone.len() < MIN_PHONE_SEARCH_LEN {
         return Ok(vec![]);
     }
 
-    let pattern = format!("%{}%", phone);
-    let rows = sqlx::query(
-        "SELECT g.id, g.full_name, g.doc_number, g.nationality,
-                COUNT(bg.booking_id) as total_stays,
-                COALESCE(SUM(b.total_price), 0) as total_spent,
-                MAX(b.check_in_at) as last_visit
-         FROM guests g
-         LEFT JOIN booking_guests bg ON bg.guest_id = g.id
-         LEFT JOIN bookings b ON b.id = bg.booking_id
-         WHERE g.phone LIKE ?
-         GROUP BY g.id
-         ORDER BY last_visit DESC
-         LIMIT 5",
-    )
-    .bind(&pattern)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    Ok(rows
-        .iter()
-        .map(|r| GuestSummary {
-            id: r.get("id"),
-            full_name: r.get("full_name"),
-            doc_number: r.get("doc_number"),
-            nationality: r.get("nationality"),
-            total_stays: r.get::<i32, _>("total_stays"),
-            total_spent: get_money_vnd(r, "total_spent"),
-            last_visit: r.get("last_visit"),
-        })
-        .collect())
+    guest_queries::search_guest_summaries_by_phone(&state.db, &phone, PHONE_SEARCH_LIMIT)
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/mhm/src-tauri/src/commands/bookings.rs
+++ b/mhm/src-tauri/src/commands/bookings.rs
@@ -1,7 +1,7 @@
 use super::AppState;
-use crate::db::row::{get_money_vnd, get_optional_money_vnd};
 use crate::models::*;
-use sqlx::{Pool, Row, Sqlite};
+use crate::queries::booking::booking_list_queries;
+use sqlx::{Pool, Sqlite};
 use tauri::State;
 
 // ─── A1: Get All Bookings (Reservations) ───
@@ -10,69 +10,9 @@ pub async fn do_get_all_bookings(
     pool: &Pool<Sqlite>,
     filter: Option<BookingFilter>,
 ) -> Result<Vec<BookingWithGuest>, String> {
-    let mut sql = String::from(
-        "SELECT b.id, b.room_id, r.name as room_name, g.full_name as guest_name,
-                b.check_in_at, b.expected_checkout, b.actual_checkout,
-                b.nights, b.total_price, b.paid_amount, b.status, b.source,
-                b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout, b.guest_phone
-         FROM bookings b
-         JOIN rooms r ON r.id = b.room_id
-         JOIN guests g ON g.id = b.primary_guest_id
-         WHERE 1=1"
-    );
-
-    let mut binds: Vec<String> = vec![];
-
-    if let Some(ref f) = filter {
-        if let Some(ref status) = f.status {
-            match status.as_str() {
-                "active" => sql.push_str(" AND b.status = 'active'"),
-                "completed" => sql.push_str(" AND b.status = 'checked_out'"),
-                "booked" => sql.push_str(" AND b.status = 'booked'"),
-                _ => {}
-            }
-        }
-        if let Some(ref from) = f.from {
-            sql.push_str(" AND b.check_in_at >= ?");
-            binds.push(from.clone());
-        }
-        if let Some(ref to) = f.to {
-            sql.push_str(" AND b.expected_checkout <= ?");
-            binds.push(to.clone());
-        }
-    }
-
-    sql.push_str(" ORDER BY b.check_in_at DESC");
-
-    let mut query = sqlx::query(&sql);
-    for b in &binds {
-        query = query.bind(b);
-    }
-
-    let rows = query.fetch_all(pool).await.map_err(|e| e.to_string())?;
-
-    Ok(rows
-        .iter()
-        .map(|r| BookingWithGuest {
-            id: r.get("id"),
-            room_id: r.get("room_id"),
-            room_name: r.get("room_name"),
-            guest_name: r.get("guest_name"),
-            check_in_at: r.get("check_in_at"),
-            expected_checkout: r.get("expected_checkout"),
-            actual_checkout: r.get("actual_checkout"),
-            nights: r.get("nights"),
-            total_price: get_money_vnd(r, "total_price"),
-            paid_amount: get_money_vnd(r, "paid_amount"),
-            status: r.get("status"),
-            source: r.get("source"),
-            booking_type: r.get("booking_type"),
-            deposit_amount: get_optional_money_vnd(r, "deposit_amount"),
-            scheduled_checkin: r.get("scheduled_checkin"),
-            scheduled_checkout: r.get("scheduled_checkout"),
-            guest_phone: r.get("guest_phone"),
-        })
-        .collect())
+    booking_list_queries::load_bookings_with_guest(pool, filter)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/mhm/src-tauri/src/commands/declaration.rs
+++ b/mhm/src-tauri/src/commands/declaration.rs
@@ -10,7 +10,9 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::declaration::catalog::Catalog;
-use crate::declaration::model::{Confidence, DeclarationRow, Finding, Identity, Severity, StayInfo};
+use crate::declaration::model::{
+    Confidence, DeclarationRow, Finding, Identity, Severity, StayInfo,
+};
 use crate::declaration::{repo, validator, writer};
 use crate::AppState;
 
@@ -134,9 +136,8 @@ pub async fn kbtt_extract_from_image(path: String) -> Result<ExtractedDto, Strin
             .and_then(|ocr| MrzExtractor::new(ocr, current_year()).try_extract(&img))
     });
 
-    let res = result.ok_or_else(|| {
-        "Không đọc được QR hay MRZ trong ảnh. Dùng form nhập tay.".to_string()
-    })?;
+    let res = result
+        .ok_or_else(|| "Không đọc được QR hay MRZ trong ảnh. Dùng form nhập tay.".to_string())?;
 
     let crop_data_url = res.crop_for_review.as_ref().and_then(|c| {
         use base64::Engine;
@@ -195,9 +196,7 @@ pub async fn kbtt_link(
 /// Danh tính đã lưu nhưng chưa ghép — nguồn sự thật là DB, không phải state của
 /// React, nên đổi tab không làm mất.
 #[tauri::command]
-pub async fn kbtt_unlinked_identities(
-    state: State<'_, AppState>,
-) -> Result<Vec<Identity>, String> {
+pub async fn kbtt_unlinked_identities(state: State<'_, AppState>) -> Result<Vec<Identity>, String> {
     repo::list_unlinked_identities(&state.db).await
 }
 
@@ -238,8 +237,7 @@ pub async fn kbtt_validate(
 
     let confidence = repo::confidence_by_link(&state.db, &link_ids).await?;
     for row in &rows {
-        if confidence.get(&row.link_id).map(String::as_str)
-            == Some(Confidence::NeedsReview.as_db())
+        if confidence.get(&row.link_id).map(String::as_str) == Some(Confidence::NeedsReview.as_db())
         {
             findings.push(Finding::warning(
                 "W05",
@@ -277,7 +275,10 @@ pub async fn kbtt_export(
             .collect();
         codes.sort_unstable();
         codes.dedup();
-        return Err(format!("Còn lỗi chặn, không xuất được: {}", codes.join(", ")));
+        return Err(format!(
+            "Còn lỗi chặn, không xuất được: {}",
+            codes.join(", ")
+        ));
     }
 
     let dir = repo::export_dir(pool).await?;
@@ -303,13 +304,8 @@ pub async fn kbtt_export(
         other => return Err(format!("Loại lô không hợp lệ: {other}")),
     };
 
-    let batch_id = repo::insert_batch(
-        pool,
-        &kind,
-        &file_path.to_string_lossy(),
-        rows.len() as i64,
-    )
-    .await?;
+    let batch_id =
+        repo::insert_batch(pool, &kind, &file_path.to_string_lossy(), rows.len() as i64).await?;
     repo::insert_entries(pool, &batch_id, &link_ids).await?;
 
     Ok(BatchDto {
@@ -413,8 +409,7 @@ mod tests {
             .join("src")
             .join("types")
             .join("index.ts");
-        std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("đọc {}: {e}", path.display()))
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("đọc {}: {e}", path.display()))
     }
 
     fn sample_row() -> DeclarationRow {

--- a/mhm/src-tauri/src/commands/groups.rs
+++ b/mhm/src-tauri/src/commands/groups.rs
@@ -1,6 +1,10 @@
 use super::{emit_db_update, get_user_id, AppState};
-use crate::db::row::{get_money_vnd, get_optional_money_vnd};
+use crate::domain::booking::room_allocation::assign_rooms_by_floor;
+use crate::domain::hotel_info::HotelInfo;
+use crate::queries::groups::group_queries;
+use crate::queries::rooms::room_admin_queries;
 use crate::services::booking::group_lifecycle;
+use crate::services::settings_store::get_setting;
 use crate::{
     app_error::{codes, log_system_error, normalize_correlation_id, CommandError, CommandResult},
     command_idempotency::WriteCommandContext,
@@ -13,7 +17,7 @@ use crate::{
     domain::booking::BookingError,
 };
 use serde_json::{json, Value};
-use sqlx::{Pool, Row, Sqlite};
+use sqlx::{Pool, Sqlite};
 use tauri::State;
 
 // ─── Group Booking Commands ───
@@ -360,111 +364,11 @@ pub async fn group_checkout(
     Ok(response)
 }
 
-/// Get group detail with bookings, services, totals
-async fn load_group_detail(
-    pool: &Pool<Sqlite>,
-    group_id: &str,
-) -> Result<GroupDetailResponse, sqlx::Error> {
-    let row = sqlx::query("SELECT * FROM booking_groups WHERE id = ?")
-        .bind(group_id)
-        .fetch_one(pool)
-        .await?;
-
-    let group = BookingGroup {
-        id: row.get("id"),
-        group_name: row.get("group_name"),
-        master_booking_id: row.get("master_booking_id"),
-        organizer_name: row.get("organizer_name"),
-        organizer_phone: row.get("organizer_phone"),
-        total_rooms: row.get("total_rooms"),
-        status: row.get("status"),
-        notes: row.get("notes"),
-        created_by: row.get("created_by"),
-        created_at: row.get("created_at"),
-    };
-
-    // Get bookings
-    let booking_rows = sqlx::query(
-        "SELECT b.id, b.room_id, r.name as room_name, g.full_name as guest_name,
-                b.check_in_at, b.expected_checkout, b.actual_checkout, b.nights,
-                b.total_price, b.paid_amount, b.status, b.source,
-                b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout, b.guest_phone
-         FROM bookings b
-         JOIN rooms r ON r.id = b.room_id
-         JOIN guests g ON g.id = b.primary_guest_id
-         WHERE b.group_id = ?
-         ORDER BY r.floor, r.id"
-    )
-    .bind(group_id)
-    .fetch_all(pool)
-    .await?;
-
-    let bookings: Vec<BookingWithGuest> = booking_rows
-        .iter()
-        .map(|r| BookingWithGuest {
-            id: r.get("id"),
-            room_id: r.get("room_id"),
-            room_name: r.get("room_name"),
-            guest_name: r.get("guest_name"),
-            check_in_at: r.get("check_in_at"),
-            expected_checkout: r.get("expected_checkout"),
-            actual_checkout: r.get("actual_checkout"),
-            nights: r.get("nights"),
-            total_price: get_money_vnd(r, "total_price"),
-            paid_amount: get_money_vnd(r, "paid_amount"),
-            status: r.get("status"),
-            source: r.get("source"),
-            booking_type: r.get("booking_type"),
-            deposit_amount: get_optional_money_vnd(r, "deposit_amount"),
-            scheduled_checkin: r.get("scheduled_checkin"),
-            scheduled_checkout: r.get("scheduled_checkout"),
-            guest_phone: r.get("guest_phone"),
-        })
-        .collect();
-
-    // Get services
-    let service_rows =
-        sqlx::query("SELECT * FROM group_services WHERE group_id = ? ORDER BY created_at")
-            .bind(group_id)
-            .fetch_all(pool)
-            .await?;
-
-    let services: Vec<GroupService> = service_rows
-        .iter()
-        .map(|r| GroupService {
-            id: r.get("id"),
-            group_id: r.get("group_id"),
-            booking_id: r.get("booking_id"),
-            name: r.get("name"),
-            quantity: r.get("quantity"),
-            unit_price: get_money_vnd(r, "unit_price"),
-            total_price: get_money_vnd(r, "total_price"),
-            note: r.get("note"),
-            created_by: r.get("created_by"),
-            created_at: r.get("created_at"),
-        })
-        .collect();
-
-    let total_room_cost = bookings.iter().map(|b| b.total_price).sum();
-    let total_service_cost = services.iter().map(|s| s.total_price).sum();
-    let paid_amount = bookings.iter().map(|b| b.paid_amount).sum();
-
-    Ok(GroupDetailResponse {
-        group,
-        bookings,
-        services,
-        total_room_cost,
-        total_service_cost,
-        grand_total: total_room_cost + total_service_cost,
-        paid_amount,
-    })
-}
-
 pub async fn do_get_group_detail(
     pool: &Pool<Sqlite>,
     group_id: &str,
 ) -> Result<GroupDetailResponse, String> {
-    load_group_detail(pool, group_id)
+    group_queries::load_group_detail(pool, group_id)
         .await
         .map_err(|error| error.to_string())
 }
@@ -474,7 +378,7 @@ pub async fn get_group_detail(
     state: State<'_, AppState>,
     group_id: String,
 ) -> CommandResult<GroupDetailResponse> {
-    load_group_detail(&state.db, &group_id)
+    group_queries::load_group_detail(&state.db, &group_id)
         .await
         .map_err(|error| map_group_detail_error(&group_id, error))
 }
@@ -485,34 +389,9 @@ pub async fn get_all_groups(
     state: State<'_, AppState>,
     status: Option<String>,
 ) -> Result<Vec<BookingGroup>, String> {
-    let rows = if let Some(ref s) = status {
-        sqlx::query("SELECT * FROM booking_groups WHERE status = ? ORDER BY created_at DESC")
-            .bind(s)
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| e.to_string())?
-    } else {
-        sqlx::query("SELECT * FROM booking_groups ORDER BY created_at DESC")
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| e.to_string())?
-    };
-
-    Ok(rows
-        .iter()
-        .map(|r| BookingGroup {
-            id: r.get("id"),
-            group_name: r.get("group_name"),
-            master_booking_id: r.get("master_booking_id"),
-            organizer_name: r.get("organizer_name"),
-            organizer_phone: r.get("organizer_phone"),
-            total_rooms: r.get("total_rooms"),
-            status: r.get("status"),
-            notes: r.get("notes"),
-            created_by: r.get("created_by"),
-            created_at: r.get("created_at"),
-        })
-        .collect())
+    group_queries::load_groups(&state.db, status.as_deref())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Add a group service (laundry, tour, motorbike, etc.)
@@ -606,89 +485,31 @@ pub async fn auto_assign_rooms(
         ));
     }
 
-    let rows = if let Some(ref rt) = req.room_type {
-        sqlx::query("SELECT * FROM rooms WHERE status = 'vacant' AND type = ? ORDER BY floor, id")
-            .bind(rt)
-            .fetch_all(&state.db)
-            .await
-            .map_err(|error| {
-                log_system_error(
-                    "auto_assign_rooms",
-                    error.to_string(),
-                    json!({ "room_count": req.room_count, "room_type": req.room_type }),
-                )
-            })?
-    } else {
-        sqlx::query("SELECT * FROM rooms WHERE status = 'vacant' ORDER BY floor, id")
-            .fetch_all(&state.db)
-            .await
-            .map_err(|error| {
-                log_system_error(
-                    "auto_assign_rooms",
-                    error.to_string(),
-                    json!({ "room_count": req.room_count, "room_type": req.room_type }),
-                )
-            })?
-    };
+    let vacant_rooms = room_admin_queries::load_vacant_rooms(&state.db, req.room_type.as_deref())
+        .await
+        .map_err(|error| {
+            log_system_error(
+                "auto_assign_rooms",
+                error.to_string(),
+                json!({ "room_count": req.room_count, "room_type": req.room_type }),
+            )
+        })?;
 
-    let vacant_rooms: Vec<Room> = rows
-        .iter()
-        .map(|r| Room {
-            id: r.get("id"),
-            name: r.get("name"),
-            room_type: r.get("type"),
-            floor: r.get("floor"),
-            has_balcony: r.get::<i32, _>("has_balcony") == 1,
-            base_price: get_money_vnd(r, "base_price"),
-            max_guests: r.try_get::<i32, _>("max_guests").unwrap_or(2),
-            extra_person_fee: get_money_vnd(r, "extra_person_fee"),
-            status: r.get("status"),
-        })
-        .collect();
-
-    if vacant_rooms.len() < req.room_count as usize {
-        return Err(map_auto_assign_error(
-            "auto_assign_rooms",
-            format!(
-                "Chỉ có {} phòng trống, cần {} phòng",
-                vacant_rooms.len(),
-                req.room_count
-            ),
-            json!({
-                "available_rooms": vacant_rooms.len(),
-                "requested_rooms": req.room_count,
-                "room_type": req.room_type,
-            }),
-        ));
-    }
-
-    // Group by floor, sort by count descending (greedy fill)
-    let mut floor_groups: std::collections::HashMap<i32, Vec<&Room>> =
-        std::collections::HashMap::new();
-    for room in &vacant_rooms {
-        floor_groups.entry(room.floor).or_default().push(room);
-    }
-
-    let mut floors_sorted: Vec<(i32, Vec<&Room>)> = floor_groups.into_iter().collect();
-    floors_sorted.sort_by_key(|(_, rooms)| std::cmp::Reverse(rooms.len()));
-
-    let mut assignments = Vec::new();
-    let needed = req.room_count as usize;
-
-    for (floor, rooms) in &floors_sorted {
-        if assignments.len() >= needed {
-            break;
-        }
-        for room in rooms {
-            if assignments.len() >= needed {
-                break;
-            }
-            assignments.push(RoomAssignment {
-                room: (*room).clone(),
-                floor: *floor,
-            });
-        }
-    }
+    let assignments =
+        assign_rooms_by_floor(&vacant_rooms, req.room_count as usize).map_err(|shortfall| {
+            map_auto_assign_error(
+                "auto_assign_rooms",
+                format!(
+                    "Chỉ có {} phòng trống, cần {} phòng",
+                    shortfall.available, shortfall.requested
+                ),
+                json!({
+                    "available_rooms": shortfall.available,
+                    "requested_rooms": shortfall.requested,
+                    "room_type": req.room_type,
+                }),
+            )
+        })?;
 
     Ok(AutoAssignResult { assignments })
 }
@@ -700,30 +521,7 @@ pub async fn do_generate_group_invoice(
 ) -> Result<GroupInvoiceData, String> {
     let detail = do_get_group_detail(pool, group_id).await?;
 
-    // Get hotel info from settings
-    let hotel_info =
-        sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'hotel_info'")
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| e.to_string())?;
-
-    let (hotel_name, hotel_address, hotel_phone) = if let Some((val,)) = hotel_info {
-        let parsed: serde_json::Value = serde_json::from_str(&val).unwrap_or_default();
-        (
-            parsed["name"]
-                .as_str()
-                .unwrap_or(crate::app_identity::APP_NAME)
-                .to_string(),
-            parsed["address"].as_str().unwrap_or("").to_string(),
-            parsed["phone"].as_str().unwrap_or("").to_string(),
-        )
-    } else {
-        (
-            crate::app_identity::APP_NAME.to_string(),
-            String::new(),
-            String::new(),
-        )
-    };
+    let hotel = HotelInfo::from_settings_json(get_setting(pool, "hotel_info").await?.as_deref());
 
     // Build room lines
     let rooms: Vec<GroupInvoiceRoomLine> = detail
@@ -755,9 +553,9 @@ pub async fn do_generate_group_invoice(
         grand_total: detail.grand_total,
         paid_amount: detail.paid_amount,
         balance_due: detail.grand_total - detail.paid_amount,
-        hotel_name,
-        hotel_address,
-        hotel_phone,
+        hotel_name: hotel.name,
+        hotel_address: hotel.address,
+        hotel_phone: hotel.phone,
     })
 }
 

--- a/mhm/src-tauri/src/commands/guests.rs
+++ b/mhm/src-tauri/src/commands/guests.rs
@@ -1,7 +1,6 @@
 use super::AppState;
-use crate::db::row::get_money_vnd;
 use crate::models::*;
-use sqlx::Row;
+use crate::queries::guests::guest_queries;
 use tauri::State;
 
 // ─── A2: Get All Guests ───
@@ -11,56 +10,9 @@ pub async fn get_all_guests(
     state: State<'_, AppState>,
     search: Option<String>,
 ) -> Result<Vec<GuestSummary>, String> {
-    let sql = if search.is_some() {
-        "SELECT g.id, g.full_name, g.doc_number, g.nationality,
-                COUNT(bg.booking_id) as total_stays,
-                COALESCE(SUM(b.total_price), 0) as total_spent,
-                MAX(b.check_in_at) as last_visit
-         FROM guests g
-         LEFT JOIN booking_guests bg ON bg.guest_id = g.id
-         LEFT JOIN bookings b ON b.id = bg.booking_id
-         WHERE g.full_name LIKE ? OR g.doc_number LIKE ?
-         GROUP BY g.id
-         ORDER BY last_visit DESC"
-    } else {
-        "SELECT g.id, g.full_name, g.doc_number, g.nationality,
-                COUNT(bg.booking_id) as total_stays,
-                COALESCE(SUM(b.total_price), 0) as total_spent,
-                MAX(b.check_in_at) as last_visit
-         FROM guests g
-         LEFT JOIN booking_guests bg ON bg.guest_id = g.id
-         LEFT JOIN bookings b ON b.id = bg.booking_id
-         GROUP BY g.id
-         ORDER BY last_visit DESC"
-    };
-
-    let rows = if let Some(ref s) = search {
-        let pattern = format!("%{}%", s);
-        sqlx::query(sql)
-            .bind(&pattern)
-            .bind(&pattern)
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| e.to_string())?
-    } else {
-        sqlx::query(sql)
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| e.to_string())?
-    };
-
-    Ok(rows
-        .iter()
-        .map(|r| GuestSummary {
-            id: r.get("id"),
-            full_name: r.get("full_name"),
-            doc_number: r.get("doc_number"),
-            nationality: r.get("nationality"),
-            total_stays: r.get::<i32, _>("total_stays"),
-            total_spent: get_money_vnd(r, "total_spent"),
-            last_visit: r.get("last_visit"),
-        })
-        .collect())
+    guest_queries::load_guest_summaries(&state.db, search.as_deref())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 // ─── A2: Get Guest History ───
@@ -70,48 +22,12 @@ pub async fn get_guest_history(
     state: State<'_, AppState>,
     guest_id: String,
 ) -> Result<GuestHistoryResponse, String> {
-    let row = sqlx::query("SELECT * FROM guests WHERE id = ?")
-        .bind(&guest_id)
-        .fetch_one(&state.db)
+    let guest = guest_queries::load_guest(&state.db, &guest_id)
         .await
         .map_err(|e| e.to_string())?;
-
-    let guest = Guest {
-        id: row.get("id"),
-        guest_type: row.get("guest_type"),
-        full_name: row.get("full_name"),
-        doc_number: row.get("doc_number"),
-        dob: row.get("dob"),
-        gender: row.get("gender"),
-        nationality: row.get("nationality"),
-        address: row.get("address"),
-        visa_expiry: row.get("visa_expiry"),
-        scan_path: row.get("scan_path"),
-        phone: row.get("phone"),
-        created_at: row.get("created_at"),
-    };
-
-    let booking_rows = sqlx::query(
-        "SELECT b.id as booking_id, b.room_id, b.check_in_at, b.expected_checkout, b.total_price, b.status
-         FROM bookings b
-         JOIN booking_guests bg ON bg.booking_id = b.id
-         WHERE bg.guest_id = ?
-         ORDER BY b.check_in_at DESC"
-    )
-    .bind(&guest_id)
-    .fetch_all(&state.db).await.map_err(|e| e.to_string())?;
-
-    let bookings = booking_rows
-        .iter()
-        .map(|r| BookingWithRoom {
-            booking_id: r.get("booking_id"),
-            room_id: r.get("room_id"),
-            check_in_at: r.get("check_in_at"),
-            expected_checkout: r.get("expected_checkout"),
-            total_price: get_money_vnd(r, "total_price"),
-            status: r.get("status"),
-        })
-        .collect();
+    let bookings = guest_queries::load_guest_bookings(&state.db, &guest_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(GuestHistoryResponse { guest, bookings })
 }

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -1,7 +1,16 @@
+//! Pricing configuration and price-preview commands.
+//!
+//! Boundary adapters only: check the caller is an admin, shape the JSON the
+//! settings screen expects, and delegate. The preview shares
+//! `services::booking::pricing_service` with the lifecycle charge, so the quote
+//! the UI shows and the amount the guest is billed come from one implementation.
+
 use super::{emit_db_update, require_admin, AppState};
-use crate::db::row::{get_f64, get_money_vnd};
-use crate::money::{validate_non_negative_money_vnd, MoneyVnd};
-use sqlx::{Pool, Row, Sqlite};
+use crate::money::MoneyVnd;
+use crate::queries::booking::pricing_queries;
+use crate::repositories::booking::pricing_repository;
+use crate::services::booking::pricing_service::{self, SavePricingRule};
+use sqlx::{Pool, Sqlite};
 use tauri::State;
 
 // ═══════════════════════════════════════════════
@@ -9,33 +18,26 @@ use tauri::State;
 // ═══════════════════════════════════════════════
 
 pub async fn do_get_pricing_rules(pool: &Pool<Sqlite>) -> Result<Vec<serde_json::Value>, String> {
-    let rows = sqlx::query(
-        "SELECT id, room_type, hourly_rate, overnight_rate, daily_rate,
-                overnight_start, overnight_end, daily_checkin, daily_checkout,
-                early_checkin_surcharge_pct, late_checkout_surcharge_pct,
-                weekend_uplift_pct
-         FROM pricing_rules ORDER BY room_type",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let listings = pricing_queries::load_pricing_rule_listings(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    Ok(rows
+    Ok(listings
         .iter()
-        .map(|r| {
+        .map(|listing| {
             serde_json::json!({
-                "id": r.get::<String, _>("id"),
-                "room_type": r.get::<String, _>("room_type"),
-                "hourly_rate": get_money_vnd(r, "hourly_rate"),
-                "overnight_rate": get_money_vnd(r, "overnight_rate"),
-                "daily_rate": get_money_vnd(r, "daily_rate"),
-                "overnight_start": r.get::<String, _>("overnight_start"),
-                "overnight_end": r.get::<String, _>("overnight_end"),
-                "daily_checkin": r.get::<String, _>("daily_checkin"),
-                "daily_checkout": r.get::<String, _>("daily_checkout"),
-                "early_checkin_surcharge_pct": get_f64(r, "early_checkin_surcharge_pct"),
-                "late_checkout_surcharge_pct": get_f64(r, "late_checkout_surcharge_pct"),
-                "weekend_uplift_pct": get_f64(r, "weekend_uplift_pct"),
+                "id": listing.id,
+                "room_type": listing.rule.room_type,
+                "hourly_rate": listing.rule.hourly_rate,
+                "overnight_rate": listing.rule.overnight_rate,
+                "daily_rate": listing.rule.daily_rate,
+                "overnight_start": listing.rule.overnight_start,
+                "overnight_end": listing.rule.overnight_end,
+                "daily_checkin": listing.rule.daily_checkin,
+                "daily_checkout": listing.rule.daily_checkout,
+                "early_checkin_surcharge_pct": listing.rule.early_checkin_surcharge_pct,
+                "late_checkout_surcharge_pct": listing.rule.late_checkout_surcharge_pct,
+                "weekend_uplift_pct": listing.rule.weekend_uplift_pct,
             })
         })
         .collect())
@@ -46,18 +48,6 @@ pub async fn get_pricing_rules(
     state: State<'_, AppState>,
 ) -> Result<Vec<serde_json::Value>, String> {
     do_get_pricing_rules(&state.db).await
-}
-
-fn validate_pricing_rule_money(
-    hourly_rate: MoneyVnd,
-    overnight_rate: MoneyVnd,
-    daily_rate: MoneyVnd,
-) -> crate::app_error::CommandResult<(MoneyVnd, MoneyVnd, MoneyVnd)> {
-    Ok((
-        validate_non_negative_money_vnd(hourly_rate, "hourly_rate")?,
-        validate_non_negative_money_vnd(overnight_rate, "overnight_rate")?,
-        validate_non_negative_money_vnd(daily_rate, "daily_rate")?,
-    ))
 }
 
 #[tauri::command]
@@ -78,73 +68,29 @@ pub async fn save_pricing_rule(
     weekend_pct: Option<f64>,
 ) -> Result<(), String> {
     require_admin(&state)?;
-    let (hourly_rate, overnight_rate, daily_rate) =
-        validate_pricing_rule_money(hourly_rate, overnight_rate, daily_rate)?;
 
-    let now = chrono::Local::now().to_rfc3339();
-    let id = uuid::Uuid::new_v4().to_string();
-
-    sqlx::query(
-        "INSERT INTO pricing_rules
-         (id, room_type, hourly_rate, overnight_rate, daily_rate,
-          overnight_start, overnight_end, daily_checkin, daily_checkout,
-          early_checkin_surcharge_pct, late_checkout_surcharge_pct,
-          weekend_uplift_pct, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT(room_type) DO UPDATE SET
-            hourly_rate = excluded.hourly_rate,
-            overnight_rate = excluded.overnight_rate,
-            daily_rate = excluded.daily_rate,
-            overnight_start = excluded.overnight_start,
-            overnight_end = excluded.overnight_end,
-            daily_checkin = excluded.daily_checkin,
-            daily_checkout = excluded.daily_checkout,
-            early_checkin_surcharge_pct = excluded.early_checkin_surcharge_pct,
-            late_checkout_surcharge_pct = excluded.late_checkout_surcharge_pct,
-            weekend_uplift_pct = excluded.weekend_uplift_pct,
-            updated_at = excluded.updated_at",
+    pricing_service::save_pricing_rule(
+        &state.db,
+        SavePricingRule {
+            room_type,
+            hourly_rate,
+            overnight_rate,
+            daily_rate,
+            overnight_start,
+            overnight_end,
+            daily_checkin,
+            daily_checkout,
+            early_pct,
+            late_pct,
+            weekend_pct,
+        },
+        uuid::Uuid::new_v4().to_string(),
+        chrono::Local::now().to_rfc3339(),
     )
-    .bind(&id)
-    .bind(&room_type)
-    .bind(hourly_rate)
-    .bind(overnight_rate)
-    .bind(daily_rate)
-    .bind(overnight_start.as_deref().unwrap_or("22:00"))
-    .bind(overnight_end.as_deref().unwrap_or("11:00"))
-    .bind(daily_checkin.as_deref().unwrap_or("14:00"))
-    .bind(daily_checkout.as_deref().unwrap_or("12:00"))
-    .bind(early_pct.unwrap_or(30.0))
-    .bind(late_pct.unwrap_or(30.0))
-    .bind(weekend_pct.unwrap_or(0.0))
-    .bind(&now)
-    .bind(&now)
-    .execute(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
+    .await?;
 
     emit_db_update(&app, "pricing");
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::validate_pricing_rule_money;
-    use crate::app_error::codes;
-
-    #[test]
-    fn save_pricing_rule_rejects_negative_money_rates() {
-        for (hourly_rate, overnight_rate, daily_rate, field) in [
-            (-1, 300_000, 400_000, "hourly_rate"),
-            (80_000, -1, 400_000, "overnight_rate"),
-            (80_000, 300_000, -1, "daily_rate"),
-        ] {
-            let error = validate_pricing_rule_money(hourly_rate, overnight_rate, daily_rate)
-                .expect_err("negative pricing money must fail");
-
-            assert_eq!(error.code, codes::VALIDATION_INVALID_INPUT);
-            assert!(error.message.contains(field));
-        }
-    }
 }
 
 pub async fn do_calculate_price_preview(
@@ -154,58 +100,9 @@ pub async fn do_calculate_price_preview(
     check_out: &str,
     pricing_type: &str,
 ) -> Result<crate::pricing::PricingResult, String> {
-    let room_type_lower = room_type.to_lowercase();
-    let row = sqlx::query(
-        "SELECT room_type, hourly_rate, overnight_rate, daily_rate,
-                overnight_start, overnight_end, daily_checkin, daily_checkout,
-                early_checkin_surcharge_pct, late_checkout_surcharge_pct,
-                weekend_uplift_pct
-         FROM pricing_rules WHERE LOWER(room_type) = ?",
-    )
-    .bind(&room_type_lower)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    let rule = match row {
-        Some(r) => crate::pricing::PricingRule {
-            room_type: r.get("room_type"),
-            hourly_rate: get_money_vnd(&r, "hourly_rate"),
-            overnight_rate: get_money_vnd(&r, "overnight_rate"),
-            daily_rate: get_money_vnd(&r, "daily_rate"),
-            overnight_start: r.get("overnight_start"),
-            overnight_end: r.get("overnight_end"),
-            daily_checkin: r.get("daily_checkin"),
-            daily_checkout: r.get("daily_checkout"),
-            early_checkin_surcharge_pct: get_f64(&r, "early_checkin_surcharge_pct"),
-            late_checkout_surcharge_pct: get_f64(&r, "late_checkout_surcharge_pct"),
-            weekend_uplift_pct: get_f64(&r, "weekend_uplift_pct"),
-        },
-        None => {
-            let fallback_row =
-                sqlx::query("SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1")
-                    .bind(&room_type_lower)
-                    .fetch_optional(pool)
-                    .await
-                    .map_err(|e| e.to_string())?;
-            let fallback_price = fallback_row
-                .as_ref()
-                .map(|r| get_money_vnd(r, "base_price"))
-                .unwrap_or(350_000);
-
-            crate::pricing::PricingRule {
-                room_type: room_type.to_string(),
-                hourly_rate: fallback_price / 5,
-                overnight_rate: fallback_price * 75 / 100,
-                daily_rate: fallback_price,
-                ..Default::default()
-            }
-        }
-    };
-
-    let special_uplift = do_get_special_uplift(pool, check_in).await;
-
-    crate::pricing::calculate_price(&rule, check_in, check_out, pricing_type, special_uplift)
+    pricing_service::calculate_price_preview(pool, room_type, check_in, check_out, pricing_type)
+        .await
+        .map_err(|error| error.to_string())
 }
 
 #[tauri::command]
@@ -219,39 +116,22 @@ pub async fn calculate_price_preview(
     do_calculate_price_preview(&state.db, &room_type, &check_in, &check_out, &pricing_type).await
 }
 
-pub async fn do_get_special_uplift(pool: &Pool<Sqlite>, date_str: &str) -> f64 {
-    let date = if date_str.len() >= 10 {
-        &date_str[..10]
-    } else {
-        date_str
-    };
-    let row: Option<(f64,)> =
-        sqlx::query_as("SELECT CAST(uplift_pct AS REAL) FROM special_dates WHERE date = ?")
-            .bind(date)
-            .fetch_optional(pool)
-            .await
-            .ok()
-            .flatten();
-    row.map(|r| r.0).unwrap_or(0.0)
-}
-
 #[tauri::command]
 pub async fn get_special_dates(
     state: State<'_, AppState>,
 ) -> Result<Vec<serde_json::Value>, String> {
-    let rows = sqlx::query("SELECT id, date, label, uplift_pct FROM special_dates ORDER BY date")
-        .fetch_all(&state.db)
+    let dates = pricing_queries::load_special_dates(&state.db)
         .await
         .map_err(|e| e.to_string())?;
 
-    Ok(rows
+    Ok(dates
         .iter()
-        .map(|r| {
+        .map(|date| {
             serde_json::json!({
-                "id": r.get::<String, _>("id"),
-                "date": r.get::<String, _>("date"),
-                "label": r.get::<String, _>("label"),
-                "uplift_pct": get_f64(r, "uplift_pct"),
+                "id": date.id,
+                "date": date.date,
+                "label": date.label,
+                "uplift_pct": date.uplift_pct,
             })
         })
         .collect())
@@ -266,24 +146,14 @@ pub async fn save_special_date(
 ) -> Result<(), String> {
     require_admin(&state)?;
 
-    let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Local::now().to_rfc3339();
-
-    sqlx::query(
-        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
-         VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(date) DO UPDATE SET
-            label = excluded.label,
-            uplift_pct = excluded.uplift_pct",
+    pricing_repository::upsert_special_date(
+        &state.db,
+        &uuid::Uuid::new_v4().to_string(),
+        &date,
+        &label,
+        uplift_pct,
+        &chrono::Local::now().to_rfc3339(),
     )
-    .bind(&id)
-    .bind(&date)
-    .bind(&label)
-    .bind(uplift_pct)
-    .bind(&now)
-    .execute(&state.db)
     .await
-    .map_err(|e| e.to_string())?;
-
-    Ok(())
+    .map_err(|e| e.to_string())
 }

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -1,18 +1,18 @@
 use super::{emit_db_update, get_user_id, AppState};
-use crate::db::row::get_money_vnd;
 use crate::{
     app_error::{
-        codes, log_system_error, normalize_correlation_id, record_command_failure_with_db_group,
-        CommandError, CommandResult,
+        codes, normalize_correlation_id, record_command_failure_with_db_group, CommandError,
+        CommandResult,
     },
     command_idempotency::WriteCommandContext,
     models::*,
     money::validate_non_negative_money_vnd,
-    queries::booking::{revenue_queries, room_queries},
-    services::booking::stay_lifecycle,
+    queries::booking::{expense_queries, revenue_queries, room_queries, stay_info_queries},
+    repositories::booking::expense_repository,
+    services::{booking::stay_lifecycle, housekeeping::housekeeping_service},
 };
 use serde_json::{json, Value};
-use sqlx::{Pool, Row, Sqlite};
+use sqlx::{Pool, Sqlite};
 use tauri::State;
 
 // ─── Room Commands ───
@@ -299,24 +299,7 @@ pub async fn extend_stay(
 pub async fn get_housekeeping_tasks(
     state: State<'_, AppState>,
 ) -> Result<Vec<HousekeepingTask>, String> {
-    let rows =
-        sqlx::query("SELECT * FROM housekeeping WHERE status != 'clean' ORDER BY triggered_at ASC")
-            .fetch_all(&state.db)
-            .await
-            .map_err(|e| e.to_string())?;
-
-    Ok(rows
-        .iter()
-        .map(|r| HousekeepingTask {
-            id: r.get("id"),
-            room_id: r.get("room_id"),
-            status: r.get("status"),
-            note: r.get("note"),
-            triggered_at: r.get("triggered_at"),
-            cleaned_at: r.get("cleaned_at"),
-            created_at: r.get("created_at"),
-        })
-        .collect())
+    housekeeping_service::list_open_tasks(&state.db).await
 }
 
 #[tauri::command]
@@ -327,141 +310,11 @@ pub async fn update_housekeeping(
     new_status: String,
     note: Option<String>,
 ) -> Result<(), String> {
-    if new_status == "clean" {
-        complete_housekeeping_clean_to_vacant(&state.db, &task_id, note.as_deref())
-            .await
-            .map_err(|error| format!("{}: {}", error.code, error.message))?;
-        emit_db_update(&app, "housekeeping");
-        return Ok(());
-    }
-
-    let now = chrono::Local::now();
-
-    let cleaned_at = if new_status == "clean" {
-        Some(now.to_rfc3339())
-    } else {
-        None
-    };
-
-    sqlx::query(
-        "UPDATE housekeeping SET status = ?, note = COALESCE(?, note), cleaned_at = ? WHERE id = ?",
-    )
-    .bind(&new_status)
-    .bind(&note)
-    .bind(&cleaned_at)
-    .bind(&task_id)
-    .execute(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
+    housekeeping_service::update_status(&state.db, &task_id, &new_status, note.as_deref())
+        .await
+        .map_err(|error| format!("{}: {}", error.code, error.message))?;
 
     emit_db_update(&app, "housekeeping");
-
-    Ok(())
-}
-
-async fn complete_housekeeping_clean_to_vacant(
-    pool: &Pool<Sqlite>,
-    task_id: &str,
-    note: Option<&str>,
-) -> CommandResult<()> {
-    let room_id: String = sqlx::query_scalar("SELECT room_id FROM housekeeping WHERE id = ?")
-        .bind(task_id)
-        .fetch_one(pool)
-        .await
-        .map_err(|error| {
-            log_system_error(
-                "update_housekeeping",
-                error.to_string(),
-                json!({
-                    "task_id": task_id,
-                    "step": "lookup_room",
-                }),
-            )
-        })?;
-
-    let _lock_guard = crate::aggregate_locks::global_manager()
-        .acquire([crate::aggregate_locks::room_key(&room_id)?])
-        .await?;
-
-    let mut tx = pool.begin().await.map_err(|error| {
-        log_system_error(
-            "update_housekeeping",
-            error.to_string(),
-            json!({
-                "task_id": task_id,
-                "room_id": room_id,
-                "step": "begin",
-            }),
-        )
-    })?;
-
-    let cleaned_at = chrono::Local::now().to_rfc3339();
-    let housekeeping_result = sqlx::query(
-        "UPDATE housekeeping
-         SET status = 'clean', note = COALESCE(?, note), cleaned_at = ?
-         WHERE id = ? AND status = 'cleaning'",
-    )
-    .bind(note)
-    .bind(&cleaned_at)
-    .bind(task_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|error| {
-        log_system_error(
-            "update_housekeeping",
-            error.to_string(),
-            json!({
-                "task_id": task_id,
-                "room_id": room_id,
-                "step": "update_housekeeping",
-            }),
-        )
-    })?;
-
-    if housekeeping_result.rows_affected() != 1 {
-        let _ = tx.rollback().await;
-        return Err(CommandError::user(
-            codes::CONFLICT_INVALID_STATE_TRANSITION,
-            "Housekeeping task is no longer cleaning",
-        ));
-    }
-
-    let room_result =
-        sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = ? AND status = 'cleaning'")
-            .bind(&room_id)
-            .execute(&mut *tx)
-            .await
-            .map_err(|error| {
-                log_system_error(
-                    "update_housekeeping",
-                    error.to_string(),
-                    json!({
-                        "task_id": task_id,
-                        "room_id": room_id,
-                        "step": "update_room",
-                    }),
-                )
-            })?;
-
-    if room_result.rows_affected() != 1 {
-        let _ = tx.rollback().await;
-        return Err(CommandError::user(
-            codes::CONFLICT_INVALID_STATE_TRANSITION,
-            "Room is no longer waiting for cleaning completion",
-        ));
-    }
-
-    tx.commit().await.map_err(|error| {
-        log_system_error(
-            "update_housekeeping",
-            error.to_string(),
-            json!({
-                "task_id": task_id,
-                "room_id": room_id,
-                "step": "commit",
-            }),
-        )
-    })?;
 
     Ok(())
 }
@@ -475,31 +328,20 @@ pub async fn create_expense(
 ) -> Result<Expense, String> {
     validate_create_expense_request(&req)?;
 
-    let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Local::now().to_rfc3339();
-
-    sqlx::query(
-        "INSERT INTO expenses (id, category, amount, note, expense_date, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)",
-    )
-    .bind(&id)
-    .bind(&req.category)
-    .bind(req.amount)
-    .bind(&req.note)
-    .bind(&req.expense_date)
-    .bind(&now)
-    .execute(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    Ok(Expense {
-        id,
+    let expense = Expense {
+        id: uuid::Uuid::new_v4().to_string(),
         category: req.category,
         amount: req.amount,
         note: req.note,
         expense_date: req.expense_date,
-        created_at: now,
-    })
+        created_at: chrono::Local::now().to_rfc3339(),
+    };
+
+    expense_repository::insert_expense(&state.db, &expense)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(expense)
 }
 
 fn validate_create_expense_request(req: &CreateExpenseRequest) -> Result<(), String> {
@@ -514,26 +356,9 @@ pub async fn get_expenses(
     from: String,
     to: String,
 ) -> Result<Vec<Expense>, String> {
-    let rows = sqlx::query(
-        "SELECT * FROM expenses WHERE expense_date BETWEEN ? AND ? ORDER BY expense_date DESC",
-    )
-    .bind(&from)
-    .bind(&to)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    Ok(rows
-        .iter()
-        .map(|r| Expense {
-            id: r.get("id"),
-            category: r.get("category"),
-            amount: get_money_vnd(r, "amount"),
-            note: r.get("note"),
-            expense_date: r.get("expense_date"),
-            created_at: r.get("created_at"),
-        })
-        .collect())
+    expense_queries::load_expenses_between(&state.db, &from, &to)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 // ─── Statistics Commands ───
@@ -556,36 +381,22 @@ pub async fn get_stay_info_text(
     state: State<'_, AppState>,
     booking_id: String,
 ) -> Result<String, String> {
-    let b = sqlx::query("SELECT * FROM bookings WHERE id = ?")
-        .bind(&booking_id)
-        .fetch_one(&state.db)
+    let info = stay_info_queries::load_stay_info(&state.db, &booking_id)
         .await
         .map_err(|e| e.to_string())?;
 
-    let g = sqlx::query("SELECT * FROM guests WHERE id = ?")
-        .bind(b.get::<String, _>("primary_guest_id"))
-        .fetch_one(&state.db)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let room_id: String = b.get("room_id");
-    let full_name: String = g.get("full_name");
-    let doc_number: String = g.get("doc_number");
-    let dob: String = g.get::<Option<String>, _>("dob").unwrap_or_default();
-    let gender: String = g.get::<Option<String>, _>("gender").unwrap_or_default();
-    let nationality: String = g
-        .get::<Option<String>, _>("nationality")
-        .unwrap_or_else(|| "Việt Nam".to_string());
-    let address: String = g.get::<Option<String>, _>("address").unwrap_or_default();
-    let check_in: String = b.get("check_in_at");
-    let checkout: String = b.get("expected_checkout");
-
-    let text = format!(
+    Ok(format!(
         "Họ và tên: {}\nSố CCCD: {}\nNgày sinh: {}\nGiới tính: {}\nQuốc tịch: {}\nĐịa chỉ: {}\nPhòng: {}\nNgày đến: {}\nNgày đi: {}",
-        full_name, doc_number, dob, gender, nationality, address, room_id, check_in, checkout
-    );
-
-    Ok(text)
+        info.full_name,
+        info.doc_number,
+        info.dob,
+        info.gender,
+        info.nationality,
+        info.address,
+        info.room_id,
+        info.check_in,
+        info.checkout
+    ))
 }
 
 // ─── OCR Scan Command ───
@@ -607,8 +418,8 @@ pub async fn scan_image(path: String) -> Result<crate::ocr::CccdInfo, String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        check_in_failure_context, check_out_failure_context, complete_housekeeping_clean_to_vacant,
-        should_request_checkout_backup, validate_create_expense_request,
+        check_in_failure_context, check_out_failure_context, should_request_checkout_backup,
+        validate_create_expense_request,
     };
     use crate::app_error::{
         codes, correlation_context, log_system_error, record_command_failure_with_db_group,
@@ -621,20 +432,7 @@ mod tests {
         CreateGuestRequest,
     };
     use serde_json::json;
-    use sqlx::{sqlite::SqlitePoolOptions, Row};
     use std::fs;
-
-    async fn migrated_pool() -> sqlx::Pool<sqlx::Sqlite> {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .expect("connect in-memory sqlite");
-        crate::db::run_migrations(&pool)
-            .await
-            .expect("run migrations");
-        pool
-    }
 
     fn parse_json_lines(contents: &str) -> Vec<serde_json::Value> {
         contents
@@ -650,58 +448,6 @@ mod tests {
             Some(value) => std::env::set_var("CAPYINN_RUNTIME_ROOT", value),
             None => std::env::remove_var("CAPYINN_RUNTIME_ROOT"),
         }
-    }
-
-    #[tokio::test]
-    async fn housekeeping_clean_does_not_mark_occupied_room_vacant() {
-        let pool = migrated_pool().await;
-        sqlx::query(
-            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind("R-HK")
-        .bind("Housekeeping Guard")
-        .bind("standard")
-        .bind(1)
-        .bind(0)
-        .bind(100000)
-        .bind(2)
-        .bind(0)
-        .bind("occupied")
-        .execute(&pool)
-        .await
-        .expect("insert occupied room");
-        sqlx::query(
-            "INSERT INTO housekeeping (id, room_id, status, note, triggered_at, cleaned_at, created_at)
-             VALUES (?, ?, ?, ?, datetime('now'), NULL, datetime('now'))",
-        )
-        .bind("HK1")
-        .bind("R-HK")
-        .bind("cleaning")
-        .bind("started")
-        .execute(&pool)
-        .await
-        .expect("insert housekeeping task");
-
-        let error = complete_housekeeping_clean_to_vacant(&pool, "HK1", None)
-            .await
-            .expect_err("occupied room should reject clean-to-vacant");
-
-        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
-
-        let room = sqlx::query("SELECT status FROM rooms WHERE id = ?")
-            .bind("R-HK")
-            .fetch_one(&pool)
-            .await
-            .expect("room status");
-        assert_eq!(room.get::<String, _>("status"), "occupied");
-
-        let housekeeping = sqlx::query("SELECT status FROM housekeeping WHERE id = ?")
-            .bind("HK1")
-            .fetch_one(&pool)
-            .await
-            .expect("housekeeping status");
-        assert_eq!(housekeeping.get::<String, _>("status"), "cleaning");
     }
 
     #[test]

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -2,15 +2,10 @@ use super::{emit_db_update, get_user_id, AppState};
 use crate::db::row::get_money_vnd;
 use crate::{
     app_error::{
-        codes, correlation_context, log_system_error, normalize_correlation_id,
-        record_command_failure_with_db_group, CommandError, CommandResult, EffectiveCorrelationId,
+        codes, log_system_error, normalize_correlation_id, record_command_failure_with_db_group,
+        CommandError, CommandResult,
     },
     command_idempotency::WriteCommandContext,
-    db_error_monitoring::{
-        classify_db_error_code, classify_db_failure, inject_db_error_group,
-        is_room_unavailable_conflict_message, DbErrorGroup, MonitoredDbFailure,
-    },
-    domain::booking::BookingError,
     models::*,
     money::validate_non_negative_money_vnd,
     queries::booking::{revenue_queries, room_queries},
@@ -46,244 +41,6 @@ pub async fn get_dashboard_stats(state: State<'_, AppState>) -> Result<Dashboard
 }
 
 // ─── Check-in Command ───
-
-#[allow(dead_code)]
-fn log_user_stay_error(
-    command_name: &str,
-    effective_correlation_id: &EffectiveCorrelationId,
-    message: &str,
-    context: &Value,
-) {
-    let context_json = serde_json::to_string(&correlation_context(
-        &effective_correlation_id.value,
-        context.clone(),
-    ))
-    .unwrap_or_else(|_| "{}".to_string());
-
-    log::warn!(
-        "user error {} correlation_id={} source={:?}: {} | context={}",
-        command_name,
-        effective_correlation_id.value,
-        effective_correlation_id.source,
-        message,
-        context_json
-    );
-}
-
-#[allow(dead_code)]
-fn map_stay_user_error(
-    code: &'static str,
-    command_name: &str,
-    effective_correlation_id: &EffectiveCorrelationId,
-    message: String,
-    context: &Value,
-) -> CommandError {
-    log_user_stay_error(
-        command_name,
-        effective_correlation_id,
-        message.as_str(),
-        context,
-    );
-    CommandError::user(code, message)
-}
-
-#[allow(dead_code)]
-fn map_known_stay_error_code(
-    command_name: &str,
-    effective_correlation_id: &EffectiveCorrelationId,
-    message: &str,
-    context: &Value,
-) -> Option<(CommandError, Option<DbErrorGroup>)> {
-    if is_room_unavailable_conflict_message(message) {
-        return Some((
-            map_stay_user_error(
-                codes::CONFLICT_ROOM_UNAVAILABLE,
-                command_name,
-                effective_correlation_id,
-                message.to_string(),
-                context,
-            ),
-            Some(DbErrorGroup::Constraint),
-        ));
-    }
-
-    match classify_db_error_code(message) {
-        Some(codes::DB_LOCKED_RETRYABLE) => Some((
-            CommandError::system(codes::DB_LOCKED_RETRYABLE, message.to_string()).retryable(true),
-            Some(DbErrorGroup::Locked),
-        )),
-        _ => None,
-    }
-}
-
-#[allow(dead_code)]
-fn map_stay_error(
-    command_name: &str,
-    effective_correlation_id: &EffectiveCorrelationId,
-    error: BookingError,
-    context: Value,
-) -> (CommandError, Option<DbErrorGroup>) {
-    match error {
-        BookingError::NotFound(message) if message.starts_with("Không tìm thấy phòng ") => (
-            map_stay_user_error(
-                codes::ROOM_NOT_FOUND,
-                command_name,
-                effective_correlation_id,
-                message,
-                &context,
-            ),
-            Some(DbErrorGroup::NotFound),
-        ),
-        BookingError::NotFound(message)
-            if message.starts_with("Không tìm thấy booking đang active ")
-                || message.starts_with("Không tìm thấy booking ") =>
-        {
-            (
-                map_stay_user_error(
-                    codes::BOOKING_NOT_FOUND,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                Some(DbErrorGroup::NotFound),
-            )
-        }
-        BookingError::Validation(message) if message == "Phải có ít nhất 1 khách" => (
-            map_stay_user_error(
-                codes::BOOKING_GUEST_REQUIRED,
-                command_name,
-                effective_correlation_id,
-                message,
-                &context,
-            ),
-            None,
-        ),
-        BookingError::Validation(message)
-            if message == "Number of nights must be greater than 0" =>
-        {
-            (
-                map_stay_user_error(
-                    codes::BOOKING_INVALID_NIGHTS,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                None,
-            )
-        }
-        BookingError::Validation(message)
-            if message == "Tổng quyết toán phải lớn hơn hoặc bằng 0"
-                || message == "final_total must be greater than or equal to 0" =>
-        {
-            (
-                map_stay_user_error(
-                    codes::BOOKING_INVALID_SETTLEMENT_TOTAL,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                None,
-            )
-        }
-        BookingError::Validation(message)
-            if message == "Overpaid booking requires refund handling before checkout" =>
-        {
-            (
-                map_stay_user_error(
-                    codes::BOOKING_INVALID_STATE,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                None,
-            )
-        }
-        BookingError::Validation(message) | BookingError::Conflict(message) => {
-            if let Some(mapped) = map_known_stay_error_code(
-                command_name,
-                effective_correlation_id,
-                &message,
-                &context,
-            ) {
-                return mapped;
-            }
-            (
-                map_stay_user_error(
-                    codes::BOOKING_INVALID_STATE,
-                    command_name,
-                    effective_correlation_id,
-                    message,
-                    &context,
-                ),
-                None,
-            )
-        }
-        BookingError::DatabaseWrite(message) => {
-            let db_error_group = classify_db_failure(MonitoredDbFailure::DatabaseWrite(&message));
-            if let Some(mapped) = map_known_stay_error_code(
-                command_name,
-                effective_correlation_id,
-                &message,
-                &context,
-            ) {
-                return mapped;
-            }
-            (
-                log_system_error(
-                    command_name,
-                    &message,
-                    inject_db_error_group(
-                        correlation_context(&effective_correlation_id.value, context),
-                        db_error_group,
-                    ),
-                ),
-                Some(db_error_group),
-            )
-        }
-        BookingError::Database(message) => {
-            let db_error_group = classify_db_failure(MonitoredDbFailure::DatabaseRead(&message));
-            if let Some(mapped) = map_known_stay_error_code(
-                command_name,
-                effective_correlation_id,
-                &message,
-                &context,
-            ) {
-                return mapped;
-            }
-            (
-                log_system_error(
-                    command_name,
-                    &message,
-                    inject_db_error_group(
-                        correlation_context(&effective_correlation_id.value, context),
-                        db_error_group,
-                    ),
-                ),
-                Some(db_error_group),
-            )
-        }
-        BookingError::DateTimeParse(message) => (
-            log_system_error(
-                command_name,
-                message,
-                correlation_context(&effective_correlation_id.value, context),
-            ),
-            None,
-        ),
-        BookingError::NotFound(message) => (
-            log_system_error(
-                command_name,
-                message,
-                correlation_context(&effective_correlation_id.value, context),
-            ),
-            None,
-        ),
-    }
-}
 
 fn check_in_failure_context(req: &CheckInRequest) -> Value {
     let notes_present = req
@@ -851,14 +608,14 @@ pub async fn scan_image(path: String) -> Result<crate::ocr::CccdInfo, String> {
 mod tests {
     use super::{
         check_in_failure_context, check_out_failure_context, complete_housekeeping_clean_to_vacant,
-        map_stay_error, should_request_checkout_backup, validate_create_expense_request,
+        should_request_checkout_backup, validate_create_expense_request,
     };
     use crate::app_error::{
-        codes, record_command_failure_with_db_group, AppErrorKind, CorrelationIdSource,
-        EffectiveCorrelationId,
+        codes, correlation_context, log_system_error, record_command_failure_with_db_group,
     };
-    use crate::db_error_monitoring::DbErrorGroup;
-    use crate::domain::booking::BookingError;
+    use crate::db_error_monitoring::{
+        classify_db_failure, inject_db_error_group, DbErrorGroup, MonitoredDbFailure,
+    };
     use crate::models::{
         CheckInRequest, CheckOutRequest, CheckoutSettlementMode, CreateExpenseRequest,
         CreateGuestRequest,
@@ -877,14 +634,6 @@ mod tests {
             .await
             .expect("run migrations");
         pool
-    }
-
-    fn frontend_correlation_id() -> EffectiveCorrelationId {
-        EffectiveCorrelationId {
-            value: "COR-1A2B3C4D".to_string(),
-            source: CorrelationIdSource::Frontend,
-            rejected_length: None,
-        }
     }
 
     fn parse_json_lines(contents: &str) -> Vec<serde_json::Value> {
@@ -956,57 +705,6 @@ mod tests {
     }
 
     #[test]
-    fn map_stay_error_maps_missing_room_to_room_not_found_contract() {
-        let (error, db_error_group) = map_stay_error(
-            "check_in",
-            &frontend_correlation_id(),
-            BookingError::not_found("Không tìm thấy phòng R101"),
-            json!({ "room_id": "R101" }),
-        );
-
-        assert_eq!(error.code, codes::ROOM_NOT_FOUND);
-        assert_eq!(error.message, "Không tìm thấy phòng R101");
-        assert_eq!(error.kind, AppErrorKind::User);
-        assert!(error.support_id.is_none());
-        assert_eq!(db_error_group, Some(DbErrorGroup::NotFound));
-    }
-
-    #[test]
-    fn map_stay_error_maps_guest_required_validation_to_shared_code() {
-        let (error, db_error_group) = map_stay_error(
-            "check_in",
-            &frontend_correlation_id(),
-            BookingError::validation("Phải có ít nhất 1 khách"),
-            json!({ "room_id": "R101" }),
-        );
-
-        assert_eq!(error.code, codes::BOOKING_GUEST_REQUIRED);
-        assert_eq!(error.message, "Phải có ít nhất 1 khách");
-        assert_eq!(error.kind, AppErrorKind::User);
-        assert!(error.support_id.is_none());
-        assert!(db_error_group.is_none());
-    }
-
-    #[test]
-    fn map_stay_error_maps_invalid_settlement_total_to_shared_code() {
-        let (error, db_error_group) = map_stay_error(
-            "check_out",
-            &frontend_correlation_id(),
-            BookingError::validation("final_total must be greater than or equal to 0"),
-            json!({ "booking_id": "booking-1" }),
-        );
-
-        assert_eq!(error.code, codes::BOOKING_INVALID_SETTLEMENT_TOTAL);
-        assert_eq!(
-            error.message,
-            "final_total must be greater than or equal to 0"
-        );
-        assert_eq!(error.kind, AppErrorKind::User);
-        assert!(error.support_id.is_none());
-        assert!(db_error_group.is_none());
-    }
-
-    #[test]
     fn create_expense_rejects_negative_amount() {
         let error = validate_create_expense_request(&CreateExpenseRequest {
             category: "supplies".to_string(),
@@ -1017,74 +715,6 @@ mod tests {
         .expect_err("negative amount must fail");
 
         assert!(error.contains("amount"));
-    }
-
-    #[test]
-    fn map_stay_error_maps_invalid_checkout_state_to_shared_code() {
-        let (error, db_error_group) = map_stay_error(
-            "check_out",
-            &frontend_correlation_id(),
-            BookingError::validation("Overpaid booking requires refund handling before checkout"),
-            json!({ "booking_id": "booking-1" }),
-        );
-
-        assert_eq!(error.code, codes::BOOKING_INVALID_STATE);
-        assert_eq!(
-            error.message,
-            "Overpaid booking requires refund handling before checkout"
-        );
-        assert_eq!(error.kind, AppErrorKind::User);
-        assert!(error.support_id.is_none());
-        assert!(db_error_group.is_none());
-    }
-
-    #[test]
-    fn map_stay_error_maps_legacy_calendar_conflict_to_stable_code() {
-        let (error, db_error_group) = map_stay_error(
-            "check_in",
-            &frontend_correlation_id(),
-            BookingError::conflict(
-                "Room R101 has a reservation starting 2026-04-20 (Guest). Max 2 nights.",
-            ),
-            json!({ "room_id": "R101" }),
-        );
-
-        assert_eq!(error.code, codes::CONFLICT_ROOM_UNAVAILABLE);
-        assert!(error.message.contains("has a reservation starting"));
-        assert_eq!(error.kind, AppErrorKind::User);
-        assert!(error.support_id.is_none());
-        assert_eq!(db_error_group, Some(DbErrorGroup::Constraint));
-    }
-
-    #[test]
-    fn map_stay_error_maps_database_write_to_system_contract_with_write_failed_group() {
-        let (error, db_error_group) = map_stay_error(
-            "check_out",
-            &frontend_correlation_id(),
-            BookingError::database_write("disk full"),
-            json!({ "booking_id": "booking-1" }),
-        );
-
-        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
-        assert_eq!(error.kind, AppErrorKind::System);
-        assert!(error.support_id.is_some());
-        assert_eq!(db_error_group, Some(DbErrorGroup::WriteFailed));
-    }
-
-    #[test]
-    fn map_stay_error_maps_locked_database_reads_to_retryable_code() {
-        let (error, db_error_group) = map_stay_error(
-            "check_out",
-            &frontend_correlation_id(),
-            BookingError::database("database is locked"),
-            json!({ "booking_id": "booking-1" }),
-        );
-
-        assert_eq!(error.code, codes::DB_LOCKED_RETRYABLE);
-        assert_eq!(error.kind, AppErrorKind::System);
-        assert!(error.support_id.is_some());
-        assert!(error.retryable);
-        assert_eq!(db_error_group, Some(DbErrorGroup::Locked));
     }
 
     #[test]
@@ -1171,18 +801,24 @@ mod tests {
             settlement_mode: CheckoutSettlementMode::BookedNights,
             final_total: 2_500_000,
         });
-        let (error, db_error_group) = map_stay_error(
+        // Mirrors what a failing check_out produces: a system error carrying a
+        // support id, tagged with the group the read failure classified into.
+        let db_error_group =
+            classify_db_failure(MonitoredDbFailure::DatabaseRead("disk I/O failure"));
+        let error = log_system_error(
             "check_out",
-            &frontend_correlation_id(),
-            BookingError::database("disk I/O failure"),
-            context.clone(),
+            "disk I/O failure",
+            inject_db_error_group(
+                correlation_context("COR-1A2B3C4D", context.clone()),
+                db_error_group,
+            ),
         );
         let support_id = error.support_id.clone().expect("system error support id");
         record_command_failure_with_db_group(
             "check_out",
             &error,
             "COR-1A2B3C4D",
-            db_error_group,
+            Some(db_error_group),
             context,
         );
         restore_runtime_root(previous_runtime_root);
@@ -1212,7 +848,7 @@ mod tests {
                 && record["code"] == codes::SYSTEM_INTERNAL_ERROR
                 && record["db_error_group"] == "unknown"
         }));
-        assert_eq!(db_error_group, Some(DbErrorGroup::Unknown));
+        assert_eq!(db_error_group, DbErrorGroup::Unknown);
 
         let _ = fs::remove_dir_all(&runtime_root);
     }

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -12,9 +12,7 @@ use sqlx::{Pool, Sqlite};
 
 use super::set_schema_version;
 
-pub(super) async fn migrate_v20_declaration_tables(
-    pool: &Pool<Sqlite>,
-) -> Result<(), sqlx::Error> {
+pub(super) async fn migrate_v20_declaration_tables(pool: &Pool<Sqlite>) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
     sqlx::query(
@@ -93,11 +91,9 @@ pub(super) async fn migrate_v20_declaration_tables(
         .execute(&mut *tx)
         .await?;
 
-    sqlx::query(
-        "CREATE INDEX IF NOT EXISTS idx_decl_entry_link ON declaration_entry(link_id)",
-    )
-    .execute(&mut *tx)
-    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_decl_entry_link ON declaration_entry(link_id)")
+        .execute(&mut *tx)
+        .await?;
 
     sqlx::query(
         "CREATE INDEX IF NOT EXISTS idx_decl_batch_status ON declaration_batch(status, verified_at)",
@@ -213,11 +209,13 @@ mod tests {
         .expect("seeds booking");
 
         for guest in ["guest-1", "guest-2"] {
-            sqlx::query("INSERT INTO booking_guests (booking_id, guest_id) VALUES ('booking-1', ?)")
-                .bind(guest)
-                .execute(&pool)
-                .await
-                .expect("seeds booking guest");
+            sqlx::query(
+                "INSERT INTO booking_guests (booking_id, guest_id) VALUES ('booking-1', ?)",
+            )
+            .bind(guest)
+            .execute(&pool)
+            .await
+            .expect("seeds booking guest");
         }
 
         pool
@@ -295,10 +293,9 @@ mod tests {
         let id = crate::declaration::repo::insert_identity(&pool, &card, "qr_cccd", "verified")
             .await
             .expect("lưu danh tính");
-        let link =
-            crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
-                .await
-                .expect("ghép");
+        let link = crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
+            .await
+            .expect("ghép");
         let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
             .await
             .expect("lô");
@@ -311,9 +308,10 @@ mod tests {
 
         let mut misread = card.clone();
         misread.full_name = "TÊN ĐỌC SAI".into();
-        let again = crate::declaration::repo::insert_identity(&pool, &misread, "qr_cccd", "verified")
-            .await
-            .expect("thả lại");
+        let again =
+            crate::declaration::repo::insert_identity(&pool, &misread, "qr_cccd", "verified")
+                .await
+                .expect("thả lại");
 
         assert_eq!(again, id, "vẫn là cùng một người");
         let name: String =
@@ -343,10 +341,9 @@ mod tests {
         )
         .await
         .expect("danh tính");
-        let link =
-            crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
-                .await
-                .expect("ghép");
+        let link = crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
+            .await
+            .expect("ghép");
 
         // Đã xuất file nhưng chưa đối soát: vẫn gỡ được.
         let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
@@ -384,10 +381,9 @@ mod tests {
         )
         .await
         .expect("danh tính");
-        let link =
-            crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
-                .await
-                .expect("ghép");
+        let link = crate::declaration::repo::insert_link(&pool, &id, Some("booking-1"), "2", None)
+            .await
+            .expect("ghép");
         let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
             .await
             .expect("lô");
@@ -461,12 +457,10 @@ mod tests {
             .await
             .expect("ghép được dù chưa có phòng");
 
-        let rows = crate::declaration::repo::load_rows_by_link_ids(
-            &pool,
-            std::slice::from_ref(&link),
-        )
-        .await
-        .expect("đọc lại được dòng");
+        let rows =
+            crate::declaration::repo::load_rows_by_link_ids(&pool, std::slice::from_ref(&link))
+                .await
+                .expect("đọc lại được dòng");
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].identity.full_name, "Phạm Thị Minh Hiền");
@@ -497,12 +491,15 @@ mod tests {
         .expect("seeds link");
 
         // Chạy lại toàn bộ migration: v21 phải bỏ qua vì version đã là 21.
-        run_migrations(&pool).await.expect("migration chạy lại được");
-
-        let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM declaration_link WHERE id='link-1'")
-            .fetch_one(&pool)
+        run_migrations(&pool)
             .await
-            .expect("đếm link");
+            .expect("migration chạy lại được");
+
+        let kept: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM declaration_link WHERE id='link-1'")
+                .fetch_one(&pool)
+                .await
+                .expect("đếm link");
         assert_eq!(kept, 1);
     }
 
@@ -637,9 +634,10 @@ mod tests {
         )
         .await
         .expect("lưu được danh tính");
-        let link = crate::declaration::repo::insert_link(&pool, &identity, Some("booking-1"), "2", None)
-            .await
-            .expect("lưu được link");
+        let link =
+            crate::declaration::repo::insert_link(&pool, &identity, Some("booking-1"), "2", None)
+                .await
+                .expect("lưu được link");
         let batch = crate::declaration::repo::insert_batch(&pool, "VN", "/tmp/x.xlsx", 1)
             .await
             .expect("lưu được lô");

--- a/mhm/src-tauri/src/declaration/catalog.rs
+++ b/mhm/src-tauri/src/declaration/catalog.rs
@@ -113,7 +113,10 @@ mod tests {
             Some("8 - Thẻ Căn Cước")
         );
         assert_eq!(c.display_for(CatalogList::GioiTinh, "F"), Some("F - Nữ"));
-        assert_eq!(c.display_for(CatalogList::LyDoCuTru, "1"), Some("1 - Du lịch"));
+        assert_eq!(
+            c.display_for(CatalogList::LyDoCuTru, "1"),
+            Some("1 - Du lịch")
+        );
         assert_eq!(
             c.display_for(CatalogList::LyDoCuTru, "20"),
             Some("20 - Mục đích khác")
@@ -133,11 +136,7 @@ mod tests {
     #[test]
     fn ward_to_province_relation_is_present() {
         let c = cat();
-        let nha_trang: Vec<_> = c
-            .phuong_xa
-            .iter()
-            .filter(|w| w.tinh == "511")
-            .collect();
+        let nha_trang: Vec<_> = c.phuong_xa.iter().filter(|w| w.tinh == "511").collect();
         assert!(!nha_trang.is_empty(), "Khánh Hòa 511 phải có phường");
     }
 

--- a/mhm/src-tauri/src/declaration/repo.rs
+++ b/mhm/src-tauri/src/declaration/repo.rs
@@ -351,7 +351,10 @@ pub async fn list_unlinked_identities(pool: &Pool<Sqlite>) -> Result<Vec<Identit
 ///
 /// Chỉ xóa được khi chưa có link nào trỏ tới: đã ghép thì đó là bằng chứng đã
 /// khai báo, phải đi đường thu hồi (§12.5) chứ không xóa thẳng.
-pub async fn delete_unlinked_identity(pool: &Pool<Sqlite>, identity_id: &str) -> Result<(), String> {
+pub async fn delete_unlinked_identity(
+    pool: &Pool<Sqlite>,
+    identity_id: &str,
+) -> Result<(), String> {
     let affected = sqlx::query(
         "DELETE FROM declaration_identity
           WHERE id = ?
@@ -459,13 +462,15 @@ pub async fn insert_entries(
         .map_err(|e| format!("Không mở được giao dịch: {e}"))?;
 
     for (index, link_id) in link_ids.iter().enumerate() {
-        sqlx::query("INSERT INTO declaration_entry (batch_id, link_id, row_index) VALUES (?, ?, ?)")
-            .bind(batch_id)
-            .bind(link_id)
-            .bind(index as i64)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| format!("Không lưu được dòng của lô: {e}"))?;
+        sqlx::query(
+            "INSERT INTO declaration_entry (batch_id, link_id, row_index) VALUES (?, ?, ?)",
+        )
+        .bind(batch_id)
+        .bind(link_id)
+        .bind(index as i64)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| format!("Không lưu được dòng của lô: {e}"))?;
     }
 
     tx.commit()
@@ -972,9 +977,15 @@ mod tests {
         let first = insert_link(&pool, &identity_id, Some("booking-1"), "1", None)
             .await
             .expect("ghép lần đầu");
-        let second = insert_link(&pool, &identity_id, Some("booking-1"), "20", Some("Đi công tác"))
-            .await
-            .expect("ghép lại");
+        let second = insert_link(
+            &pool,
+            &identity_id,
+            Some("booking-1"),
+            "20",
+            Some("Đi công tác"),
+        )
+        .await
+        .expect("ghép lại");
 
         assert_eq!(first, second, "phải là cùng một link");
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM declaration_link")
@@ -997,9 +1008,15 @@ mod tests {
                 .await
                 .expect("lưu danh tính");
             links.push(
-                insert_link(&pool, &identity_id, Some(&format!("booking-{n}")), "1", None)
-                    .await
-                    .expect("ghép link"),
+                insert_link(
+                    &pool,
+                    &identity_id,
+                    Some(&format!("booking-{n}")),
+                    "1",
+                    None,
+                )
+                .await
+                .expect("ghép link"),
             );
         }
         links.reverse();
@@ -1028,14 +1045,17 @@ mod tests {
 
         assert_eq!(batch_row_count(&pool, &batch).await.unwrap(), 1);
 
-        let status: String = sqlx::query_scalar("SELECT status FROM declaration_batch WHERE id = ?")
-            .bind(&batch)
-            .fetch_one(&pool)
-            .await
-            .expect("đọc trạng thái");
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM declaration_batch WHERE id = ?")
+                .bind(&batch)
+                .fetch_one(&pool)
+                .await
+                .expect("đọc trạng thái");
         assert_eq!(status, "exported", "xuất file chưa phải là đã khai");
 
-        set_batch_verified(&pool, &batch, 1).await.expect("verified");
+        set_batch_verified(&pool, &batch, 1)
+            .await
+            .expect("verified");
         let (status, seen): (String, i64) =
             sqlx::query_as("SELECT status, verified_count FROM declaration_batch WHERE id = ?")
                 .bind(&batch)
@@ -1058,7 +1078,9 @@ mod tests {
         assert_eq!(seen, 0);
 
         assert!(
-            set_batch_verified(&pool, "khong-co-lo-nay", 1).await.is_err(),
+            set_batch_verified(&pool, "khong-co-lo-nay", 1)
+                .await
+                .is_err(),
             "lô không tồn tại phải báo lỗi chứ không im lặng"
         );
     }
@@ -1116,7 +1138,9 @@ mod tests {
             .expect("lưu dòng");
 
         // Lô mới đối chiếu xong hôm nay: chưa đến hạn che.
-        set_batch_verified(&pool, &batch, 1).await.expect("verified");
+        set_batch_verified(&pool, &batch, 1)
+            .await
+            .expect("verified");
         assert_eq!(redact_old_identities(&pool, 90).await.unwrap(), 0);
 
         // Đẩy ngày đối chiếu lùi 200 ngày.

--- a/mhm/src-tauri/src/declaration/writer/xlsx.rs
+++ b/mhm/src-tauri/src/declaration/writer/xlsx.rs
@@ -74,23 +74,31 @@ pub fn write_batch(
                 );
             }
             if let Some(v) = id.doc_type_name.as_deref() {
-                sheet.cell_mut(cell("G", row_no).as_str()).set_value_string(v);
+                sheet
+                    .cell_mut(cell("G", row_no).as_str())
+                    .set_value_string(v);
             }
             sheet
                 .cell_mut(cell("H", row_no).as_str())
                 .set_value_string(id.doc_no.as_deref().unwrap_or(""));
             if let Some(v) = id.phone.as_deref() {
-                sheet.cell_mut(cell("I", row_no).as_str()).set_value_string(v);
+                sheet
+                    .cell_mut(cell("I", row_no).as_str())
+                    .set_value_string(v);
             }
             if let Some(code) = id.residence_status.as_deref() {
                 if let Some(d) = catalog.display_for(CatalogList::NoiCuTru, code) {
-                    sheet.cell_mut(cell("J", row_no).as_str()).set_value_string(d);
+                    sheet
+                        .cell_mut(cell("J", row_no).as_str())
+                        .set_value_string(d);
                 }
             }
             // K, L để trống có chủ ý: danh mục hành chính đã đổi mà giấy tờ
             // thì chưa, và fuzzy-match tên phường tạo ra khai báo sai im lặng.
             if let Some(v) = id.address_detail.as_deref() {
-                sheet.cell_mut(cell("M", row_no).as_str()).set_value_string(v);
+                sheet
+                    .cell_mut(cell("M", row_no).as_str())
+                    .set_value_string(v);
             }
             sheet.cell_mut(cell("N", row_no).as_str()).set_value_string(
                 iso_to_portal(&r.stay.check_in)
@@ -111,7 +119,9 @@ pub fn write_batch(
                     .ok_or_else(|| format!("Lý do cư trú không có: {}", r.stay_reason))?,
             );
             if let Some(v) = r.stay_reason_note.as_deref() {
-                sheet.cell_mut(cell("R", row_no).as_str()).set_value_string(v);
+                sheet
+                    .cell_mut(cell("R", row_no).as_str())
+                    .set_value_string(v);
             }
         }
     }
@@ -219,7 +229,9 @@ pub fn verify_output(out: &Path, rows: &[DeclarationRow]) -> Result<(), String> 
     ] {
         let got = count_col(dm, col, upto);
         if got != want {
-            return Err(format!("Gate 5 fail: {name} còn {got} dòng, phải là {want}"));
+            return Err(format!(
+                "Gate 5 fail: {name} còn {got} dòng, phải là {want}"
+            ));
         }
     }
 
@@ -229,7 +241,9 @@ pub fn verify_output(out: &Path, rows: &[DeclarationRow]) -> Result<(), String> 
         .map_err(|_| "Gate 6 fail: mất sheet TINH_THANH".to_string())?;
     let tt_n = count_col(tt, "C", 35);
     if tt_n != 34 {
-        return Err(format!("Gate 6 fail: TINH_THANH còn {tt_n} dòng, phải là 34"));
+        return Err(format!(
+            "Gate 6 fail: TINH_THANH còn {tt_n} dòng, phải là 34"
+        ));
     }
     let px = book
         .sheet_by_name("PHUONG_XA")

--- a/mhm/src-tauri/src/declaration/writer/xml.rs
+++ b/mhm/src-tauri/src/declaration/writer/xml.rs
@@ -24,7 +24,8 @@ pub fn escape(s: &str) -> String {
 
 fn record(seq: usize, r: &DeclarationRow) -> Result<String, String> {
     let id = &r.identity;
-    let dob = iso_to_portal(&id.dob).ok_or_else(|| format!("Ngày sinh không hợp lệ: {}", id.dob))?;
+    let dob =
+        iso_to_portal(&id.dob).ok_or_else(|| format!("Ngày sinh không hợp lệ: {}", id.dob))?;
     let check_in = iso_to_portal(&r.stay.check_in)
         .ok_or_else(|| format!("Ngày đến không hợp lệ: {}", r.stay.check_in))?;
     let expected = iso_to_portal(&r.stay.expected_out)
@@ -38,7 +39,10 @@ fn record(seq: usize, r: &DeclarationRow) -> Result<String, String> {
     let mut s = String::new();
     s.push_str("    <THONG_TIN_KHACH>\n");
     s.push_str(&format!("        <so_thu_tu>{seq}</so_thu_tu>\n"));
-    s.push_str(&format!("        <ho_ten>{}</ho_ten>\n", escape(&id.full_name)));
+    s.push_str(&format!(
+        "        <ho_ten>{}</ho_ten>\n",
+        escape(&id.full_name)
+    ));
     s.push_str(&format!("        <ngay_sinh>{dob}</ngay_sinh>\n"));
     // v1 chỉ xuất khách có ngày sinh đủ, nên luôn là D
     s.push_str("        <ngay_sinh_dung_den>D</ngay_sinh_dung_den>\n");
@@ -65,7 +69,9 @@ fn record(seq: usize, r: &DeclarationRow) -> Result<String, String> {
     ));
     // F9: bỏ hẳn tag nếu khách chưa trả phòng
     if let Some(actual) = r.stay.actual_out.as_deref().and_then(iso_to_portal) {
-        s.push_str(&format!("        <ngay_tra_phong>{actual}</ngay_tra_phong>\n"));
+        s.push_str(&format!(
+            "        <ngay_tra_phong>{actual}</ngay_tra_phong>\n"
+        ));
     }
     s.push_str(&format!(
         "        <thoi_han_tam_tru>{visa}</thoi_han_tam_tru>\n"

--- a/mhm/src-tauri/src/domain/auth/credentials.rs
+++ b/mhm/src-tauri/src/domain/auth/credentials.rs
@@ -1,0 +1,44 @@
+//! How a PIN becomes the value stored in `users.pin_hash`.
+//!
+//! This lived in three places — `login`, `create_user`, and the setup
+//! provisioner — each with its own copy of the same four lines. They agreed,
+//! but nothing made them agree: any drift would have provisioned users who
+//! could never log in, and the symptom would have looked like a wrong PIN.
+
+use sha2::{Digest, Sha256};
+
+/// The stored form of a PIN. Callers compare hashes, never the PIN itself.
+pub fn pin_hash(pin: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(pin.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pin_hash;
+
+    #[test]
+    fn the_hash_is_lowercase_hex_sha256() {
+        let hash = pin_hash("1234");
+        assert_eq!(
+            hash, "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+            "the stored format is the plain lowercase-hex SHA-256 of the PIN; \
+             changing it locks every existing user out"
+        );
+        assert_eq!(hash.len(), 64);
+    }
+
+    #[test]
+    fn different_pins_hash_differently_and_the_same_pin_is_stable() {
+        assert_eq!(pin_hash("0000"), pin_hash("0000"));
+        assert_ne!(pin_hash("0000"), pin_hash("0001"));
+        assert_ne!(pin_hash("1234"), pin_hash("12345"));
+    }
+
+    #[test]
+    fn an_empty_pin_still_hashes_rather_than_panicking() {
+        assert_eq!(pin_hash("").len(), 64);
+        assert_ne!(pin_hash(""), pin_hash("0"));
+    }
+}

--- a/mhm/src-tauri/src/domain/auth/mod.rs
+++ b/mhm/src-tauri/src/domain/auth/mod.rs
@@ -1,0 +1,1 @@
+pub mod credentials;

--- a/mhm/src-tauri/src/domain/booking/mod.rs
+++ b/mhm/src-tauri/src/domain/booking/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod origin;
 pub mod pricing;
+pub mod room_allocation;
 
 pub use error::{BookingError, BookingResult};
 pub use origin::OriginSideEffect;

--- a/mhm/src-tauri/src/domain/booking/room_allocation.rs
+++ b/mhm/src-tauri/src/domain/booking/room_allocation.rs
@@ -1,0 +1,175 @@
+//! Choosing which vacant rooms a group gets.
+//!
+//! Pure: it takes the vacant rooms and the count, and returns the picks. No
+//! database, so the policy is testable on its own.
+//!
+//! The policy is *keep the group together*: fill from the floor with the most
+//! vacancies first, so a party of four lands on one floor rather than scattered
+//! across three.
+
+use std::collections::BTreeMap;
+
+use crate::models::{Room, RoomAssignment};
+
+/// Not enough vacant rooms to satisfy the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NotEnoughRooms {
+    pub available: usize,
+    pub requested: usize,
+}
+
+/// Picks `requested` rooms, preferring floors that can host the most of the
+/// group.
+///
+/// Ties are broken by floor number ascending. That tie-break is load-bearing:
+/// this used to group into a `std::collections::HashMap` and sort by size
+/// alone, so two floors with equally many vacancies came out in whatever order
+/// the hash seed produced — a different answer on each app launch for the same
+/// database.
+pub fn assign_rooms_by_floor(
+    vacant_rooms: &[Room],
+    requested: usize,
+) -> Result<Vec<RoomAssignment>, NotEnoughRooms> {
+    if vacant_rooms.len() < requested {
+        return Err(NotEnoughRooms {
+            available: vacant_rooms.len(),
+            requested,
+        });
+    }
+
+    let mut by_floor: BTreeMap<i32, Vec<&Room>> = BTreeMap::new();
+    for room in vacant_rooms {
+        by_floor.entry(room.floor).or_default().push(room);
+    }
+
+    // BTreeMap yields floors ascending; `sort_by_key` is stable, so equal-sized
+    // floors keep that ascending order.
+    let mut floors: Vec<(i32, Vec<&Room>)> = by_floor.into_iter().collect();
+    floors.sort_by_key(|(_, rooms)| std::cmp::Reverse(rooms.len()));
+
+    let mut assignments = Vec::with_capacity(requested);
+    for (floor, rooms) in &floors {
+        for room in rooms {
+            if assignments.len() >= requested {
+                return Ok(assignments);
+            }
+            assignments.push(RoomAssignment {
+                room: (*room).clone(),
+                floor: *floor,
+            });
+        }
+    }
+
+    Ok(assignments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::assign_rooms_by_floor;
+    use crate::models::Room;
+
+    fn room(id: &str, floor: i32) -> Room {
+        Room {
+            id: id.to_string(),
+            name: format!("Room {id}"),
+            room_type: "standard".to_string(),
+            floor,
+            has_balcony: false,
+            base_price: 300_000,
+            max_guests: 2,
+            extra_person_fee: 0,
+            status: "vacant".to_string(),
+        }
+    }
+
+    fn ids(rooms: &[Room], requested: usize) -> Vec<String> {
+        assign_rooms_by_floor(rooms, requested)
+            .unwrap_or_else(|_| panic!("expected {requested} rooms to be assignable"))
+            .into_iter()
+            .map(|assignment| assignment.room.id)
+            .collect()
+    }
+
+    #[test]
+    fn the_floor_that_can_host_the_whole_group_wins_over_a_lower_floor() {
+        let rooms = vec![
+            room("101", 1),
+            room("201", 2),
+            room("202", 2),
+            room("203", 2),
+        ];
+
+        assert_eq!(
+            ids(&rooms, 3),
+            vec!["201", "202", "203"],
+            "floor 2 keeps the group together; floor 1 cannot"
+        );
+    }
+
+    #[test]
+    fn equally_sized_floors_break_the_tie_by_floor_number() {
+        let rooms = vec![
+            room("301", 3),
+            room("302", 3),
+            room("101", 1),
+            room("102", 1),
+        ];
+
+        // Input order puts floor 3 first; the answer must not depend on that.
+        assert_eq!(ids(&rooms, 2), vec!["101", "102"]);
+    }
+
+    #[test]
+    fn the_same_input_always_gives_the_same_answer() {
+        // Enough distinct equal-sized floors that a hash-ordered grouping would
+        // reorder them across runs.
+        let rooms: Vec<_> = (1..=8).flat_map(|f| [room(&format!("{f}01"), f)]).collect();
+
+        let first = ids(&rooms, 3);
+        for _ in 0..25 {
+            assert_eq!(ids(&rooms, 3), first);
+        }
+        assert_eq!(first, vec!["101", "201", "301"]);
+    }
+
+    #[test]
+    fn a_group_larger_than_one_floor_spills_onto_the_next_biggest() {
+        let rooms = vec![
+            room("101", 1),
+            room("201", 2),
+            room("202", 2),
+            room("301", 3),
+        ];
+
+        assert_eq!(
+            ids(&rooms, 3),
+            vec!["201", "202", "101"],
+            "floor 2 first, then the tie between floors 1 and 3 goes to floor 1"
+        );
+    }
+
+    #[test]
+    fn asking_for_more_than_is_vacant_reports_both_numbers() {
+        let rooms = vec![room("101", 1), room("102", 1)];
+
+        let error = assign_rooms_by_floor(&rooms, 5).expect_err("should fail");
+        assert_eq!(error.available, 2);
+        assert_eq!(error.requested, 5);
+    }
+
+    #[test]
+    fn asking_for_none_assigns_none_even_when_rooms_are_free() {
+        assert!(assign_rooms_by_floor(&[room("101", 1)], 0)
+            .expect("zero is satisfiable")
+            .is_empty());
+    }
+
+    #[test]
+    fn every_assignment_reports_the_floor_of_its_own_room() {
+        let rooms = vec![room("101", 1), room("201", 2), room("202", 2)];
+
+        for assignment in assign_rooms_by_floor(&rooms, 3).expect("assignable") {
+            assert_eq!(assignment.floor, assignment.room.floor);
+        }
+    }
+}

--- a/mhm/src-tauri/src/domain/booking/room_allocation.rs
+++ b/mhm/src-tauri/src/domain/booking/room_allocation.rs
@@ -106,30 +106,52 @@ mod tests {
         );
     }
 
-    #[test]
-    fn equally_sized_floors_break_the_tie_by_floor_number() {
-        let rooms = vec![
-            room("301", 3),
-            room("302", 3),
-            room("101", 1),
-            room("102", 1),
-        ];
-
-        // Input order puts floor 3 first; the answer must not depend on that.
-        assert_eq!(ids(&rooms, 2), vec!["101", "102"]);
+    /// Six floors of one room each — all tied, so every one of them is a
+    /// candidate and the answer is decided purely by the tie-break.
+    ///
+    /// Six rather than two on purpose. With two tied floors a hash-ordered
+    /// grouping returns the right answer half the time, so a two-floor test
+    /// only catches the historical `HashMap` bug on a coin flip. Six makes a
+    /// wrong order overwhelmingly likely to be seen.
+    fn six_tied_floors() -> Vec<Room> {
+        // Input order is deliberately not ascending: the answer must come from
+        // the tie-break, not from the order rooms happened to arrive in.
+        [4, 1, 6, 3, 5, 2]
+            .into_iter()
+            .map(|floor| room(&format!("{floor}01"), floor))
+            .collect()
     }
 
     #[test]
-    fn the_same_input_always_gives_the_same_answer() {
-        // Enough distinct equal-sized floors that a hash-ordered grouping would
-        // reorder them across runs.
-        let rooms: Vec<_> = (1..=8).flat_map(|f| [room(&format!("{f}01"), f)]).collect();
+    fn equally_sized_floors_break_the_tie_by_floor_number() {
+        assert_eq!(
+            ids(&six_tied_floors(), 3),
+            vec!["101", "201", "301"],
+            "all six floors are tied, so the lowest three win"
+        );
+    }
 
-        let first = ids(&rooms, 3);
-        for _ in 0..25 {
-            assert_eq!(ids(&rooms, 3), first);
+    #[test]
+    fn the_answer_does_not_depend_on_the_order_the_rooms_arrive_in() {
+        // The historical bug was an order the caller could not see or control.
+        // Feeding the same set in several different orders is what a caller can
+        // actually vary, and every permutation must land on the same rooms.
+        let expected = vec!["101", "201", "301"];
+        let mut rooms = six_tied_floors();
+
+        for _ in 0..rooms.len() {
+            rooms.rotate_left(1);
+            assert_eq!(ids(&rooms, 3), expected, "rotated input changed the answer");
         }
-        assert_eq!(first, vec!["101", "201", "301"]);
+
+        rooms.reverse();
+        assert_eq!(
+            ids(&rooms, 3),
+            expected,
+            "reversed input changed the answer"
+        );
+        rooms.sort_by_key(|room| room.floor);
+        assert_eq!(ids(&rooms, 3), expected, "sorted input changed the answer");
     }
 
     #[test]

--- a/mhm/src-tauri/src/domain/hotel_info.rs
+++ b/mhm/src-tauri/src/domain/hotel_info.rs
@@ -1,0 +1,110 @@
+//! The hotel's own name, address and phone, as printed on invoices.
+//!
+//! Stored as one JSON blob under the `hotel_info` setting. Two callers decode
+//! it — the per-booking invoice and the group invoice — and each used to carry
+//! its own copy of the fallback rules. Same rules, written twice, on the
+//! letterhead of a document the guest keeps.
+
+use crate::app_identity::APP_NAME;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotelInfo {
+    pub name: String,
+    pub address: String,
+    pub phone: String,
+}
+
+impl Default for HotelInfo {
+    /// An unconfigured hotel still prints a header: the app's own name, and
+    /// nothing where the address and phone would be.
+    fn default() -> Self {
+        Self {
+            name: APP_NAME.to_string(),
+            address: String::new(),
+            phone: String::new(),
+        }
+    }
+}
+
+impl HotelInfo {
+    /// Decodes the stored blob. Missing, malformed, or partially filled all
+    /// fall back field by field rather than failing — an invoice must print.
+    pub fn from_settings_json(stored: Option<&str>) -> Self {
+        let Some(parsed) =
+            stored.and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+        else {
+            return Self::default();
+        };
+
+        let field = |key: &str| {
+            parsed
+                .get(key)
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        };
+
+        Self {
+            name: field("name").unwrap_or_else(|| APP_NAME.to_string()),
+            address: field("address").unwrap_or_default(),
+            phone: field("phone").unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HotelInfo;
+    use crate::app_identity::APP_NAME;
+
+    #[test]
+    fn a_complete_blob_is_used_as_written() {
+        let info = HotelInfo::from_settings_json(Some(
+            r#"{"name":"Nhà nghỉ Bình Minh","address":"12 Trần Phú","phone":"0901234567"}"#,
+        ));
+
+        assert_eq!(info.name, "Nhà nghỉ Bình Minh");
+        assert_eq!(info.address, "12 Trần Phú");
+        assert_eq!(info.phone, "0901234567");
+    }
+
+    #[test]
+    fn no_setting_at_all_falls_back_to_the_app_name() {
+        assert_eq!(HotelInfo::from_settings_json(None), HotelInfo::default());
+        assert_eq!(HotelInfo::from_settings_json(None).name, APP_NAME);
+    }
+
+    #[test]
+    fn a_malformed_blob_falls_back_rather_than_failing() {
+        // An invoice must print even if the setting was corrupted.
+        assert_eq!(
+            HotelInfo::from_settings_json(Some("{not-json")),
+            HotelInfo::default()
+        );
+        assert_eq!(
+            HotelInfo::from_settings_json(Some("")),
+            HotelInfo::default()
+        );
+        assert_eq!(
+            HotelInfo::from_settings_json(Some("[1,2,3]")),
+            HotelInfo::default(),
+            "valid JSON of the wrong shape is still a fallback"
+        );
+    }
+
+    #[test]
+    fn each_field_falls_back_on_its_own() {
+        let info = HotelInfo::from_settings_json(Some(r#"{"address":"12 Trần Phú"}"#));
+
+        assert_eq!(info.name, APP_NAME, "a missing name is the app name");
+        assert_eq!(info.address, "12 Trần Phú", "a present field survives");
+        assert_eq!(info.phone, "", "a missing phone is blank, not the app name");
+    }
+
+    #[test]
+    fn a_non_string_field_is_treated_as_missing() {
+        let info = HotelInfo::from_settings_json(Some(r#"{"name":42,"phone":null}"#));
+
+        assert_eq!(info.name, APP_NAME);
+        assert_eq!(info.phone, "");
+    }
+}

--- a/mhm/src-tauri/src/domain/mod.rs
+++ b/mhm/src-tauri/src/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
 pub mod booking;
+pub mod hotel_info;

--- a/mhm/src-tauri/src/domain/mod.rs
+++ b/mhm/src-tauri/src/domain/mod.rs
@@ -1,1 +1,2 @@
+pub mod auth;
 pub mod booking;

--- a/mhm/src-tauri/src/gateway/observer.rs
+++ b/mhm/src-tauri/src/gateway/observer.rs
@@ -1,12 +1,12 @@
 use async_stream::stream;
 use axum::{
-    Json,
     extract::{Query, State},
     http::{HeaderMap, StatusCode},
     response::{
-        IntoResponse,
         sse::{Event, KeepAlive, Sse},
+        IntoResponse,
     },
+    Json,
 };
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
@@ -345,7 +345,7 @@ fn observer_error_event(error: ObserverError) -> Event {
 
 #[cfg(test)]
 mod tests {
-    use super::{ObserverErrorCode, parse_cursor};
+    use super::{parse_cursor, ObserverErrorCode};
     use axum::http::{HeaderMap, HeaderValue};
 
     #[test]
@@ -427,9 +427,9 @@ mod tests {
 
 #[cfg(test)]
 mod db_tests {
-    use super::{ObserverErrorCode, load_observer_events_after, resolve_start_after_event_id};
+    use super::{load_observer_events_after, resolve_start_after_event_id, ObserverErrorCode};
     use serde_json::json;
-    use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
 
     async fn test_pool() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()

--- a/mhm/src-tauri/src/queries/auth/mod.rs
+++ b/mhm/src-tauri/src/queries/auth/mod.rs
@@ -1,0 +1,1 @@
+pub mod user_queries;

--- a/mhm/src-tauri/src/queries/auth/user_queries.rs
+++ b/mhm/src-tauri/src/queries/auth/user_queries.rs
@@ -1,0 +1,42 @@
+//! Reads over the `users` table.
+
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::models::User;
+
+const USER_COLUMNS: &str = "SELECT id, name, role, active, created_at FROM users";
+
+/// The single active user holding this PIN hash, if any.
+///
+/// Inactive users are filtered in SQL rather than by the caller: an
+/// unauthenticated login must not be able to tell a deactivated account from a
+/// wrong PIN.
+pub async fn load_active_user_by_pin_hash(
+    pool: &Pool<Sqlite>,
+    pin_hash: &str,
+) -> Result<Option<User>, sqlx::Error> {
+    let row = sqlx::query(&format!("{USER_COLUMNS} WHERE pin_hash = ? AND active = 1"))
+        .bind(pin_hash)
+        .fetch_optional(pool)
+        .await?;
+
+    Ok(row.as_ref().map(map_user))
+}
+
+pub async fn load_users(pool: &Pool<Sqlite>) -> Result<Vec<User>, sqlx::Error> {
+    let rows = sqlx::query(&format!("{USER_COLUMNS} ORDER BY created_at"))
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows.iter().map(map_user).collect())
+}
+
+fn map_user(row: &sqlx::sqlite::SqliteRow) -> User {
+    User {
+        id: row.get("id"),
+        name: row.get("name"),
+        role: row.get("role"),
+        active: row.get::<i32, _>("active") == 1,
+        created_at: row.get("created_at"),
+    }
+}

--- a/mhm/src-tauri/src/queries/booking/activity_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/activity_queries.rs
@@ -3,6 +3,10 @@
 //! Three independent "most recent N" queries. They are not unioned in SQL
 //! because each one carries different columns; the command merges and sorts
 //! them, which it can do as a pure function once the rows are in hand.
+//!
+//! Every loader clamps its limit at zero first. SQLite reads a negative
+//! `LIMIT` as *unbounded*, so without the clamp a nonsense limit turned into
+//! three full-table scans whose rows the caller then threw away.
 
 use sqlx::{Pool, Row, Sqlite};
 
@@ -33,7 +37,7 @@ pub async fn load_recent_check_ins(
          FROM bookings b JOIN guests g ON g.id = b.primary_guest_id
          ORDER BY b.check_in_at DESC LIMIT ?",
     )
-    .bind(limit)
+    .bind(limit.max(0))
     .fetch_all(pool)
     .await?;
 
@@ -57,7 +61,7 @@ pub async fn load_recent_check_outs(
          WHERE b.actual_checkout IS NOT NULL
          ORDER BY b.actual_checkout DESC LIMIT ?",
     )
-    .bind(limit)
+    .bind(limit.max(0))
     .fetch_all(pool)
     .await?;
 
@@ -79,7 +83,7 @@ pub async fn load_recent_housekeeping(
         "SELECT room_id, status, triggered_at FROM housekeeping
          ORDER BY triggered_at DESC LIMIT ?",
     )
-    .bind(limit)
+    .bind(limit.max(0))
     .fetch_all(pool)
     .await?;
 

--- a/mhm/src-tauri/src/queries/booking/activity_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/activity_queries.rs
@@ -1,0 +1,94 @@
+//! Reads behind the dashboard activity feed.
+//!
+//! Three independent "most recent N" queries. They are not unioned in SQL
+//! because each one carries different columns; the command merges and sorts
+//! them, which it can do as a pure function once the rows are in hand.
+
+use sqlx::{Pool, Row, Sqlite};
+
+pub struct RecentCheckIn {
+    pub room_id: String,
+    pub guest_name: String,
+    pub check_in_at: String,
+}
+
+pub struct RecentCheckOut {
+    pub room_id: String,
+    pub guest_name: String,
+    pub actual_checkout: String,
+}
+
+pub struct RecentHousekeeping {
+    pub room_id: String,
+    pub status: String,
+    pub triggered_at: String,
+}
+
+pub async fn load_recent_check_ins(
+    pool: &Pool<Sqlite>,
+    limit: i32,
+) -> Result<Vec<RecentCheckIn>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT b.room_id, g.full_name, b.check_in_at
+         FROM bookings b JOIN guests g ON g.id = b.primary_guest_id
+         ORDER BY b.check_in_at DESC LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| RecentCheckIn {
+            room_id: row.get("room_id"),
+            guest_name: row.get("full_name"),
+            check_in_at: row.get("check_in_at"),
+        })
+        .collect())
+}
+
+pub async fn load_recent_check_outs(
+    pool: &Pool<Sqlite>,
+    limit: i32,
+) -> Result<Vec<RecentCheckOut>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT b.room_id, g.full_name, b.actual_checkout
+         FROM bookings b JOIN guests g ON g.id = b.primary_guest_id
+         WHERE b.actual_checkout IS NOT NULL
+         ORDER BY b.actual_checkout DESC LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| RecentCheckOut {
+            room_id: row.get("room_id"),
+            guest_name: row.get("full_name"),
+            actual_checkout: row.get("actual_checkout"),
+        })
+        .collect())
+}
+
+pub async fn load_recent_housekeeping(
+    pool: &Pool<Sqlite>,
+    limit: i32,
+) -> Result<Vec<RecentHousekeeping>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT room_id, status, triggered_at FROM housekeeping
+         ORDER BY triggered_at DESC LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| RecentHousekeeping {
+            room_id: row.get("room_id"),
+            status: row.get("status"),
+            triggered_at: row.get("triggered_at"),
+        })
+        .collect())
+}

--- a/mhm/src-tauri/src/queries/booking/booking_list_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/booking_list_queries.rs
@@ -163,6 +163,38 @@ mod tests {
         pool
     }
 
+    #[tokio::test]
+    async fn a_status_string_cannot_reach_the_sql() {
+        let pool = seeded_pool().await;
+
+        // The module doc claims the caller's string selects a branch and never
+        // reaches the SQL. This is that claim as evidence rather than prose: a
+        // payload that would be devastating if concatenated returns the
+        // unfiltered list, because it simply fails to match any branch.
+        for payload in [
+            "' OR 1=1 --",
+            "active'; DROP TABLE bookings; --",
+            "\u{0}active",
+        ] {
+            assert_eq!(
+                status_clause(payload),
+                None,
+                "payload matched a branch: {payload}"
+            );
+
+            let bookings = load_bookings_with_guest(&pool, filter(Some(payload), None, None))
+                .await
+                .expect("an unmatched status must not error");
+            assert_eq!(bookings.len(), 3, "payload changed the result: {payload}");
+        }
+
+        let still_there: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM bookings")
+            .fetch_one(&pool)
+            .await
+            .expect("count bookings");
+        assert_eq!(still_there.0, 3, "the bookings table survived");
+    }
+
     #[test]
     fn status_clause_translates_the_ui_vocabulary_and_ignores_the_unknown() {
         assert_eq!(status_clause("active"), Some(" AND b.status = 'active'"));

--- a/mhm/src-tauri/src/queries/booking/booking_list_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/booking_list_queries.rs
@@ -1,0 +1,236 @@
+//! The reservations list read.
+//!
+//! The only query in the codebase that builds its WHERE clause at runtime. The
+//! status filter appends fixed literals — the caller's string selects a branch,
+//! it never reaches the SQL — while the date bounds are bound as parameters.
+
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::db::row::{get_money_vnd, get_optional_money_vnd};
+use crate::models::{BookingFilter, BookingWithGuest};
+
+const BOOKING_LIST_SQL: &str = "SELECT b.id, b.room_id, r.name as room_name, g.full_name as guest_name,
+                b.check_in_at, b.expected_checkout, b.actual_checkout,
+                b.nights, b.total_price, b.paid_amount, b.status, b.source,
+                b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout, b.guest_phone
+         FROM bookings b
+         JOIN rooms r ON r.id = b.room_id
+         JOIN guests g ON g.id = b.primary_guest_id
+         WHERE 1=1";
+
+/// The UI's vocabulary is not the database's: `completed` means `checked_out`.
+/// An unrecognised value filters nothing rather than erroring, which is the
+/// behaviour the list has always had.
+fn status_clause(status: &str) -> Option<&'static str> {
+    match status {
+        "active" => Some(" AND b.status = 'active'"),
+        "completed" => Some(" AND b.status = 'checked_out'"),
+        "booked" => Some(" AND b.status = 'booked'"),
+        _ => None,
+    }
+}
+
+pub async fn load_bookings_with_guest(
+    pool: &Pool<Sqlite>,
+    filter: Option<BookingFilter>,
+) -> Result<Vec<BookingWithGuest>, sqlx::Error> {
+    let mut sql = String::from(BOOKING_LIST_SQL);
+    let mut binds: Vec<String> = Vec::new();
+
+    if let Some(filter) = &filter {
+        if let Some(status) = filter.status.as_deref().and_then(status_clause) {
+            sql.push_str(status);
+        }
+        if let Some(from) = &filter.from {
+            sql.push_str(" AND b.check_in_at >= ?");
+            binds.push(from.clone());
+        }
+        if let Some(to) = &filter.to {
+            sql.push_str(" AND b.expected_checkout <= ?");
+            binds.push(to.clone());
+        }
+    }
+
+    sql.push_str(" ORDER BY b.check_in_at DESC");
+
+    let mut query = sqlx::query(&sql);
+    for bind in &binds {
+        query = query.bind(bind);
+    }
+
+    let rows = query.fetch_all(pool).await?;
+
+    Ok(rows.iter().map(map_booking_with_guest).collect())
+}
+
+fn map_booking_with_guest(row: &sqlx::sqlite::SqliteRow) -> BookingWithGuest {
+    BookingWithGuest {
+        id: row.get("id"),
+        room_id: row.get("room_id"),
+        room_name: row.get("room_name"),
+        guest_name: row.get("guest_name"),
+        check_in_at: row.get("check_in_at"),
+        expected_checkout: row.get("expected_checkout"),
+        actual_checkout: row.get("actual_checkout"),
+        nights: row.get("nights"),
+        total_price: get_money_vnd(row, "total_price"),
+        paid_amount: get_money_vnd(row, "paid_amount"),
+        status: row.get("status"),
+        source: row.get("source"),
+        booking_type: row.get("booking_type"),
+        deposit_amount: get_optional_money_vnd(row, "deposit_amount"),
+        scheduled_checkin: row.get("scheduled_checkin"),
+        scheduled_checkout: row.get("scheduled_checkout"),
+        guest_phone: row.get("guest_phone"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_bookings_with_guest, status_clause};
+    use crate::models::BookingFilter;
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+
+    fn filter(status: Option<&str>, from: Option<&str>, to: Option<&str>) -> Option<BookingFilter> {
+        Some(BookingFilter {
+            status: status.map(str::to_string),
+            from: from.map(str::to_string),
+            to: to.map(str::to_string),
+        })
+    }
+
+    async fn seeded_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES ('R1', 'Room 1', 'standard', 1, 0, 300000, 2, 0, 'vacant')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed room");
+        sqlx::query(
+            "INSERT INTO guests (id, guest_type, full_name, doc_number, created_at)
+             VALUES ('G1', 'domestic', 'Nguyen Van A', 'DOC-1', '2026-04-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed guest");
+
+        for (id, status, check_in, checkout) in [
+            (
+                "B-ACTIVE",
+                "active",
+                "2026-04-10T14:00:00+07:00",
+                "2026-04-12T12:00:00+07:00",
+            ),
+            (
+                "B-OUT",
+                "checked_out",
+                "2026-04-05T14:00:00+07:00",
+                "2026-04-07T12:00:00+07:00",
+            ),
+            (
+                "B-BOOKED",
+                "booked",
+                "2026-04-20T14:00:00+07:00",
+                "2026-04-22T12:00:00+07:00",
+            ),
+        ] {
+            sqlx::query(
+                "INSERT INTO bookings (
+                    id, room_id, primary_guest_id, check_in_at, expected_checkout, nights,
+                    total_price, paid_amount, status, booking_type, pricing_type, created_at
+                 ) VALUES (?, 'R1', 'G1', ?, ?, 2, 600000, 0, ?, 'walk-in', 'nightly', ?)",
+            )
+            .bind(id)
+            .bind(check_in)
+            .bind(checkout)
+            .bind(status)
+            .bind("2026-04-01T00:00:00+07:00")
+            .execute(&pool)
+            .await
+            .expect("seed booking");
+        }
+
+        pool
+    }
+
+    #[test]
+    fn status_clause_translates_the_ui_vocabulary_and_ignores_the_unknown() {
+        assert_eq!(status_clause("active"), Some(" AND b.status = 'active'"));
+        assert_eq!(
+            status_clause("completed"),
+            Some(" AND b.status = 'checked_out'"),
+            "the UI says completed, the column says checked_out"
+        );
+        assert_eq!(status_clause("booked"), Some(" AND b.status = 'booked'"));
+        assert_eq!(status_clause("nonsense"), None);
+        assert_eq!(status_clause(""), None);
+    }
+
+    #[tokio::test]
+    async fn no_filter_returns_everything_newest_first() {
+        let pool = seeded_pool().await;
+
+        let bookings = load_bookings_with_guest(&pool, None)
+            .await
+            .expect("load bookings");
+
+        let ids: Vec<&str> = bookings.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, vec!["B-BOOKED", "B-ACTIVE", "B-OUT"]);
+        assert_eq!(bookings[0].room_name, "Room 1");
+        assert_eq!(bookings[0].guest_name, "Nguyen Van A");
+    }
+
+    #[tokio::test]
+    async fn the_completed_filter_selects_checked_out_bookings() {
+        let pool = seeded_pool().await;
+
+        let bookings = load_bookings_with_guest(&pool, filter(Some("completed"), None, None))
+            .await
+            .expect("load bookings");
+
+        let ids: Vec<&str> = bookings.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, vec!["B-OUT"]);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_status_filters_nothing() {
+        let pool = seeded_pool().await;
+
+        let bookings = load_bookings_with_guest(&pool, filter(Some("nonsense"), None, None))
+            .await
+            .expect("load bookings");
+
+        assert_eq!(bookings.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn the_date_bounds_are_inclusive_and_combine_with_status() {
+        let pool = seeded_pool().await;
+
+        let bookings =
+            load_bookings_with_guest(&pool, filter(None, Some("2026-04-10T14:00:00+07:00"), None))
+                .await
+                .expect("load from");
+        let ids: Vec<&str> = bookings.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, vec!["B-BOOKED", "B-ACTIVE"], "from is inclusive");
+
+        let bookings = load_bookings_with_guest(
+            &pool,
+            filter(Some("active"), Some("2026-04-01"), Some("2026-04-13")),
+        )
+        .await
+        .expect("load combined");
+        let ids: Vec<&str> = bookings.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, vec!["B-ACTIVE"]);
+    }
+}

--- a/mhm/src-tauri/src/queries/booking/expense_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/expense_queries.rs
@@ -1,0 +1,39 @@
+//! Operating-expense reads.
+//!
+//! Expenses are part of financial reporting rather than a booking, but they feed
+//! `revenue_queries`, which is why they live in the same context.
+
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::db::row::get_money_vnd;
+use crate::models::Expense;
+
+/// `from`/`to` are inclusive `YYYY-MM-DD` bounds matched against `expense_date`.
+pub async fn load_expenses_between(
+    pool: &Pool<Sqlite>,
+    from: &str,
+    to: &str,
+) -> Result<Vec<Expense>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, category, amount, note, expense_date, created_at
+         FROM expenses
+         WHERE expense_date BETWEEN ? AND ?
+         ORDER BY expense_date DESC",
+    )
+    .bind(from)
+    .bind(to)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| Expense {
+            id: row.get("id"),
+            category: row.get("category"),
+            amount: get_money_vnd(row, "amount"),
+            note: row.get("note"),
+            expense_date: row.get("expense_date"),
+            created_at: row.get("created_at"),
+        })
+        .collect())
+}

--- a/mhm/src-tauri/src/queries/booking/mod.rs
+++ b/mhm/src-tauri/src/queries/booking/mod.rs
@@ -1,5 +1,7 @@
+pub mod activity_queries;
 pub mod audit_queries;
 pub mod billing_queries;
+pub mod booking_list_queries;
 pub mod ceo_read_queries;
 pub mod expense_queries;
 pub mod pricing_queries;

--- a/mhm/src-tauri/src/queries/booking/mod.rs
+++ b/mhm/src-tauri/src/queries/booking/mod.rs
@@ -1,6 +1,8 @@
 pub mod audit_queries;
 pub mod billing_queries;
 pub mod ceo_read_queries;
+pub mod expense_queries;
 pub mod pricing_queries;
 pub mod revenue_queries;
 pub mod room_queries;
+pub mod stay_info_queries;

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -2,12 +2,12 @@
 //!
 //! Split out of `domain::booking::pricing`, which is now pure.
 //!
-//! Every loader takes the caller's transaction. Pricing is only ever computed
-//! as part of a lifecycle write, which needs to read rows it has inserted but
-//! not committed, so a pool-based read would see stale data. The pool variants
-//! that used to sit beside these were reachable only from tests.
+//! The `_tx` loaders take the caller's transaction: a lifecycle write needs to
+//! read rows it has inserted but not committed, so a pool-based read would see
+//! stale data. The pool loaders below serve the *preview* path, which has no
+//! transaction and keys off a room type rather than a room id.
 
-use sqlx::{Row, Sqlite, Transaction};
+use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::db::row::{get_f64, get_money_vnd};
 use crate::domain::booking::pricing::{StayPricingInputs, StoredPricingRule};
@@ -26,6 +26,30 @@ const FALLBACK_BASE_PRICE_SQL: &str = "SELECT base_price FROM rooms WHERE LOWER(
 
 const SPECIAL_UPLIFT_SQL: &str =
     "SELECT CAST(uplift_pct AS REAL) FROM special_dates WHERE date = ?";
+
+const PRICING_RULE_LISTING_SQL: &str =
+    "SELECT id, room_type, hourly_rate, overnight_rate, daily_rate,
+                overnight_start, overnight_end, daily_checkin, daily_checkout,
+                early_checkin_surcharge_pct, late_checkout_surcharge_pct,
+                weekend_uplift_pct
+         FROM pricing_rules ORDER BY room_type";
+
+const SPECIAL_DATES_SQL: &str =
+    "SELECT id, date, label, uplift_pct FROM special_dates ORDER BY date";
+
+/// A stored rule plus its row id, which the settings screen needs and the
+/// pricing rules themselves do not.
+pub(crate) struct PricingRuleListing {
+    pub(crate) id: String,
+    pub(crate) rule: StoredPricingRule,
+}
+
+pub struct SpecialDate {
+    pub id: String,
+    pub date: String,
+    pub label: String,
+    pub uplift_pct: f64,
+}
 
 fn database_error(error: sqlx::Error) -> BookingError {
     BookingError::database(error.to_string())
@@ -86,6 +110,106 @@ pub(crate) async fn load_stay_pricing_inputs_tx(
         check_out: check_out.to_string(),
         pricing_type: pricing_type.to_string(),
     })
+}
+
+/// The preview counterpart of `load_stay_pricing_inputs_tx`. Callers of the
+/// preview supply a room *type* directly — there is no booking or room yet — so
+/// this skips the room lookup and is otherwise identical.
+///
+/// The special-date read is deliberately lenient: a failure prices the stay at a
+/// 0% uplift rather than failing the preview, which is the behaviour the
+/// preview command has always had. The lifecycle path, which actually charges
+/// money, propagates the error instead.
+pub(crate) async fn load_stay_pricing_inputs_for_room_type(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+) -> BookingResult<StayPricingInputs> {
+    let stored_rule = load_stored_pricing_rule(pool, room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price(pool, room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+
+    Ok(StayPricingInputs {
+        room_type: room_type.to_string(),
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+    })
+}
+
+async fn load_stored_pricing_rule(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+) -> BookingResult<Option<StoredPricingRule>> {
+    let row = sqlx::query(STORED_PRICING_RULE_SQL)
+        .bind(room_type.to_lowercase())
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row.as_ref().map(stored_rule_from_row))
+}
+
+async fn load_fallback_base_price(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+) -> BookingResult<Option<MoneyVnd>> {
+    let row = sqlx::query(FALLBACK_BASE_PRICE_SQL)
+        .bind(room_type.to_lowercase())
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row.as_ref().map(|row| get_money_vnd(row, "base_price")))
+}
+
+async fn load_special_uplift(pool: &Pool<Sqlite>, date_str: &str) -> BookingResult<f64> {
+    let row: Option<(f64,)> = sqlx::query_as(SPECIAL_UPLIFT_SQL)
+        .bind(date_key(date_str))
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row.map(|value| value.0).unwrap_or(0.0))
+}
+
+pub(crate) async fn load_pricing_rule_listings(
+    pool: &Pool<Sqlite>,
+) -> Result<Vec<PricingRuleListing>, sqlx::Error> {
+    let rows = sqlx::query(PRICING_RULE_LISTING_SQL)
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| PricingRuleListing {
+            id: row.get("id"),
+            rule: stored_rule_from_row(row),
+        })
+        .collect())
+}
+
+pub async fn load_special_dates(pool: &Pool<Sqlite>) -> Result<Vec<SpecialDate>, sqlx::Error> {
+    let rows = sqlx::query(SPECIAL_DATES_SQL).fetch_all(pool).await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| SpecialDate {
+            id: row.get("id"),
+            date: row.get("date"),
+            label: row.get("label"),
+            uplift_pct: get_f64(row, "uplift_pct"),
+        })
+        .collect())
 }
 
 async fn load_room_type_tx(

--- a/mhm/src-tauri/src/queries/booking/stay_info_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/stay_info_queries.rs
@@ -1,0 +1,59 @@
+//! The read behind the "copy lưu trú" text block.
+//!
+//! Two lookups — the booking, then its primary guest — flattened into the exact
+//! fields the clipboard text needs. Formatting stays in the command; this module
+//! only knows where the values come from.
+
+use sqlx::{Pool, Row, Sqlite};
+
+pub struct StayInfo {
+    pub room_id: String,
+    pub full_name: String,
+    pub doc_number: String,
+    pub dob: String,
+    pub gender: String,
+    pub nationality: String,
+    pub address: String,
+    pub check_in: String,
+    pub checkout: String,
+}
+
+/// Errors when the booking or its primary guest is missing: the caller is
+/// working from a booking it just displayed, so either absence is a surprise.
+pub async fn load_stay_info(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+) -> Result<StayInfo, sqlx::Error> {
+    let booking = sqlx::query(
+        "SELECT room_id, primary_guest_id, check_in_at, expected_checkout
+         FROM bookings WHERE id = ?",
+    )
+    .bind(booking_id)
+    .fetch_one(pool)
+    .await?;
+
+    let guest = sqlx::query(
+        "SELECT full_name, doc_number, dob, gender, nationality, address
+         FROM guests WHERE id = ?",
+    )
+    .bind(booking.get::<String, _>("primary_guest_id"))
+    .fetch_one(pool)
+    .await?;
+
+    Ok(StayInfo {
+        room_id: booking.get("room_id"),
+        full_name: guest.get("full_name"),
+        doc_number: guest.get("doc_number"),
+        dob: guest.get::<Option<String>, _>("dob").unwrap_or_default(),
+        gender: guest.get::<Option<String>, _>("gender").unwrap_or_default(),
+        // The overwhelmingly common case, and the form has to say something.
+        nationality: guest
+            .get::<Option<String>, _>("nationality")
+            .unwrap_or_else(|| "Việt Nam".to_string()),
+        address: guest
+            .get::<Option<String>, _>("address")
+            .unwrap_or_default(),
+        check_in: booking.get("check_in_at"),
+        checkout: booking.get("expected_checkout"),
+    })
+}

--- a/mhm/src-tauri/src/queries/groups/group_queries.rs
+++ b/mhm/src-tauri/src/queries/groups/group_queries.rs
@@ -1,0 +1,163 @@
+//! Reads behind the group screens.
+//!
+//! `load_group_detail` composes three reads and totals them. That composition
+//! is a read, so it belongs here rather than in a service — there is no state
+//! machine, only arithmetic over rows.
+
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::db::row::{get_money_vnd, get_optional_money_vnd};
+use crate::models::{BookingGroup, BookingWithGuest, GroupDetailResponse, GroupService};
+
+const GROUP_BOOKINGS_SQL: &str =
+    "SELECT b.id, b.room_id, r.name as room_name, g.full_name as guest_name,
+            b.check_in_at, b.expected_checkout, b.actual_checkout, b.nights,
+            b.total_price, b.paid_amount, b.status, b.source,
+            b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout,
+            b.guest_phone
+     FROM bookings b
+     JOIN rooms r ON r.id = b.room_id
+     JOIN guests g ON g.id = b.primary_guest_id
+     WHERE b.group_id = ?
+     ORDER BY r.floor, r.id";
+
+pub async fn load_group(pool: &Pool<Sqlite>, group_id: &str) -> Result<BookingGroup, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM booking_groups WHERE id = ?")
+        .bind(group_id)
+        .fetch_one(pool)
+        .await?;
+
+    Ok(map_group(&row))
+}
+
+/// Every group, or only those in `status`, newest first.
+pub async fn load_groups(
+    pool: &Pool<Sqlite>,
+    status: Option<&str>,
+) -> Result<Vec<BookingGroup>, sqlx::Error> {
+    let rows = match status {
+        Some(status) => {
+            sqlx::query("SELECT * FROM booking_groups WHERE status = ? ORDER BY created_at DESC")
+                .bind(status)
+                .fetch_all(pool)
+                .await?
+        }
+        None => {
+            sqlx::query("SELECT * FROM booking_groups ORDER BY created_at DESC")
+                .fetch_all(pool)
+                .await?
+        }
+    };
+
+    Ok(rows.iter().map(map_group).collect())
+}
+
+pub async fn load_group_bookings(
+    pool: &Pool<Sqlite>,
+    group_id: &str,
+) -> Result<Vec<BookingWithGuest>, sqlx::Error> {
+    let rows = sqlx::query(GROUP_BOOKINGS_SQL)
+        .bind(group_id)
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows.iter().map(map_group_booking).collect())
+}
+
+pub async fn load_group_services(
+    pool: &Pool<Sqlite>,
+    group_id: &str,
+) -> Result<Vec<GroupService>, sqlx::Error> {
+    let rows = sqlx::query("SELECT * FROM group_services WHERE group_id = ? ORDER BY created_at")
+        .bind(group_id)
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows.iter().map(map_group_service).collect())
+}
+
+/// The group, its rooms, its services, and what they add up to.
+pub async fn load_group_detail(
+    pool: &Pool<Sqlite>,
+    group_id: &str,
+) -> Result<GroupDetailResponse, sqlx::Error> {
+    let group = load_group(pool, group_id).await?;
+    let bookings = load_group_bookings(pool, group_id).await?;
+    let services = load_group_services(pool, group_id).await?;
+
+    Ok(total_group_detail(group, bookings, services))
+}
+
+/// The arithmetic half of `load_group_detail`, kept separate so the totals can
+/// be checked without a database.
+fn total_group_detail(
+    group: BookingGroup,
+    bookings: Vec<BookingWithGuest>,
+    services: Vec<GroupService>,
+) -> GroupDetailResponse {
+    let total_room_cost = bookings.iter().map(|b| b.total_price).sum();
+    let total_service_cost = services.iter().map(|s| s.total_price).sum();
+    let paid_amount = bookings.iter().map(|b| b.paid_amount).sum();
+
+    GroupDetailResponse {
+        group,
+        bookings,
+        services,
+        total_room_cost,
+        total_service_cost,
+        grand_total: total_room_cost + total_service_cost,
+        paid_amount,
+    }
+}
+
+fn map_group(row: &sqlx::sqlite::SqliteRow) -> BookingGroup {
+    BookingGroup {
+        id: row.get("id"),
+        group_name: row.get("group_name"),
+        master_booking_id: row.get("master_booking_id"),
+        organizer_name: row.get("organizer_name"),
+        organizer_phone: row.get("organizer_phone"),
+        total_rooms: row.get("total_rooms"),
+        status: row.get("status"),
+        notes: row.get("notes"),
+        created_by: row.get("created_by"),
+        created_at: row.get("created_at"),
+    }
+}
+
+fn map_group_booking(row: &sqlx::sqlite::SqliteRow) -> BookingWithGuest {
+    BookingWithGuest {
+        id: row.get("id"),
+        room_id: row.get("room_id"),
+        room_name: row.get("room_name"),
+        guest_name: row.get("guest_name"),
+        check_in_at: row.get("check_in_at"),
+        expected_checkout: row.get("expected_checkout"),
+        actual_checkout: row.get("actual_checkout"),
+        nights: row.get("nights"),
+        total_price: get_money_vnd(row, "total_price"),
+        paid_amount: get_money_vnd(row, "paid_amount"),
+        status: row.get("status"),
+        source: row.get("source"),
+        booking_type: row.get("booking_type"),
+        deposit_amount: get_optional_money_vnd(row, "deposit_amount"),
+        scheduled_checkin: row.get("scheduled_checkin"),
+        scheduled_checkout: row.get("scheduled_checkout"),
+        guest_phone: row.get("guest_phone"),
+    }
+}
+
+fn map_group_service(row: &sqlx::sqlite::SqliteRow) -> GroupService {
+    GroupService {
+        id: row.get("id"),
+        group_id: row.get("group_id"),
+        booking_id: row.get("booking_id"),
+        name: row.get("name"),
+        quantity: row.get("quantity"),
+        unit_price: get_money_vnd(row, "unit_price"),
+        total_price: get_money_vnd(row, "total_price"),
+        note: row.get("note"),
+        created_by: row.get("created_by"),
+        created_at: row.get("created_at"),
+    }
+}

--- a/mhm/src-tauri/src/queries/groups/group_queries.rs
+++ b/mhm/src-tauri/src/queries/groups/group_queries.rs
@@ -90,7 +90,7 @@ pub async fn load_group_detail(
 
 /// The arithmetic half of `load_group_detail`, kept separate so the totals can
 /// be checked without a database.
-fn total_group_detail(
+pub(crate) fn total_group_detail(
     group: BookingGroup,
     bookings: Vec<BookingWithGuest>,
     services: Vec<GroupService>,
@@ -159,5 +159,123 @@ fn map_group_service(row: &sqlx::sqlite::SqliteRow) -> GroupService {
         note: row.get("note"),
         created_by: row.get("created_by"),
         created_at: row.get("created_at"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::total_group_detail;
+    use crate::models::{BookingGroup, BookingWithGuest, GroupService};
+
+    fn group() -> BookingGroup {
+        BookingGroup {
+            id: "GRP-1".to_string(),
+            group_name: "Đoàn Hà Nội".to_string(),
+            master_booking_id: None,
+            organizer_name: "Nguyen Van A".to_string(),
+            organizer_phone: Some("0901234567".to_string()),
+            total_rooms: 2,
+            status: "active".to_string(),
+            notes: None,
+            created_by: Some("user-1".to_string()),
+            created_at: "2026-04-01T00:00:00+07:00".to_string(),
+        }
+    }
+
+    fn booking(id: &str, total_price: i64, paid_amount: i64) -> BookingWithGuest {
+        BookingWithGuest {
+            id: id.to_string(),
+            room_id: "101".to_string(),
+            room_name: "Room 101".to_string(),
+            guest_name: "Guest".to_string(),
+            check_in_at: "2026-04-10T14:00:00+07:00".to_string(),
+            expected_checkout: "2026-04-12T12:00:00+07:00".to_string(),
+            actual_checkout: None,
+            nights: 2,
+            total_price,
+            paid_amount,
+            status: "active".to_string(),
+            source: None,
+            booking_type: Some("walk-in".to_string()),
+            deposit_amount: None,
+            scheduled_checkin: None,
+            scheduled_checkout: None,
+            guest_phone: None,
+        }
+    }
+
+    fn service(id: &str, total_price: i64) -> GroupService {
+        GroupService {
+            id: id.to_string(),
+            group_id: "GRP-1".to_string(),
+            booking_id: None,
+            name: "Giặt là".to_string(),
+            quantity: 1,
+            unit_price: total_price,
+            total_price,
+            note: None,
+            created_by: Some("user-1".to_string()),
+            created_at: "2026-04-11T09:00:00+07:00".to_string(),
+        }
+    }
+
+    #[test]
+    fn the_totals_add_rooms_and_services_separately_then_together() {
+        let detail = total_group_detail(
+            group(),
+            vec![booking("B1", 600_000, 200_000), booking("B2", 400_000, 0)],
+            vec![service("S1", 150_000), service("S2", 50_000)],
+        );
+
+        assert_eq!(detail.total_room_cost, 1_000_000);
+        assert_eq!(detail.total_service_cost, 200_000);
+        assert_eq!(detail.grand_total, 1_200_000);
+    }
+
+    #[test]
+    fn paid_amount_counts_room_payments_only_never_services() {
+        // The group invoice's balance_due is grand_total - paid_amount, so a
+        // service payment counted here would under-bill the group. Services
+        // carry no payment field at all; this pins that reading.
+        let detail = total_group_detail(
+            group(),
+            vec![
+                booking("B1", 600_000, 200_000),
+                booking("B2", 400_000, 100_000),
+            ],
+            vec![service("S1", 900_000)],
+        );
+
+        assert_eq!(detail.paid_amount, 300_000, "200k + 100k, the rooms only");
+        assert_eq!(
+            detail.grand_total - detail.paid_amount,
+            1_600_000,
+            "the 900k service is owed, not paid"
+        );
+    }
+
+    #[test]
+    fn an_empty_group_totals_to_zero_rather_than_failing() {
+        let detail = total_group_detail(group(), vec![], vec![]);
+
+        assert_eq!(detail.total_room_cost, 0);
+        assert_eq!(detail.total_service_cost, 0);
+        assert_eq!(detail.grand_total, 0);
+        assert_eq!(detail.paid_amount, 0);
+    }
+
+    #[test]
+    fn the_rows_are_passed_through_untouched() {
+        let detail = total_group_detail(
+            group(),
+            vec![booking("B1", 600_000, 0)],
+            vec![service("S1", 150_000)],
+        );
+
+        assert_eq!(detail.group.id, "GRP-1");
+        assert_eq!(detail.bookings.len(), 1);
+        assert_eq!(detail.bookings[0].id, "B1");
+        assert_eq!(detail.services.len(), 1);
+        assert_eq!(detail.services[0].id, "S1");
     }
 }

--- a/mhm/src-tauri/src/queries/groups/mod.rs
+++ b/mhm/src-tauri/src/queries/groups/mod.rs
@@ -1,0 +1,1 @@
+pub mod group_queries;

--- a/mhm/src-tauri/src/queries/guests/guest_queries.rs
+++ b/mhm/src-tauri/src/queries/guests/guest_queries.rs
@@ -210,19 +210,33 @@ mod tests {
     }
 
     #[test]
-    fn the_three_filters_share_one_projection() {
+    fn the_three_filters_are_the_same_query_with_a_different_where() {
         let unfiltered = summary_sql("", None);
         let searched = summary_sql("g.full_name LIKE ? OR g.doc_number LIKE ?", None);
         let by_phone = summary_sql("g.phone LIKE ?", Some(5));
 
+        // Asserted against the shared constant rather than against literals
+        // copied out of it: this should fail when the three stop being one
+        // query, not when someone reformats the SQL.
         for sql in [&unfiltered, &searched, &by_phone] {
-            assert!(sql.contains("COALESCE(SUM(b.total_price), 0) as total_spent"));
-            assert!(sql.contains("GROUP BY g.id ORDER BY last_visit DESC"));
+            assert!(
+                sql.starts_with(super::GUEST_SUMMARY_SELECT),
+                "every filter must reuse the one projection"
+            );
+            assert!(sql.contains(super::GUEST_SUMMARY_TAIL));
         }
-        assert!(!unfiltered.contains("WHERE"), "no filter, no WHERE clause");
-        assert!(searched.contains("WHERE g.full_name LIKE ? OR g.doc_number LIKE ?"));
+
+        assert_eq!(
+            unfiltered,
+            format!(
+                "{}{}",
+                super::GUEST_SUMMARY_SELECT,
+                super::GUEST_SUMMARY_TAIL
+            ),
+            "no filter adds nothing at all"
+        );
         assert!(by_phone.ends_with(" LIMIT 5"));
-        assert!(!unfiltered.contains("LIMIT"));
+        assert!(!unfiltered.contains("LIMIT") && !searched.contains("LIMIT"));
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/queries/guests/guest_queries.rs
+++ b/mhm/src-tauri/src/queries/guests/guest_queries.rs
@@ -1,0 +1,319 @@
+//! Reads over guests and their stay history.
+//!
+//! The guest-summary projection (stay count, lifetime spend, last visit) was
+//! written out three times across two command modules — the unfiltered list,
+//! the name/document search, and the phone lookup behind quick check-in — as
+//! three copies of the same nine lines of joins and aggregates. They are one
+//! query with three filters, and they are that here.
+
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::db::row::get_money_vnd;
+use crate::models::{BookingWithRoom, Guest, GuestSummary};
+
+const GUEST_SUMMARY_SELECT: &str = "SELECT g.id, g.full_name, g.doc_number, g.nationality,
+                COUNT(bg.booking_id) as total_stays,
+                COALESCE(SUM(b.total_price), 0) as total_spent,
+                MAX(b.check_in_at) as last_visit
+         FROM guests g
+         LEFT JOIN booking_guests bg ON bg.guest_id = g.id
+         LEFT JOIN bookings b ON b.id = bg.booking_id";
+
+const GUEST_SUMMARY_TAIL: &str = " GROUP BY g.id ORDER BY last_visit DESC";
+
+fn summary_sql(where_clause: &str, limit: Option<i32>) -> String {
+    let mut sql = String::from(GUEST_SUMMARY_SELECT);
+    if !where_clause.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(where_clause);
+    }
+    sql.push_str(GUEST_SUMMARY_TAIL);
+    if let Some(limit) = limit {
+        sql.push_str(&format!(" LIMIT {limit}"));
+    }
+    sql
+}
+
+/// Every guest, or those whose name or document number contains `search`.
+pub async fn load_guest_summaries(
+    pool: &Pool<Sqlite>,
+    search: Option<&str>,
+) -> Result<Vec<GuestSummary>, sqlx::Error> {
+    let rows = match search {
+        Some(search) => {
+            let pattern = format!("%{search}%");
+            sqlx::query(&summary_sql(
+                "g.full_name LIKE ? OR g.doc_number LIKE ?",
+                None,
+            ))
+            .bind(&pattern)
+            .bind(&pattern)
+            .fetch_all(pool)
+            .await?
+        }
+        None => sqlx::query(&summary_sql("", None)).fetch_all(pool).await?,
+    };
+
+    Ok(rows.iter().map(map_guest_summary).collect())
+}
+
+/// Guests whose phone number contains `phone`, most recent visit first.
+pub async fn search_guest_summaries_by_phone(
+    pool: &Pool<Sqlite>,
+    phone: &str,
+    limit: i32,
+) -> Result<Vec<GuestSummary>, sqlx::Error> {
+    let rows = sqlx::query(&summary_sql("g.phone LIKE ?", Some(limit)))
+        .bind(format!("%{phone}%"))
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows.iter().map(map_guest_summary).collect())
+}
+
+pub async fn load_guest(pool: &Pool<Sqlite>, guest_id: &str) -> Result<Guest, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM guests WHERE id = ?")
+        .bind(guest_id)
+        .fetch_one(pool)
+        .await?;
+
+    Ok(Guest {
+        id: row.get("id"),
+        guest_type: row.get("guest_type"),
+        full_name: row.get("full_name"),
+        doc_number: row.get("doc_number"),
+        dob: row.get("dob"),
+        gender: row.get("gender"),
+        nationality: row.get("nationality"),
+        address: row.get("address"),
+        visa_expiry: row.get("visa_expiry"),
+        scan_path: row.get("scan_path"),
+        phone: row.get("phone"),
+        created_at: row.get("created_at"),
+    })
+}
+
+pub async fn load_guest_bookings(
+    pool: &Pool<Sqlite>,
+    guest_id: &str,
+) -> Result<Vec<BookingWithRoom>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT b.id as booking_id, b.room_id, b.check_in_at, b.expected_checkout,
+                b.total_price, b.status
+         FROM bookings b
+         JOIN booking_guests bg ON bg.booking_id = b.id
+         WHERE bg.guest_id = ?
+         ORDER BY b.check_in_at DESC",
+    )
+    .bind(guest_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| BookingWithRoom {
+            booking_id: row.get("booking_id"),
+            room_id: row.get("room_id"),
+            check_in_at: row.get("check_in_at"),
+            expected_checkout: row.get("expected_checkout"),
+            total_price: get_money_vnd(row, "total_price"),
+            status: row.get("status"),
+        })
+        .collect())
+}
+
+fn map_guest_summary(row: &sqlx::sqlite::SqliteRow) -> GuestSummary {
+    GuestSummary {
+        id: row.get("id"),
+        full_name: row.get("full_name"),
+        doc_number: row.get("doc_number"),
+        nationality: row.get("nationality"),
+        total_stays: row.get::<i32, _>("total_stays"),
+        total_spent: get_money_vnd(row, "total_spent"),
+        last_visit: row.get("last_visit"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        load_guest, load_guest_bookings, load_guest_summaries, search_guest_summaries_by_phone,
+        summary_sql,
+    };
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+
+    async fn seeded_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES ('R1', 'Room 1', 'standard', 1, 0, 300000, 2, 0, 'vacant')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed room");
+
+        for (id, name, doc, phone) in [
+            ("G1", "Nguyen Van A", "DOC-111", "0901234567"),
+            ("G2", "Tran Thi B", "DOC-222", "0909999999"),
+            ("G3", "Le Van C", "DOC-333", "0901111111"),
+        ] {
+            sqlx::query(
+                "INSERT INTO guests (id, guest_type, full_name, doc_number, phone, created_at)
+                 VALUES (?, 'domestic', ?, ?, ?, '2026-04-01T00:00:00+07:00')",
+            )
+            .bind(id)
+            .bind(name)
+            .bind(doc)
+            .bind(phone)
+            .execute(&pool)
+            .await
+            .expect("seed guest");
+        }
+
+        // G1 stayed twice, G2 once, G3 never.
+        for (booking, guest, check_in, price) in [
+            ("B1", "G1", "2026-04-02T14:00:00+07:00", 600000),
+            ("B2", "G1", "2026-04-08T14:00:00+07:00", 400000),
+            ("B3", "G2", "2026-04-05T14:00:00+07:00", 250000),
+        ] {
+            sqlx::query(
+                "INSERT INTO bookings (
+                    id, room_id, primary_guest_id, check_in_at, expected_checkout, nights,
+                    total_price, paid_amount, status, booking_type, pricing_type, created_at
+                 ) VALUES (?, 'R1', ?, ?, '2026-04-30T12:00:00+07:00', 1, ?, 0, 'active',
+                           'walk-in', 'nightly', '2026-04-01T00:00:00+07:00')",
+            )
+            .bind(booking)
+            .bind(guest)
+            .bind(check_in)
+            .bind(price)
+            .execute(&pool)
+            .await
+            .expect("seed booking");
+            sqlx::query("INSERT INTO booking_guests (booking_id, guest_id) VALUES (?, ?)")
+                .bind(booking)
+                .bind(guest)
+                .execute(&pool)
+                .await
+                .expect("link guest");
+        }
+
+        pool
+    }
+
+    #[test]
+    fn the_three_filters_share_one_projection() {
+        let unfiltered = summary_sql("", None);
+        let searched = summary_sql("g.full_name LIKE ? OR g.doc_number LIKE ?", None);
+        let by_phone = summary_sql("g.phone LIKE ?", Some(5));
+
+        for sql in [&unfiltered, &searched, &by_phone] {
+            assert!(sql.contains("COALESCE(SUM(b.total_price), 0) as total_spent"));
+            assert!(sql.contains("GROUP BY g.id ORDER BY last_visit DESC"));
+        }
+        assert!(!unfiltered.contains("WHERE"), "no filter, no WHERE clause");
+        assert!(searched.contains("WHERE g.full_name LIKE ? OR g.doc_number LIKE ?"));
+        assert!(by_phone.ends_with(" LIMIT 5"));
+        assert!(!unfiltered.contains("LIMIT"));
+    }
+
+    #[tokio::test]
+    async fn the_summary_aggregates_stays_and_lifetime_spend() {
+        let pool = seeded_pool().await;
+
+        let guests = load_guest_summaries(&pool, None).await.expect("load all");
+
+        assert_eq!(guests.len(), 3);
+        let g1 = guests.iter().find(|g| g.id == "G1").expect("G1");
+        assert_eq!(g1.total_stays, 2);
+        assert_eq!(g1.total_spent, 1_000_000, "600k + 400k");
+        assert_eq!(g1.last_visit.as_deref(), Some("2026-04-08T14:00:00+07:00"));
+
+        let g3 = guests.iter().find(|g| g.id == "G3").expect("G3");
+        assert_eq!(
+            g3.total_stays, 0,
+            "the left join keeps guests with no stays"
+        );
+        assert_eq!(g3.total_spent, 0);
+        assert_eq!(g3.last_visit, None);
+    }
+
+    #[tokio::test]
+    async fn the_search_matches_the_name_or_the_document_number() {
+        let pool = seeded_pool().await;
+
+        let by_name = load_guest_summaries(&pool, Some("Tran"))
+            .await
+            .expect("by name");
+        assert_eq!(
+            by_name.iter().map(|g| g.id.as_str()).collect::<Vec<_>>(),
+            vec!["G2"]
+        );
+
+        let by_doc = load_guest_summaries(&pool, Some("DOC-333"))
+            .await
+            .expect("by doc");
+        assert_eq!(
+            by_doc.iter().map(|g| g.id.as_str()).collect::<Vec<_>>(),
+            vec!["G3"]
+        );
+
+        assert!(load_guest_summaries(&pool, Some("nobody"))
+            .await
+            .expect("no match")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_phone_lookup_is_a_substring_match_and_honours_its_limit() {
+        let pool = seeded_pool().await;
+
+        let matches = search_guest_summaries_by_phone(&pool, "0901", 5)
+            .await
+            .expect("by phone");
+        let ids: Vec<&str> = matches.iter().map(|g| g.id.as_str()).collect();
+        assert_eq!(ids, vec!["G1", "G3"], "newest visit first, G3 has none");
+
+        let capped = search_guest_summaries_by_phone(&pool, "090", 1)
+            .await
+            .expect("capped");
+        assert_eq!(capped.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn the_history_returns_the_guest_and_their_stays_newest_first() {
+        let pool = seeded_pool().await;
+
+        let guest = load_guest(&pool, "G1").await.expect("load guest");
+        assert_eq!(guest.full_name, "Nguyen Van A");
+        assert_eq!(guest.phone.as_deref(), Some("0901234567"));
+
+        let bookings = load_guest_bookings(&pool, "G1").await.expect("load stays");
+        let ids: Vec<&str> = bookings.iter().map(|b| b.booking_id.as_str()).collect();
+        assert_eq!(ids, vec!["B2", "B1"]);
+        assert_eq!(bookings[0].total_price, 400_000);
+
+        assert!(load_guest_bookings(&pool, "G3")
+            .await
+            .expect("no stays")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn loading_an_unknown_guest_is_an_error_not_an_empty_guest() {
+        let pool = seeded_pool().await;
+
+        assert!(matches!(
+            load_guest(&pool, "NOPE").await,
+            Err(sqlx::Error::RowNotFound)
+        ));
+    }
+}

--- a/mhm/src-tauri/src/queries/guests/mod.rs
+++ b/mhm/src-tauri/src/queries/guests/mod.rs
@@ -1,0 +1,1 @@
+pub mod guest_queries;

--- a/mhm/src-tauri/src/queries/housekeeping/housekeeping_queries.rs
+++ b/mhm/src-tauri/src/queries/housekeeping/housekeeping_queries.rs
@@ -1,0 +1,40 @@
+//! Housekeeping reads.
+
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::models::HousekeepingTask;
+
+/// Everything still needing attention. `clean` tasks are done and are excluded
+/// rather than filtered client-side.
+pub async fn load_open_tasks(pool: &Pool<Sqlite>) -> Result<Vec<HousekeepingTask>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, room_id, status, note, triggered_at, cleaned_at, created_at
+         FROM housekeeping
+         WHERE status != 'clean'
+         ORDER BY triggered_at ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| HousekeepingTask {
+            id: row.get("id"),
+            room_id: row.get("room_id"),
+            status: row.get("status"),
+            note: row.get("note"),
+            triggered_at: row.get("triggered_at"),
+            cleaned_at: row.get("cleaned_at"),
+            created_at: row.get("created_at"),
+        })
+        .collect())
+}
+
+/// Errors when the task does not exist — the caller has a task id it believes in,
+/// so a missing row is a system-level surprise rather than a user outcome.
+pub async fn load_task_room_id(pool: &Pool<Sqlite>, task_id: &str) -> Result<String, sqlx::Error> {
+    sqlx::query_scalar("SELECT room_id FROM housekeeping WHERE id = ?")
+        .bind(task_id)
+        .fetch_one(pool)
+        .await
+}

--- a/mhm/src-tauri/src/queries/housekeeping/mod.rs
+++ b/mhm/src-tauri/src/queries/housekeeping/mod.rs
@@ -1,0 +1,1 @@
+pub mod housekeeping_queries;

--- a/mhm/src-tauri/src/queries/mod.rs
+++ b/mhm/src-tauri/src/queries/mod.rs
@@ -1,3 +1,4 @@
 pub mod booking;
 pub mod export_queries;
+pub mod housekeeping;
 pub mod rooms;

--- a/mhm/src-tauri/src/queries/mod.rs
+++ b/mhm/src-tauri/src/queries/mod.rs
@@ -1,4 +1,6 @@
+pub mod auth;
 pub mod booking;
 pub mod export_queries;
+pub mod guests;
 pub mod housekeeping;
 pub mod rooms;

--- a/mhm/src-tauri/src/queries/mod.rs
+++ b/mhm/src-tauri/src/queries/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod booking;
 pub mod export_queries;
+pub mod groups;
 pub mod guests;
 pub mod housekeeping;
 pub mod rooms;

--- a/mhm/src-tauri/src/queries/rooms/room_admin_queries.rs
+++ b/mhm/src-tauri/src/queries/rooms/room_admin_queries.rs
@@ -26,6 +26,33 @@ pub async fn load_room(pool: &Pool<Sqlite>, room_id: &str) -> Result<Option<Room
     Ok(row.as_ref().map(map_room))
 }
 
+/// Vacant rooms, optionally of one type, ordered by floor then id.
+///
+/// The order matters to the caller: `domain::booking::room_allocation` groups
+/// by floor and needs a stable sequence within each floor.
+pub async fn load_vacant_rooms(
+    pool: &Pool<Sqlite>,
+    room_type: Option<&str>,
+) -> Result<Vec<Room>, sqlx::Error> {
+    let rows = match room_type {
+        Some(room_type) => {
+            sqlx::query(
+                "SELECT * FROM rooms WHERE status = 'vacant' AND type = ? ORDER BY floor, id",
+            )
+            .bind(room_type)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query("SELECT * FROM rooms WHERE status = 'vacant' ORDER BY floor, id")
+                .fetch_all(pool)
+                .await?
+        }
+    };
+
+    Ok(rows.iter().map(map_room).collect())
+}
+
 pub async fn room_exists(pool: &Pool<Sqlite>, room_id: &str) -> Result<bool, sqlx::Error> {
     let existing: Option<(String,)> = sqlx::query_as("SELECT id FROM rooms WHERE id = ?")
         .bind(room_id)

--- a/mhm/src-tauri/src/queries/rooms/room_admin_queries.rs
+++ b/mhm/src-tauri/src/queries/rooms/room_admin_queries.rs
@@ -145,3 +145,111 @@ pub async fn count_rooms_with_type(
 
     Ok(count.0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::load_vacant_rooms;
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+
+    /// Rooms are inserted in an order that is neither by floor nor by id, so a
+    /// missing `ORDER BY` would show up as the insertion order leaking through.
+    async fn seeded_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+
+        for (id, floor, room_type, status) in [
+            ("305", 3, "deluxe", "vacant"),
+            ("101", 1, "standard", "vacant"),
+            ("204", 2, "standard", "occupied"),
+            ("201", 2, "deluxe", "vacant"),
+            ("102", 1, "deluxe", "vacant"),
+            ("301", 3, "standard", "cleaning"),
+        ] {
+            sqlx::query(
+                "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price,
+                                    max_guests, extra_person_fee, status)
+                 VALUES (?, ?, ?, ?, 0, 300000, 2, 0, ?)",
+            )
+            .bind(id)
+            .bind(format!("Room {id}"))
+            .bind(room_type)
+            .bind(floor)
+            .bind(status)
+            .execute(&pool)
+            .await
+            .expect("seed room");
+        }
+
+        pool
+    }
+
+    async fn vacant_ids(pool: &Pool<Sqlite>, room_type: Option<&str>) -> Vec<String> {
+        load_vacant_rooms(pool, room_type)
+            .await
+            .expect("load vacant rooms")
+            .into_iter()
+            .map(|room| room.id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn only_vacant_rooms_come_back() {
+        let pool = seeded_pool().await;
+
+        let ids = vacant_ids(&pool, None).await;
+
+        assert!(
+            !ids.contains(&"204".to_string()) && !ids.contains(&"301".to_string()),
+            "occupied and cleaning rooms are not vacant: {ids:?}"
+        );
+        assert_eq!(ids.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn the_order_is_by_floor_then_id_not_by_insertion() {
+        let pool = seeded_pool().await;
+
+        // Room 305 was inserted first; it must still come last.
+        assert_eq!(
+            vacant_ids(&pool, None).await,
+            vec!["101", "102", "201", "305"]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_type_filter_narrows_without_disturbing_the_order() {
+        let pool = seeded_pool().await;
+
+        assert_eq!(
+            vacant_ids(&pool, Some("deluxe")).await,
+            vec!["102", "201", "305"]
+        );
+        assert_eq!(vacant_ids(&pool, Some("standard")).await, vec!["101"]);
+        assert!(
+            vacant_ids(&pool, Some("presidential")).await.is_empty(),
+            "an unknown type matches nothing rather than everything"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_rows_decode_into_whole_rooms() {
+        let pool = seeded_pool().await;
+
+        let rooms = load_vacant_rooms(&pool, Some("deluxe"))
+            .await
+            .expect("load vacant rooms");
+
+        assert_eq!(rooms[0].id, "102");
+        assert_eq!(rooms[0].floor, 1);
+        assert_eq!(rooms[0].room_type, "deluxe");
+        assert_eq!(rooms[0].status, "vacant");
+        assert_eq!(rooms[0].base_price, 300_000);
+        assert_eq!(rooms[0].max_guests, 2);
+    }
+}

--- a/mhm/src-tauri/src/repositories/auth/mod.rs
+++ b/mhm/src-tauri/src/repositories/auth/mod.rs
@@ -1,0 +1,1 @@
+pub mod user_repository;

--- a/mhm/src-tauri/src/repositories/auth/user_repository.rs
+++ b/mhm/src-tauri/src/repositories/auth/user_repository.rs
@@ -1,0 +1,30 @@
+//! Writes over the `users` table.
+
+use sqlx::{Pool, Sqlite};
+
+pub struct NewUser<'a> {
+    pub id: &'a str,
+    pub name: &'a str,
+    pub pin_hash: &'a str,
+    pub role: &'a str,
+    pub created_at: &'a str,
+}
+
+/// Inserts an active user. The PIN hash must come from
+/// `domain::auth::credentials::pin_hash` — this layer stores it, it does not
+/// derive it.
+pub async fn insert_user(pool: &Pool<Sqlite>, user: NewUser<'_>) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO users (id, name, pin_hash, role, active, created_at)
+         VALUES (?, ?, ?, ?, 1, ?)",
+    )
+    .bind(user.id)
+    .bind(user.name)
+    .bind(user.pin_hash)
+    .bind(user.role)
+    .bind(user.created_at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/mhm/src-tauri/src/repositories/booking/expense_repository.rs
+++ b/mhm/src-tauri/src/repositories/booking/expense_repository.rs
@@ -1,0 +1,22 @@
+//! Operating-expense writes.
+
+use sqlx::{Pool, Sqlite};
+
+use crate::models::Expense;
+
+pub async fn insert_expense(pool: &Pool<Sqlite>, expense: &Expense) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO expenses (id, category, amount, note, expense_date, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&expense.id)
+    .bind(&expense.category)
+    .bind(expense.amount)
+    .bind(&expense.note)
+    .bind(&expense.expense_date)
+    .bind(&expense.created_at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/mhm/src-tauri/src/repositories/booking/mod.rs
+++ b/mhm/src-tauri/src/repositories/booking/mod.rs
@@ -1,3 +1,4 @@
 pub mod expense_repository;
 pub mod folio_repository;
 pub mod night_audit_repository;
+pub mod pricing_repository;

--- a/mhm/src-tauri/src/repositories/booking/mod.rs
+++ b/mhm/src-tauri/src/repositories/booking/mod.rs
@@ -1,2 +1,3 @@
+pub mod expense_repository;
 pub mod folio_repository;
 pub mod night_audit_repository;

--- a/mhm/src-tauri/src/repositories/booking/pricing_repository.rs
+++ b/mhm/src-tauri/src/repositories/booking/pricing_repository.rs
@@ -1,0 +1,98 @@
+//! Pricing-configuration writes.
+//!
+//! Both are upserts keyed on the natural business key — one rule per room type,
+//! one uplift per date — so saving twice replaces rather than duplicating.
+
+use sqlx::{Pool, Sqlite};
+
+use crate::money::MoneyVnd;
+
+/// Already-validated and already-defaulted values. Deciding what a missing
+/// `overnight_start` should be is the service's job, not the writer's.
+pub struct PricingRuleUpsert {
+    pub id: String,
+    pub room_type: String,
+    pub hourly_rate: MoneyVnd,
+    pub overnight_rate: MoneyVnd,
+    pub daily_rate: MoneyVnd,
+    pub overnight_start: String,
+    pub overnight_end: String,
+    pub daily_checkin: String,
+    pub daily_checkout: String,
+    pub early_checkin_surcharge_pct: f64,
+    pub late_checkout_surcharge_pct: f64,
+    pub weekend_uplift_pct: f64,
+    pub now: String,
+}
+
+pub async fn upsert_pricing_rule(
+    pool: &Pool<Sqlite>,
+    rule: &PricingRuleUpsert,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO pricing_rules
+         (id, room_type, hourly_rate, overnight_rate, daily_rate,
+          overnight_start, overnight_end, daily_checkin, daily_checkout,
+          early_checkin_surcharge_pct, late_checkout_surcharge_pct,
+          weekend_uplift_pct, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(room_type) DO UPDATE SET
+            hourly_rate = excluded.hourly_rate,
+            overnight_rate = excluded.overnight_rate,
+            daily_rate = excluded.daily_rate,
+            overnight_start = excluded.overnight_start,
+            overnight_end = excluded.overnight_end,
+            daily_checkin = excluded.daily_checkin,
+            daily_checkout = excluded.daily_checkout,
+            early_checkin_surcharge_pct = excluded.early_checkin_surcharge_pct,
+            late_checkout_surcharge_pct = excluded.late_checkout_surcharge_pct,
+            weekend_uplift_pct = excluded.weekend_uplift_pct,
+            updated_at = excluded.updated_at",
+    )
+    .bind(&rule.id)
+    .bind(&rule.room_type)
+    .bind(rule.hourly_rate)
+    .bind(rule.overnight_rate)
+    .bind(rule.daily_rate)
+    .bind(&rule.overnight_start)
+    .bind(&rule.overnight_end)
+    .bind(&rule.daily_checkin)
+    .bind(&rule.daily_checkout)
+    .bind(rule.early_checkin_surcharge_pct)
+    .bind(rule.late_checkout_surcharge_pct)
+    .bind(rule.weekend_uplift_pct)
+    .bind(&rule.now)
+    .bind(&rule.now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// `created_at` is only written on insert; an update leaves the original date in
+/// place, which is why it is not in the `DO UPDATE SET` list.
+pub async fn upsert_special_date(
+    pool: &Pool<Sqlite>,
+    id: &str,
+    date: &str,
+    label: &str,
+    uplift_pct: f64,
+    now: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(date) DO UPDATE SET
+            label = excluded.label,
+            uplift_pct = excluded.uplift_pct",
+    )
+    .bind(id)
+    .bind(date)
+    .bind(label)
+    .bind(uplift_pct)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/mhm/src-tauri/src/repositories/housekeeping/housekeeping_repository.rs
+++ b/mhm/src-tauri/src/repositories/housekeeping/housekeeping_repository.rs
@@ -1,0 +1,65 @@
+//! Housekeeping writes.
+//!
+//! The two `_tx` functions exist because finishing a clean has to flip the task
+//! and the room together or not at all; they take the caller's transaction and
+//! return `rows_affected` so the service can enforce the state transition
+//! instead of trusting it.
+
+use sqlx::{Pool, Sqlite, Transaction};
+
+/// Any move that is *not* completing a clean. Clears `cleaned_at`, because a task
+/// going back to needing attention is no longer a finished clean.
+pub async fn update_task_status(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    status: &str,
+    note: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE housekeeping SET status = ?, note = COALESCE(?, note), cleaned_at = NULL WHERE id = ?",
+    )
+    .bind(status)
+    .bind(note)
+    .bind(task_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Guarded by `status = 'cleaning'`, so a task that already finished or was never
+/// started reports zero rows rather than being force-completed.
+pub async fn mark_task_clean_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    task_id: &str,
+    note: Option<&str>,
+    cleaned_at: &str,
+) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE housekeeping
+         SET status = 'clean', note = COALESCE(?, note), cleaned_at = ?
+         WHERE id = ? AND status = 'cleaning'",
+    )
+    .bind(note)
+    .bind(cleaned_at)
+    .bind(task_id)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Guarded by `status = 'cleaning'`, which is what stops a re-occupied room from
+/// being marked vacant by a late housekeeping update.
+pub async fn mark_room_vacant_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_id: &str,
+) -> Result<u64, sqlx::Error> {
+    let result =
+        sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = ? AND status = 'cleaning'")
+            .bind(room_id)
+            .execute(&mut **tx)
+            .await?;
+
+    Ok(result.rows_affected())
+}

--- a/mhm/src-tauri/src/repositories/housekeeping/mod.rs
+++ b/mhm/src-tauri/src/repositories/housekeeping/mod.rs
@@ -1,0 +1,1 @@
+pub mod housekeeping_repository;

--- a/mhm/src-tauri/src/repositories/mod.rs
+++ b/mhm/src-tauri/src/repositories/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod booking;
 pub mod housekeeping;
 pub mod rooms;

--- a/mhm/src-tauri/src/repositories/mod.rs
+++ b/mhm/src-tauri/src/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub mod booking;
+pub mod housekeeping;
 pub mod rooms;

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -50,37 +50,8 @@ pub async fn generate_invoice_tx(
             .fetch_optional(&mut **tx)
             .await
             .map_err(|e| e.to_string())?;
-    let (hotel_name, hotel_address, hotel_phone) = match hotel_info {
-        Some(json_str) => {
-            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&json_str) {
-                (
-                    v.get("name")
-                        .and_then(|s| s.as_str())
-                        .unwrap_or(crate::app_identity::APP_NAME)
-                        .to_string(),
-                    v.get("address")
-                        .and_then(|s| s.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                    v.get("phone")
-                        .and_then(|s| s.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                )
-            } else {
-                (
-                    crate::app_identity::APP_NAME.to_string(),
-                    String::new(),
-                    String::new(),
-                )
-            }
-        }
-        None => (
-            crate::app_identity::APP_NAME.to_string(),
-            String::new(),
-            String::new(),
-        ),
-    };
+    let hotel = crate::domain::hotel_info::HotelInfo::from_settings_json(hotel_info.as_deref());
+    let (hotel_name, hotel_address, hotel_phone) = (hotel.name, hotel.address, hotel.phone);
 
     let room_name: String = b.get("room_name");
     let room_type: String = b.get("room_type");

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -3,12 +3,23 @@
 //! The split is deliberate — `queries::booking::pricing_queries` owns the
 //! reads, `domain::booking::pricing` owns the rules, and this module is the
 //! only place that knows both exist.
+//!
+//! Both the lifecycle charge and the UI preview come through here, so they
+//! cannot drift apart. `commands::pricing` used to carry its own copy of the
+//! rule-building — stored rule wins, else derive from the room's base price,
+//! else a 350k house default — which meant a preview could in principle
+//! disagree with what the guest was actually charged.
 
-use sqlx::{Sqlite, Transaction};
+use sqlx::{Pool, Sqlite, Transaction};
 
+use crate::app_error::CommandResult;
 use crate::domain::booking::pricing::calculate_from_loaded_inputs;
 use crate::domain::booking::BookingResult;
-use crate::queries::booking::pricing_queries::load_stay_pricing_inputs_tx;
+use crate::money::{validate_non_negative_money_vnd, MoneyVnd};
+use crate::queries::booking::pricing_queries::{
+    load_stay_pricing_inputs_for_room_type, load_stay_pricing_inputs_tx,
+};
+use crate::repositories::booking::pricing_repository::{self, PricingRuleUpsert};
 
 /// Prices inside the caller's transaction so a lifecycle write can read the
 /// rows it just inserted but has not committed.
@@ -22,4 +33,386 @@ pub async fn calculate_stay_price_tx(
     let inputs =
         load_stay_pricing_inputs_tx(tx, room_id, check_in, check_out, pricing_type).await?;
     calculate_from_loaded_inputs(&inputs)
+}
+
+/// The quote the UI shows before anything is booked. Keyed by room type, since
+/// no room has been picked yet.
+pub async fn calculate_price_preview(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let inputs =
+        load_stay_pricing_inputs_for_room_type(pool, room_type, check_in, check_out, pricing_type)
+            .await?;
+    calculate_from_loaded_inputs(&inputs)
+}
+
+/// The values a caller may leave unset, and what the house uses instead.
+const DEFAULT_OVERNIGHT_START: &str = "22:00";
+const DEFAULT_OVERNIGHT_END: &str = "11:00";
+const DEFAULT_DAILY_CHECKIN: &str = "14:00";
+const DEFAULT_DAILY_CHECKOUT: &str = "12:00";
+const DEFAULT_SURCHARGE_PCT: f64 = 30.0;
+const DEFAULT_WEEKEND_UPLIFT_PCT: f64 = 0.0;
+
+/// What `save_pricing_rule` was handed, before defaults and validation.
+pub struct SavePricingRule {
+    pub room_type: String,
+    pub hourly_rate: MoneyVnd,
+    pub overnight_rate: MoneyVnd,
+    pub daily_rate: MoneyVnd,
+    pub overnight_start: Option<String>,
+    pub overnight_end: Option<String>,
+    pub daily_checkin: Option<String>,
+    pub daily_checkout: Option<String>,
+    pub early_pct: Option<f64>,
+    pub late_pct: Option<f64>,
+    pub weekend_pct: Option<f64>,
+}
+
+pub async fn save_pricing_rule(
+    pool: &Pool<Sqlite>,
+    request: SavePricingRule,
+    id: String,
+    now: String,
+) -> CommandResult<()> {
+    let upsert = PricingRuleUpsert {
+        id,
+        room_type: request.room_type,
+        hourly_rate: validate_non_negative_money_vnd(request.hourly_rate, "hourly_rate")?,
+        overnight_rate: validate_non_negative_money_vnd(request.overnight_rate, "overnight_rate")?,
+        daily_rate: validate_non_negative_money_vnd(request.daily_rate, "daily_rate")?,
+        overnight_start: request
+            .overnight_start
+            .unwrap_or_else(|| DEFAULT_OVERNIGHT_START.to_string()),
+        overnight_end: request
+            .overnight_end
+            .unwrap_or_else(|| DEFAULT_OVERNIGHT_END.to_string()),
+        daily_checkin: request
+            .daily_checkin
+            .unwrap_or_else(|| DEFAULT_DAILY_CHECKIN.to_string()),
+        daily_checkout: request
+            .daily_checkout
+            .unwrap_or_else(|| DEFAULT_DAILY_CHECKOUT.to_string()),
+        early_checkin_surcharge_pct: request.early_pct.unwrap_or(DEFAULT_SURCHARGE_PCT),
+        late_checkout_surcharge_pct: request.late_pct.unwrap_or(DEFAULT_SURCHARGE_PCT),
+        weekend_uplift_pct: request.weekend_pct.unwrap_or(DEFAULT_WEEKEND_UPLIFT_PCT),
+        now,
+    };
+
+    pricing_repository::upsert_pricing_rule(pool, &upsert)
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "save_pricing_rule",
+                error.to_string(),
+                serde_json::json!({ "step": "upsert_pricing_rule", "room_type": &upsert.room_type }),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        calculate_price_preview, calculate_stay_price_tx, save_pricing_rule, SavePricingRule,
+    };
+    use crate::app_error::codes;
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite};
+
+    const CHECK_IN: &str = "2026-04-20T14:00:00+07:00";
+    const CHECK_OUT: &str = "2026-04-22T12:00:00+07:00";
+
+    fn request(hourly: i64, overnight: i64, daily: i64) -> SavePricingRule {
+        SavePricingRule {
+            room_type: "standard".to_string(),
+            hourly_rate: hourly,
+            overnight_rate: overnight,
+            daily_rate: daily,
+            overnight_start: None,
+            overnight_end: None,
+            daily_checkin: None,
+            daily_checkout: None,
+            early_pct: None,
+            late_pct: None,
+            weekend_pct: None,
+        }
+    }
+
+    async fn migrated_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    async fn seed_room(pool: &Pool<Sqlite>, room_id: &str, room_type: &str, base_price: i64) {
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES (?, ?, ?, 1, 0, ?, 2, 0, 'vacant')",
+        )
+        .bind(room_id)
+        .bind(format!("Room {room_id}"))
+        .bind(room_type)
+        .bind(base_price)
+        .execute(pool)
+        .await
+        .expect("seed room");
+    }
+
+    /// The point of routing both paths through this module: the quote the UI
+    /// shows and the amount charged at check-in must agree.
+    ///
+    /// Covers the two rule sources both paths can reach — a configured rule, and
+    /// a rule derived from the room's base price. The 350k house default cannot
+    /// be compared: it only applies when no room of the type exists, and the
+    /// lifecycle path starts from a room id, so that room's own type always
+    /// supplies a base price. `the_house_default_only_applies_to_types_with_no_rooms`
+    /// covers that branch on the preview side.
+    #[tokio::test]
+    async fn the_preview_and_the_lifecycle_charge_agree_on_every_reachable_rule_source() {
+        let pool = migrated_pool().await;
+
+        // 1. configured rule
+        seed_room(&pool, "R-CONF", "configured", 400_000).await;
+        save_pricing_rule(
+            &pool,
+            SavePricingRule {
+                room_type: "configured".to_string(),
+                hourly_rate: 90_000,
+                overnight_rate: 320_000,
+                daily_rate: 480_000,
+                overnight_start: None,
+                overnight_end: None,
+                daily_checkin: None,
+                daily_checkout: None,
+                early_pct: Some(10.0),
+                late_pct: Some(15.0),
+                weekend_pct: Some(5.0),
+            },
+            "rule-configured".to_string(),
+            "2026-04-22T00:00:00+07:00".to_string(),
+        )
+        .await
+        .expect("save rule");
+
+        // 2. no rule, but the room carries a base price
+        seed_room(&pool, "R-BASE", "derived", 620_000).await;
+
+        for (room_id, room_type) in [("R-CONF", "configured"), ("R-BASE", "derived")] {
+            let preview = calculate_price_preview(&pool, room_type, CHECK_IN, CHECK_OUT, "nightly")
+                .await
+                .unwrap_or_else(|error| panic!("preview for {room_type}: {error}"));
+
+            let mut tx = pool.begin().await.expect("begin");
+            let charged = calculate_stay_price_tx(&mut tx, room_id, CHECK_IN, CHECK_OUT, "nightly")
+                .await
+                .unwrap_or_else(|error| panic!("charge for {room_type}: {error}"));
+            tx.rollback().await.expect("rollback");
+
+            assert_eq!(preview.total, charged.total, "total for {room_type}");
+            assert_eq!(
+                preview.base_amount, charged.base_amount,
+                "base for {room_type}"
+            );
+            assert_eq!(
+                preview.weekend_amount, charged.weekend_amount,
+                "weekend for {room_type}"
+            );
+            assert_eq!(
+                preview.surcharge_amount, charged.surcharge_amount,
+                "surcharge for {room_type}"
+            );
+            assert_eq!(
+                preview.breakdown.len(),
+                charged.breakdown.len(),
+                "breakdown for {room_type}"
+            );
+        }
+    }
+
+    /// The 350k house default is preview-only in practice: it needs a room type
+    /// with no rooms behind it, which a check-in can never be.
+    #[tokio::test]
+    async fn the_house_default_only_applies_to_types_with_no_rooms() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-BASE", "derived", 350_000).await;
+
+        let house = calculate_price_preview(&pool, "no-such-type", CHECK_IN, CHECK_OUT, "nightly")
+            .await
+            .expect("house preview");
+        let derived = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
+            .await
+            .expect("derived preview");
+
+        // The house default *is* 350k, so a room priced at 350k must quote the same.
+        assert_eq!(house.total, derived.total);
+        assert!(house.total > 0);
+    }
+
+    /// A configured rule must actually change the quote, otherwise the test above
+    /// could pass on two identically-wrong numbers.
+    #[tokio::test]
+    async fn the_three_rule_sources_produce_different_quotes() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-CONF", "configured", 400_000).await;
+        save_pricing_rule(
+            &pool,
+            SavePricingRule {
+                room_type: "configured".to_string(),
+                hourly_rate: 90_000,
+                overnight_rate: 320_000,
+                daily_rate: 480_000,
+                overnight_start: None,
+                overnight_end: None,
+                daily_checkin: None,
+                daily_checkout: None,
+                early_pct: None,
+                late_pct: None,
+                weekend_pct: None,
+            },
+            "rule-configured".to_string(),
+            "2026-04-22T00:00:00+07:00".to_string(),
+        )
+        .await
+        .expect("save rule");
+        seed_room(&pool, "R-BASE", "derived", 620_000).await;
+
+        let configured =
+            calculate_price_preview(&pool, "configured", CHECK_IN, CHECK_OUT, "nightly")
+                .await
+                .expect("configured preview");
+        let derived = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
+            .await
+            .expect("derived preview");
+        let house = calculate_price_preview(&pool, "no-such-type", CHECK_IN, CHECK_OUT, "nightly")
+            .await
+            .expect("house preview");
+
+        assert_ne!(configured.total, derived.total);
+        assert_ne!(derived.total, house.total);
+        assert_ne!(configured.total, house.total);
+    }
+
+    #[tokio::test]
+    async fn a_special_date_uplifts_the_preview() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-SPECIAL", "derived", 500_000).await;
+
+        let plain = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
+            .await
+            .expect("plain preview");
+
+        sqlx::query("INSERT INTO special_dates (id, date, label, uplift_pct, created_at) VALUES (?, ?, ?, ?, ?)")
+            .bind("sd-1")
+            .bind("2026-04-20")
+            .bind("Lễ")
+            .bind(10.0)
+            .bind("2026-04-01T00:00:00+07:00")
+            .execute(&pool)
+            .await
+            .expect("seed special date");
+
+        let uplifted = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
+            .await
+            .expect("uplifted preview");
+
+        assert!(uplifted.surcharge_amount > plain.surcharge_amount);
+        assert!(uplifted.total > plain.total);
+    }
+
+    #[tokio::test]
+    async fn save_pricing_rule_rejects_negative_money_rates() {
+        let pool = migrated_pool().await;
+
+        for (hourly, overnight, daily, field) in [
+            (-1, 300_000, 400_000, "hourly_rate"),
+            (80_000, -1, 400_000, "overnight_rate"),
+            (80_000, 300_000, -1, "daily_rate"),
+        ] {
+            let error = save_pricing_rule(
+                &pool,
+                request(hourly, overnight, daily),
+                "rule-1".to_string(),
+                "2026-04-22T00:00:00+07:00".to_string(),
+            )
+            .await
+            .expect_err("negative pricing money must fail");
+
+            assert_eq!(error.code, codes::VALIDATION_INVALID_INPUT);
+            assert!(error.message.contains(field));
+        }
+
+        let saved: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM pricing_rules")
+            .fetch_one(&pool)
+            .await
+            .expect("count rules");
+        assert_eq!(saved, 0, "a rejected rule must not be written");
+    }
+
+    #[tokio::test]
+    async fn save_pricing_rule_fills_in_the_house_defaults() {
+        let pool = migrated_pool().await;
+
+        save_pricing_rule(
+            &pool,
+            request(80_000, 300_000, 400_000),
+            "rule-defaults".to_string(),
+            "2026-04-22T00:00:00+07:00".to_string(),
+        )
+        .await
+        .expect("save rule");
+
+        let row = sqlx::query(
+            "SELECT overnight_start, overnight_end, daily_checkin, daily_checkout,
+                    early_checkin_surcharge_pct, late_checkout_surcharge_pct, weekend_uplift_pct
+             FROM pricing_rules WHERE room_type = ?",
+        )
+        .bind("standard")
+        .fetch_one(&pool)
+        .await
+        .expect("saved rule");
+
+        assert_eq!(row.get::<String, _>("overnight_start"), "22:00");
+        assert_eq!(row.get::<String, _>("overnight_end"), "11:00");
+        assert_eq!(row.get::<String, _>("daily_checkin"), "14:00");
+        assert_eq!(row.get::<String, _>("daily_checkout"), "12:00");
+        assert_eq!(row.get::<f64, _>("early_checkin_surcharge_pct"), 30.0);
+        assert_eq!(row.get::<f64, _>("late_checkout_surcharge_pct"), 30.0);
+        assert_eq!(row.get::<f64, _>("weekend_uplift_pct"), 0.0);
+    }
+
+    #[tokio::test]
+    async fn save_pricing_rule_replaces_the_rule_for_a_room_type() {
+        let pool = migrated_pool().await;
+
+        for (id, daily) in [("rule-a", 400_000), ("rule-b", 550_000)] {
+            save_pricing_rule(
+                &pool,
+                request(80_000, 300_000, daily),
+                id.to_string(),
+                "2026-04-22T00:00:00+07:00".to_string(),
+            )
+            .await
+            .expect("save rule");
+        }
+
+        let rows: Vec<(String, i64)> =
+            sqlx::query_as("SELECT id, daily_rate FROM pricing_rules WHERE room_type = ?")
+                .bind("standard")
+                .fetch_all(&pool)
+                .await
+                .expect("saved rules");
+
+        assert_eq!(rows.len(), 1, "one rule per room type");
+        assert_eq!(rows[0].1, 550_000, "the later save wins");
+        assert_eq!(rows[0].0, "rule-a", "the original row id is kept");
+    }
 }

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -55,7 +55,7 @@ fn ensure_locked_room_matches_booking(
     }
 }
 
-fn map_check_in_command_error(error: BookingError) -> CommandError {
+pub(super) fn map_check_in_command_error(error: BookingError) -> CommandError {
     match error {
         BookingError::Validation(message) => {
             CommandError::user(codes::BOOKING_INVALID_STATE, message)
@@ -82,7 +82,7 @@ fn map_check_in_command_error(error: BookingError) -> CommandError {
     }
 }
 
-fn map_check_out_command_error(error: BookingError) -> CommandError {
+pub(super) fn map_check_out_command_error(error: BookingError) -> CommandError {
     match error {
         BookingError::Validation(message)
             if message == "Tổng quyết toán phải lớn hơn hoặc bằng 0"
@@ -111,7 +111,7 @@ fn map_check_out_command_error(error: BookingError) -> CommandError {
     }
 }
 
-fn map_extend_stay_command_error(error: BookingError) -> CommandError {
+pub(super) fn map_extend_stay_command_error(error: BookingError) -> CommandError {
     match error {
         BookingError::Conflict(message) => {
             if is_room_unavailable_conflict_message(&message) {

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -55,4 +55,5 @@ mod pricing;
 mod reporting;
 mod reservation_idempotency;
 mod reservations;
+mod stay_error_mapping;
 mod stays;

--- a/mhm/src-tauri/src/services/booking/tests/stay_error_mapping.rs
+++ b/mhm/src-tauri/src/services/booking/tests/stay_error_mapping.rs
@@ -1,0 +1,160 @@
+//! Contract tests for the `BookingError` -> `CommandError` mappers that the
+//! stay lifecycle actually uses.
+//!
+//! These assertions were previously written against `commands::rooms::map_stay_error`,
+//! a duplicate of this logic that was `#[allow(dead_code)]` and reachable from
+//! nothing but its own tests. The mapping had moved into `stay_lifecycle`, so the
+//! error contract was only ever verified against code that never ran. Deleting
+//! the duplicate and pointing the tests at the live mappers is the point.
+//!
+//! One behaviour differs from the retired duplicate and is pinned below rather
+//! than quietly changed: a zero-guest check-in reports `BOOKING_INVALID_STATE`,
+//! not `BOOKING_GUEST_REQUIRED`. No live path emits `BOOKING_GUEST_REQUIRED`.
+
+use super::prelude::*;
+
+use crate::app_error::AppErrorKind;
+use crate::services::booking::stay_lifecycle::{
+    map_check_in_command_error, map_check_out_command_error, map_extend_stay_command_error,
+};
+
+#[test]
+fn check_in_maps_missing_room_to_room_not_found() {
+    let error = map_check_in_command_error(BookingError::not_found("Không tìm thấy phòng R101"));
+
+    assert_eq!(error.code, "ROOM_NOT_FOUND");
+    assert_eq!(error.message, "Không tìm thấy phòng R101");
+    assert_eq!(error.kind, AppErrorKind::User);
+    assert!(error.support_id.is_none());
+}
+
+#[test]
+fn check_in_maps_other_missing_rows_to_booking_not_found() {
+    let error = map_check_in_command_error(BookingError::not_found("Không tìm thấy booking B1"));
+
+    assert_eq!(error.code, "BOOKING_NOT_FOUND");
+    assert_eq!(error.kind, AppErrorKind::User);
+}
+
+/// Pins the divergence from the retired duplicate — see the module docs.
+#[test]
+fn check_in_maps_the_zero_guest_validation_to_invalid_state_not_guest_required() {
+    let error = map_check_in_command_error(BookingError::validation("Phải có ít nhất 1 khách"));
+
+    assert_eq!(error.code, "BOOKING_INVALID_STATE");
+    assert_eq!(error.message, "Phải có ít nhất 1 khách");
+    assert_eq!(error.kind, AppErrorKind::User);
+}
+
+#[test]
+fn check_in_maps_a_calendar_conflict_to_the_stable_room_unavailable_code() {
+    let error = map_check_in_command_error(BookingError::conflict(
+        "Room R101 has a reservation starting 2026-04-20 (Guest). Max 2 nights.",
+    ));
+
+    assert_eq!(error.code, "CONFLICT_ROOM_UNAVAILABLE");
+    assert!(error.message.contains("has a reservation starting"));
+    assert_eq!(error.kind, AppErrorKind::User);
+    assert!(error.support_id.is_none());
+}
+
+#[test]
+fn check_in_maps_an_unrecognised_conflict_to_invalid_state() {
+    let error = map_check_in_command_error(BookingError::conflict("something else entirely"));
+
+    assert_eq!(error.code, "BOOKING_INVALID_STATE");
+    assert_eq!(error.kind, AppErrorKind::User);
+}
+
+#[test]
+fn check_in_maps_a_write_failure_to_a_system_error_with_a_support_id() {
+    let error = map_check_in_command_error(BookingError::database_write("disk full"));
+
+    assert_eq!(error.code, "SYSTEM_INTERNAL_ERROR");
+    assert_eq!(error.kind, AppErrorKind::System);
+    assert!(error.support_id.is_some());
+    assert!(!error.retryable);
+}
+
+#[test]
+fn check_in_maps_a_locked_database_to_a_retryable_code() {
+    let error = map_check_in_command_error(BookingError::database("database is locked"));
+
+    assert_eq!(error.code, "DB_LOCKED_RETRYABLE");
+    assert_eq!(error.kind, AppErrorKind::System);
+    assert!(error.retryable);
+}
+
+#[test]
+fn check_out_maps_both_invalid_settlement_total_messages_to_one_code() {
+    for message in [
+        "Tổng quyết toán phải lớn hơn hoặc bằng 0",
+        "final_total must be greater than or equal to 0",
+    ] {
+        let error = map_check_out_command_error(BookingError::validation(message));
+
+        assert_eq!(error.code, "BOOKING_INVALID_SETTLEMENT_TOTAL", "{message}");
+        assert_eq!(error.message, message);
+        assert_eq!(error.kind, AppErrorKind::User);
+    }
+}
+
+#[test]
+fn check_out_maps_the_overpaid_guard_to_invalid_state() {
+    let error = map_check_out_command_error(BookingError::validation(
+        "Overpaid booking requires refund handling before checkout",
+    ));
+
+    assert_eq!(error.code, "BOOKING_INVALID_STATE");
+    assert_eq!(
+        error.message,
+        "Overpaid booking requires refund handling before checkout"
+    );
+    assert_eq!(error.kind, AppErrorKind::User);
+}
+
+/// Unlike check-in, check-out has no room lookup, so *every* missing row is a
+/// missing booking.
+#[test]
+fn check_out_maps_a_missing_room_message_to_booking_not_found() {
+    let error = map_check_out_command_error(BookingError::not_found("Không tìm thấy phòng R101"));
+
+    assert_eq!(error.code, "BOOKING_NOT_FOUND");
+}
+
+#[test]
+fn check_out_maps_a_locked_database_read_to_a_retryable_code() {
+    let error = map_check_out_command_error(BookingError::database("database is locked"));
+
+    assert_eq!(error.code, "DB_LOCKED_RETRYABLE");
+    assert_eq!(error.kind, AppErrorKind::System);
+    assert!(error.retryable);
+    assert!(error.support_id.is_some());
+}
+
+#[test]
+fn extend_stay_maps_a_calendar_conflict_to_room_unavailable() {
+    let error = map_extend_stay_command_error(BookingError::conflict(
+        "Room R101 is booked on 2026-04-21 (Guest).",
+    ));
+
+    assert_eq!(error.code, "CONFLICT_ROOM_UNAVAILABLE");
+    assert_eq!(error.kind, AppErrorKind::User);
+}
+
+#[test]
+fn extend_stay_maps_missing_room_to_room_not_found() {
+    let error = map_extend_stay_command_error(BookingError::not_found("Không tìm thấy phòng R101"));
+
+    assert_eq!(error.code, "ROOM_NOT_FOUND");
+    assert_eq!(error.kind, AppErrorKind::User);
+}
+
+#[test]
+fn extend_stay_maps_a_datetime_parse_failure_to_a_system_error() {
+    let error = map_extend_stay_command_error(BookingError::DateTimeParse("bad date".to_string()));
+
+    assert_eq!(error.code, "SYSTEM_INTERNAL_ERROR");
+    assert_eq!(error.kind, AppErrorKind::System);
+    assert!(error.support_id.is_some());
+}

--- a/mhm/src-tauri/src/services/housekeeping/housekeeping_service.rs
+++ b/mhm/src-tauri/src/services/housekeeping/housekeeping_service.rs
@@ -1,0 +1,305 @@
+//! Housekeeping status rules.
+//!
+//! Completing a clean is the only interesting transition: it flips the task to
+//! `clean` and the room to `vacant`, in one transaction, under the room's
+//! aggregate lock. Both updates are guarded on `status = 'cleaning'`, so a room
+//! that has been re-occupied in the meantime is never marked vacant by a late
+//! housekeeping update — the guard that
+//! `housekeeping_clean_does_not_mark_occupied_room_vacant` exercises.
+//!
+//! This moved out of `commands::rooms`, where it sat inline with its SQL. The
+//! `log_system_error` step names are unchanged.
+
+use serde_json::json;
+use sqlx::{Pool, Sqlite};
+
+use crate::app_error::{codes, log_system_error, CommandError, CommandResult};
+use crate::models::HousekeepingTask;
+use crate::queries::housekeeping::housekeeping_queries as housekeeping_reads;
+use crate::repositories::housekeeping::housekeeping_repository as housekeeping_writes;
+
+pub async fn list_open_tasks(pool: &Pool<Sqlite>) -> Result<Vec<HousekeepingTask>, String> {
+    housekeeping_reads::load_open_tasks(pool)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+pub async fn update_status(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    new_status: &str,
+    note: Option<&str>,
+) -> CommandResult<()> {
+    if new_status == "clean" {
+        return complete_clean_to_vacant(pool, task_id, note).await;
+    }
+
+    housekeeping_writes::update_task_status(pool, task_id, new_status, note)
+        .await
+        .map_err(|error| {
+            log_system_error(
+                "update_housekeeping",
+                error.to_string(),
+                json!({ "task_id": task_id, "step": "update_status" }),
+            )
+        })
+}
+
+pub(crate) async fn complete_clean_to_vacant(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    note: Option<&str>,
+) -> CommandResult<()> {
+    let room_id = housekeeping_reads::load_task_room_id(pool, task_id)
+        .await
+        .map_err(|error| {
+            log_system_error(
+                "update_housekeeping",
+                error.to_string(),
+                json!({
+                    "task_id": task_id,
+                    "step": "lookup_room",
+                }),
+            )
+        })?;
+
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::room_key(&room_id)?])
+        .await?;
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        log_system_error(
+            "update_housekeeping",
+            error.to_string(),
+            json!({
+                "task_id": task_id,
+                "room_id": room_id,
+                "step": "begin",
+            }),
+        )
+    })?;
+
+    let cleaned_at = chrono::Local::now().to_rfc3339();
+    let housekeeping_rows =
+        housekeeping_writes::mark_task_clean_tx(&mut tx, task_id, note, &cleaned_at)
+            .await
+            .map_err(|error| {
+                log_system_error(
+                    "update_housekeeping",
+                    error.to_string(),
+                    json!({
+                        "task_id": task_id,
+                        "room_id": room_id,
+                        "step": "update_housekeeping",
+                    }),
+                )
+            })?;
+
+    if housekeeping_rows != 1 {
+        let _ = tx.rollback().await;
+        return Err(CommandError::user(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            "Housekeeping task is no longer cleaning",
+        ));
+    }
+
+    let room_rows = housekeeping_writes::mark_room_vacant_tx(&mut tx, &room_id)
+        .await
+        .map_err(|error| {
+            log_system_error(
+                "update_housekeeping",
+                error.to_string(),
+                json!({
+                    "task_id": task_id,
+                    "room_id": room_id,
+                    "step": "update_room",
+                }),
+            )
+        })?;
+
+    if room_rows != 1 {
+        let _ = tx.rollback().await;
+        return Err(CommandError::user(
+            codes::CONFLICT_INVALID_STATE_TRANSITION,
+            "Room is no longer waiting for cleaning completion",
+        ));
+    }
+
+    tx.commit().await.map_err(|error| {
+        log_system_error(
+            "update_housekeeping",
+            error.to_string(),
+            json!({
+                "task_id": task_id,
+                "room_id": room_id,
+                "step": "commit",
+            }),
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{complete_clean_to_vacant, update_status};
+    use crate::app_error::codes;
+    use sqlx::{sqlite::SqlitePoolOptions, Row};
+
+    async fn migrated_pool() -> sqlx::Pool<sqlx::Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    async fn seed_room(pool: &sqlx::Pool<sqlx::Sqlite>, room_id: &str, status: &str) {
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(room_id)
+        .bind("Housekeeping Guard")
+        .bind("standard")
+        .bind(1)
+        .bind(0)
+        .bind(100000)
+        .bind(2)
+        .bind(0)
+        .bind(status)
+        .execute(pool)
+        .await
+        .expect("insert room");
+    }
+
+    async fn seed_task(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        task_id: &str,
+        room_id: &str,
+        status: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO housekeeping (id, room_id, status, note, triggered_at, cleaned_at, created_at)
+             VALUES (?, ?, ?, ?, datetime('now'), NULL, datetime('now'))",
+        )
+        .bind(task_id)
+        .bind(room_id)
+        .bind(status)
+        .bind("started")
+        .execute(pool)
+        .await
+        .expect("insert housekeeping task");
+    }
+
+    async fn status_of(pool: &sqlx::Pool<sqlx::Sqlite>, table: &str, id: &str) -> String {
+        sqlx::query(&format!("SELECT status FROM {table} WHERE id = ?"))
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .expect("status row")
+            .get::<String, _>("status")
+    }
+
+    #[tokio::test]
+    async fn housekeeping_clean_does_not_mark_occupied_room_vacant() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-HK", "occupied").await;
+        seed_task(&pool, "HK1", "R-HK", "cleaning").await;
+
+        let error = complete_clean_to_vacant(&pool, "HK1", None)
+            .await
+            .expect_err("occupied room should reject clean-to-vacant");
+
+        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+        assert_eq!(status_of(&pool, "rooms", "R-HK").await, "occupied");
+        assert_eq!(status_of(&pool, "housekeeping", "HK1").await, "cleaning");
+    }
+
+    #[tokio::test]
+    async fn housekeeping_clean_frees_a_room_that_is_still_cleaning() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-HK2", "cleaning").await;
+        seed_task(&pool, "HK2", "R-HK2", "cleaning").await;
+
+        update_status(&pool, "HK2", "clean", Some("done"))
+            .await
+            .expect("clean-to-vacant should succeed");
+
+        assert_eq!(status_of(&pool, "rooms", "R-HK2").await, "vacant");
+        assert_eq!(status_of(&pool, "housekeeping", "HK2").await, "clean");
+
+        let cleaned_at: Option<String> =
+            sqlx::query_scalar("SELECT cleaned_at FROM housekeeping WHERE id = ?")
+                .bind("HK2")
+                .fetch_one(&pool)
+                .await
+                .expect("cleaned_at");
+        assert!(cleaned_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn housekeeping_clean_rejects_a_task_that_was_never_started() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-HK3", "cleaning").await;
+        seed_task(&pool, "HK3", "R-HK3", "needs_cleaning").await;
+
+        let error = update_status(&pool, "HK3", "clean", None)
+            .await
+            .expect_err("a task that is not cleaning cannot be completed");
+
+        assert_eq!(error.code, codes::CONFLICT_INVALID_STATE_TRANSITION);
+        assert_eq!(status_of(&pool, "rooms", "R-HK3").await, "cleaning");
+    }
+
+    #[tokio::test]
+    async fn a_non_clean_transition_clears_the_cleaned_timestamp() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-HK4", "cleaning").await;
+        seed_task(&pool, "HK4", "R-HK4", "cleaning").await;
+        sqlx::query("UPDATE housekeeping SET cleaned_at = ? WHERE id = ?")
+            .bind("2026-04-22T00:00:00+07:00")
+            .bind("HK4")
+            .execute(&pool)
+            .await
+            .expect("preset cleaned_at");
+
+        update_status(&pool, "HK4", "needs_cleaning", None)
+            .await
+            .expect("move back to needs_cleaning");
+
+        let cleaned_at: Option<String> =
+            sqlx::query_scalar("SELECT cleaned_at FROM housekeeping WHERE id = ?")
+                .bind("HK4")
+                .fetch_one(&pool)
+                .await
+                .expect("cleaned_at");
+        assert_eq!(cleaned_at, None);
+        assert_eq!(
+            status_of(&pool, "housekeeping", "HK4").await,
+            "needs_cleaning"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_non_clean_transition_keeps_the_existing_note_when_none_is_given() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-HK5", "cleaning").await;
+        seed_task(&pool, "HK5", "R-HK5", "cleaning").await;
+
+        update_status(&pool, "HK5", "needs_cleaning", None)
+            .await
+            .expect("move back to needs_cleaning");
+
+        let note: Option<String> = sqlx::query_scalar("SELECT note FROM housekeeping WHERE id = ?")
+            .bind("HK5")
+            .fetch_one(&pool)
+            .await
+            .expect("note");
+        assert_eq!(note.as_deref(), Some("started"));
+    }
+}

--- a/mhm/src-tauri/src/services/housekeeping/mod.rs
+++ b/mhm/src-tauri/src/services/housekeeping/mod.rs
@@ -1,0 +1,1 @@
+pub mod housekeeping_service;

--- a/mhm/src-tauri/src/services/mod.rs
+++ b/mhm/src-tauri/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod booking;
+pub mod housekeeping;
 pub mod rooms;
 pub mod settings_store;
 pub mod setup;

--- a/mhm/src-tauri/src/services/setup/provisioning.rs
+++ b/mhm/src-tauri/src/services/setup/provisioning.rs
@@ -180,7 +180,7 @@ async fn insert_initial_admin(
     tx: &mut Transaction<'_, Sqlite>,
     app_lock: &OnboardingAppLockInput,
 ) -> Result<User, String> {
-    use sha2::{Digest, Sha256};
+    use crate::domain::auth::credentials::pin_hash;
 
     let id = uuid::Uuid::new_v4().to_string();
     let name = app_lock
@@ -194,9 +194,7 @@ async fn insert_initial_admin(
         .clone()
         .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string()[..4].to_string());
 
-    let mut hasher = Sha256::new();
-    hasher.update(pin_source.as_bytes());
-    let pin_hash = format!("{:x}", hasher.finalize());
+    let pin_hash = pin_hash(&pin_source);
     let now = chrono::Local::now().to_rfc3339();
 
     sqlx::query(

--- a/mhm/src-tauri/src/services/setup/tests.rs
+++ b/mhm/src-tauri/src/services/setup/tests.rs
@@ -223,6 +223,41 @@ async fn complete_setup_without_app_lock_creates_a_default_user_ready_for_login(
 }
 
 #[tokio::test]
+async fn the_admin_provisioned_by_setup_can_log_in_with_the_pin_that_was_entered() {
+    let pool = test_pool().await;
+
+    complete_setup(&pool, sample_onboarding_request(true))
+        .await
+        .expect("complete_setup should succeed when app lock is enabled");
+
+    // Setup writes the hash and login reads it. They used to derive it from
+    // separate copies of the same four lines; this is the seam that would
+    // break silently, and it would look to the owner like a wrong PIN.
+    let user = crate::queries::auth::user_queries::load_active_user_by_pin_hash(
+        &pool,
+        &crate::domain::auth::credentials::pin_hash("1234"),
+    )
+    .await
+    .expect("the lookup should succeed")
+    .expect("the PIN entered during setup should find the provisioned admin");
+
+    assert_eq!(user.name, "Owner");
+    assert_eq!(user.role, "admin");
+    assert!(user.active);
+
+    assert!(
+        crate::queries::auth::user_queries::load_active_user_by_pin_hash(
+            &pool,
+            &crate::domain::auth::credentials::pin_hash("9999"),
+        )
+        .await
+        .expect("the lookup should succeed")
+        .is_none(),
+        "a different PIN must not find the admin"
+    );
+}
+
+#[tokio::test]
 async fn complete_setup_returns_locked_status_when_app_lock_is_enabled() {
     let pool = test_pool().await;
 

--- a/mhm/src-tauri/src/window_state.rs
+++ b/mhm/src-tauri/src/window_state.rs
@@ -284,8 +284,10 @@ mod tests {
 
     #[test]
     fn growing_to_the_minimum_never_exceeds_the_work_area() {
-        let grown =
-            clamp_to_minimum(LogicalSize::new(600.0, 400.0), LogicalSize::new(1000.0, 600.0));
+        let grown = clamp_to_minimum(
+            LogicalSize::new(600.0, 400.0),
+            LogicalSize::new(1000.0, 600.0),
+        );
 
         assert_eq!(grown, Some(LogicalSize::new(1000.0, 600.0)));
     }


### PR DESCRIPTION
Finishes the boundary work started in the commits already on `main`. `docs/architecture/core-pms-boundaries.md` defines two dependency directions:

```
write:  UI -> command -> service/lifecycle -> repository/transaction -> SQLite
read:   UI -> command -> query -> SQLite
```

Both now hold — and they are held by a test rather than by intent. `architecture_guard.rs` reads the source tree on every `cargo test`, so the boundary survives the next person who hasn't read the doc. Its `COMMANDS_STILL_HOLDING_SQL` ratchet is now **empty**, and it was mutation-checked in that state: injecting one `sqlx::query` into a command module fails the test by name.

## What the refactor actually bought

Moving the SQL out made nine defects visible that were invisible while the code sat inside command functions. These are the reason the branch is worth reviewing, not the file moves.

| # | defect | fixed? |
| --- | --- | --- |
| 21 | `auto_assign_rooms` suggested **different rooms on each app launch** — vacant rooms were grouped into a `std::collections::HashMap` and sorted by floor size alone, so equally-sized floors came out in hash-seed order | **fixed**, `BTreeMap` + floor tie-break |
| 18 | the **PIN hash was derived in three places** (`login`, `create_user`, the setup provisioner) with nothing keeping them equal; drift would provision an admin who could never log in, and it would read as a wrong PIN | **fixed**, one `domain::auth::credentials::pin_hash` |
| 13 | **the quote and the charge came from different pricing code** — `do_calculate_price_preview` duplicated the rule/base-price/default logic `domain::booking::pricing` already owned | **fixed**, one implementation |
| 9 | the entire pool-based pricing path was dead in production | **fixed** |
| 11 | 237 lines of dead error mapping, while the live mapper had no tests at all | **fixed**, dead code deleted and the live mapper tested |
| 22 | the invoice letterhead fallback written twice, in `groups.rs` and `invoice_generation.rs` | **fixed**, one `domain::hotel_info` |
| 12 | `BOOKING_GUEST_REQUIRED` is emitted by nothing — the live check-in mapper returns `BOOKING_INVALID_STATE` | **reported, not changed** — pinned by a test |
| 15 | the 350k house-default price is unreachable from check-in | **reported, not changed** — pinned by a test |
| 16 | the price preview swallows special-date read errors and quotes 0% uplift | **reported, not changed** — **doc comment only, no test** |

The last three are user-facing contract decisions rather than refactor calls, so they are left for you. Note the asymmetry: #12 and #15 are pinned by named tests; **#16 is not** — the only artefact is a comment at `queries/booking/pricing_queries.rs:136`. If that behaviour changes, nothing catches it.

## Behaviour changes

Three, each deliberate and each pinned by a test named for it:

- **#21** — ties between equally-sized floors now break by floor number. Where the old code was determinate the picks are unchanged; where it wasn't, it now is.
- **negative `limit` in `get_recent_activity`** used to return *everything* (`truncate(limit as usize)` was a no-op and SQLite reads a negative `LIMIT` as unbounded). It now returns nothing, and the loaders clamp before SQLite sees the value, so it no longer runs three unbounded scans to discard the rows.
- **#18** — the PIN hash format is unchanged, but is now pinned by a test, because changing it locks out every existing user.

**Two further changes not previously listed here**, both in error reporting rather than data. Where `update_housekeeping` (non-`clean` status) and `save_pricing_rule` used to surface the raw sqlx string to the UI, they now go through `log_system_error`, so the user sees `"Có lỗi hệ thống, vui lòng thử lại"` and the failure additionally writes a log line and a support record. That is a more consistent contract, but it is a change, and `save_pricing_rule`'s support record now carries the user-supplied `room_type`.

Everything else is semantically identical SQL and identical output, including tie-break ordering in the activity feed. Note "semantically", not byte-for-byte: three moved reads replaced `SELECT *` with an explicit column list (`housekeeping_queries`, `expense_queries`, `stay_info_queries`), and several were re-indented. The mapped column set is identical in every case.

## Blast radius worth naming

`update_housekeeping` is in `WRITE_COMMAND_MANIFEST` with `enforced_in_foundation: true`, and this PR moves it from `commands/rooms.rs` into `services/housekeeping/housekeeping_service.rs`. The safety infrastructure moved with it verbatim — same `aggregate_locks::room_key`, same transaction, both `status = 'cleaning'` guards, both `rows_affected() != 1` rollbacks. It is the only manifest-enforced write this PR relocates, and it is worth a reviewer's attention.

## Not in this PR, on purpose

- one 2.66 MB frontend chunk with no route-level code splitting — a frontend build concern, its own branch
- the 24 flat root modules — the canonical doc forbids mixing folder moves with command changes, and this branch is nothing but command changes
- `services/booking/*_lifecycle.rs` still carry SQL inline rather than going through `repositories/`. This is the honest remaining gap, but the boundaries doc *allows* it (services may own their transactions), so it is a preference and should be an explicit decision, not something smuggled in at the end of a long branch.

## One change beyond the refactor

CI ran `cargo test` and clippy but never `cargo fmt -- --check`, which is why twelve untouched files had drifted. One commit formats them **and adds the check to CI** so it doesn't recur. If you'd rather not gate CI on formatting, drop that hunk of `.github/workflows/ci.yml` — but note `architecture_guard.rs::production_source` now depends on formatted input to strip test modules correctly, and would report a false clean on a badly-formatted file.

## Verification

Run on the rebased head, not just before the rebase:

| gate | result |
| --- | --- |
| `cargo test --lib` | 913 passed, 0 failed (869 at branch point) |
| `cargo clippy --all-targets -- -D warnings` | exit 0 |
| `cargo fmt -- --check` | exit 0 |
| `npm run verify:full` | exit 0 — vitest 358 passed, native smoke booted and reported ready |

## Review note

`/code-review` is `disable-model-invocation` in this environment and could not be run — attempting it returns *"Skill code-review cannot be used with Skill tool due to disable-model-invocation"*. Three independent agents reviewed the diff instead, along three lenses: behaviour preservation, the money and auth paths, and whether the new tests have teeth.

The money and auth review came back clean, and proved it globally rather than by sampling: every `(accessor, column)` pair was extracted on both refs and the sets diffed, so no money column moved between `get_money_vnd`, `get_optional_money_vnd`, or a raw decode.

The test review did **not** come back clean, and the last commit on this branch is the response to it. It demonstrated that `the_same_input_always_gives_the_same_answer` — the test this PR leaned on hardest — was worthless for the property it was named for: a 25x loop inside one process cannot show stability across app launches, and against a per-launch-seeded HashMap it fired zero times in 200 runs. `equally_sized_floors_break_the_tie_by_floor_number` used only two tied floors, making it a coin flip against the real historical bug (115/200). Both are replaced; the new pair fails 30 out of 30 runs against the historical `HashMap` code. The same review found `load_vacant_rooms` and `total_group_detail` untested, which is also fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)