### PR TITLE
docs(readme): drop the untracked PRD.md references

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ CapyInn/
 │   ├── tests/              # Vitest suites and mocked desktop flows
 │   ├── public/             # Static assets
 │   └── models/             # OCR models
-├── PRD.md                  # Product requirements
 ├── CONTRIBUTING.md
 ├── SECURITY.md
 └── README.md
@@ -245,7 +244,6 @@ CapyInn/
 
 ## Additional docs
 
-- [PRD](PRD.md)
 - [Contributing guide](CONTRIBUTING.md)
 - [Release checklist](docs/release-checklist.md)
 - [Security policy](SECURITY.md)


### PR DESCRIPTION
## Problem

`README.md` referenced `PRD.md` in two places, but that file is an internal document excluded from the public tree — it is not tracked in this repository. The link 404'd for anyone browsing the repo on GitHub, and the layout tree advertised a file that isn't there.

- `README.md:248` — `- [PRD](PRD.md)` in the "Additional docs" list
- `README.md:234` — `├── PRD.md   # Product requirements` in the repository-layout block

## Change

Removed both references. No replacement link was added: `docs/PRD.md`, `CLAUDE.md`, and `AGENTS.md` are all untracked here too, so pointing at any of them would just move the 404.

## Verification

Scanned all **43 tracked `.md` files** and resolved every relative link (fenced code blocks stripped, `#anchors`/`http`/`mailto` skipped) against `git ls-files`:

```
tracked .md files scanned : 43
relative links checked    : 12
broken relative links     : 0
```

README's own links all resolve: `Public/dashboard.png` (x2), `CONTRIBUTING.md` (x2), `docs/release-checklist.md`, `SECURITY.md`, `CHANGELOG.md`, `LICENSE`.

## Out of scope (pre-existing, not touched)

Two internal design docs contain **29 absolute filesystem paths** — links like `[app_error.rs](/Users/binhan/HotelManager/mhm/src-tauri/src/app_error.rs)` — which are machine-local and also break on GitHub. These are absolute, not relative, links and predate this change:

- `docs/superpowers/specs/2026-04-22-command-failure-monitoring-design.md`
- `docs/superpowers/specs/2026-04-23-db-error-monitoring-design.md`

Happy to convert them to repo-relative paths in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)