### PR TITLE
Quote the price the backend will charge — check-in, group check-in, and both previews

### DIFF
--- a/docs/architecture/core-pms-boundaries.md
+++ b/docs/architecture/core-pms-boundaries.md
@@ -111,6 +111,31 @@ Use these defaults when adding or moving SQL:
 - command modules should not accumulate unrelated read SQL, write SQL, and business state-machine logic in the same function;
 - direct PMS table writes from UI, bots, agents, or integrations are forbidden.
 
+## Pricing Is Keyed On Room Type
+
+Price is a property of the room type, not of the room. Two rooms of one type cost
+the same night, whichever key the guest is handed.
+
+- the configured price of a type is its `pricing_rules` row; when a type has no
+  row, a type price is *derived* from one room's `base_price` (lowest room id, so
+  the derivation is reproducible);
+- `rooms.base_price` is therefore per-room data the pricing model does not honour
+  as a price. Do not present it to an operator as what a stay will cost, and do
+  not place it beside a computed total;
+- rooms of one type holding different `base_price` values is a data problem, not
+  a pricing bug: a type cannot express two prices, so give it a rule;
+- the *extra-person surcharge* is the deliberate exception. `rooms.extra_person_fee`
+  is read from the booked room, because two rooms of one type may legitimately
+  charge differently for an extra guest. This is why a quote for a chosen room
+  goes through `calculate_room_price_preview`, not the type-keyed preview;
+- the number shown before a stay must come from the same code that charges for
+  it. Frontends ask a preview command; they do not multiply in JavaScript.
+  `base_price × nights` ignores the configured rate, the weekend uplift, any
+  `special_dates` surcharge and the extra-person fee — all of which check-in
+  charges;
+- a preview that cannot read the prices must fail, not quote a default. Guessing
+  a 0% holiday uplift produces a figure below what the desk will collect.
+
 ## Implementation Path And Rename Debt
 
 `mhm/` is the current implementation path. It is not the product name.
@@ -128,3 +153,4 @@ Before approving a cleanup or feature PR, check:
 - Are transactional outbox writes kept with the business mutation when they are part of the safety contract?
 - Are outbox dispatchers, observers, gateway, MCP, agent, digest, Telegram, CEO, and OpenAI surfaces disabled from the normal PMS profile?
 - Does the PR avoid mixing folder rename debt with runtime or command-safety changes?
+- If it shows the guest a price, does that number come from a preview command rather than arithmetic over `base_price`?

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -22,7 +22,28 @@ const STORED_PRICING_RULE_SQL: &str = "SELECT room_type, hourly_rate, overnight_
 
 const ROOM_TYPE_SQL: &str = "SELECT type FROM rooms WHERE id = ? LIMIT 1";
 
-const FALLBACK_BASE_PRICE_SQL: &str = "SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1";
+/// The base price a room type falls back to when it has no `pricing_rules` row.
+///
+/// **Price is a property of the room type, not of the room.** That is the
+/// operator's decision, and everything here follows from it: two rooms of one
+/// type cost the same night, whichever key the guest is handed.
+///
+/// So `rooms.base_price` is not a price the system charges. It is per-room data
+/// predating the rule table, read here only to derive a *type* price when the
+/// type has no rule configured. `ORDER BY id` makes that derivation
+/// reproducible: without it SQLite returns whichever row it likes, so a type
+/// whose rooms disagree about `base_price` could quote one figure and charge
+/// another across app restarts.
+///
+/// When rooms of one type do disagree, the lowest id wins and the rest of the
+/// type bills at its rate. Under a type-keyed price that is not an error to fix
+/// in the SQL — it means the operator holds per-room prices the model cannot
+/// express, and the answer is to give the type a `pricing_rules` row.
+///
+/// Both loaders share this constant, so the quote and the charge cannot
+/// disagree about which room they derived from.
+const FALLBACK_BASE_PRICE_SQL: &str =
+    "SELECT base_price FROM rooms WHERE LOWER(type) = ? ORDER BY id LIMIT 1";
 
 const ROOM_GUEST_PRICING_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_guests,
             COALESCE(extra_person_fee, 0) AS extra_person_fee
@@ -184,10 +205,17 @@ pub(crate) async fn load_stay_pricing_inputs_tx(
 /// preview supply a room *type* directly — there is no booking or room yet — so
 /// this skips the room lookup and is otherwise identical.
 ///
-/// The special-date read is deliberately lenient: a failure prices the stay at a
-/// 0% uplift rather than failing the preview, which is the behaviour the
-/// preview command has always had. The lifecycle path, which actually charges
-/// money, propagates the error instead.
+/// Every read here propagates, exactly as the transactional twin does. The
+/// special-date read used to be lenient — a failure priced the stay at a 0%
+/// uplift instead of failing the preview — so on a holiday the quote came out
+/// *below* what the lifecycle path would charge, silently and in the guest's
+/// favour until the desk collected the difference.
+///
+/// How often that read can fail is not the point, and the honest answer is
+/// rarely: the pool opens WAL with a 5s `busy_timeout` (`db.rs`), so a plain
+/// `SELECT` does not queue behind a writer. The point is that guessing 0% is the
+/// wrong response to not knowing. A preview that cannot read the prices should
+/// say so rather than quote low.
 pub(crate) async fn load_stay_pricing_inputs_for_room_type(
     pool: &Pool<Sqlite>,
     room_type: &str,
@@ -202,7 +230,7 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
     } else {
         None
     };
-    let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+    let special_uplift_pct = load_special_uplift(pool, check_in).await?;
     let guest_pricing = load_room_guest_pricing_for_type(pool, room_type).await?;
 
     Ok(StayPricingInputs {
@@ -223,8 +251,10 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
 /// người là thuộc tính của từng phòng, nên phòng đã chọn rồi thì phải đọc đúng
 /// phòng đó — hai phòng cùng loại có thể đặt phụ thu khác nhau.
 ///
-/// Đọc lệnh với ngày đặc biệt giống bản theo loại phòng: lỗi thì coi như 0%,
-/// vì đây là xem trước chứ chưa thu tiền.
+/// Ngày đặc biệt đọc y như bản theo loại phòng: lỗi thì **báo lỗi**, không coi
+/// như 0%. Chính vì đây là xem trước nên mới phải chặt: con số này được đọc cho
+/// khách nghe trước khi thu tiền, nên đoán 0% đúng vào ngày lễ chỉ tạo ra một
+/// báo giá thấp hơn số thực thu. Không đọc được giá thì phải nói là không biết.
 pub(crate) async fn load_stay_pricing_inputs_for_room(
     pool: &Pool<Sqlite>,
     room_id: &str,
@@ -240,7 +270,7 @@ pub(crate) async fn load_stay_pricing_inputs_for_room(
     } else {
         None
     };
-    let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+    let special_uplift_pct = load_special_uplift(pool, check_in).await?;
     let guest_pricing = load_room_guest_pricing(pool, room_id).await?;
 
     Ok(StayPricingInputs {

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -142,10 +142,12 @@ pub async fn save_pricing_rule(
 #[cfg(test)]
 mod tests {
     use super::{
-        calculate_price_preview, calculate_stay_price_tx, save_pricing_rule, SavePricingRule,
+        calculate_price_preview, calculate_room_price_preview, calculate_stay_price_tx,
+        save_pricing_rule, SavePricingRule,
     };
     use crate::app_error::codes;
-    use sqlx::{sqlite::SqlitePoolOptions, Pool, Row, Sqlite};
+    use crate::domain::booking::BookingError;
+    use sqlx::{sqlite::SqlitePoolOptions, Executor, Pool, Row, Sqlite};
 
     const CHECK_IN: &str = "2026-04-20T14:00:00+07:00";
     const CHECK_OUT: &str = "2026-04-22T12:00:00+07:00";
@@ -190,6 +192,145 @@ mod tests {
         .execute(pool)
         .await
         .expect("seed room");
+    }
+
+    async fn seed_special_date(pool: &Pool<Sqlite>, date: &str, uplift_pct: f64) {
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES (?, ?, 'Lễ', ?, '2026-04-01T00:00:00+07:00')",
+        )
+        .bind(format!("sd-{date}"))
+        .bind(date)
+        .bind(uplift_pct)
+        .execute(pool)
+        .await
+        .expect("seed special date");
+    }
+
+    /// Price belongs to the room type, so the room a guest is given must not
+    /// change what they pay. This is the test that says so.
+    ///
+    /// The case that can break it: no `pricing_rules` row, so the type price is
+    /// derived from *one* room's `base_price` via `FALLBACK_BASE_PRICE_SQL`.
+    /// Three properties, all of which the decision requires:
+    ///
+    /// 1. Every room of the type is charged the same — the 800k room and the
+    ///    600k room cost the same night.
+    /// 2. The quote and the charge derive from the same room. They do only
+    ///    because both loaders share one SQL constant.
+    /// 3. The pick does not drift between runs. `ORDER BY id` is what makes that
+    ///    true; without it SQLite is free to return either row.
+    #[tokio::test]
+    async fn the_room_a_guest_is_given_does_not_change_what_the_type_costs() {
+        let pool = migrated_pool().await;
+        // Inserted expensive-first so insertion order and id order disagree.
+        seed_room(&pool, "R-902", "mixed", 800_000).await;
+        seed_room(&pool, "R-901", "mixed", 600_000).await;
+
+        let preview = calculate_price_preview(&pool, "mixed", CHECK_IN, CHECK_OUT, "nightly", None)
+            .await
+            .expect("preview");
+
+        let mut charged_by_room = Vec::new();
+        for room_id in ["R-901", "R-902"] {
+            let mut tx = pool.begin().await.expect("begin");
+            let charged =
+                calculate_stay_price_tx(&mut tx, room_id, CHECK_IN, CHECK_OUT, "nightly", None)
+                    .await
+                    .unwrap_or_else(|error| panic!("charge for {room_id}: {error}"));
+            tx.rollback().await.expect("rollback");
+
+            assert_eq!(
+                preview.total, charged.total,
+                "the quote and the charge disagreed for {room_id}"
+            );
+            charged_by_room.push(charged.total);
+        }
+
+        // The decision itself, stated without going through the preview: two
+        // rooms of one type, 200k apart in `base_price`, cost the same night.
+        assert_eq!(
+            charged_by_room[0], charged_by_room[1],
+            "the cheap room and the expensive room of one type were charged differently"
+        );
+
+        // Which room won: the lowest id, not the lowest price, not the insertion
+        // order. Compared against types holding exactly one room at that price,
+        // so the expectation does not restate the derivation arithmetic.
+        seed_room(&pool, "R-801", "lone-600", 600_000).await;
+        seed_room(&pool, "R-802", "lone-800", 800_000).await;
+        let lone_600 =
+            calculate_price_preview(&pool, "lone-600", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("lone 600k preview");
+        let lone_800 =
+            calculate_price_preview(&pool, "lone-800", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("lone 800k preview");
+
+        assert_eq!(
+            preview.total, lone_600.total,
+            "R-901 has the lower id, so its 600k sets the mixed-type price"
+        );
+        assert_ne!(
+            preview.total, lone_800.total,
+            "a type cannot hold two prices: the 800k room bills at its sibling's rate"
+        );
+    }
+
+    /// Both previews used to swallow a failed `special_dates` read and quote a
+    /// 0% uplift. On a holiday that is a number below what check-in charges,
+    /// read aloud to the guest before anyone takes their money.
+    #[tokio::test]
+    async fn a_failed_special_date_read_fails_both_previews_instead_of_quoting_no_uplift() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-901", "derived", 500_000).await;
+        seed_special_date(&pool, "2026-04-20", 10.0).await;
+
+        // Precondition: the holiday really is reaching both previews, so the
+        // failure below is about the read and not about an uplift that was never
+        // applied to begin with.
+        let by_type =
+            calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("type preview");
+        let by_room =
+            calculate_room_price_preview(&pool, "R-901", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("room preview");
+        assert!(
+            by_type.surcharge_amount > 0,
+            "precondition: the holiday uplift is not reaching the type preview"
+        );
+        assert_eq!(
+            by_type.total, by_room.total,
+            "the two previews disagreed before anything was broken"
+        );
+
+        pool.execute("DROP TABLE special_dates")
+            .await
+            .expect("drop special_dates");
+
+        // Pinned on the error *variant*, not on SQLite's wording. Only this
+        // test's own DROP produces "no such table", so asserting that text would
+        // prove the test rather than the code.
+        let type_error =
+            calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect_err("the type preview quoted a price it could not read");
+        assert!(
+            matches!(type_error, BookingError::Database(_)),
+            "type preview: {type_error:?}"
+        );
+
+        let room_error =
+            calculate_room_price_preview(&pool, "R-901", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect_err("the room preview quoted a price it could not read");
+        assert!(
+            matches!(room_error, BookingError::Database(_)),
+            "room preview: {room_error:?}"
+        );
     }
 
     /// The point of routing both paths through this module: the quote the UI

--- a/mhm/src/__mocks__/tauri-core.ts
+++ b/mhm/src/__mocks__/tauri-core.ts
@@ -130,6 +130,7 @@ export const invoke = vi.fn(async (command: string, args?: Record<string, unknow
         logout: undefined,
         search_guest_by_phone: [],
         calculate_price_preview: { total: 0, breakdown: [] },
+        calculate_room_price_preview: { total: 0, breakdown: [] },
         get_folio_lines: [],
         get_rooms_availability: [],
     };

--- a/mhm/src/components/CheckinSheet.pricing.test.tsx
+++ b/mhm/src/components/CheckinSheet.pricing.test.tsx
@@ -1,0 +1,172 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-core";
+import { useHotelStore } from "@/stores/useHotelStore";
+import type { Room } from "@/types";
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import CheckinSheet from "./CheckinSheet";
+
+const ROOM: Room = {
+  id: "R101",
+  name: "R101",
+  // A real, multi-word type name — the shipped values have spaces in them.
+  type: "Deluxe Balcony",
+  floor: 1,
+  has_balcony: true,
+  // Round on purpose: `base_price × 1 night` is 500.000, which is not what the
+  // backend quotes below.
+  base_price: 500000,
+  max_guests: 2,
+  extra_person_fee: 0,
+  status: "vacant",
+};
+
+/** What a configured rule plus a holiday surcharge actually produces. */
+const BACKEND_TOTAL = 632_500;
+
+function pricingResult(total: number, breakdown: { label: string; amount: number }[] = []) {
+  return {
+    pricing_type: "nightly",
+    base_amount: total,
+    surcharge_amount: 0,
+    weekend_amount: 0,
+    total,
+    breakdown,
+    capped: false,
+  };
+}
+
+function previewArgs(): { roomId: string; checkIn: string; checkOut: string; guests: unknown }[] {
+  return invoke.mock.calls
+    .filter(([command]) => command === "calculate_room_price_preview")
+    .map(([, args]) => args as never);
+}
+
+describe("CheckinSheet total price", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+    useHotelStore.setState({ isCheckinOpen: true, rooms: [] });
+    setMockResponse("get_rooms", () => [ROOM]);
+    setMockResponse("calculate_room_price_preview", () => pricingResult(BACKEND_TOTAL));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /// The sheet rendered `base_price × nights` computed in JavaScript, which
+  /// ignores the configured nightly rate, the weekend uplift and any holiday
+  /// surcharge. Staff read that number aloud and took a deposit against it.
+  it("shows the price the backend will charge, not base_price times nights", async () => {
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stay-price-total")).toHaveTextContent("632.500");
+    });
+    expect(screen.getByTestId("stay-price-total")).not.toHaveTextContent("500.000");
+  });
+
+  /// A walk-in is charged from `Local::now()` for `nights` days
+  /// (`stay_lifecycle.rs`). A bare date, or a `Z` stamp, prices a different stay
+  /// than the one about to be written.
+  it("asks about the same instants the check-in will charge for", async () => {
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+
+    const { roomId, checkIn, checkOut } = previewArgs()[0];
+    expect(roomId).toBe("R101");
+    for (const stamp of [checkIn, checkOut]) {
+      expect(stamp).toMatch(/[+-]\d{2}:\d{2}$/);
+      expect(stamp).not.toContain("Z");
+    }
+    // `nights` defaults to 1, and the span between the two stamps IS the price.
+    expect(Date.parse(checkOut) - Date.parse(checkIn)).toBe(86_400_000);
+  });
+
+  /// `stay_lifecycle::check_in` prices with `None`, so a walk-in is never billed
+  /// the extra-person fee. Sending a guest count here would quote above what the
+  /// desk collects — the same defect as the multiplication, in the other
+  /// direction.
+  it("asks with no guest count, exactly as the check-in charges", async () => {
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+    expect(previewArgs()[0].guests).toBeNull();
+  });
+
+  /// The local day is what `special_dates` is looked up by. `toISOString()`
+  /// reports the UTC day, which before 07:00 in Vietnam is still yesterday.
+  it("quotes against the local calendar day, not the UTC one", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 20, 2, 0, 0));
+
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await vi.waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+    expect(previewArgs()[0].checkIn.slice(0, 10)).toBe("2026-04-20");
+  });
+
+  /// A wrong total shown with confidence is worse than no total. The old code
+  /// always had a number to show and no way to say "I do not know".
+  it("says it could not price the stay rather than falling back to a guess", async () => {
+    setMockResponse("calculate_room_price_preview", () => {
+      throw new Error("database is locked");
+    });
+
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => expect(screen.getByTestId("stay-price-error")).toBeInTheDocument());
+    expect(screen.queryByTestId("stay-price-total")).not.toBeInTheDocument();
+    expect(screen.queryByText(/500\.000/)).not.toBeInTheDocument();
+  });
+
+  /// The number came from the breakdown, which was fetched and thrown away.
+  /// Without it a total that no longer equals base_price × nights cannot be
+  /// explained at the desk.
+  it("shows the breakdown behind a total that is not a simple multiplication", async () => {
+    setMockResponse("calculate_room_price_preview", () =>
+      pricingResult(BACKEND_TOTAL, [
+        { label: "Tiền phòng", amount: 550_000 },
+        { label: "Phụ thu ngày lễ", amount: 82_500 },
+      ]),
+    );
+
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => expect(screen.getByTestId("stay-price-breakdown")).toBeInTheDocument());
+    const breakdown = screen.getByTestId("stay-price-breakdown");
+    expect(breakdown).toHaveTextContent("Phụ thu ngày lễ");
+    expect(breakdown).toHaveTextContent("82.500");
+  });
+
+  /// Price is keyed on the room type, so `rooms.base_price` is not a price the
+  /// system charges. Printing it in the picker put a per-room figure beside a
+  /// total that no longer derives from it.
+  it("does not print a per-room base price beside the quoted total", async () => {
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => expect(screen.getByTestId("stay-price-total")).toBeInTheDocument());
+
+    const option = screen.getByRole("option", { name: /R101/ });
+    expect(option).not.toHaveTextContent("500.000");
+  });
+});

--- a/mhm/src/components/CheckinSheet.tsx
+++ b/mhm/src/components/CheckinSheet.tsx
@@ -11,6 +11,8 @@ import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtMoney } from "@/lib/format";
 import { createDeferredCleanup } from "@/lib/deferredCleanup";
+import { addDays, localRfc3339 } from "@/lib/timelineSelection";
+import { usePricePreview } from "@/hooks/usePricePreview";
 import { toast } from "sonner";
 import type { CccdInfo, GuestInput, GuestSummary } from "@/types";
 
@@ -146,9 +148,33 @@ export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: {
     }, [rooms, selectedRoom, vacantRooms]);
 
     const selectedRoomData = rooms.find((r) => r.id === selectedRoom);
-    const totalPrice = selectedRoomData
-        ? selectedRoomData.base_price * nights
-        : 0;
+
+    // Nhận phòng vãng lai được tính tiền từ `Local::now()` cho `nights` ngày
+    // (`stay_lifecycle.rs`), nên bản xem trước phải hỏi đúng hai mốc đó — không
+    // phải ngày trần, vốn là cách đặt phòng trước được tính.
+    const { quoteCheckIn, quoteCheckOut } = useMemo(() => {
+        const now = new Date();
+        return {
+            quoteCheckIn: localRfc3339(now),
+            quoteCheckOut: localRfc3339(addDays(now, Math.max(nights, 0))),
+        };
+    }, [nights]);
+
+    // Con số phải do engine trả về. `base_price × nights` bỏ qua bảng giá đã
+    // cấu hình, phụ thu cuối tuần và phụ thu ngày lễ — những thứ lúc thu tiền
+    // đều tính.
+    const {
+        preview: stayPrice,
+        loading: priceLoading,
+        error: priceFailed,
+    } = usePricePreview({
+        roomId: selectedRoom,
+        checkIn: quoteCheckIn,
+        checkOut: quoteCheckOut,
+        // `stay_lifecycle::check_in` truyền `None`, nên khách vãng lai không bị
+        // tính phụ thu thêm người. Gửi số khách ở đây sẽ báo cao hơn số thực thu.
+        guests: null,
+    });
 
     const { fromDate, toDate } = useMemo(() => {
         const now = new Date();
@@ -419,8 +445,7 @@ export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: {
                                 <option value="">Chọn phòng...</option>
                                 {vacantRooms.map((r) => (
                                 <option key={r.id} value={r.id}>
-                                        {r.id} — {getRoomTypeLabel(r.type)} (
-                                        {fmtMoney(r.base_price)})
+                                        {r.id} — {getRoomTypeLabel(r.type)}
                                     </option>
                                 ))}
                             </select>
@@ -470,15 +495,42 @@ export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: {
                         </div>
                     )}
 
-                    {/* Total price */}
+                    {/* Total price — con số do engine tính, không phải phép nhân ở đây */}
                     {selectedRoomData && (
-                        <div className="bg-slate-50 rounded-xl p-3 flex justify-between items-center">
-                            <span className="text-xs text-brand-muted font-medium">
-                                Tổng tiền ({nights} đêm × {fmtMoney(selectedRoomData.base_price)})
-                            </span>
-                            <span className="text-base font-bold text-emerald-600 tabular-nums">
-                                {fmtMoney(totalPrice)}
-                            </span>
+                        <div className="bg-slate-50 rounded-xl p-3 space-y-1">
+                            <div className="flex justify-between items-center">
+                                <span className="text-xs text-brand-muted font-medium">
+                                    Tổng tiền ({nights} đêm)
+                                </span>
+                                {priceFailed ? (
+                                    <span
+                                        data-testid="stay-price-error"
+                                        className="text-xs font-semibold text-amber-600"
+                                    >
+                                        Chưa tính được giá
+                                    </span>
+                                ) : (
+                                    <span
+                                        data-testid="stay-price-total"
+                                        className="text-base font-bold text-emerald-600 tabular-nums"
+                                    >
+                                        {priceLoading || !stayPrice ? "…" : fmtMoney(stayPrice.total)}
+                                    </span>
+                                )}
+                            </div>
+                            {!priceFailed && stayPrice && stayPrice.breakdown.length > 1 && (
+                                <ul data-testid="stay-price-breakdown" className="space-y-0.5">
+                                    {stayPrice.breakdown.map((line, index) => (
+                                        <li
+                                            key={`${line.label}-${index}`}
+                                            className="flex justify-between text-[11px] text-brand-muted"
+                                        >
+                                            <span>{line.label}</span>
+                                            <span className="tabular-nums">{fmtMoney(line.amount)}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
                         </div>
                     )}
 

--- a/mhm/src/components/GroupCheckinSheet.pricing.test.tsx
+++ b/mhm/src/components/GroupCheckinSheet.pricing.test.tsx
@@ -1,0 +1,242 @@
+import type {
+  ButtonHTMLAttributes,
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+  ReactNode,
+} from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-core";
+
+const autoAssignRooms = vi.hoisted(() => vi.fn());
+const groupCheckIn = vi.hoisted(() => vi.fn());
+const setGroupCheckinOpen = vi.hoisted(() => vi.fn());
+
+// Two rooms, two prices, and a multi-word type name. Deliberately not tidier
+// than production data: the shipped type names contain spaces, and a fixture
+// without one has hidden a bug in this exact code path before.
+const ROOMS = [
+  {
+    id: "R101",
+    name: "R101",
+    type: "Standard Room",
+    room_type: "Standard Room",
+    floor: 1,
+    has_balcony: false,
+    base_price: 500000,
+    max_guests: 2,
+    extra_person_fee: 0,
+    status: "vacant",
+  },
+  {
+    id: "R202",
+    name: "R202",
+    type: "Deluxe Balcony",
+    room_type: "Deluxe Balcony",
+    floor: 2,
+    has_balcony: true,
+    base_price: 800000,
+    max_guests: 2,
+    extra_person_fee: 0,
+    status: "vacant",
+  },
+];
+
+vi.mock("@/stores/useHotelStore", () => ({
+  useHotelStore: () => ({
+    isGroupCheckinOpen: true,
+    setGroupCheckinOpen,
+    rooms: ROOMS,
+    groupCheckIn,
+    autoAssignRooms,
+    loading: false,
+  }),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import GroupCheckinSheet from "./GroupCheckinSheet";
+
+/** Two rooms, quoted individually — not 500.000 + 800.000. */
+const QUOTES: Record<string, number> = { R101: 632_500, R202: 1_012_000 };
+
+function pricingResult(total: number) {
+  return {
+    pricing_type: "nightly",
+    base_amount: total,
+    surcharge_amount: 0,
+    weekend_amount: 0,
+    total,
+    breakdown: [],
+    capped: false,
+  };
+}
+
+function previewArgs(): { roomId: string; checkIn: string; checkOut: string; guests: unknown }[] {
+  return invoke.mock.calls
+    .filter(([command]) => command === "calculate_room_price_preview")
+    .map(([, args]) => args as never);
+}
+
+/** Clicks forward until the summary, which is where the group total is shown. */
+async function advanceToSummary(user: ReturnType<typeof userEvent.setup>) {
+  for (let step = 0; step < 3; step += 1) {
+    if (screen.queryByTestId("group-price-total") || screen.queryByTestId("group-price-error")) {
+      return;
+    }
+    const next = screen.queryByRole("button", { name: /Tiếp theo/i });
+    if (!next) return;
+    await user.click(next);
+  }
+}
+
+/** Walks the wizard as far as picking both rooms, which is what starts quoting. */
+async function pickBothRooms() {
+  const user = userEvent.setup();
+  render(<GroupCheckinSheet />);
+
+  const textboxes = screen.getAllByRole("textbox");
+  await user.type(textboxes[0], "Đoàn Hà Nội");
+  await user.type(textboxes[1], "Trần Văn B");
+  await user.click(screen.getByRole("button", { name: /Tiếp theo/i }));
+  await user.click(screen.getByRole("button", { name: /Chọn tay/i }));
+  await user.click(screen.getByRole("button", { name: /R101/ }));
+  await user.click(screen.getByRole("button", { name: /R202/ }));
+
+  // The wizard will not advance without a master room, and the master picker
+  // renders below the grid with the same room names — take the later one.
+  const masterCandidates = screen.getAllByRole("button", { name: /R101/ });
+  await user.click(masterCandidates[masterCandidates.length - 1]);
+
+  return user;
+}
+
+describe("GroupCheckinSheet total price", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockResponses();
+    invoke.mockClear();
+    groupCheckIn.mockResolvedValue(undefined);
+    autoAssignRooms.mockResolvedValue({ assignments: [] });
+    setMockResponse("calculate_room_price_preview", (args) =>
+      pricingResult(QUOTES[(args as { roomId: string }).roomId] ?? 0),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /// The sheet summed `base_price × nights` per room in JavaScript, which
+  /// ignores the configured rate, the weekend uplift and any holiday surcharge —
+  /// once per room, so the group total was wrong by a multiple.
+  it("quotes each room through the engine instead of multiplying", async () => {
+    const user = await pickBothRooms();
+
+    await waitFor(() =>
+      expect(Array.from(new Set(previewArgs().map((a) => a.roomId))).sort()).toEqual([
+        "R101",
+        "R202",
+      ]),
+    );
+
+    await advanceToSummary(user);
+
+    // 632.500 + 1.012.000, the two engine quotes — not 500.000 + 800.000, which
+    // is what multiplying the base prices by one night would have shown.
+    const total = await screen.findByTestId("group-price-total");
+    expect(total).toHaveTextContent("1.644.500");
+    expect(total).not.toHaveTextContent("1.300.000");
+  });
+
+  /// `group_lifecycle.rs` charges with `None`, so the group is never billed the
+  /// extra-person fee. Quoting a guest count would show more than it collects.
+  it("asks with no guest count, exactly as the group charge does", async () => {
+    await pickBothRooms();
+
+    await waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+    for (const args of previewArgs()) {
+      expect(args.guests).toBeNull();
+    }
+  });
+
+  /// A walk-in group is priced from `Local::now()`; a reservation from bare
+  /// dates. Asking with the wrong pair prices a different stay than the one
+  /// being booked.
+  it("asks about the instants a walk-in group will be charged for", async () => {
+    await pickBothRooms();
+
+    await waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+
+    const { checkIn, checkOut } = previewArgs()[0];
+    expect(checkIn).toMatch(/[+-]\d{2}:\d{2}$/);
+    expect(checkIn).not.toContain("Z");
+    expect(Date.parse(checkOut) - Date.parse(checkIn)).toBe(86_400_000);
+  });
+
+  /// `toISOString()` reports the UTC day, which before 07:00 in Vietnam is
+  /// yesterday. `isReservation` compares the arrival against it, so at 02:00 a
+  /// walk-in group read as a *reservation* and was quoted from bare dates —
+  /// while `group_lifecycle.rs`, comparing against its own local today, would
+  /// charge it down the walk-in branch. Two branches, one stay.
+  ///
+  /// Asserting the day alone does not catch this: both branches say
+  /// "2026-04-20" here. The offset is what distinguishes them.
+  it("prices a 02:00 group as the walk-in the backend will charge it as", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 20, 2, 0, 0));
+
+    await pickBothRooms();
+
+    await vi.waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+    const { checkIn } = previewArgs()[0];
+    expect(checkIn.slice(0, 10)).toBe("2026-04-20");
+    expect(checkIn).toMatch(/T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+  });
+
+  /// A total summed from one of two rooms is the same class of lie the
+  /// multiplication was. There has to be a way to say "I do not know".
+  it("says it could not price the group rather than showing a partial total", async () => {
+    setMockResponse("calculate_room_price_preview", (args) => {
+      if ((args as { roomId: string }).roomId === "R202") {
+        throw new Error("database is locked");
+      }
+      return pricingResult(632_500);
+    });
+
+    const user = await pickBothRooms();
+    await advanceToSummary(user);
+
+    await screen.findByTestId("group-price-error");
+    expect(screen.queryByTestId("group-price-total")).not.toBeInTheDocument();
+    // Neither the multiplication nor a total summed from the one room that did
+    // price successfully.
+    expect(screen.queryByText(/1\.300\.000/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/632\.500/)).not.toBeInTheDocument();
+  });
+});

--- a/mhm/src/components/GroupCheckinSheet.tsx
+++ b/mhm/src/components/GroupCheckinSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useHotelStore } from "../stores/useHotelStore";
 import {
     Sheet,
@@ -12,6 +12,8 @@ import { Label } from "@/components/ui/label";
 import { FormField, FormFieldSelect } from "@/components/shared/FormField";
 import { formatAppError } from "@/lib/appError";
 import { fmtMoney } from "@/lib/format";
+import { addDays, addDaysIso, localDateIso, localRfc3339 } from "@/lib/timelineSelection";
+import { sumRoomPrices, useRoomPrices } from "@/hooks/useRoomPrices";
 import { toast } from "sonner";
 import { Sparkles, Hand, Check, ChevronLeft, ChevronRight, Users, Star, CalendarClock } from "lucide-react";
 import type { CheckInGuestInput, RoomAssignment } from "@/types";
@@ -38,12 +40,12 @@ export default function GroupCheckinSheet() {
     const [roomType, setRoomType] = useState("all");
     const [nights, setNights] = useState(1);
     const [source, setSource] = useState("walk-in");
-    const [checkInDate, setCheckInDate] = useState(() => {
-        const d = new Date();
-        return d.toISOString().split("T")[0];
-    });
+    // Ngày địa phương. `toISOString()` trả ngày UTC, mà trước 07:00 giờ Việt Nam
+    // vẫn còn là hôm qua — đủ để mặc định sai ngày nhận phòng và để
+    // `isReservation` phán nhầm chế độ ngay trong ca đêm.
+    const [checkInDate, setCheckInDate] = useState(() => localDateIso(new Date()));
 
-    const todayStr = new Date().toISOString().split("T")[0];
+    const todayStr = localDateIso(new Date());
     const isReservation = checkInDate > todayStr;
 
     // Step 2: Room selection
@@ -101,10 +103,41 @@ export default function GroupCheckinSheet() {
         );
     };
 
-    const totalPrice = selectedRooms.reduce((sum, id) => {
-        const room = rooms.find((r) => r.id === id);
-        return sum + (room ? room.base_price * nights : 0);
-    }, 0);
+    // `group_lifecycle.rs` tính tiền cho đặt trước bằng ngày trần, còn khách vãng
+    // lai bằng `Local::now()` và `now + nights`. Bản xem trước phải hỏi đúng cặp
+    // mốc mà nhánh tương ứng sẽ dùng, nếu không con số báo cho khách là của một
+    // kỳ nghỉ khác.
+    const { quoteCheckIn, quoteCheckOut } = useMemo(() => {
+        if (isReservation) {
+            return {
+                quoteCheckIn: checkInDate,
+                quoteCheckOut: addDaysIso(checkInDate, Math.max(nights, 0)),
+            };
+        }
+        const now = new Date();
+        return {
+            quoteCheckIn: localRfc3339(now),
+            quoteCheckOut: localRfc3339(addDays(now, Math.max(nights, 0))),
+        };
+    }, [checkInDate, isReservation, nights]);
+
+    const {
+        byRoomId: priceByRoom,
+        loading: priceLoading,
+        failed: priceFailed,
+    } = useRoomPrices({
+        roomIds: selectedRooms,
+        checkIn: quoteCheckIn,
+        checkOut: quoteCheckOut,
+        // `group_lifecycle.rs` charges with `None`, so the group is not billed an
+        // extra-person fee. Quoting one would show more than the desk collects.
+        guests: null,
+        disabled: !isGroupCheckinOpen,
+    });
+
+    // `null` khi còn phòng chưa có giá — thà không hiện tổng còn hơn hiện một
+    // tổng thiếu mất một phòng.
+    const totalPrice = sumRoomPrices(selectedRooms, priceByRoom);
 
     const handleSubmit = async () => {
         try {
@@ -267,8 +300,10 @@ export default function GroupCheckinSheet() {
                                                 }`}
                                         >
                                             <p className="font-bold text-sm">{room.name}</p>
+                                            {/* Không in `base_price`: giá gắn với loại
+                                                phòng, nên con số theo từng phòng đặt
+                                                cạnh tổng đã báo giá là số không ai thu. */}
                                             <p className="text-xs text-brand-muted">{room.type} • T{room.floor}</p>
-                                            <p className="text-xs font-semibold text-brand-primary mt-1">{fmtMoney(room.base_price)}</p>
                                             {selectedRooms.includes(room.id) && (
                                                 <Check size={14} className="text-brand-primary mt-1" />
                                             )}
@@ -387,14 +422,30 @@ export default function GroupCheckinSheet() {
                                     return (
                                         <div key={id} className="flex justify-between text-sm">
                                             <span>{room?.name || id}</span>
-                                            <span className="font-medium">{fmtMoney((room?.base_price || 0) * nights)}</span>
+                                            <span className="font-medium tabular-nums">
+                                                {priceByRoom[id] ? fmtMoney(priceByRoom[id].total) : "—"}
+                                            </span>
                                         </div>
                                     );
                                 })}
                                 <hr className="border-slate-200" />
                                 <div className="flex justify-between text-base font-bold">
                                     <span>Tổng cộng</span>
-                                    <span className="text-brand-primary">{fmtMoney(totalPrice)}</span>
+                                    {priceFailed ? (
+                                        <span
+                                            data-testid="group-price-error"
+                                            className="text-amber-600 text-sm"
+                                        >
+                                            Chưa tính được giá
+                                        </span>
+                                    ) : (
+                                        <span
+                                            data-testid="group-price-total"
+                                            className="text-brand-primary tabular-nums"
+                                        >
+                                            {priceLoading || totalPrice == null ? "…" : fmtMoney(totalPrice)}
+                                        </span>
+                                    )}
                                 </div>
                             </div>
 

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -303,7 +303,10 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                             <option value="">— Chọn phòng —</option>
                             {vacantRooms.map((r) => (
                                 <option key={r.id} value={r.id}>
-                                    {r.name} ({r.type}) — {fmtNumber(r.base_price)}₫/đêm
+                                    {/* Không kèm `base_price`: giá gắn với loại phòng,
+                                        nên con số theo từng phòng đứng cạnh tổng do
+                                        engine tính là số không ai thu. */}
+                                    {r.name} ({r.type})
                                 </option>
                             ))}
                         </select>

--- a/mhm/src/hooks/usePricePreview.ts
+++ b/mhm/src/hooks/usePricePreview.ts
@@ -7,7 +7,10 @@ interface UsePricePreviewOptions {
     roomId: string;
     checkIn: string;
     checkOut: string;
-    guests: number;
+    /// `null` asks the backend the way a walk-in check-in charges — with no
+    /// guest count, so no extra-person fee. `stay_lifecycle::check_in` passes
+    /// `None`; sending a count here would quote above what the desk collects.
+    guests: number | null;
     debounceMs?: number;
 }
 

--- a/mhm/src/hooks/useRoomPrices.test.tsx
+++ b/mhm/src/hooks/useRoomPrices.test.tsx
@@ -1,0 +1,139 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-core";
+import type { PricingResult } from "@/types";
+
+import { sumRoomPrices, useRoomPrices } from "./useRoomPrices";
+
+function pricingResult(total: number): PricingResult {
+  return {
+    pricing_type: "nightly",
+    base_amount: total,
+    surcharge_amount: 0,
+    weekend_amount: 0,
+    total,
+    breakdown: [],
+    capped: false,
+  };
+}
+
+const WINDOW = { checkIn: "2026-04-20", checkOut: "2026-04-22" };
+
+describe("useRoomPrices", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+  });
+
+  it("quotes every room and keys the answers by room id", async () => {
+    setMockResponse("calculate_room_price_preview", (args) =>
+      pricingResult(args?.roomId === "R101" ? 600_000 : 800_000),
+    );
+
+    const { result } = renderHook(() =>
+      useRoomPrices({ roomIds: ["R101", "R202"], ...WINDOW, guests: null }),
+    );
+
+    await waitFor(() => expect(Object.keys(result.current.byRoomId)).toHaveLength(2));
+    expect(result.current.byRoomId.R101.total).toBe(600_000);
+    expect(result.current.byRoomId.R202.total).toBe(800_000);
+    expect(result.current.failed).toBe(false);
+  });
+
+  /// Room ids are operator-entered free text. An earlier version of this idea
+  /// round-tripped the list through a space-delimited string, which tore
+  /// `"Phòng 5A"` into two ids that do not exist — and each fragment still
+  /// *priced*, at the house default, so nothing reported an error.
+  it("survives a room id containing a space", async () => {
+    setMockResponse("calculate_room_price_preview", () => pricingResult(500_000));
+
+    const { result } = renderHook(() =>
+      useRoomPrices({ roomIds: ["Phòng 5A"], ...WINDOW, guests: null }),
+    );
+
+    await waitFor(() => expect(result.current.byRoomId["Phòng 5A"]).toBeDefined());
+    const asked = invoke.mock.calls
+      .filter(([command]) => command === "calculate_room_price_preview")
+      .map(([, args]) => (args as { roomId: string }).roomId);
+    expect(asked).toEqual(["Phòng 5A"]);
+  });
+
+  /// `roomIds` is a fresh array on every render. Keying the effect on the array
+  /// itself would re-quote forever; keying on nothing would never re-quote.
+  it("does not re-quote when the same ids arrive in a new array", async () => {
+    setMockResponse("calculate_room_price_preview", () => pricingResult(500_000));
+
+    const { rerender, result } = renderHook(
+      ({ ids }: { ids: string[] }) => useRoomPrices({ roomIds: ids, ...WINDOW, guests: null }),
+      { initialProps: { ids: ["R101"] } },
+    );
+
+    await waitFor(() => expect(result.current.byRoomId.R101).toBeDefined());
+    const before = invoke.mock.calls.length;
+
+    rerender({ ids: ["R101"] });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(invoke.mock.calls.length).toBe(before);
+  });
+
+  /// A failure must also clear what an *earlier* success left behind. Without
+  /// that, changing the dates to a window that cannot be priced leaves the old
+  /// quotes on screen, and the group total keeps adding up — from a stay nobody
+  /// is booking any more.
+  it("clears the previous quotes when a later lookup fails", async () => {
+    setMockResponse("calculate_room_price_preview", () => pricingResult(600_000));
+
+    const { rerender, result } = renderHook(
+      ({ checkIn }: { checkIn: string }) =>
+        useRoomPrices({ roomIds: ["R101"], checkIn, checkOut: "2026-04-30", guests: null }),
+      { initialProps: { checkIn: "2026-04-20" } },
+    );
+
+    await waitFor(() => expect(result.current.byRoomId.R101).toBeDefined());
+
+    setMockResponse("calculate_room_price_preview", () => {
+      throw new Error("database is locked");
+    });
+    rerender({ checkIn: "2026-04-21" });
+
+    await waitFor(() => expect(result.current.failed).toBe(true));
+    expect(result.current.byRoomId).toEqual({});
+    expect(sumRoomPrices(["R101"], result.current.byRoomId)).toBeNull();
+  });
+
+  /// One failure must not leave a partial map behind: a total summed from three
+  /// of four rooms is the same class of lie as multiplying in JavaScript.
+  it("reports failure rather than a partial set of quotes", async () => {
+    setMockResponse("calculate_room_price_preview", (args) => {
+      if (args?.roomId === "R202") throw new Error("database is locked");
+      return pricingResult(600_000);
+    });
+
+    const { result } = renderHook(() =>
+      useRoomPrices({ roomIds: ["R101", "R202"], ...WINDOW, guests: null }),
+    );
+
+    await waitFor(() => expect(result.current.failed).toBe(true));
+    expect(result.current.byRoomId).toEqual({});
+  });
+});
+
+describe("sumRoomPrices", () => {
+  it("adds the quotes up", () => {
+    expect(
+      sumRoomPrices(["A", "B"], { A: pricingResult(100), B: pricingResult(250) }),
+    ).toBe(350);
+  });
+
+  /// The caller renders `…` on `null`. Returning a number here would show a
+  /// total that silently leaves a booked room out of it.
+  it("refuses to total a set with an unpriced room", () => {
+    expect(sumRoomPrices(["A", "B"], { A: pricingResult(100) })).toBeNull();
+  });
+
+  it("totals an empty selection as zero, not null", () => {
+    expect(sumRoomPrices([], {})).toBe(0);
+  });
+});

--- a/mhm/src/hooks/useRoomPrices.ts
+++ b/mhm/src/hooks/useRoomPrices.ts
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import type { PricingResult } from "@/types";
+
+/**
+ * The batch form of {@link usePricePreview}: one quote per room, same command.
+ *
+ * A group check-in books many rooms at once, and hooks cannot be called in a
+ * loop, so the single-room hook does not fit. It asks
+ * `calculate_room_price_preview` per room rather than per room *type*, because
+ * `rooms.extra_person_fee` is a per-room column — two rooms of one type may
+ * legitimately surcharge an extra guest differently, and only the room-keyed
+ * preview reads the room the guest is actually getting.
+ */
+interface UseRoomPricesOptions {
+    roomIds: string[];
+    checkIn: string;
+    checkOut: string;
+    /** `null` mirrors what the group charge passes, which is `None`. */
+    guests: number | null;
+    disabled?: boolean;
+}
+
+export function useRoomPrices({
+    roomIds,
+    checkIn,
+    checkOut,
+    guests,
+    disabled = false,
+}: UseRoomPricesOptions): {
+    byRoomId: Record<string, PricingResult>;
+    loading: boolean;
+    failed: boolean;
+} {
+    const [byRoomId, setByRoomId] = useState<Record<string, PricingResult>>({});
+    const [loading, setLoading] = useState(false);
+    const [failed, setFailed] = useState(false);
+    const requestIdRef = useRef(0);
+
+    // `roomIds` is a fresh array on every render, so keying the effect on it
+    // directly would refire forever. Serialised with JSON rather than joined on
+    // a delimiter: room ids are operator-entered free text, and a delimiter that
+    // appears inside one silently splits it into rooms that do not exist.
+    const idKey = useMemo(
+        () => JSON.stringify(Array.from(new Set(roomIds)).sort()),
+        [roomIds],
+    );
+
+    useEffect(() => {
+        const ids: string[] = JSON.parse(idKey);
+        if (disabled || ids.length === 0 || !checkIn || !checkOut) {
+            requestIdRef.current += 1;
+            setByRoomId({});
+            setLoading(false);
+            setFailed(false);
+            return;
+        }
+
+        const requestId = requestIdRef.current + 1;
+        requestIdRef.current = requestId;
+        let active = true;
+
+        const run = async () => {
+            setLoading(true);
+            setFailed(false);
+            try {
+                const results = await Promise.all(
+                    ids.map((roomId) =>
+                        invoke<PricingResult>("calculate_room_price_preview", {
+                            roomId,
+                            checkIn,
+                            checkOut,
+                            pricingType: "nightly",
+                            guests,
+                        }).then((price) => [roomId, price] as const),
+                    ),
+                );
+                if (active && requestIdRef.current === requestId) {
+                    setByRoomId(Object.fromEntries(results));
+                }
+            } catch {
+                // No fallback number and no partial map. A total that silently
+                // omits one room is the same class of lie as multiplying
+                // `base_price` in JavaScript.
+                if (active && requestIdRef.current === requestId) {
+                    setByRoomId({});
+                    setFailed(true);
+                }
+            } finally {
+                if (active && requestIdRef.current === requestId) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        void run();
+
+        return () => {
+            active = false;
+        };
+    }, [checkIn, checkOut, disabled, guests, idKey]);
+
+    return { byRoomId, loading, failed };
+}
+
+/**
+ * Adds up quotes for a set of rooms.
+ *
+ * `null` when any room has not been priced, so a caller cannot render a total
+ * that quietly leaves a room out of it.
+ */
+export function sumRoomPrices(
+    roomIds: string[],
+    byRoomId: Record<string, PricingResult>,
+): number | null {
+    let total = 0;
+    for (const roomId of roomIds) {
+        const price = byRoomId[roomId];
+        if (!price) return null;
+        total += price.total;
+    }
+    return total;
+}

--- a/mhm/src/lib/timelineSelection.ts
+++ b/mhm/src/lib/timelineSelection.ts
@@ -26,6 +26,26 @@ export function addDaysIso(date: string, days: number): string {
     return localDateIso(new Date(y, m - 1, d + days));
 }
 
+// Đồng hồ địa phương kèm độ lệch: "2026-07-29T16:40:00+07:00".
+//
+// Nhận phòng vãng lai được tính tiền từ `Local::now()` ở `stay_lifecycle.rs`,
+// nên bản xem trước phải hỏi đúng thời điểm đó — không phải ngày trần (thứ mà
+// đặt phòng trước dùng). `toISOString()` không dùng được: nó quy về UTC, và ở
+// Việt Nam có bảy giờ mỗi ngày mà UTC vẫn còn là hôm qua — đủ để tra nhầm ngày
+// lễ trong `special_dates`.
+export function localRfc3339(d: Date): string {
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const offsetMinutes = -d.getTimezoneOffset();
+    const sign = offsetMinutes < 0 ? "-" : "+";
+    const abs = Math.abs(offsetMinutes);
+    const clock = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+    return `${localDateIso(d)}T${clock}${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
+}
+
+export function addDays(d: Date, days: number): Date {
+    return new Date(d.getTime() + days * 86_400_000);
+}
+
 // Ngày dạng "YYYY-MM-DD" (không giờ) được JS phân giải theo UTC — dùng nguyên
 // dạng đó (không thêm "T00:00:00") để tránh lệch ngày ở múi giờ dương như
 // Asia/Ho_Chi_Minh khi quy đổi qua toISOString(). Dùng chung cho

--- a/mhm/vitest.config.ts
+++ b/mhm/vitest.config.ts
@@ -36,5 +36,10 @@ export default defineConfig({
     include: ["tests/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
     css: false,
     reporters: ["verbose"],
+    // Pinned because the app is a Vietnamese PMS and CI runs at UTC, where the
+    // local-vs-UTC calendar-day tests stop discriminating: at +00:00 a
+    // `toISOString()` day and a local day are the same string, so a test that
+    // exists to catch that confusion would pass against the bug.
+    env: { TZ: "Asia/Ho_Chi_Minh" },
   },
 });


### PR DESCRIPTION
> **Rebuilt on current `main`.** The previous version of this branch carried a parallel pricing-preview mechanism written before `usePricePreview` and `calculate_room_price_preview` landed. Keeping both would have left two ways to ask the same question. This is the same work, rebuilt on main's, and it is two commits with no merge commit.

The number shown to a guest before a stay must come from the code that charges for it. In three places it did not.

**Price is a property of the room type**, with one deliberate exception. Recorded in `docs/architecture/core-pms-boundaries.md`.

## Backend — `dc46467`

Both preview loaders swallowed a failed `special_dates` read and priced the stay at a **0% uplift**. The lifecycle path, which actually charges, propagates. On a holiday the quote came out *below* what the desk would collect — silently, and the leniency was documented as intentional in both loaders.

It is the wrong way round. A preview is exactly where a wrong number does damage: it is read to the guest before anyone takes their money. How rarely the read can fail is not the point (WAL, 5s `busy_timeout` — a plain `SELECT` does not queue behind a writer); guessing 0% is the wrong answer to not knowing.

`FALLBACK_BASE_PRICE_SQL` gains `ORDER BY id`. Without it SQLite returns whichever row it likes, so a type whose rooms disagree about `base_price` could quote one figure and charge another across restarts.

## Frontend — `bf3fc62`

`ReservationSheet` already asks the engine. `CheckinSheet` and `GroupCheckinSheet` still multiplied `base_price × nights` in the browser — the group sheet once per room, so its total was wrong by a multiple. Both now go through `calculate_room_price_preview`.

Keyed on the **room**, not the type: `rooms.extra_person_fee` is a per-room column, and only the room-keyed preview reads the room the guest is actually getting. `useRoomPrices` is the batch form for the group sheet, which books many rooms at once and so cannot call a single-room hook in a loop.

Four defects found while wiring it up:

| | |
|---|---|
| a walk-in is charged from `Local::now()`, a reservation from bare dates | the quote must ask what the charge asks — `localRfc3339` instead of `toISOString()` |
| `GroupCheckinSheet` derived `todayStr` from the UTC day | at 02:00 in Vietnam a walk-in group read as a **reservation** and was quoted from bare dates while the backend charged it down the walk-in branch |
| both charge paths pass `guests: None` | quoting a guest count would show **more** than the desk collects — the same defect in the other direction |
| `disabled: !open` in `GroupCheckinSheet` | resolved to `window.open`, a DOM global, so it was never disabled. TypeScript accepted it |

Room pickers stop printing `base_price`: price is keyed on the type, so a per-room figure beside a quoted total is a number nobody is charged.

## Mutation evidence

Every claim was checked by breaking the code and confirming a **named** test fails, then restoring and verifying the restore byte-for-byte.

| mutation | caught by |
|---|---|
| restore either `.unwrap_or(0.0)` | `a_failed_special_date_read_fails_both_previews_…` |
| `ORDER BY id` → `ORDER BY base_price DESC` | `the_room_a_guest_is_given_does_not_change_what_the_type_costs` |
| drop `ORDER BY` entirely | same |
| restore `base_price × nights` in check-in | `shows the price the backend will charge` |
| send a guest count | `asks with no guest count, exactly as the check-in charges` |
| quote bare dates for a walk-in | `asks about the same instants the check-in will charge for` |
| `localRfc3339` → `toISOString` | `quotes against the local calendar day` |
| restore `base_price` in the picker | `does not print a per-room base price` |
| restore the group multiplication | `quotes each room through the engine` |
| `todayStr` → UTC day | `prices a 02:00 group as the walk-in the backend will charge it as` |
| `sumRoomPrices` skips an unpriced room | `refuses to total a set with an unpriced room` |
| drop the map reset on failure | `clears the previous quotes when a later lookup fails` |
| join room ids on a space | `survives a room id containing a space` |

Two of these survived the first pass and are the reason the `todayStr` branch bug and the stale-price-map bug were found at all.

`vitest.config.ts` pins `TZ=Asia/Ho_Chi_Minh`, because CI runs at UTC where a `toISOString()` day and a local day are the same string — every test above that exists to catch that confusion would pass against the bug.

## Verification

950 Rust tests · 436 frontend tests · `cargo clippy --all-targets -- -D warnings` clean · `cargo fmt --check` clean · `npm run verify:full` **exit 0** (boots the real Tauri app).

## Not fixed here

- **Walk-in check-in never charges the extra-person fee** — `stay_lifecycle.rs` and `group_lifecycle.rs` both price with `None`. This PR makes the quote match that. Whether the charge itself is right is a product question, deliberately untouched.
- **No re-quote when the local date turns.** A sheet held open from 23:50 to 00:05 still shows the previous day's quote. Pre-existing in `usePricePreview` too, so `ReservationSheet` has it as well.
- `paidAmount` accepts a deposit above the total.
- Room cards and detail panels still print `base_price` as `/đêm` — same misleading number as the pickers, but not beside a computed total, and showing a real figure there needs a quote per visible room.
