### PR TITLE
Cải thiện UX calendar đặt phòng: bar đúng ngày trả, vạch rõ, bấm/kéo để đặt

### DIFF
--- a/docs/superpowers/plans/2026-07-28-dat-phong-truoc-gia-theo-so-khach.md
+++ b/docs/superpowers/plans/2026-07-28-dat-phong-truoc-gia-theo-so-khach.md
@@ -1,0 +1,2001 @@
+# Đặt phòng trước — Giá theo số khách — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sheet "Đặt phòng trước" bấm được lịch cho ngày đi, bỏ ô Số đêm, và tính tiền phòng theo số khách qua `rooms.extra_person_fee` thay vì để người dùng bó tay với giá cứng.
+
+**Architecture:** Engine tính giá vẫn là nơi duy nhất quyết định một kỳ lưu trú giá bao nhiêu. Số khách được lưu trên booking (`bookings.guests`), luồn qua `calculate_stay_price_tx` vào `StayPricingInputs`, và biến thành một dòng phụ thu phẳng theo đêm trong `PricingResult.breakdown`. Không có cột giá đè, không có nhánh nào bỏ qua engine.
+
+**Tech Stack:** Rust + Tauri 2 + sqlx/SQLite (backend), React + TypeScript + Vite + Vitest (frontend), `cargo test` cho backend.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-dat-phong-truoc-gia-theo-so-khach-design.md`
+
+## Global Constraints
+
+- **Nhánh làm việc:** `feature/reservation-guest-pricing`, worktree `/Users/binhan/HotelManager/.worktrees/reservation-guest-pricing`. Mọi đường dẫn dưới đây tính từ gốc worktree.
+- **Tiền tệ là số nguyên VNĐ.** Kiểu `MoneyVnd = i64`. Cấm `f64` cho mọi giá trị tiền — `scripts/verify/no-float-money.mjs` quét theo tên biến và sẽ chặn.
+- **`bookings.guests` là số đếm, KHÔNG phải cột tiền.** Không đăng ký nó vào `MONEY_COLUMNS` / `MONEY_TABLES` trong `mhm/src-tauri/src/money_migration.rs`, cũng không thêm vào danh sách trong `scripts/verify/no-float-money.mjs`.
+- **Phụ thu thêm người không bị nhân %.** Nó nằm ngoài `base_amount`, nên `weekend_uplift_pct` và uplift ngày lễ không chạm tới.
+- **Booking cũ không được đổi giá.** `guests` rỗng ⇒ phụ thu bằng 0 ⇒ tổng đúng bằng kết quả trước khi làm việc này.
+- **Số khách không có trần.** `rooms.max_guests` là mốc tính giá base, không phải sức chứa.
+- **Rust build phải sạch dưới `-D warnings`.** Dự án bật cảnh báo thành lỗi.
+- Chạy lệnh Rust từ `mhm/src-tauri/`, lệnh npm từ `mhm/`.
+
+---
+
+### Task 1: Engine biết tính phụ thu thêm người
+
+Đây là task nền. Nó đổi chữ ký `calculate_stay_price_tx`, nên cả sáu nơi gọi phải sửa theo trong cùng task này để cây build còn xanh — nhưng tất cả đều truyền `None`, tức **không đổi hành vi**. Giá trị thật đến ở Task 2–5.
+
+**Files:**
+- Modify: `mhm/src-tauri/src/domain/booking/pricing.rs`
+- Modify: `mhm/src-tauri/src/queries/booking/pricing_queries.rs`
+- Modify: `mhm/src-tauri/src/services/booking/pricing_service.rs:26-50`
+- Modify: `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs:240,609,758`
+- Modify: `mhm/src-tauri/src/services/booking/stay_lifecycle.rs:318,680,1074`
+- Modify: `mhm/src-tauri/src/services/booking/group_lifecycle.rs:441`
+- Modify: `mhm/src-tauri/src/commands/pricing.rs:96-116`
+- Test: `mhm/src-tauri/src/domain/booking/pricing.rs` (khối `#[cfg(test)] mod tests` sẵn có)
+
+**Interfaces:**
+- Consumes: không có (task đầu).
+- Produces:
+  - `StayPricingInputs` thêm ba trường: `guests: Option<i32>`, `base_guests: i32`, `extra_person_fee: MoneyVnd`
+  - `pricing_service::calculate_stay_price_tx(tx, room_id: &str, check_in: &str, check_out: &str, pricing_type: &str, guests: Option<i32>) -> BookingResult<PricingResult>`
+  - `pricing_service::calculate_price_preview(pool, room_type: &str, check_in: &str, check_out: &str, pricing_type: &str, guests: Option<i32>) -> BookingResult<PricingResult>`
+  - `queries::booking::pricing_queries::load_stay_pricing_inputs_tx(tx, room_id, check_in, check_out, pricing_type, guests: Option<i32>)`
+  - `queries::booking::pricing_queries::load_stay_pricing_inputs_for_room_type(pool, room_type, check_in, check_out, pricing_type, guests: Option<i32>)`
+
+- [ ] **Step 1: Viết test thất bại cho phần tính phụ thu**
+
+Trong `mhm/src-tauri/src/domain/booking/pricing.rs`, sửa `sample_inputs()` trong `mod tests` để có ba trường mới, rồi thêm bốn test.
+
+Sửa helper sẵn có (khoảng dòng 101):
+
+```rust
+    fn sample_inputs() -> StayPricingInputs {
+        StayPricingInputs {
+            room_type: "standard".to_string(),
+            stored_rule: None,
+            fallback_base_price: None,
+            special_uplift_pct: 0.0,
+            check_in: "2026-04-20".to_string(),
+            check_out: "2026-04-22".to_string(),
+            pricing_type: "nightly".to_string(),
+            guests: None,
+            base_guests: 2,
+            extra_person_fee: 0,
+        }
+    }
+```
+
+Thêm vào cuối `mod tests`:
+
+```rust
+    /// 500.000₫ × 2 đêm = 1.000.000₫, cộng 2 khách vượt mốc × 50.000₫ × 2 đêm.
+    /// Đây đúng con số người dùng mô tả: 600.000₫/đêm cho 4 khách.
+    #[test]
+    fn calculate_from_loaded_inputs_adds_flat_extra_guest_line() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = Some(4);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.base_amount, 1_000_000);
+        assert_eq!(pricing.total, 1_200_000);
+        assert_eq!(pricing.breakdown.len(), 2);
+        assert_eq!(pricing.breakdown[1].label, "Phụ thu 2 khách");
+        assert_eq!(pricing.breakdown[1].amount, 200_000);
+    }
+
+    #[test]
+    fn calculate_from_loaded_inputs_charges_nothing_within_base_guests() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = Some(2);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.total, 1_000_000);
+        assert_eq!(pricing.breakdown.len(), 1);
+    }
+
+    /// Booking cũ: cột `guests` rỗng ⇒ giá y hệt trước khi có tính năng này.
+    /// Phòng chưa khai phụ thu ⇒ số khách bao nhiêu cũng không đổi giá.
+    #[test]
+    fn calculate_from_loaded_inputs_charges_nothing_when_fee_is_zero() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = Some(6);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 0;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.total, 1_000_000);
+        assert_eq!(pricing.breakdown.len(), 1);
+    }
+
+    #[test]
+    fn calculate_from_loaded_inputs_ignores_extra_fee_when_guests_unknown() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = None;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.total, 1_000_000);
+        assert_eq!(pricing.breakdown.len(), 1);
+    }
+
+    /// Phụ thu là khoản phẳng: uplift ngày lễ chỉ ăn vào `base_amount`,
+    /// không nhân lên phần thêm người.
+    #[test]
+    fn extra_guest_line_is_not_multiplied_by_uplift() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.special_uplift_pct = 10.0;
+        inputs.guests = Some(3);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.base_amount, 1_000_000);
+        assert_eq!(pricing.surcharge_amount, 100_000);
+        assert_eq!(pricing.total, 1_200_000);
+        assert_eq!(pricing.breakdown[2].amount, 100_000);
+    }
+```
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+Chạy từ `mhm/src-tauri/`:
+
+```bash
+cargo test --lib domain::booking::pricing
+```
+
+Kỳ vọng: **FAIL** khi biên dịch, báo `struct StayPricingInputs has no field named guests`.
+
+- [ ] **Step 3: Thêm ba trường vào `StayPricingInputs`**
+
+Trong `mhm/src-tauri/src/domain/booking/pricing.rs`, sửa struct ở dòng 14:
+
+```rust
+/// Everything the pricing rules need, already read out of the database.
+#[derive(Debug, Clone)]
+pub(crate) struct StayPricingInputs {
+    pub(crate) room_type: String,
+    pub(crate) stored_rule: Option<StoredPricingRule>,
+    pub(crate) fallback_base_price: Option<MoneyVnd>,
+    pub(crate) special_uplift_pct: f64,
+    pub(crate) check_in: String,
+    pub(crate) check_out: String,
+    pub(crate) pricing_type: String,
+    /// Số khách trên booking. `None` là booking chưa khai số khách — booking cũ,
+    /// hoặc một nơi gọi không quan tâm — và có nghĩa là không phụ thu.
+    pub(crate) guests: Option<i32>,
+    /// `rooms.max_guests`: số khách đã nằm trong giá base.
+    pub(crate) base_guests: i32,
+    /// `rooms.extra_person_fee`: phụ thu mỗi khách vượt mốc, mỗi đêm.
+    pub(crate) extra_person_fee: MoneyVnd,
+}
+```
+
+- [ ] **Step 4: Viết phần tính phụ thu**
+
+Trong cùng file, thêm `use chrono::NaiveDate;` vào đầu file (cạnh `use super::{BookingError, BookingResult};`), rồi thay hàm `calculate_from_loaded_inputs` ở dòng 78 và thêm hai hàm phụ ngay trên nó:
+
+```rust
+/// Số đêm giữa hai mốc, chấp nhận cả `YYYY-MM-DD` lẫn RFC3339 (cắt 10 ký tự đầu).
+/// Trả 0 khi ngày đi không sau ngày đến — đúng lúc `calculate_price` cũng trả 0.
+fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
+    let parse = |value: &str| {
+        let head = &value[..value.len().min(10)];
+        NaiveDate::parse_from_str(head, "%Y-%m-%d")
+            .map_err(|error| BookingError::datetime_parse(error.to_string()))
+    };
+    Ok((parse(check_out)? - parse(check_in)?).num_days().max(0))
+}
+
+/// Phụ thu thêm người: khoản phẳng theo đêm.
+///
+/// Cố ý **không** đi qua `percentage_money_line` và cố ý nằm ngoài `base_amount`,
+/// nên uplift cuối tuần / ngày lễ không nhân lên nó. Thêm một người là thêm một
+/// khoản cố định, giải thích với khách được và dò ngược trên hoá đơn được.
+fn extra_guest_charge(inputs: &StayPricingInputs, nights: i64) -> BookingResult<(i64, MoneyVnd)> {
+    let Some(guests) = inputs.guests else {
+        return Ok((0, 0));
+    };
+    let extra_guests = i64::from(guests.saturating_sub(inputs.base_guests)).max(0);
+    if extra_guests == 0 || inputs.extra_person_fee <= 0 || nights <= 0 {
+        return Ok((0, 0));
+    }
+
+    let amount = inputs
+        .extra_person_fee
+        .checked_mul(extra_guests)
+        .and_then(|per_night| per_night.checked_mul(nights))
+        .ok_or_else(|| {
+            BookingError::validation("extra guest charge overflowed MoneyVnd".to_string())
+        })?;
+
+    Ok((extra_guests, amount))
+}
+
+pub(crate) fn calculate_from_loaded_inputs(
+    inputs: &StayPricingInputs,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let rule = build_effective_pricing_rule(inputs);
+
+    let mut result = crate::pricing::calculate_price(
+        &rule,
+        &inputs.check_in,
+        &inputs.check_out,
+        &inputs.pricing_type,
+        inputs.special_uplift_pct,
+    )
+    .map_err(BookingError::datetime_parse)?;
+
+    let nights = nights_between(&inputs.check_in, &inputs.check_out)?;
+    let (extra_guests, extra_amount) = extra_guest_charge(inputs, nights)?;
+    if extra_amount > 0 {
+        result.breakdown.push(crate::pricing::PricingLine {
+            label: format!("Phụ thu {} khách", extra_guests),
+            amount: extra_amount,
+        });
+        result.total = result.total.checked_add(extra_amount).ok_or_else(|| {
+            BookingError::validation("stay total overflowed MoneyVnd".to_string())
+        })?;
+    }
+
+    Ok(result)
+}
+```
+
+- [ ] **Step 5: Luồn `guests` qua tầng nạp dữ liệu**
+
+Trong `mhm/src-tauri/src/queries/booking/pricing_queries.rs`, thêm câu lệnh và hàm đọc thông tin khách của phòng. Đặt hằng cạnh `FALLBACK_BASE_PRICE_SQL` (dòng 25):
+
+```rust
+const ROOM_GUEST_PRICING_SQL: &str =
+    "SELECT COALESCE(max_guests, 2) AS max_guests,
+            COALESCE(extra_person_fee, 0) AS extra_person_fee
+     FROM rooms WHERE id = ?";
+
+const ROOM_GUEST_PRICING_BY_TYPE_SQL: &str =
+    "SELECT COALESCE(max_guests, 2) AS max_guests,
+            COALESCE(extra_person_fee, 0) AS extra_person_fee
+     FROM rooms WHERE LOWER(type) = ? LIMIT 1";
+
+/// Mốc tính giá của một phòng. Phòng không tìm thấy thì dùng mặc định của schema
+/// (`max_guests` mặc định 2, `extra_person_fee` mặc định 0) — tức không phụ thu.
+struct RoomGuestPricing {
+    base_guests: i32,
+    extra_person_fee: MoneyVnd,
+}
+
+impl Default for RoomGuestPricing {
+    fn default() -> Self {
+        Self {
+            base_guests: 2,
+            extra_person_fee: 0,
+        }
+    }
+}
+
+fn room_guest_pricing_from_row(row: &sqlx::sqlite::SqliteRow) -> RoomGuestPricing {
+    RoomGuestPricing {
+        base_guests: row.get("max_guests"),
+        extra_person_fee: get_money_vnd(row, "extra_person_fee"),
+    }
+}
+
+async fn load_room_guest_pricing_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_id: &str,
+) -> BookingResult<RoomGuestPricing> {
+    let row = sqlx::query(ROOM_GUEST_PRICING_SQL)
+        .bind(room_id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row
+        .as_ref()
+        .map(room_guest_pricing_from_row)
+        .unwrap_or_default())
+}
+
+async fn load_room_guest_pricing_for_type(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+) -> BookingResult<RoomGuestPricing> {
+    let row = sqlx::query(ROOM_GUEST_PRICING_BY_TYPE_SQL)
+        .bind(room_type.to_lowercase())
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row
+        .as_ref()
+        .map(room_guest_pricing_from_row)
+        .unwrap_or_default())
+}
+```
+
+Sửa `load_stay_pricing_inputs_tx` (dòng 88) — thêm tham số `guests` và ba trường mới:
+
+```rust
+pub(crate) async fn load_stay_pricing_inputs_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<StayPricingInputs> {
+    let room_type = load_room_type_tx(tx, room_id).await?;
+    let stored_rule = load_stored_pricing_rule_tx(tx, &room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price_tx(tx, &room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift_tx(tx, check_in).await?;
+    let guest_pricing = load_room_guest_pricing_tx(tx, room_id).await?;
+
+    Ok(StayPricingInputs {
+        room_type,
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+        guests,
+        base_guests: guest_pricing.base_guests,
+        extra_person_fee: guest_pricing.extra_person_fee,
+    })
+}
+```
+
+Sửa `load_stay_pricing_inputs_for_room_type` (dòng 123) y hệt, chỉ khác nguồn:
+
+```rust
+pub(crate) async fn load_stay_pricing_inputs_for_room_type(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<StayPricingInputs> {
+    let stored_rule = load_stored_pricing_rule(pool, room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price(pool, room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+    let guest_pricing = load_room_guest_pricing_for_type(pool, room_type).await?;
+
+    Ok(StayPricingInputs {
+        room_type: room_type.to_string(),
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+        guests,
+        base_guests: guest_pricing.base_guests,
+        extra_person_fee: guest_pricing.extra_person_fee,
+    })
+}
+```
+
+Trong `mhm/src-tauri/src/services/booking/pricing_service.rs`, thêm tham số cho hai hàm (dòng 26 và 40):
+
+```rust
+pub async fn calculate_stay_price_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let inputs =
+        load_stay_pricing_inputs_tx(tx, room_id, check_in, check_out, pricing_type, guests).await?;
+    calculate_from_loaded_inputs(&inputs)
+}
+
+pub async fn calculate_price_preview(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let inputs = load_stay_pricing_inputs_for_room_type(
+        pool,
+        room_type,
+        check_in,
+        check_out,
+        pricing_type,
+        guests,
+    )
+    .await?;
+    calculate_from_loaded_inputs(&inputs)
+}
+```
+
+- [ ] **Step 6: Cập nhật mọi nơi gọi, truyền `None`**
+
+Thêm `None,` làm tham số cuối ở từng chỗ sau. Không đổi gì khác — hành vi giữ nguyên tuyệt đối.
+
+| File | Dòng | Hàm chứa nó |
+|---|---|---|
+| `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs` | 240 | `create_reservation_tx` |
+| `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs` | 609 | `confirm_reservation_tx` |
+| `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs` | 758 | `modify_reservation_tx` |
+| `mhm/src-tauri/src/services/booking/stay_lifecycle.rs` | 318 | `check_in_tx` |
+| `mhm/src-tauri/src/services/booking/stay_lifecycle.rs` | 680 | `preview_checkout_settlement_tx` |
+| `mhm/src-tauri/src/services/booking/stay_lifecycle.rs` | 1074 | `extend_stay_tx` |
+| `mhm/src-tauri/src/services/booking/group_lifecycle.rs` | 441 | check-in theo đoàn |
+| `mhm/src-tauri/src/commands/pricing.rs` | 103 | `do_calculate_price_preview` |
+
+Ví dụ, `reservation_lifecycle.rs:240` thành:
+
+```rust
+    let pricing = calculate_stay_price_tx(
+        tx,
+        &req.room_id,
+        &req.check_in_date,
+        &req.check_out_date,
+        "nightly",
+        None,
+    )
+    .await?;
+```
+
+Các test sẵn có trong `mhm/src-tauri/src/services/booking/tests/pricing.rs` gọi trực tiếp `calculate_stay_price_tx` cũng phải thêm `None`.
+
+- [ ] **Step 7: Chạy test, kỳ vọng xanh**
+
+```bash
+cargo test --lib domain::booking::pricing
+```
+
+Kỳ vọng: **PASS**, cả bốn test mới.
+
+```bash
+cargo test --lib services::booking::tests::pricing
+```
+
+Kỳ vọng: **PASS** — mọi test giá cũ giữ nguyên con số, chứng minh truyền `None` không đổi hành vi.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mhm/src-tauri/src/domain/booking/pricing.rs mhm/src-tauri/src/queries/booking/pricing_queries.rs mhm/src-tauri/src/services/booking/ mhm/src-tauri/src/commands/pricing.rs
+git commit -m "feat(pricing): teach the engine a flat extra-guest charge"
+```
+
+---
+
+### Task 2: Cột `bookings.guests` và đường tạo đặt phòng
+
+**Files:**
+- Modify: `mhm/src-tauri/src/db/core_extensions.rs` (thêm `migrate_v22_booking_guest_count`)
+- Modify: `mhm/src-tauri/src/db.rs:310-313` (bậc thang migration)
+- Modify: `mhm/src-tauri/src/models.rs:490-501` (`CreateReservationRequest`)
+- Modify: `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs:209-290` (`create_reservation_tx`)
+- Test: `mhm/src-tauri/src/services/booking/tests/reservations.rs`
+- Test: `mhm/src-tauri/src/services/booking/tests/support/seed.rs` (thêm seeder)
+
+**Interfaces:**
+- Consumes: `calculate_stay_price_tx(..., guests: Option<i32>)` từ Task 1.
+- Produces:
+  - Cột `bookings.guests INTEGER` (cho phép NULL)
+  - `CreateReservationRequest.guests: Option<i32>`
+  - Test seeder `seed_room_with_guest_pricing(pool, room_id, base_price, max_guests, extra_person_fee)`
+
+- [ ] **Step 1: Viết test thất bại**
+
+Thêm seeder vào `mhm/src-tauri/src/services/booking/tests/support/seed.rs`:
+
+```rust
+/// Phòng có mốc tính giá theo số khách: `max_guests` là số khách nằm trong giá
+/// base, `extra_person_fee` là phụ thu mỗi khách vượt mốc mỗi đêm.
+pub async fn seed_room_with_guest_pricing(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    base_price: MoneyVnd,
+    max_guests: i32,
+    extra_person_fee: MoneyVnd,
+) -> BookingResult<()> {
+    sqlx::query(
+        "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+         VALUES (?, ?, ?, ?, 0, ?, ?, ?, 'vacant')",
+    )
+    .bind(room_id)
+    .bind(format!("Room {}", room_id))
+    .bind("standard")
+    .bind(1_i32)
+    .bind(base_price)
+    .bind(max_guests)
+    .bind(extra_person_fee)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+```
+
+Thêm test vào cuối `mhm/src-tauri/src/services/booking/tests/reservations.rs`:
+
+```rust
+#[tokio::test]
+async fn create_reservation_charges_extra_guests() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R300", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R300".to_string(),
+            guest_name: "Nguyễn Nhật Huy".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: Some("phone".to_string()),
+            notes: None,
+            guests: Some(4),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let row = sqlx::query("SELECT total_price, guests FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<i64, _>("total_price"), 1_200_000);
+    assert_eq!(row.get::<Option<i32>, _>("guests"), Some(4));
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn create_reservation_without_guests_prices_like_before() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R301", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R301".to_string(),
+            guest_name: "Khách cũ".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: None,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+
+    assert_eq!(total, 1_000_000);
+
+    tx.rollback().await.unwrap();
+}
+```
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+```bash
+cargo test --lib services::booking::tests::reservations::create_reservation_charges_extra_guests
+```
+
+Kỳ vọng: **FAIL** khi biên dịch, báo `struct CreateReservationRequest has no field named guests`.
+
+- [ ] **Step 3: Thêm migration v22**
+
+Trong `mhm/src-tauri/src/db/core_extensions.rs`, thêm vào cuối file:
+
+```rust
+/// Số khách trên booking. Là **số đếm, không phải tiền** — cố ý đứng ngoài
+/// `money_migration`, và tên cột cố ý không chứa từ khoá tiền tệ nào.
+///
+/// Cho phép NULL: booking tạo trước phiên bản này không khai số khách, và NULL
+/// có nghĩa là không phụ thu, nên giá của chúng không đổi.
+pub(super) async fn migrate_v22_booking_guest_count(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    execute_compat_alter(&mut tx, "ALTER TABLE bookings ADD COLUMN guests INTEGER").await?;
+
+    set_schema_version(&mut tx, 22).await?;
+    tx.commit().await?;
+    Ok(())
+}
+```
+
+Trong `mhm/src-tauri/src/db.rs`, thêm ngay sau khối `if current < 21 { … }` (dòng 310-312), trước `Ok(())`:
+
+```rust
+    // -- V22: số khách trên booking, để tính phụ thu thêm người --
+    if current < 22 {
+        core_extensions::migrate_v22_booking_guest_count(pool).await?;
+    }
+```
+
+- [ ] **Step 4: Thêm trường vào request và lưu nó**
+
+Trong `mhm/src-tauri/src/models.rs`, sửa struct ở dòng 490:
+
+```rust
+pub struct CreateReservationRequest {
+    pub room_id: String,
+    pub guest_name: String,
+    pub guest_phone: Option<String>,
+    pub guest_doc_number: Option<String>,
+    pub check_in_date: String,
+    pub check_out_date: String,
+    pub nights: i32,
+    pub deposit_amount: Option<MoneyVnd>,
+    pub source: Option<String>,
+    pub notes: Option<String>,
+    /// Số khách ở thực tế. `None` ⇒ không phụ thu, giá giữ nguyên như cũ.
+    /// Kiểu `Option` để gateway và agent không phải sửa theo.
+    pub guests: Option<i32>,
+}
+```
+
+Trong `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs`, hàm `create_reservation_tx`: đổi lời gọi giá ở dòng 240 từ `None` sang `req.guests`, và thêm cột `guests` vào câu INSERT.
+
+```rust
+    let pricing = calculate_stay_price_tx(
+        tx,
+        &req.room_id,
+        &req.check_in_date,
+        &req.check_out_date,
+        "nightly",
+        req.guests,
+    )
+    .await?;
+```
+
+Câu INSERT (dòng 262-267) thêm `guests` vào danh sách cột và một `?` nữa vào `VALUES`:
+
+```rust
+    sqlx::query(
+        "INSERT INTO bookings (
+            id, room_id, primary_guest_id, check_in_at, expected_checkout, actual_checkout,
+            nights, total_price, paid_amount, status, source, notes, created_by,
+            booking_type, pricing_type, deposit_amount, guest_phone, scheduled_checkin,
+            scheduled_checkout, pricing_snapshot, guests, created_at
+         ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, 0, ?, ?, ?, NULL, 'reservation', 'nightly', ?, ?, ?, ?, NULL, ?, ?)",
+    )
+```
+
+và thêm `.bind(req.guests)` **ngay trước** `.bind(&now)` ở cuối chuỗi bind, khớp đúng thứ tự cột.
+
+- [ ] **Step 5: Chạy test, kỳ vọng xanh**
+
+```bash
+cargo test --lib services::booking::tests::reservations
+```
+
+Kỳ vọng: **PASS**, cả hai test mới.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mhm/src-tauri/src/db/core_extensions.rs mhm/src-tauri/src/db.rs mhm/src-tauri/src/models.rs mhm/src-tauri/src/services/booking/
+git commit -m "feat(reservations): store a guest count and price the reservation with it"
+```
+
+---
+
+### Task 3: Giữ số khách khi sửa đặt phòng và khi khách nhận phòng
+
+Đây là hai trong ba chỗ rò giá mà spec nêu. Không có task này, khách đặt 4 người sẽ tụt về giá 2 người ngay khi dời ngày hoặc nhận phòng.
+
+**Files:**
+- Modify: `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs:1043-1080` (`load_booked_reservation`), `:1103-1108` (`BookedReservation`), `:609` (confirm), `:758` (modify)
+- Modify: `mhm/src-tauri/src/models.rs:503-509` (`ModifyReservationRequest`)
+- Test: `mhm/src-tauri/src/services/booking/tests/reservations.rs`
+
+**Interfaces:**
+- Consumes: cột `bookings.guests`, `CreateReservationRequest.guests` từ Task 2.
+- Produces: `ModifyReservationRequest.new_guests: Option<i32>`; `BookedReservation.guests: Option<i32>`.
+
+- [ ] **Step 1: Viết test thất bại**
+
+Thêm vào `mhm/src-tauri/src/services/booking/tests/reservations.rs`:
+
+```rust
+#[tokio::test]
+async fn modify_reservation_keeps_the_extra_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R310", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R310".to_string(),
+            guest_name: "Nguyễn Nhật Huy".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: Some(4),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Dời sang 3 đêm, không nói gì về số khách.
+    let booking = reservation_lifecycle::modify_reservation_tx(
+        &mut tx,
+        ModifyReservationRequest {
+            booking_id: booking_id.clone(),
+            new_check_in_date: "2026-08-10".to_string(),
+            new_check_out_date: "2026-08-13".to_string(),
+            new_nights: 3,
+            new_guests: None,
+        },
+        "R310",
+    )
+    .await
+    .unwrap();
+
+    // 600.000₫/đêm × 3 đêm — không tụt về 500.000₫.
+    assert_eq!(booking.total_price, 1_800_000);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn confirm_reservation_keeps_the_extra_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R311", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let today = Local::now().date_naive();
+    let check_in = today.format("%Y-%m-%d").to_string();
+    let check_out = (today + Duration::days(2)).format("%Y-%m-%d").to_string();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R311".to_string(),
+            guest_name: "Nguyễn Nhật Huy".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: check_in,
+            check_out_date: check_out,
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: Some(4),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let booking = reservation_lifecycle::confirm_reservation_tx(&mut tx, &booking_id, "R311", None)
+        .await
+        .unwrap();
+
+    assert_eq!(booking.total_price, 1_200_000);
+
+    tx.rollback().await.unwrap();
+}
+```
+
+Thêm `ModifyReservationRequest` vào danh sách `models::{…}` trong khối `prelude` của `mhm/src-tauri/src/services/booking/tests/mod.rs`.
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+```bash
+cargo test --lib services::booking::tests::reservations::modify_reservation_keeps_the_extra_guest_charge
+```
+
+Kỳ vọng: **FAIL** khi biên dịch, báo `struct ModifyReservationRequest has no field named new_guests`.
+
+- [ ] **Step 3: Cho `BookedReservation` mang theo số khách**
+
+Trong `mhm/src-tauri/src/services/booking/reservation_lifecycle.rs`, sửa struct ở dòng 1103:
+
+```rust
+struct BookedReservation {
+    room_id: String,
+    paid_amount: MoneyVnd,
+    scheduled_checkout: String,
+    pricing_type: String,
+    guests: Option<i32>,
+}
+```
+
+Sửa `load_booked_reservation` (dòng 1043): thêm `guests` vào câu SELECT và vào struct trả về.
+
+```rust
+    let row = sqlx::query(
+        "SELECT room_id, status, paid_amount, scheduled_checkout, pricing_type, guests
+         FROM bookings
+         WHERE id = ?",
+    )
+```
+
+```rust
+    Ok(BookedReservation {
+        room_id: row.get("room_id"),
+        paid_amount: read_money_vnd_or_zero(&row, "paid_amount"),
+        scheduled_checkout,
+        pricing_type: row
+            .get::<Option<String>, _>("pricing_type")
+            .unwrap_or_else(|| "nightly".to_string()),
+        guests: row.get("guests"),
+    })
+}
+```
+
+- [ ] **Step 4: Truyền số khách vào hai chỗ tính giá**
+
+`confirm_reservation_tx`, dòng 609 — đổi `None` thành `reservation.guests`:
+
+```rust
+    let pricing = calculate_stay_price_tx(
+        tx,
+        &reservation.room_id,
+        &today.format("%Y-%m-%d").to_string(),
+        &effective_checkout,
+        &reservation.pricing_type,
+        reservation.guests,
+    )
+    .await?;
+```
+
+Trong `mhm/src-tauri/src/models.rs`, sửa struct ở dòng 503:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ModifyReservationRequest {
+    pub booking_id: String,
+    pub new_check_in_date: String,
+    pub new_check_out_date: String,
+    pub new_nights: i32,
+    /// `None` ⇒ giữ nguyên số khách đang lưu. Đây **không** phải lệnh xoá:
+    /// muốn bỏ phụ thu thì gửi số khách mới nhỏ hơn hoặc bằng `max_guests`.
+    pub new_guests: Option<i32>,
+}
+```
+
+`modify_reservation_tx`, dòng 758 — dùng số khách mới nếu có, không thì giữ số đang lưu, rồi ghi lại vào cột:
+
+```rust
+    let effective_guests = req.new_guests.or(reservation.guests);
+    let pricing = calculate_stay_price_tx(
+        tx,
+        &reservation.room_id,
+        &req.new_check_in_date,
+        &req.new_check_out_date,
+        &reservation.pricing_type,
+        effective_guests,
+    )
+    .await?;
+    let total_price = pricing.total;
+```
+
+Câu UPDATE ngay dưới (dòng 770) thêm `guests = ?`:
+
+```rust
+    let result = sqlx::query(
+        "UPDATE bookings
+         SET check_in_at = ?, expected_checkout = ?, scheduled_checkin = ?, scheduled_checkout = ?, nights = ?, total_price = ?, guests = ?
+         WHERE id = ? AND status = ? AND room_id = ?",
+    )
+```
+
+và thêm `.bind(effective_guests)` ngay sau `.bind(total_price)`.
+
+- [ ] **Step 5: Chạy test, kỳ vọng xanh**
+
+```bash
+cargo test --lib services::booking::tests::reservations
+```
+
+Kỳ vọng: **PASS**.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mhm/src-tauri/src/models.rs mhm/src-tauri/src/services/booking/
+git commit -m "fix(reservations): stop modify and check-in from dropping the guest charge"
+```
+
+---
+
+### Task 4: Giữ số khách khi gia hạn và khi trả phòng sớm
+
+Chỗ rò thứ tư và thứ năm. Hai chỗ này rò cùng một hướng: đều tính thiếu tiền của chủ khách sạn.
+
+**Files:**
+- Modify: `mhm/src-tauri/src/services/booking/stay_lifecycle.rs:645-652` (SELECT của settlement), `:680`
+- Modify: `mhm/src-tauri/src/services/booking/stay_lifecycle.rs:1010-1013` (SELECT của extend), `:1074`
+- Test: `mhm/src-tauri/src/services/booking/tests/extend_stay.rs`, `mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs`
+
+**Interfaces:**
+- Consumes: cột `bookings.guests`, `calculate_stay_price_tx(…, guests)`.
+- Produces: không có API mới.
+
+- [ ] **Step 1: Viết test thất bại cho gia hạn**
+
+Thêm vào `mhm/src-tauri/src/services/booking/tests/extend_stay.rs`:
+
+```rust
+#[tokio::test]
+async fn extend_stay_prices_the_extra_night_with_the_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R320", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+    let booking_id = uuid::Uuid::new_v4().to_string();
+    seed_active_booking(&pool, &booking_id, "R320").await.unwrap();
+
+    sqlx::query("UPDATE bookings SET guests = 4, total_price = 1200000, nights = 2 WHERE id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let booking = stay_lifecycle::extend_stay(&pool, &booking_id).await.unwrap();
+
+    // 1.200.000₫ cũ + 600.000₫ cho đêm thêm, không phải + 500.000₫.
+    assert_eq!(booking.total_price, 1_800_000);
+}
+```
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+```bash
+cargo test --lib services::booking::tests::extend_stay::extend_stay_prices_the_extra_night_with_the_guest_charge
+```
+
+Kỳ vọng: **FAIL** với `assertion `left == right` failed: left: 1700000, right: 1800000` — đêm thêm bị tính 500.000₫.
+
+- [ ] **Step 3: Sửa đường gia hạn**
+
+Trong `mhm/src-tauri/src/services/booking/stay_lifecycle.rs`, câu SELECT của `extend_stay_tx` (dòng 1010) thêm `guests`:
+
+```rust
+    let booking = sqlx::query(
+        "SELECT room_id, nights, total_price, expected_checkout, pricing_type, guests, status
+         FROM bookings WHERE id = ?",
+    )
+```
+
+Sau dòng đọc `pricing_type` (khoảng dòng 1040), thêm:
+
+```rust
+    let guests: Option<i32> = booking.get("guests");
+```
+
+Lời gọi giá ở dòng 1074 đổi `None` thành `guests`:
+
+```rust
+    let incremental_pricing = calculate_stay_price_tx(
+        tx,
+        &room_id,
+        &old_expected_checkout,
+        &new_expected.to_rfc3339(),
+        &pricing_type,
+        guests,
+    )
+    .await?;
+```
+
+- [ ] **Step 4: Chạy test gia hạn, kỳ vọng xanh**
+
+```bash
+cargo test --lib services::booking::tests::extend_stay
+```
+
+Kỳ vọng: **PASS**.
+
+- [ ] **Step 5: Viết test thất bại cho trả phòng sớm**
+
+Thêm vào `mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs`:
+
+```rust
+#[tokio::test]
+async fn actual_nights_settlement_keeps_the_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R330", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+    let booking_id = uuid::Uuid::new_v4().to_string();
+    seed_active_booking(&pool, &booking_id, "R330").await.unwrap();
+
+    let check_in = Local::now() - Duration::days(2);
+    sqlx::query(
+        "UPDATE bookings SET guests = 4, nights = 3, total_price = 1800000, check_in_at = ? WHERE id = ?",
+    )
+    .bind(check_in.to_rfc3339())
+    .bind(&booking_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let settlement = stay_lifecycle::preview_checkout_settlement(
+        &pool,
+        &CheckoutSettlementPreviewRequest {
+            booking_id: booking_id.clone(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Ở 2 đêm thật × 600.000₫, không phải × 500.000₫.
+    assert_eq!(settlement.recommended_total, 1_200_000);
+}
+```
+
+- [ ] **Step 6: Chạy test để xác nhận nó hỏng**
+
+```bash
+cargo test --lib services::booking::tests::checkout_settlement::actual_nights_settlement_keeps_the_guest_charge
+```
+
+Kỳ vọng: **FAIL** với `left: 1000000, right: 1200000`.
+
+- [ ] **Step 7: Sửa đường trả phòng sớm**
+
+Câu SELECT của `preview_checkout_settlement_tx` (dòng 645) thêm `guests`:
+
+```rust
+    let booking = sqlx::query(
+        "SELECT room_id, check_in_at, nights, total_price, paid_amount,
+                COALESCE(pricing_type, 'nightly') AS pricing_type, guests, status
+         FROM bookings WHERE id = ?",
+    )
+```
+
+Sau dòng `let original_total = read_money_vnd_or_zero(&booking, "total_price");` (khoảng dòng 673), thêm:
+
+```rust
+    let guests: Option<i32> = booking.get("guests");
+```
+
+Lời gọi giá ở dòng 680 đổi `None` thành `guests`:
+
+```rust
+            let pricing = calculate_stay_price_tx(
+                tx,
+                &room_id,
+                &check_in_at,
+                &settlement_boundary,
+                &pricing_type,
+                guests,
+            )
+            .await?;
+```
+
+- [ ] **Step 8: Chạy toàn bộ test backend, kỳ vọng xanh**
+
+```bash
+cargo test --lib services::booking
+```
+
+Kỳ vọng: **PASS** toàn bộ.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mhm/src-tauri/src/services/booking/
+git commit -m "fix(stays): keep the guest charge through extend-stay and early checkout"
+```
+
+---
+
+### Task 5: Xem trước giá theo mã phòng
+
+Form cần một con số **giống hệt** con số sẽ ghi vào sổ. Đường xem trước hiện tra theo *loại phòng*, mà phụ thu lại là thuộc tính của *từng phòng*.
+
+**Files:**
+- Modify: `mhm/src-tauri/src/queries/booking/pricing_queries.rs` (thêm `load_stay_pricing_inputs_for_room`)
+- Modify: `mhm/src-tauri/src/services/booking/pricing_service.rs` (thêm `calculate_room_price_preview`)
+- Modify: `mhm/src-tauri/src/commands/pricing.rs` (thêm lệnh Tauri)
+- Modify: `mhm/src-tauri/src/lib.rs:393` (đăng ký lệnh)
+- Test: `mhm/src-tauri/src/services/booking/tests/pricing.rs`
+
+**Interfaces:**
+- Consumes: `load_room_guest_pricing_tx` và `StayPricingInputs` từ Task 1.
+- Produces: lệnh Tauri `calculate_room_price_preview(room_id, check_in, check_out, pricing_type, guests)` trả `PricingResult` — Task 8 gọi nó.
+
+- [ ] **Step 1: Viết test thất bại**
+
+Thêm vào `mhm/src-tauri/src/services/booking/tests/pricing.rs`:
+
+```rust
+#[tokio::test]
+async fn room_price_preview_matches_what_the_reservation_will_be_charged() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R340", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let preview = pricing_service::calculate_room_price_preview(
+        &pool,
+        "R340",
+        "2026-08-06",
+        "2026-08-08",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.total, 1_200_000);
+    assert_eq!(preview.breakdown.len(), 2);
+    assert_eq!(preview.breakdown[1].label, "Phụ thu 2 khách");
+}
+```
+
+Thêm `pricing_service` vào danh sách `services::booking::{…}` trong `prelude` của `mhm/src-tauri/src/services/booking/tests/mod.rs`.
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+```bash
+cargo test --lib services::booking::tests::pricing::room_price_preview_matches_what_the_reservation_will_be_charged
+```
+
+Kỳ vọng: **FAIL** khi biên dịch, `cannot find function calculate_room_price_preview`.
+
+- [ ] **Step 3: Thêm hàm nạp inputs theo mã phòng**
+
+Trong `mhm/src-tauri/src/queries/booking/pricing_queries.rs`, thêm cạnh `load_stay_pricing_inputs_for_room_type`:
+
+```rust
+/// Bản xem trước theo **mã phòng**. Khác `..._for_room_type` ở chỗ phụ thu thêm
+/// người là thuộc tính của từng phòng, nên phòng đã chọn rồi thì phải đọc đúng
+/// phòng đó — hai phòng cùng loại có thể đặt phụ thu khác nhau.
+///
+/// Đọc lệnh với ngày đặc biệt giống bản theo loại phòng: lỗi thì coi như 0%,
+/// vì đây là xem trước chứ chưa thu tiền.
+pub(crate) async fn load_stay_pricing_inputs_for_room(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<StayPricingInputs> {
+    let room_type = load_room_type(pool, room_id).await?;
+    let stored_rule = load_stored_pricing_rule(pool, &room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price(pool, &room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+    let guest_pricing = load_room_guest_pricing(pool, room_id).await?;
+
+    Ok(StayPricingInputs {
+        room_type,
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+        guests,
+        base_guests: guest_pricing.base_guests,
+        extra_person_fee: guest_pricing.extra_person_fee,
+    })
+}
+
+async fn load_room_type(pool: &Pool<Sqlite>, room_id: &str) -> BookingResult<String> {
+    sqlx::query_scalar::<_, String>(ROOM_TYPE_SQL)
+        .bind(room_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?
+        .ok_or_else(|| room_not_found(room_id))
+}
+
+async fn load_room_guest_pricing(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+) -> BookingResult<RoomGuestPricing> {
+    let row = sqlx::query(ROOM_GUEST_PRICING_SQL)
+        .bind(room_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row
+        .as_ref()
+        .map(room_guest_pricing_from_row)
+        .unwrap_or_default())
+}
+```
+
+- [ ] **Step 4: Thêm hàm dịch vụ và lệnh Tauri**
+
+Trong `mhm/src-tauri/src/services/booking/pricing_service.rs`, thêm `load_stay_pricing_inputs_for_room` vào khối `use` sẵn có rồi thêm:
+
+```rust
+/// Bản xem trước mà form đặt phòng dùng: keyed theo phòng đã chọn, nên con số
+/// nó trả về đúng bằng con số `calculate_stay_price_tx` sẽ tính khi ghi sổ.
+pub async fn calculate_room_price_preview(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let inputs = load_stay_pricing_inputs_for_room(
+        pool,
+        room_id,
+        check_in,
+        check_out,
+        pricing_type,
+        guests,
+    )
+    .await?;
+    calculate_from_loaded_inputs(&inputs)
+}
+```
+
+Trong `mhm/src-tauri/src/commands/pricing.rs`, thêm sau `calculate_price_preview` (dòng 117):
+
+```rust
+#[tauri::command]
+pub async fn calculate_room_price_preview(
+    state: State<'_, AppState>,
+    room_id: String,
+    check_in: String,
+    check_out: String,
+    pricing_type: String,
+    guests: Option<i32>,
+) -> Result<crate::pricing::PricingResult, String> {
+    pricing_service::calculate_room_price_preview(
+        &state.db,
+        &room_id,
+        &check_in,
+        &check_out,
+        &pricing_type,
+        guests,
+    )
+    .await
+    .map_err(|error| error.to_string())
+}
+```
+
+Trong `mhm/src-tauri/src/lib.rs`, thêm vào danh sách `generate_handler!` ngay dưới `commands::pricing::calculate_price_preview,` (dòng 393):
+
+```rust
+            commands::pricing::calculate_room_price_preview,
+```
+
+- [ ] **Step 5: Chạy test, kỳ vọng xanh**
+
+```bash
+cargo test --lib services::booking::tests::pricing
+```
+
+Kỳ vọng: **PASS**.
+
+- [ ] **Step 6: Kiểm tra toàn bộ backend và canh gác tiền tệ**
+
+```bash
+cargo test --lib
+```
+
+Kỳ vọng: **PASS** toàn bộ.
+
+```bash
+npm run verify:money
+```
+
+Chạy từ `mhm/`. Kỳ vọng: **PASS** — không phát hiện tiền kiểu số thực.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mhm/src-tauri/src/queries/booking/pricing_queries.rs mhm/src-tauri/src/services/booking/pricing_service.rs mhm/src-tauri/src/commands/pricing.rs mhm/src-tauri/src/lib.rs
+git commit -m "feat(pricing): add a room-keyed preview so the sheet quotes the real price"
+```
+
+---
+
+### Task 6: Form — bỏ ô Số đêm, ngày đi bấm được lịch
+
+**Files:**
+- Modify: `mhm/src/components/ReservationSheet.tsx:30-87,203-243`
+- Test: `mhm/src/components/ReservationSheet.test.tsx`
+
+**Interfaces:**
+- Consumes: không có gì từ backend.
+- Produces: form không còn state `nights`; số đêm suy ra từ hai ngày qua `nightsBetween(checkInDate, checkOutDate)`.
+
+- [ ] **Step 1: Viết test thất bại**
+
+Thêm vào `mhm/src/components/ReservationSheet.test.tsx`:
+
+```tsx
+it("để người dùng chọn ngày đi và không còn ô số đêm", async () => {
+  render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+  expect(screen.queryByLabelText(/số đêm/i)).not.toBeInTheDocument();
+
+  const checkOut = screen.getByLabelText(/ngày đi/i) as HTMLInputElement;
+  expect(checkOut.readOnly).toBe(false);
+
+  // Dòng tổng tiền chỉ hiện khi đã chọn phòng — đó là chỗ số đêm hiện ra.
+  fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+  fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+    target: { value: "2026-08-06" },
+  });
+  fireEvent.change(checkOut, { target: { value: "2026-08-09" } });
+
+  await waitFor(() => {
+    expect(screen.getByText(/3 đêm/i)).toBeInTheDocument();
+  });
+});
+
+it("khoá nút đặt phòng khi ngày đi không sau ngày đến", async () => {
+  render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+  // Điền đủ phòng và tên khách trước, để nút bị khoá *chỉ vì* ngày sai —
+  // không điền thì nút vốn đã khoá và test không chứng minh được gì.
+  fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+  fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
+    target: { value: "Nguyễn Nhật Huy" },
+  });
+  fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+    target: { value: "2026-08-06" },
+  });
+
+  const submit = screen.getByRole("button", { name: /đặt phòng/i });
+  await waitFor(() => expect(submit).toBeEnabled());
+
+  fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+    target: { value: "2026-08-06" },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText(/ngày đi phải sau ngày đến/i)).toBeInTheDocument();
+  });
+  expect(submit).toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+Chạy từ `mhm/`:
+
+```bash
+npm test -- ReservationSheet
+```
+
+Kỳ vọng: **FAIL** — `getByLabelText(/ngày đi/i)` không tìm thấy nhãn (ô hiện chưa gắn `htmlFor`/`id`), và ô đang `readOnly`.
+
+- [ ] **Step 3: Thay state số đêm bằng hàm suy ra**
+
+Trong `mhm/src/components/ReservationSheet.tsx`, bỏ dòng `const [nights, setNights] = useState(1);` (dòng 32) và hàm `updateCheckout` (dòng 82-87). Thêm ngay trên `export default function`:
+
+```tsx
+function nightsBetween(checkIn: string, checkOut: string): number {
+    if (!checkIn || !checkOut) return 0;
+    const ms = new Date(`${checkOut}T00:00:00`).getTime() - new Date(`${checkIn}T00:00:00`).getTime();
+    if (Number.isNaN(ms)) return 0;
+    return Math.round(ms / 86_400_000);
+}
+
+function addDays(date: string, days: number): string {
+    const d = new Date(`${date}T00:00:00`);
+    d.setDate(d.getDate() + days);
+    return d.toISOString().split("T")[0];
+}
+```
+
+Trong thân component, thay chỗ dùng `nights` bằng:
+
+```tsx
+    const nights = nightsBetween(checkInDate, checkOutDate);
+    const datesValid = nights > 0;
+```
+
+Trong `useEffect` khởi tạo (dòng 53-76), nhánh tạo mới đổi thành:
+
+```tsx
+            } else {
+                // Mặc định: nhận phòng ngày mai, ở 1 đêm.
+                const tomorrow = addDays(new Date().toISOString().split("T")[0], 1);
+                setCheckInDate(tomorrow);
+                setCheckOutDate(addDays(tomorrow, 1));
+            }
+```
+
+Nhánh sửa (`editBooking`) bỏ dòng `setNights(editBooking.nights);`. Hàm `resetForm` bỏ dòng `setNights(1);`.
+
+- [ ] **Step 4: Sửa phần hiển thị hai ô ngày**
+
+Trước hết gắn nhãn cho ô chọn phòng — hiện `<label>` và `<select>` không nối với nhau nên test không tìm được ô này, và trình đọc màn hình cũng vậy. Trong khối `{/* Room Selection */}` (dòng 185-200), thêm `htmlFor` vào `<label>` và `id` vào `<select>`:
+
+```tsx
+                        <label htmlFor="reservation-room" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Phòng</label>
+                        <select
+                            id="reservation-room"
+                            className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
+```
+
+Rồi thay cả khối `{/* Dates */}` và khối `{/* Nights */}` (dòng 202-243) bằng:
+
+```tsx
+                    {/* Dates */}
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <label htmlFor="reservation-check-in" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Ngày đến</label>
+                            <input
+                                id="reservation-check-in"
+                                type="date"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                value={checkInDate}
+                                min={new Date().toISOString().split("T")[0]}
+                                onChange={(e) => {
+                                    const nextCheckIn = e.target.value;
+                                    setCheckInDate(nextCheckIn);
+                                    // Giữ ngày đi hợp lệ: đẩy nó ra sau ngày đến mới.
+                                    if (nextCheckIn && nightsBetween(nextCheckIn, checkOutDate) <= 0) {
+                                        setCheckOutDate(addDays(nextCheckIn, 1));
+                                    }
+                                }}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <label htmlFor="reservation-check-out" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Ngày đi</label>
+                            <input
+                                id="reservation-check-out"
+                                type="date"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                value={checkOutDate}
+                                min={checkInDate ? addDays(checkInDate, 1) : undefined}
+                                onChange={(e) => setCheckOutDate(e.target.value)}
+                            />
+                        </div>
+                    </div>
+
+                    {checkInDate && checkOutDate && !datesValid && (
+                        <div className="rounded-xl p-3 text-sm bg-red-50 text-red-700 border border-red-200">
+                            Ngày đi phải sau ngày đến ít nhất 1 đêm.
+                        </div>
+                    )}
+```
+
+- [ ] **Step 5: Chặn gửi khi ngày sai**
+
+Trong `handleSubmit`, ngay sau khối kiểm tra `!roomId || !checkInDate || !checkOutDate`, thêm:
+
+```tsx
+        if (nights <= 0) {
+            toast.error("Ngày đi phải sau ngày đến");
+            return;
+        }
+```
+
+Nút gửi (dòng 388) thêm điều kiện `!datesValid`:
+
+```tsx
+                        disabled={loading || (!isEditMode && !guestName) || !roomId || !datesValid || (availability !== null && !availability.available)}
+```
+
+- [ ] **Step 6: Chạy test, kỳ vọng xanh**
+
+```bash
+npm test -- ReservationSheet
+```
+
+Kỳ vọng: **PASS**.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mhm/src/components/ReservationSheet.tsx mhm/src/components/ReservationSheet.test.tsx
+git commit -m "feat(reservation-sheet): let the checkout date open a calendar, drop the nights box"
+```
+
+---
+
+### Task 7: Form — ô Số khách
+
+**Files:**
+- Modify: `mhm/src-tauri/src/models.rs:344-362` (`BookingWithGuest`)
+- Modify: `mhm/src-tauri/src/queries/booking/booking_list_queries.rs:15,66-85`
+- Modify: `mhm/src/types/index.ts:18-26` (`Room`), `:177-191` (`EditableBooking`), `:265-284` (`BookingWithGuest`)
+- Modify: `mhm/src/components/ReservationSheet.tsx`
+- Test: `mhm/src/components/ReservationSheet.test.tsx`
+
+**Interfaces:**
+- Consumes: `CreateReservationRequest.guests` (Task 2), `ModifyReservationRequest.new_guests` (Task 3).
+- Produces: form gửi `guests` trong `create_reservation` và `new_guests` trong `modify_reservation`; `get_all_bookings` trả thêm `guests`.
+
+- [ ] **Step 1: Viết test thất bại**
+
+Thêm vào `mhm/src/components/ReservationSheet.test.tsx`:
+
+```tsx
+it("nạp số khách theo phòng và gửi nó khi đặt phòng", async () => {
+  render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+  fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+
+  const guests = screen.getByLabelText(/số khách/i) as HTMLInputElement;
+  await waitFor(() => expect(guests.value).toBe("2"));
+
+  fireEvent.change(guests, { target: { value: "4" } });
+  fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
+    target: { value: "Nguyễn Nhật Huy" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /đặt phòng/i }));
+
+  await waitFor(() => {
+    expect(invokeWriteCommand).toHaveBeenCalledWith(
+      "create_reservation",
+      expect.objectContaining({
+        req: expect.objectContaining({ guests: 4 }),
+      }),
+      expect.anything(),
+    );
+  });
+});
+```
+
+Trong khối `vi.mock("@/stores/useHotelStore", …)` ở đầu file test, thêm `max_guests: 2` và `extra_person_fee: 50000` vào phòng giả `R101`.
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+```bash
+npm test -- ReservationSheet
+```
+
+Kỳ vọng: **FAIL** — không tìm thấy nhãn `/số khách/i`.
+
+- [ ] **Step 3: Cho đường đọc trả về số khách**
+
+Không có bước này, màn hình sửa luôn hiện 2 khách kể cả với booking 4 khách — `editBooking` thực chất là `BookingWithGuest` lấy từ lệnh `get_all_bookings`, và câu truy vấn đó không đọc cột `guests`.
+
+Trong `mhm/src-tauri/src/models.rs`, thêm vào cuối struct `BookingWithGuest` (dòng 361, sau `guest_phone`):
+
+```rust
+    pub guests: Option<i32>,
+```
+
+Trong `mhm/src-tauri/src/queries/booking/booking_list_queries.rs`, câu SELECT ở dòng 15 thêm `b.guests`:
+
+```rust
+                b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout, b.guest_phone, b.guests
+```
+
+và `map_booking_with_guest` (dòng 66) thêm dòng cuối, sau `guest_phone`:
+
+```rust
+        guests: row.get("guests"),
+```
+
+- [ ] **Step 4: Bổ sung kiểu dữ liệu phía giao diện**
+
+Trong `mhm/src/types/index.ts`, sửa `Room` (dòng 18) — backend đã trả sẵn hai trường này qua `get_rooms`:
+
+```ts
+export interface Room {
+  id: string;
+  name: string;
+  type: string;
+  floor: number;
+  has_balcony: boolean;
+  base_price: MoneyVnd;
+  max_guests: number;
+  extra_person_fee: MoneyVnd;
+  status: RoomStatus;
+}
+```
+
+Sửa `EditableBooking` (dòng 177) — thêm sau `nights`:
+
+```ts
+  guests: number | null;
+```
+
+Sửa `BookingWithGuest` (dòng 265) — thêm sau `guest_phone`, khớp với struct Rust vừa sửa:
+
+```ts
+  guests: number | null;
+```
+
+- [ ] **Step 5: Thêm ô Số khách vào form**
+
+Trong `mhm/src/components/ReservationSheet.tsx`, thêm state cạnh các state khác:
+
+```tsx
+    const [guests, setGuests] = useState(2);
+```
+
+Trong `useEffect` khởi tạo, nhánh `editBooking` thêm:
+
+```tsx
+                setGuests(editBooking.guests ?? 2);
+```
+
+Thêm effect nạp lại số khách khi đổi phòng — mốc tính giá gắn với từng phòng, nên đổi phòng phải nạp lại kể cả khi người dùng đã sửa tay:
+
+```tsx
+    useEffect(() => {
+        if (isEditMode || !roomId) return;
+        const room = rooms.find((r) => r.id === roomId);
+        if (room) setGuests(room.max_guests);
+    }, [roomId, rooms, isEditMode]);
+```
+
+Trong `resetForm`, thêm `setGuests(2);`.
+
+Thêm khối hiển thị vào đúng chỗ ô Số đêm cũ, ngay dưới cặp ngày:
+
+```tsx
+                    {/* Guests */}
+                    <div className="space-y-1.5">
+                        <label htmlFor="reservation-guests" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Số khách</label>
+                        <input
+                            id="reservation-guests"
+                            type="number"
+                            min={1}
+                            className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            value={guests}
+                            onChange={(e) => setGuests(Math.max(1, parseInt(e.target.value) || 1))}
+                        />
+                    </div>
+```
+
+- [ ] **Step 6: Gửi số khách xuống backend**
+
+Trong `handleSubmit`, nhánh sửa thêm `new_guests`:
+
+```tsx
+                await invokeWriteCommand("modify_reservation", {
+                    req: {
+                        booking_id: editBooking.id,
+                        new_check_in_date: checkInDate,
+                        new_check_out_date: checkOutDate,
+                        new_nights: nights,
+                        new_guests: guests,
+                    },
+                }, {
+```
+
+Nhánh tạo mới thêm `guests` vào `req`, ngay sau `nights`:
+
+```tsx
+                        nights,
+                        guests,
+```
+
+- [ ] **Step 7: Chạy test, kỳ vọng xanh**
+
+```bash
+npm test -- ReservationSheet
+```
+
+Kỳ vọng: **PASS**.
+
+```bash
+cargo test --lib queries::booking
+```
+
+Chạy từ `mhm/src-tauri/`. Kỳ vọng: **PASS** — câu truy vấn danh sách booking vẫn chạy sau khi thêm cột.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mhm/src-tauri/src/models.rs mhm/src-tauri/src/queries/booking/booking_list_queries.rs mhm/src/types/index.ts mhm/src/components/ReservationSheet.tsx mhm/src/components/ReservationSheet.test.tsx
+git commit -m "feat(reservation-sheet): add a guest count and send it with the booking"
+```
+
+---
+
+### Task 8: Form — dòng tổng tiền lấy từ engine
+
+Bước cuối, và là bước đóng lại lỗi "số trên màn hình khác số trong sổ".
+
+**Files:**
+- Create: `mhm/src/hooks/usePricePreview.ts`
+- Modify: `mhm/src/components/ReservationSheet.tsx:353-369`
+- Test: `mhm/src/components/ReservationSheet.test.tsx`
+
+**Interfaces:**
+- Consumes: lệnh Tauri `calculate_room_price_preview` (Task 5); state `guests`, `checkInDate`, `checkOutDate`, `roomId`.
+- Produces: `usePricePreview({ roomId, checkIn, checkOut, guests, debounceMs })` trả `{ preview, loading }`, `preview` kiểu `PricingResult | null`.
+
+- [ ] **Step 1: Viết test thất bại**
+
+Thêm vào `mhm/src/components/ReservationSheet.test.tsx`:
+
+```tsx
+it("hiện tổng tiền do engine trả về, kèm dòng phụ thu", async () => {
+  invoke.mockImplementation(async (command: string) => {
+    if (command === "calculate_room_price_preview") {
+      return {
+        pricing_type: "nightly",
+        base_amount: 1_000_000,
+        surcharge_amount: 0,
+        weekend_amount: 0,
+        total: 1_200_000,
+        capped: false,
+        breakdown: [
+          { label: "2 night(s) x 500.000", amount: 1_000_000 },
+          { label: "Phụ thu 2 khách", amount: 200_000 },
+        ],
+      };
+    }
+    return { available: true, conflicts: [], max_nights: null };
+  });
+
+  render(<ReservationSheet open onOpenChange={vi.fn()} />);
+  fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+  fireEvent.change(screen.getByLabelText(/số khách/i), { target: { value: "4" } });
+
+  await waitFor(() => {
+    expect(screen.getByText("Phụ thu 2 khách")).toBeInTheDocument();
+    expect(screen.getByText("1.200.000₫")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Chạy test để xác nhận nó hỏng**
+
+```bash
+npm test -- ReservationSheet
+```
+
+Kỳ vọng: **FAIL** — không thấy chữ "Phụ thu 2 khách"; form vẫn tự nhân giá.
+
+- [ ] **Step 3: Viết hook**
+
+Tạo `mhm/src/hooks/usePricePreview.ts`. Nó theo đúng khuôn `useAvailability`: chống đua bằng số thứ tự yêu cầu, có trễ, huỷ khi unmount.
+
+```ts
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import type { PricingResult } from "@/types";
+
+interface UsePricePreviewOptions {
+    roomId: string;
+    checkIn: string;
+    checkOut: string;
+    guests: number;
+    debounceMs?: number;
+}
+
+/// Con số hiển thị phải do engine trả về, không phải do giao diện tự nhân —
+/// đó là cách duy nhất để số trên màn hình bằng số ghi vào sổ.
+export function usePricePreview({
+    roomId,
+    checkIn,
+    checkOut,
+    guests,
+    debounceMs = 0,
+}: UsePricePreviewOptions) {
+    const [preview, setPreview] = useState<PricingResult | null>(null);
+    const [loading, setLoading] = useState(false);
+    const requestIdRef = useRef(0);
+
+    useEffect(() => {
+        if (!roomId || !checkIn || !checkOut) {
+            requestIdRef.current += 1;
+            setPreview(null);
+            setLoading(false);
+            return;
+        }
+
+        const requestId = requestIdRef.current + 1;
+        requestIdRef.current = requestId;
+        let active = true;
+
+        const run = async () => {
+            setLoading(true);
+            try {
+                const result = await invoke<PricingResult>("calculate_room_price_preview", {
+                    roomId,
+                    checkIn,
+                    checkOut,
+                    pricingType: "nightly",
+                    guests,
+                });
+                if (active && requestIdRef.current === requestId) {
+                    setPreview(result);
+                }
+            } catch {
+                if (active && requestIdRef.current === requestId) {
+                    setPreview(null);
+                }
+            } finally {
+                if (active && requestIdRef.current === requestId) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        const timer = debounceMs > 0 ? window.setTimeout(run, debounceMs) : null;
+        if (timer == null) {
+            void run();
+        }
+
+        return () => {
+            active = false;
+            if (timer != null) {
+                clearTimeout(timer);
+            }
+        };
+    }, [checkIn, checkOut, debounceMs, guests, roomId]);
+
+    return { preview, loading };
+}
+```
+
+Nếu `mhm/src/types/index.ts` chưa có `PricingResult`, thêm:
+
+```ts
+export interface PricingLine {
+  label: string;
+  amount: MoneyVnd;
+}
+
+export interface PricingResult {
+  pricing_type: string;
+  base_amount: MoneyVnd;
+  surcharge_amount: MoneyVnd;
+  weekend_amount: MoneyVnd;
+  total: MoneyVnd;
+  breakdown: PricingLine[];
+  capped: boolean;
+}
+```
+
+- [ ] **Step 4: Thay khối tổng tiền trong form**
+
+Trong `mhm/src/components/ReservationSheet.tsx`, thêm import và lời gọi hook cạnh `useAvailability`:
+
+```tsx
+import { usePricePreview } from "@/hooks/usePricePreview";
+```
+
+```tsx
+    const { preview, loading: pricing } = usePricePreview({
+        roomId,
+        checkIn: checkInDate,
+        checkOut: checkOutDate,
+        guests,
+        debounceMs: 300,
+    });
+```
+
+Thay toàn bộ khối `{/* Price Estimate */}` (dòng 353-369) bằng:
+
+```tsx
+                    {/* Price Estimate — con số do engine tính, không phải phép nhân ở đây */}
+                    {roomId && datesValid && (
+                        <div className="bg-blue-50 rounded-xl p-4 space-y-1">
+                            {pricing && !preview ? (
+                                <div className="text-sm text-slate-500">Đang tính giá...</div>
+                            ) : preview ? (
+                                <>
+                                    {preview.breakdown.map((line, i) => (
+                                        <div key={i} className="flex justify-between text-sm">
+                                            <span className="text-slate-600">{line.label}</span>
+                                            <span className="text-slate-700">{fmtNumber(line.amount)}₫</span>
+                                        </div>
+                                    ))}
+                                    <div className="flex justify-between text-sm pt-1 border-t border-blue-100">
+                                        <span className="text-slate-600">Tổng</span>
+                                        <span className="font-bold text-slate-800">{fmtNumber(preview.total)}₫</span>
+                                    </div>
+                                    {deposit && parseFloat(deposit) > 0 && (
+                                        <div className="flex justify-between text-sm">
+                                            <span className="text-slate-600">Tiền cọc</span>
+                                            <span className="font-semibold text-emerald-700">-{fmtNumber(parseFloat(deposit))}₫</span>
+                                        </div>
+                                    )}
+                                </>
+                            ) : null}
+                        </div>
+                    )}
+```
+
+- [ ] **Step 5: Chạy test, kỳ vọng xanh**
+
+```bash
+npm test -- ReservationSheet
+```
+
+Kỳ vọng: **PASS**.
+
+- [ ] **Step 6: Chạy toàn bộ kiểm chứng**
+
+Chạy từ `mhm/`:
+
+```bash
+npm run verify:full
+```
+
+Kỳ vọng: **PASS** — lint, typecheck, test frontend, test Rust, và canh gác tiền tệ.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mhm/src/hooks/usePricePreview.ts mhm/src/types/index.ts mhm/src/components/ReservationSheet.tsx mhm/src/components/ReservationSheet.test.tsx
+git commit -m "feat(reservation-sheet): quote the price the engine will actually charge"
+```
+
+---
+
+## Ngoài phạm vi
+
+Spec ghi rõ hai việc **không** làm trong kế hoạch này:
+
+1. Màn hình khai báo mùa cao điểm (`special_dates` đã có bảng, engine đã đọc, thiếu chỗ nhập).
+2. Ô số khách cho khách vãng lai check-in thẳng (`stay_lifecycle.rs:258`).
+
+Ở Task 1, `check_in_tx` (dòng 318) và `group_lifecycle.rs:441` cố ý giữ `None` — đó là hai đường vào của khách vãng lai và khách đoàn, chưa có số khách để truyền. Chúng giữ nguyên hành vi cũ.

--- a/docs/superpowers/specs/2026-07-28-dat-phong-truoc-gia-theo-so-khach-design.md
+++ b/docs/superpowers/specs/2026-07-28-dat-phong-truoc-gia-theo-so-khach-design.md
@@ -1,0 +1,208 @@
+# Đặt phòng trước — Ngày đi bấm được lịch, và giá theo số khách
+
+Ngày: 2026-07-28
+Phạm vi: `mhm/src/components/ReservationSheet.tsx`, `mhm/src-tauri/src/domain/booking/pricing.rs`,
+`mhm/src-tauri/src/queries/booking/pricing_queries.rs`, `mhm/src-tauri/src/services/booking/{reservation_lifecycle,stay_lifecycle,pricing_service}.rs`,
+`mhm/src-tauri/src/db/migrations.rs`, `mhm/src-tauri/src/models.rs`, `mhm/src-tauri/src/commands/pricing.rs`.
+
+## Bối cảnh
+
+Người dùng báo hai triệu chứng ở sheet "Đặt phòng trước". Khảo sát cho thấy triệu chứng thứ hai
+che một lỗi tiền tệ rộng hơn nhiều so với vẻ ngoài của nó.
+
+| # | Triệu chứng | Nguyên nhân | Vị trí |
+|---|---|---|---|
+| 1 | Ô "Ngày đi" bấm không ra lịch | Ô để `readOnly`, giá trị suy ra từ Ngày đến + Số đêm | `ReservationSheet.tsx:219-224` |
+| 2 | Không có cách nào đổi tiền phòng | Form không có ô giá; `CreateReservationRequest` không nhận giá | `models.rs:490-501` |
+| 2a | Số trên form có thể lệch số lưu vào sổ | Form tự nhân `base_price × số đêm`; backend lại hỏi engine (có cộng % cuối tuần / ngày lễ) | `ReservationSheet.tsx:359` |
+| 2b | Phụ thu thêm người khai báo rồi vẫn không có tác dụng | Settings lưu `rooms.extra_person_fee` xuống DB, nhưng engine tính giá không bao giờ đọc tới | `RoomFormDialog.tsx:116` ↔ `domain/booking/pricing.rs` |
+
+Bối cảnh thực tế của người dùng: phòng 2A niêm yết 500.000₫ là giá cho 2 người. Khách đặt 4 người,
+phụ thu 50.000₫/người → 600.000₫/đêm. Đây là **luật giá thường trực của khách sạn**, không phải
+tình huống cá biệt.
+
+## Quyết định thiết kế
+
+Sáu quyết định đã chốt với người dùng:
+
+1. **Bỏ hẳn ô "Số đêm".** Chỉ còn Ngày đến + Ngày đi, cả hai bấm ra lịch. Số đêm suy ra từ hai ngày.
+2. **Giá đến từ số khách, không phải từ ô gõ tay.** Người dùng đã cân nhắc phương án gõ giá tay
+   và loại bỏ nó.
+3. **Engine vẫn là nơi duy nhất định giá.** Không có cột giá đè, không có nhánh "bỏ qua engine".
+4. **Phụ thu là khoản tiền phẳng theo đêm**, không bị nhân thêm % cuối tuần hay ngày lễ.
+5. **Form gọi engine để xem trước giá**, bỏ phép nhân phía giao diện.
+6. **Số khách không có trần.** Ô trong Settings tên là "số khách tính giá base" — là mốc tính tiền,
+   không phải sức chứa.
+
+### Vì sao không chọn phương án gõ giá tay
+
+Phương án đó cần thêm một **cột tiền** mới, kéo theo việc đăng ký vào ba danh sách canh gác tiền tệ
+(`MONEY_COLUMNS` và `MONEY_TABLES` trong `money_migration.rs`, cộng danh sách tên cột viết cứng trong
+`scripts/verify/no-float-money.mjs`). Quên một trong ba thì không có gì báo lỗi.
+
+Nặng hơn: nó đưa vào hệ thống một **nguồn định giá thứ hai** cạnh engine, buộc cả năm chỗ tính tiền
+phải rẽ nhánh "có giá đè không?". Hướng số khách chỉ cần một cột **số đếm** — nằm ngoài mọi danh sách
+canh gác tiền — và cả năm chỗ chỉ truyền thêm một tham số, không chỗ nào rẽ nhánh.
+
+## 1. Form đặt phòng
+
+`ReservationSheet.tsx`. Ô "Số khách" chiếm đúng chỗ ô "Số đêm" cũ.
+
+| Ô | Thay đổi |
+|---|---|
+| Phòng | giữ nguyên |
+| Ngày đến \| Ngày đi | bỏ `readOnly` ở Ngày đi; cả hai là `<input type="date">` bấm ra lịch |
+| ~~Số đêm~~ | bỏ hẳn |
+| **Số khách** | ô mới, `type="number"`, `min={1}`, không có `max` |
+| Thông tin khách, Nguồn, Tiền cọc, Ghi chú | giữ nguyên |
+
+**Nạp giá trị mặc định.** Chọn phòng → ô Số khách nạp `room.max_guests`. Đổi sang phòng khác →
+nạp lại theo phòng mới, kể cả khi người dùng đã sửa tay, vì mốc tính giá base gắn với từng phòng.
+
+**Ràng buộc ngày.** Trước đây Ngày đi luôn hợp lệ vì máy tự tính; giờ gõ tay được nên phải chặn:
+
+- `min` của ô Ngày đi = Ngày đến + 1 ngày.
+- Ngày đi ≤ Ngày đến → hiện lỗi và khoá nút "Đặt phòng".
+- Số đêm = `differenceInCalendarDays(checkOut, checkIn)`, gửi xuống backend như cũ.
+
+**Chế độ sửa** (`editBooking`) dùng đúng bộ ô này; ô Số khách nạp từ `booking.guests`.
+
+## 2. Cột `bookings.guests`
+
+Thêm qua `execute_compat_alter` trong `db/migrations.rs`, cùng lối với các cột đã có
+(`pricing_snapshot` ở dòng 224, `pricing_type` ở dòng 231):
+
+```sql
+ALTER TABLE bookings ADD COLUMN guests INTEGER
+```
+
+Cột **cho phép rỗng**. Booking cũ để rỗng, được hiểu là *không phụ thu* — giá của chúng không đổi
+một đồng nào sau khi nâng cấp.
+
+Đây là **số đếm, không phải tiền**. Không đăng ký vào `MONEY_COLUMNS`, `MONEY_TABLES`, hay danh sách
+trong `no-float-money.mjs`. Tên cột cũng cố ý không chứa từ khoá tiền tệ nào để không lọt vào lưới quét.
+
+`CreateReservationRequest` (`models.rs:490`) nhận thêm `guests: Option<i32>`. Rỗng ⇒ không phụ thu,
+giá đúng bằng kết quả hôm nay. Form luôn gửi giá trị; kiểu `Option` là để các nơi gọi khác
+(gateway, agent) không phải sửa theo.
+
+## 3. Engine: một dòng phụ thu
+
+`StayPricingInputs` (`domain/booking/pricing.rs:14`) là khớp nối có sẵn cho việc này — nó chính là
+"mọi thứ engine cần, đã đọc xong khỏi DB". Thêm ba trường:
+
+```rust
+pub(crate) guests: Option<i32>,
+pub(crate) base_guests: i32,          // rooms.max_guests
+pub(crate) extra_person_fee: MoneyVnd, // rooms.extra_person_fee
+```
+
+`pricing_queries.rs` đọc thêm `max_guests` và `extra_person_fee` khi nạp inputs. Đường theo `room_id`
+(`load_stay_pricing_inputs_tx`) đọc thẳng từ dòng phòng. Đường theo loại phòng
+(`FALLBACK_BASE_PRICE_SQL`, dòng 25) mở rộng cùng câu lệnh đang có.
+
+Công thức, cộng vào sau khi engine đã tính xong phần % cuối tuần và ngày lễ:
+
+```
+khách_thêm = max(0, guests - base_guests)
+phụ_thu    = khách_thêm × extra_person_fee × số_đêm
+```
+
+**Đặt phép cộng ở đâu.** Trong `calculate_from_loaded_inputs` (`domain/booking/pricing.rs:77`),
+*sau* khi `crate::pricing::calculate_price` đã trả kết quả: đẩy thêm một dòng nhãn
+`"Phụ thu N khách"` vào `PricingResult.breakdown` rồi cộng vào `total`. Module `crate::pricing`
+giữ nguyên, không đổi một dòng — nó vẫn chỉ biết về giá phòng và các loại %, còn luật thêm người
+nằm ở tầng domain cùng chỗ với các đầu vào của nó.
+
+Hệ quả: phụ thu **không** nằm trong `base_amount`, nên không bị `weekend_uplift_pct` hay
+`special_dates.uplift_pct` nhân lên.
+
+Lý do: thêm người là khoản phẳng. Cho % chồng lên nó vừa khó giải thích với khách, vừa khó soát
+khi cầm hoá đơn dò ngược. `guests` rỗng hoặc `extra_person_fee = 0` → phụ thu bằng 0, kết quả
+giống hệt hôm nay.
+
+Phép nhân dùng `checked_mul_money` như phần còn lại của module, để số khách nhập bậy không tràn số.
+
+## 4. Năm chỗ tính tiền
+
+Cả năm đều gọi `calculate_stay_price_tx`. Chúng nhận thêm một tham số `guests` và truyền thẳng vào
+engine — **không chỗ nào rẽ nhánh**, vì không có gì để rẽ.
+
+| Chỗ | Vị trí | Lấy `guests` từ đâu |
+|---|---|---|
+| Tạo đặt phòng | `reservation_lifecycle.rs:240` | `req.guests` |
+| Khách nhận phòng | `reservation_lifecycle.rs:609` | `load_booked_reservation` (`:1043`) đọc thêm cột |
+| Sửa đặt phòng | `reservation_lifecycle.rs:758` | như trên |
+| Gia hạn ở thêm | `stay_lifecycle.rs:1074` | dòng booking đang đọc sẵn |
+| Trả phòng sớm | `stay_lifecycle.rs:680` | dòng booking đang đọc sẵn |
+
+Hai chỗ cuối nằm ngoài màn đặt phòng nhưng nằm trong phạm vi có chủ ý: bỏ chúng lại thì khách đặt
+600.000₫/đêm sẽ bị tính 500.000₫ cho đêm gia hạn, và bị tính thiếu khi trả phòng sớm hơn dự kiến.
+
+`ModifyReservationRequest` (`models.rs:504`) nhận thêm `new_guests: Option<i32>`; rỗng nghĩa là
+giữ nguyên số khách đang lưu, không phải xoá về không.
+
+## 5. Xem trước giá — bỏ phép nhân phía giao diện
+
+Form đang tự tính `base_price × nights` (`ReservationSheet.tsx:359`). Đó là nguồn gốc của việc số
+trên màn hình lệch số trong sổ, và nếu để nguyên thì thêm phụ thu sẽ làm khoảng lệch rộng ra.
+
+Bỏ phép nhân đó. Form gọi lệnh `calculate_price_preview` đã có (`commands/pricing.rs:109`), theo đúng
+lối `useAvailability` đang dùng (gọi có trễ, có cờ đang tải). Hiển thị breakdown do engine trả về:
+
+```
+Giá phòng × 2 đêm                 1.000.000₫
+Phụ thu 2 khách × 50.000 × 2 đêm    200.000₫
+                                  1.200.000₫
+```
+
+**Lệch giữa hai đường tra cứu.** Phụ thu là thuộc tính của **từng phòng**, còn `calculate_price_preview`
+tra theo **loại phòng**. Hai phòng cùng loại đặt phí thêm người khác nhau thì số xem trước sẽ sai.
+Xử lý: thêm đường nhận thẳng `room_id` cho `calculate_price_preview`, dùng khi form đã chọn phòng.
+Giữ nguyên đường theo loại phòng cho các nơi gọi khác (`gateway/tools.rs:1237`).
+
+## 6. Kiểm chứng
+
+Chạy `npm run verify:full`. Test viết thêm:
+
+**Tiền — mỗi chỗ trong bảng ở mục 4 một test.** Phòng base 500.000₫/2 người, phụ thu 50.000₫:
+
+- Đặt 4 khách, 2 đêm → tổng 1.200.000₫.
+- Đặt xong dời ngày → vẫn 600.000₫/đêm.
+- Đặt xong khách nhận phòng → vẫn 600.000₫/đêm.
+- Gia hạn thêm 1 đêm → đêm thêm tính 600.000₫.
+- Trả phòng sớm 1 đêm → 600.000₫ × số đêm ở thực tế.
+
+**Biên:**
+
+- 2 khách → phụ thu bằng 0, tổng đúng bằng kết quả hôm nay.
+- `extra_person_fee = 0` → giá không đổi dù nhập bao nhiêu khách.
+- Booking cũ, cột `guests` rỗng → giá không đổi.
+- Phụ thu không bị `weekend_uplift_pct` nhân lên: cùng một booking, đặt vào cuối tuần và ngày thường,
+  phần chênh lệch chỉ nằm ở `base_amount`.
+
+**Form:**
+
+- Ô Ngày đi bấm ra được lịch (không còn `readOnly`).
+- Ngày đi ≤ Ngày đến → nút "Đặt phòng" khoá.
+- Đổi phòng → ô Số khách nạp lại theo `max_guests` của phòng mới.
+- Dòng tổng tiền lấy từ `calculate_price_preview`, không phải phép nhân phía giao diện.
+
+## Ngoài phạm vi
+
+Ghi lại để làm đợt sau, không làm trong đợt này:
+
+1. **Màn hình khai báo mùa cao điểm.** Bảng `special_dates` đã có trong DB và engine đã đọc
+   `uplift_pct`, nhưng không có màn hình nào để nhập. Ví dụ ban đầu của người dùng ("mùa cao điểm
+   với 4 người") có hai yếu tố; spec này phủ yếu tố số khách, còn yếu tố mùa cao điểm cần màn hình đó.
+2. **Số khách cho khách vãng lai.** `check_in_tx` (`stay_lifecycle.rs:258`) tạo booking mới không qua
+   đặt phòng trước, nên chưa có ô số khách. Cùng một cột `guests`, chỉ thiếu ô nhập.
+
+## Rủi ro
+
+| Rủi ro | Mức | Xử lý |
+|---|---|---|
+| Số xem trước lệch số thật khi hai phòng cùng loại khác phí thêm người | Trung bình | Đường xem trước nhận `room_id`, mục 5 |
+| Sót một trong năm chỗ tính tiền → tụt giá âm thầm | Trung bình | Mỗi chỗ một test tiền, mục 6 |
+| Người dùng nhập số khách âm hoặc rất lớn | Thấp | `min={1}` ở form, kẹp `max(0, …)` và `checked_mul_money` ở engine |
+| Booking cũ đổi giá sau nâng cấp | Thấp | Cột cho phép rỗng, rỗng ⇒ không phụ thu; có test |

--- a/docs/superpowers/specs/2026-07-28-dat-phong-truoc-gia-theo-so-khach-design.md
+++ b/docs/superpowers/specs/2026-07-28-dat-phong-truoc-gia-theo-so-khach-design.md
@@ -110,9 +110,8 @@ phụ_thu    = khách_thêm × extra_person_fee × số_đêm
 
 **Đặt phép cộng ở đâu.** Trong `calculate_from_loaded_inputs` (`domain/booking/pricing.rs:77`),
 *sau* khi `crate::pricing::calculate_price` đã trả kết quả: đẩy thêm một dòng nhãn
-`"Phụ thu N khách"` vào `PricingResult.breakdown` rồi cộng vào `total`. Module `crate::pricing`
-giữ nguyên, không đổi một dòng — nó vẫn chỉ biết về giá phòng và các loại %, còn luật thêm người
-nằm ở tầng domain cùng chỗ với các đầu vào của nó.
+`"Phụ thu N khách"` vào `PricingResult.breakdown` rồi cộng vào `total`. Luật thêm người nằm ở tầng
+domain cùng chỗ với các đầu vào của nó, không chui vào phần tính giá phòng và các loại phần trăm.
 
 Hệ quả: phụ thu **không** nằm trong `base_amount`, nên không bị `weekend_uplift_pct` hay
 `special_dates.uplift_pct` nhân lên.
@@ -188,6 +187,25 @@ Chạy `npm run verify:full`. Test viết thêm:
 - Đổi phòng → ô Số khách nạp lại theo `max_guests` của phòng mới.
 - Dòng tổng tiền lấy từ `calculate_price_preview`, không phải phép nhân phía giao diện.
 
+## Sai lệch đã chấp nhận so với bản spec đầu
+
+Ghi lại lúc thi công, để spec và code không nói ngược nhau:
+
+1. **`crate::pricing` có bị sửa.** Bản đầu viết là module này giữ nguyên không đổi một dòng. Thực tế
+   nó bị sửa hai lần, và đều đúng: toàn bộ 17 nhãn `PricingLine` được dịch sang tiếng Việt (trước đó
+   là `"N night(s) x ..."`, `"Weekend surcharge"`, `"Holiday surcharge"`), vì đợt này cho form hiển
+   thị thẳng breakdown của engine nên nhân viên đọc phải nhãn tiếng Anh mỗi lần đặt phòng. Giá trị
+   máy `PricingResult.pricing_type` giữ nguyên tiếng Anh. Đã kiểm: không có chỗ nào trong code sản
+   xuất so khớp chuỗi nhãn, chỉ hiển thị.
+2. **Trần 90 đêm phải dựng lại.** Ô "Số đêm" cũ mang `max={90}`; bỏ ô đi là mất trần, mà backend
+   chưa từng có trần riêng. Đã thêm ở cả ba nơi: `max` trên ô ngày đi, chặn trong `handleSubmit`,
+   và giới hạn trong `validate_requested_nights` để đường gateway/agent cũng được phủ.
+3. **Phép nhân phụ thu đi qua `checked_mul_money`/`checked_add_money`**, không phải `checked_mul`
+   thô — tức là qua cả `validate_transport_money_vnd`, giống mọi dòng tiền khác trong engine.
+4. **Chế độ sửa giữ NULL.** Booking cũ chưa có số khách, mở ra sửa ngày mà không đụng ô Số khách thì
+   gửi `new_guests: null`, không phải một con số bịa ra. Ô hiển thị `max_guests` của phòng làm giá
+   trị gợi ý, và giá trị đó trung tính về giá.
+
 ## Ngoài phạm vi
 
 Ghi lại để làm đợt sau, không làm trong đợt này:
@@ -196,7 +214,19 @@ Ghi lại để làm đợt sau, không làm trong đợt này:
    `uplift_pct`, nhưng không có màn hình nào để nhập. Ví dụ ban đầu của người dùng ("mùa cao điểm
    với 4 người") có hai yếu tố; spec này phủ yếu tố số khách, còn yếu tố mùa cao điểm cần màn hình đó.
 2. **Số khách cho khách vãng lai.** `check_in_tx` (`stay_lifecycle.rs:258`) tạo booking mới không qua
-   đặt phòng trước, nên chưa có ô số khách. Cùng một cột `guests`, chỉ thiếu ô nhập.
+   đặt phòng trước, nên chưa có ô số khách. Cùng một cột `guests`, chỉ thiếu ô nhập. Check-in theo
+   đoàn (`group_lifecycle.rs:441`) cũng vậy, và ở đó danh sách khách đã nằm sẵn trong tay.
+3. **Đặt phòng qua AI agent chưa có số khách.** `gateway/models.rs` `CreateReservationInput` không có
+   trường `guests`, nên booking do agent tạo luôn tính theo số khách base. Sửa đặt phòng thì an toàn:
+   `modify_reservation_tx` dùng `.or(reservation.guests)` nên agent không thể xoá mất phụ thu đã có.
+4. **Nhãn trên hoá đơn vẫn tiếng Anh.** Hoá đơn không dùng breakdown của engine —
+   `invoice_generation.rs:120` tự dựng `"{} night(s) x {}d"`, `InvoiceDialog.tsx:175` và
+   `InvoicePDF.tsx:407` in `"{nights} night(s)"`. **Tiền thì đúng**: hoá đơn lấy `total_price` thật
+   rồi chia số đêm, nên đã gồm phụ thu. Việc còn lại thuần hiển thị, cộng với chuyện phụ thu chưa
+   được tách thành dòng riêng trên hoá đơn.
+5. **"Hôm nay" tính theo giờ UTC.** `new Date().toISOString().split("T")[0]` dùng cho ngày đến mặc
+   định và cho thuộc tính `min`. Từ nửa đêm tới 7h sáng giờ Việt Nam nó trả ngày hôm trước. Lỗi có
+   sẵn từ trước đợt này, không phải hồi quy.
 
 ## Rủi ro
 

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -47,7 +47,8 @@ pub fn command_recovery_risk_level(command_name: &str) -> RecoveryRiskLevel {
         | "extend_stay"
         | "group_checkin"
         | "group_checkout"
-        | "generate_invoice" => RecoveryRiskLevel::High,
+        | "generate_invoice"
+        | "backfill_stay" => RecoveryRiskLevel::High,
         name if name.contains("night_audit") => RecoveryRiskLevel::High,
         _ => RecoveryRiskLevel::Low,
     }
@@ -952,6 +953,18 @@ mod tests {
         .expect_err("requires reason");
         assert_eq!(missing_reason.code, codes::APPROVAL_REQUIRED);
         assert_eq!(action_count(&pool, id).await, 0);
+    }
+
+    #[test]
+    fn backfill_stay_is_classified_high_risk() {
+        // backfill_stay writes a booking row, a room charge, a payment, room-calendar
+        // rows, guest records, and (in "still staying" mode) flips a room to occupied --
+        // the same blast radius as check_in. A failed backfill must not be dismissable
+        // or retryable without operator confirmation and a stated reason.
+        assert_eq!(
+            command_recovery_risk_level("backfill_stay"),
+            RecoveryRiskLevel::High
+        );
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/commands/declaration.rs
+++ b/mhm/src-tauri/src/commands/declaration.rs
@@ -340,7 +340,7 @@ pub async fn kbtt_reconcile(
 
 #[tauri::command]
 pub async fn kbtt_undeclared_count(state: State<'_, AppState>) -> Result<i64, String> {
-    repo::count_undeclared_within_48h(&state.db).await
+    repo::count_undeclared_stays(&state.db).await
 }
 
 #[tauri::command]

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -100,9 +100,16 @@ pub async fn do_calculate_price_preview(
     check_out: &str,
     pricing_type: &str,
 ) -> Result<crate::pricing::PricingResult, String> {
-    pricing_service::calculate_price_preview(pool, room_type, check_in, check_out, pricing_type)
-        .await
-        .map_err(|error| error.to_string())
+    pricing_service::calculate_price_preview(
+        pool,
+        room_type,
+        check_in,
+        check_out,
+        pricing_type,
+        None,
+    )
+    .await
+    .map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -124,6 +124,27 @@ pub async fn calculate_price_preview(
 }
 
 #[tauri::command]
+pub async fn calculate_room_price_preview(
+    state: State<'_, AppState>,
+    room_id: String,
+    check_in: String,
+    check_out: String,
+    pricing_type: String,
+    guests: Option<i32>,
+) -> Result<crate::pricing::PricingResult, String> {
+    pricing_service::calculate_room_price_preview(
+        &state.db,
+        &room_id,
+        &check_in,
+        &check_out,
+        &pricing_type,
+        guests,
+    )
+    .await
+    .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 pub async fn get_special_dates(
     state: State<'_, AppState>,
 ) -> Result<Vec<serde_json::Value>, String> {

--- a/mhm/src-tauri/src/commands/reservations.rs
+++ b/mhm/src-tauri/src/commands/reservations.rs
@@ -706,6 +706,7 @@ mod tests {
             deposit_amount: Some(500_000),
             source: Some("zalo".to_string()),
             notes: Some("Khách thích tầng cao".to_string()),
+            guests: None,
         }
     }
 

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -9,7 +9,10 @@ use crate::{
     money::validate_non_negative_money_vnd,
     queries::booking::{expense_queries, revenue_queries, room_queries, stay_info_queries},
     repositories::booking::expense_repository,
-    services::{booking::stay_lifecycle, housekeeping::housekeeping_service},
+    services::{
+        booking::{backfill, stay_lifecycle},
+        housekeeping::housekeeping_service,
+    },
 };
 use serde_json::{json, Value};
 use sqlx::{Pool, Sqlite};
@@ -127,6 +130,73 @@ pub async fn check_in(
         "check_in success correlation_id={} source={:?} booking_id={} room_id={}",
         effective_correlation_id.value,
         effective_correlation_id.source,
+        booking.id,
+        booking.room_id
+    );
+
+    emit_db_update(&app, "rooms");
+
+    Ok(booking)
+}
+
+// ─── Backfill Stay Command ───
+
+fn backfill_stay_failure_context(req: &BackfillStayRequest) -> Value {
+    json!({
+        "room_id": req.room_id.clone(),
+        "guest_count": req.guests.len(),
+        "still_staying": req.check_out_date.is_none(),
+        "source": req.source.clone(),
+    })
+}
+
+#[tauri::command]
+pub async fn backfill_stay(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    req: BackfillStayRequest,
+    correlation_id: Option<String>,
+    idempotency_key: String,
+) -> CommandResult<Booking> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let error_context = backfill_stay_failure_context(&req);
+    let actor_id = get_user_id(&state)
+        .ok_or_else(|| CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập"))?;
+    let mut write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "backfill_stay",
+    )?;
+    write_command_context.actor_id = Some(actor_id.clone());
+    log::info!(
+        "backfill_stay start correlation_id={} room_id={} guest_count={}",
+        effective_correlation_id.value,
+        req.room_id,
+        req.guests.len()
+    );
+    let result =
+        backfill::backfill_stay_idempotent(&state.db, &write_command_context, req, Some(actor_id))
+            .await
+            .inspect_err(|command_error| {
+                record_command_failure_with_db_group(
+                    "backfill_stay",
+                    command_error,
+                    &effective_correlation_id.value,
+                    None,
+                    error_context.clone(),
+                );
+            })?;
+    let booking: Booking = serde_json::from_value(result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid backfill_stay idempotent response: {error}"),
+        )
+        .with_request_id(write_command_context.request_id.clone())
+    })?;
+
+    log::info!(
+        "backfill_stay success correlation_id={} booking_id={} room_id={}",
+        effective_correlation_id.value,
         booking.id,
         booking.room_id
     );

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -310,6 +310,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
     if current < 21 {
         declaration::migrate_v21_optional_stay(pool).await?;
     }
+
+    // -- V22: số khách trên booking, để tính phụ thu thêm người --
+    if current < 22 {
+        core_extensions::migrate_v22_booking_guest_count(pool).await?;
+    }
     Ok(())
 }
 
@@ -793,6 +798,16 @@ mod tests {
     }
 
     async fn create_legacy_billing_tables_for_partial_upgrade(pool: &SqlitePool) {
+        // Minimal shape: v22 ALTERs `bookings` directly (like v9's group columns
+        // before it), so a partial-upgrade fixture starting past v9 needs the
+        // table to exist even though this fixture never runs the real v1 schema.
+        // No money columns here on purpose — money_migration's table/column
+        // guards already skip tables that don't carry the columns it converts.
+        sqlx::query("CREATE TABLE bookings (id TEXT PRIMARY KEY)")
+            .execute(pool)
+            .await
+            .expect("creates legacy bookings table");
+
         sqlx::query(
             "CREATE TABLE transactions (
                 id          TEXT PRIMARY KEY,
@@ -837,7 +852,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -851,7 +866,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -872,7 +887,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1160,7 +1175,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1227,7 +1242,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1307,7 +1322,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1347,7 +1362,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1365,7 +1380,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1395,7 +1410,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1408,7 +1423,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1441,7 +1456,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]
@@ -1465,7 +1480,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -128,3 +128,20 @@ pub(super) async fn migrate_v9_group_booking_system(
     tx.commit().await?;
     Ok(())
 }
+
+/// Số khách trên booking. Là **số đếm, không phải tiền** — cố ý đứng ngoài
+/// `money_migration`, và tên cột cố ý không chứa từ khoá tiền tệ nào.
+///
+/// Cho phép NULL: booking tạo trước phiên bản này không khai số khách, và NULL
+/// có nghĩa là không phụ thu, nên giá của chúng không đổi.
+pub(super) async fn migrate_v22_booking_guest_count(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    execute_compat_alter(&mut tx, "ALTER TABLE bookings ADD COLUMN guests INTEGER").await?;
+
+    set_schema_version(&mut tx, 22).await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -429,7 +429,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .expect("reads schema version");
-        assert_eq!(version, 21);
+        assert_eq!(version, 22);
     }
 
     /// Khách tới trước khi có booking: phải khai báo được ngay, không phải chờ

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -615,7 +615,7 @@ mod tests {
     async fn undeclared_count_drops_only_when_a_batch_is_verified() {
         let pool = seeded_pool().await;
 
-        let before = crate::declaration::repo::count_undeclared_within_48h(&pool)
+        let before = crate::declaration::repo::count_undeclared_stays(&pool)
             .await
             .expect("đếm được");
         assert_eq!(before, 2, "hai khách trong booking, chưa ai được khai");
@@ -646,7 +646,7 @@ mod tests {
             .expect("lưu được dòng của lô");
 
         // Lô mới xuất ('exported') chưa tính là đã khai.
-        let exported = crate::declaration::repo::count_undeclared_within_48h(&pool)
+        let exported = crate::declaration::repo::count_undeclared_stays(&pool)
             .await
             .expect("đếm được");
         assert_eq!(exported, 2, "xuất file chưa phải là đã khai");
@@ -654,7 +654,7 @@ mod tests {
         crate::declaration::repo::set_batch_verified(&pool, &batch, 1)
             .await
             .expect("đối chiếu xong");
-        let verified = crate::declaration::repo::count_undeclared_within_48h(&pool)
+        let verified = crate::declaration::repo::count_undeclared_stays(&pool)
             .await
             .expect("đếm được");
         assert_eq!(verified, 1, "một khách đã khai, còn một chưa");
@@ -664,9 +664,156 @@ mod tests {
         crate::declaration::repo::set_batch_failed(&pool, &batch, 0)
             .await
             .expect("đánh dấu lô hỏng");
-        let failed = crate::declaration::repo::count_undeclared_within_48h(&pool)
+        let failed = crate::declaration::repo::count_undeclared_stays(&pool)
             .await
             .expect("đếm được");
         assert_eq!(failed, 2);
+    }
+
+    /// Dấu thời gian đúng định dạng PMS thật ghi ra (RFC3339 giờ địa phương,
+    /// xem `services::booking::backfill::local_datetime_rfc3339`). Dùng
+    /// `datetime('now', ...)` của SQLite sẽ ra "YYYY-MM-DD HH:MM:SS" — một
+    /// định dạng không bao giờ có trong DB thật, và `booking_ts_to_iso_date`
+    /// không đọc nổi.
+    fn days_ago_rfc3339(days: i64) -> String {
+        (chrono::Local::now() - chrono::Duration::days(days)).to_rfc3339()
+    }
+
+    /// Một lượt lưu trú đứng riêng (phòng + khách + booking), đủ để thử cửa sổ
+    /// thời gian của hai câu đọc PMS mà không lẫn với `booking-1` của
+    /// `seeded_pool`. Các tham số ngày tính bằng "số ngày trước hôm nay".
+    async fn pool_with_one_stay(
+        status: &str,
+        check_in_days_ago: i64,
+        actual_checkout_days_ago: Option<i64>,
+        guests: usize,
+    ) -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("runs migrations");
+
+        sqlx::query(
+            "INSERT INTO rooms (
+                id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status
+             ) VALUES ('room-1', 'Phòng 5B', 'standard', 1, 0, 100000, 2, 0, 'vacant')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds room");
+
+        for n in 0..guests {
+            sqlx::query(
+                "INSERT INTO guests (id, guest_type, full_name, doc_number, created_at)
+                 VALUES (?, 'domestic', 'Khách thử', 'DOC-1', datetime('now'))",
+            )
+            .bind(format!("guest-{n}"))
+            .execute(&pool)
+            .await
+            .expect("seeds guest");
+        }
+
+        sqlx::query(
+            "INSERT INTO bookings (
+                id, room_id, primary_guest_id, check_in_at, expected_checkout,
+                actual_checkout, nights, total_price, status, created_at
+             ) VALUES ('booking-x', 'room-1', 'guest-0', ?, ?, ?, 1, 500000, ?, ?)",
+        )
+        .bind(days_ago_rfc3339(check_in_days_ago))
+        // Ngày trả dự kiến của một lượt đã trả nằm cùng chỗ với ngày trả thật;
+        // với lượt đang ở thì là tương lai.
+        .bind(days_ago_rfc3339(
+            actual_checkout_days_ago.unwrap_or(check_in_days_ago - 1),
+        ))
+        .bind(actual_checkout_days_ago.map(days_ago_rfc3339))
+        .bind(status)
+        .bind(days_ago_rfc3339(check_in_days_ago))
+        .execute(&pool)
+        .await
+        .expect("seeds booking");
+
+        for n in 0..guests {
+            sqlx::query(
+                "INSERT INTO booking_guests (booking_id, guest_id) VALUES ('booking-x', ?)",
+            )
+            .bind(format!("guest-{n}"))
+            .execute(&pool)
+            .await
+            .expect("seeds booking guest");
+        }
+
+        pool
+    }
+
+    /// Ghi bù một khách ĐÃ TRẢ PHÒNG là chính lý do tính năng ghi bù tồn tại —
+    /// khách đó phải vào được danh sách khai báo, nếu không thì không có đường
+    /// nào nộp cho công an.
+    #[tokio::test]
+    async fn a_recently_checked_out_stay_still_shows_up_for_declaration() {
+        let pool = pool_with_one_stay("checked_out", 4, Some(2), 2).await;
+
+        let stays = crate::declaration::repo::load_stays_for_declaration(&pool)
+            .await
+            .expect("đọc được lượt lưu trú");
+        assert_eq!(
+            stays.iter().map(|s| s.stay_id.as_str()).collect::<Vec<_>>(),
+            vec!["booking-x"],
+        );
+        assert!(
+            stays[0].actual_out.is_some(),
+            "ngày trả thật phải theo về cùng dòng"
+        );
+
+        assert_eq!(
+            crate::declaration::repo::count_undeclared_stays(&pool)
+                .await
+                .expect("đếm được"),
+            2,
+            "badge phải nhắc cho tới khi khách vừa ghi bù được khai"
+        );
+    }
+
+    /// Danh sách khai báo là hàng chờ việc, không phải kho lưu trữ: một lượt đã
+    /// trả từ lâu không được nằm mãi ở đó.
+    #[tokio::test]
+    async fn a_long_checked_out_stay_drops_off_the_declaration_list() {
+        let pool = pool_with_one_stay("checked_out", 62, Some(60), 2).await;
+
+        assert!(
+            crate::declaration::repo::load_stays_for_declaration(&pool)
+                .await
+                .expect("đọc được lượt lưu trú")
+                .is_empty(),
+            "lượt đã trả quá cửa sổ không còn trong danh sách"
+        );
+        assert_eq!(
+            crate::declaration::repo::count_undeclared_stays(&pool)
+                .await
+                .expect("đếm được"),
+            0,
+        );
+    }
+
+    /// Luật cũ cho khách ĐANG Ở không đổi: danh sách lấy mọi lượt `active` bất
+    /// kể nhận phòng từ bao giờ, còn badge vẫn chỉ đếm trong 48h.
+    #[tokio::test]
+    async fn active_stays_keep_their_old_rules() {
+        let pool = pool_with_one_stay("active", 30, None, 2).await;
+
+        assert_eq!(
+            crate::declaration::repo::load_stays_for_declaration(&pool)
+                .await
+                .expect("đọc được lượt lưu trú")
+                .len(),
+            1,
+            "khách đang ở luôn nằm trong danh sách, không có cửa sổ thời gian"
+        );
+        assert_eq!(
+            crate::declaration::repo::count_undeclared_stays(&pool)
+                .await
+                .expect("đếm được"),
+            0,
+            "badge 48h của khách đang ở giữ nguyên như cũ"
+        );
     }
 }

--- a/mhm/src-tauri/src/declaration/repo.rs
+++ b/mhm/src-tauri/src/declaration/repo.rs
@@ -25,6 +25,37 @@ const KEY_REDACT_AFTER_DAYS: &str = "declaration.redact_after_days";
 const DEFAULT_CSLT_NAME: &str = "CSLT";
 const DEFAULT_REDACT_AFTER_DAYS: i64 = 90;
 
+/// Bao lâu sau khi trả phòng thì một lượt lưu trú rời khỏi tầm khai báo.
+///
+/// Khách ĐÃ TRẢ PHÒNG phải nằm trong tầm, nếu không thì chính thứ mà tính năng
+/// "ghi bù sổ khách" sinh ra để cứu — một khách cũ bị bỏ quên, cần khai lên
+/// công an — lại vô hình với màn khai báo. Nhưng danh sách này là HÀNG CHỜ
+/// VIỆC chứ không phải kho lưu trữ: không có cửa sổ thì mọi lượt đã trả trong
+/// đời khách sạn dồn hết vào đó.
+///
+/// 30 ngày: đủ rộng để chủ soát sổ cuối tháng vẫn còn ghi bù và khai kịp, đủ
+/// hẹp để danh sách không phình, và vẫn nằm gọn trong hạn che dữ liệu 90 ngày
+/// (`DEFAULT_REDACT_AFTER_DAYS`) nên không bao giờ lòi ra một dòng đã bị che.
+const CHECKED_OUT_WINDOW_DAYS: i64 = 30;
+
+/// Điều kiện "lượt lưu trú còn trong tầm khai báo", dùng chung cho câu dựng
+/// danh sách và câu đếm badge — hai câu lệch nhau thì badge nhắc một khách mà
+/// danh sách không có (hoặc ngược lại), và người vận hành không có đường đi
+/// tiếp. `b` là alias của `bookings`.
+///
+/// Khách đang ở: giữ nguyên luật cũ, không có cửa sổ thời gian.
+/// Khách đã trả: dùng `actual_checkout`, lùi về `expected_checkout` cho những
+/// booking cũ không ghi ngày trả thật.
+fn stay_in_declaration_scope() -> String {
+    format!(
+        "(b.status = 'active'
+          OR (b.status = 'checked_out'
+              AND julianday('now')
+                  - julianday(COALESCE(b.actual_checkout, b.expected_checkout))
+                  <= {CHECKED_OUT_WINDOW_DAYS}))"
+    )
+}
+
 fn now() -> String {
     chrono::Local::now().to_rfc3339()
 }
@@ -37,14 +68,15 @@ fn placeholders(n: usize) -> String {
 
 /// Đường DUY NHẤT module này đọc dữ liệu của PMS. Chỉ SELECT.
 pub async fn load_stays_for_declaration(pool: &Pool<Sqlite>) -> Result<Vec<StayInfo>, String> {
-    let rows = sqlx::query(
+    let rows = sqlx::query(&format!(
         "SELECT b.id AS stay_id, r.name AS room_name, b.check_in_at,
                 b.expected_checkout, b.actual_checkout
            FROM bookings b
            JOIN rooms r ON r.id = b.room_id
-          WHERE b.status = 'active'
+          WHERE {}
           ORDER BY b.check_in_at DESC",
-    )
+        stay_in_declaration_scope()
+    ))
     .fetch_all(pool)
     .await
     .map_err(|e| format!("Không đọc được lượt lưu trú: {e}"))?;
@@ -70,8 +102,15 @@ pub async fn load_stays_for_declaration(pool: &Pool<Sqlite>) -> Result<Vec<StayI
 
 /// Khách chưa khai = lượt lưu trú không có link nào thuộc lô `verified`.
 /// Tính bằng query, không cần cột mới ở bảng cũ (§5.3).
-pub async fn count_undeclared_within_48h(pool: &Pool<Sqlite>) -> Result<i64, String> {
-    let rows = sqlx::query(
+///
+/// Chỉ đếm những lượt mà danh sách khai báo thực sự hiện ra
+/// (`stay_in_declaration_scope`), cộng thêm một hạn hẹp hơn cho khách ĐANG Ở:
+/// 48h kể từ lúc nhận phòng — đó là luật cũ của badge, giữ nguyên. Khách ĐÃ
+/// TRẢ PHÒNG mà vẫn chưa khai thì đã quá hạn theo định nghĩa, nên được đếm
+/// suốt thời gian còn nằm trong danh sách; badge im trong khi danh sách vẫn
+/// còn việc là kiểu lệch khiến người vận hành không biết mình còn nợ ai.
+pub async fn count_undeclared_stays(pool: &Pool<Sqlite>) -> Result<i64, String> {
+    let rows = sqlx::query(&format!(
         "SELECT
             (SELECT COUNT(*) FROM booking_guests bg WHERE bg.booking_id = b.id) AS guest_count,
             (SELECT COUNT(*) FROM declaration_link dl
@@ -79,9 +118,11 @@ pub async fn count_undeclared_within_48h(pool: &Pool<Sqlite>) -> Result<i64, Str
                JOIN declaration_batch dbt ON dbt.id     = de.batch_id
               WHERE dl.stay_id = b.id AND dbt.status = 'verified') AS declared_count
            FROM bookings b
-          WHERE b.status = 'active'
-            AND julianday('now') - julianday(b.check_in_at) <= 2",
-    )
+          WHERE {}
+            AND (b.status <> 'active'
+                 OR julianday('now') - julianday(b.check_in_at) <= 2)",
+        stay_in_declaration_scope()
+    ))
     .fetch_all(pool)
     .await
     .map_err(|e| format!("Không đếm được khách chưa khai: {e}"))?;
@@ -661,7 +702,7 @@ pub async fn confidence_by_link(
 /// Link đã ghép nhưng chưa nằm trong lô `verified` nào.
 ///
 /// Đây là định nghĩa "còn phải khai" ở mức từng hồ sơ, khác với
-/// `count_undeclared_within_48h` vốn đếm theo lượt lưu trú cho badge sidebar.
+/// `count_undeclared_stays` vốn đếm theo lượt lưu trú cho badge sidebar.
 pub async fn pending_link_ids(pool: &Pool<Sqlite>) -> Result<Vec<String>, String> {
     sqlx::query_scalar::<_, String>(
         "SELECT dl.id

--- a/mhm/src-tauri/src/declaration/repo.rs
+++ b/mhm/src-tauri/src/declaration/repo.rs
@@ -34,8 +34,29 @@ const DEFAULT_REDACT_AFTER_DAYS: i64 = 90;
 /// đời khách sạn dồn hết vào đó.
 ///
 /// 30 ngày: đủ rộng để chủ soát sổ cuối tháng vẫn còn ghi bù và khai kịp, đủ
-/// hẹp để danh sách không phình, và vẫn nằm gọn trong hạn che dữ liệu 90 ngày
-/// (`DEFAULT_REDACT_AFTER_DAYS`) nên không bao giờ lòi ra một dòng đã bị che.
+/// hẹp để danh sách không phình.
+///
+/// Con số này còn một nghĩa thứ hai, không chỉ khống chế độ dài danh sách:
+/// `load_rows_by_link_ids` (dưới) ghép `StayInfo` cho mỗi link qua
+/// `load_stays_for_declaration` — mà `load_stays_for_declaration` chỉ trả về
+/// những lượt lưu trú còn nằm trong đúng cửa sổ 30 ngày này. Một
+/// `declaration_link` còn tồn đọng (chưa gộp lô/chưa verify) quá 30 ngày sau
+/// checkout của lượt lưu trú nó trỏ tới sẽ không khớp được `StayInfo` nào và
+/// rơi vào nhánh `unwrap_or(StayInfo { stay_id, ..Default::default() })` —
+/// tức là XUẤT ra XML với số phòng và ngày tháng RỖNG; validator W01 chỉ cảnh
+/// báo, không chặn xuất. Vậy
+/// 30 ngày còn là hạn chót ngầm để một link giữ được dữ liệu lưu trú đầy đủ
+/// lúc xuất, không riêng gì việc nó có hiện trong màn chọn hay không.
+///
+/// (Trước đây có thêm một vế nói cửa sổ này luôn nằm gọn trong hạn che dữ
+/// liệu 90 ngày nên "không bao giờ lòi ra một dòng đã bị che" — vế đó sai và
+/// đã bị bỏ: `redact_old_identities` chỉ che `declaration_identity`, còn
+/// `load_stays_for_declaration` vốn không đọc bảng đó và không trả về dữ liệu
+/// danh tính nào cả, nên một dòng bị che không thể lọt vào đây bất kể cửa sổ
+/// dài ngắn ra sao. Hơn nữa hạn che 90 ngày chỉ là mặc định —
+/// `redact_after_days()` đọc từ cấu hình `declaration.redact_after_days`, và
+/// test của chính module này đặt nó thành 30 — nên "luôn nằm gọn trong 90
+/// ngày" chưa từng là một điều đảm bảo được.)
 const CHECKED_OUT_WINDOW_DAYS: i64 = 30;
 
 /// Điều kiện "lượt lưu trú còn trong tầm khai báo", dùng chung cho câu dựng

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -112,9 +112,12 @@ fn extra_guest_charge(inputs: &StayPricingInputs, nights: i64) -> BookingResult<
     // `crate::pricing` (`checked_mul_money` ends in `validate_transport_money_vnd`),
     // instead of a raw `checked_mul` that would let a fat-fingered guest count
     // write an unsafe-integer total straight to `bookings.total_price`.
-    let per_night =
-        crate::pricing::checked_mul_money(inputs.extra_person_fee, extra_guests, "extra_guest_charge")
-            .map_err(BookingError::validation)?;
+    let per_night = crate::pricing::checked_mul_money(
+        inputs.extra_person_fee,
+        extra_guests,
+        "extra_guest_charge",
+    )
+    .map_err(BookingError::validation)?;
     let amount = crate::pricing::checked_mul_money(per_night, nights, "extra_guest_charge")
         .map_err(BookingError::validation)?;
 

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -108,13 +108,15 @@ fn extra_guest_charge(inputs: &StayPricingInputs, nights: i64) -> BookingResult<
         return Ok((0, 0));
     }
 
-    let amount = inputs
-        .extra_person_fee
-        .checked_mul(extra_guests)
-        .and_then(|per_night| per_night.checked_mul(nights))
-        .ok_or_else(|| {
-            BookingError::validation("extra guest charge overflowed MoneyVnd".to_string())
-        })?;
+    // Goes through the same transport-safe guard as every other money line in
+    // `crate::pricing` (`checked_mul_money` ends in `validate_transport_money_vnd`),
+    // instead of a raw `checked_mul` that would let a fat-fingered guest count
+    // write an unsafe-integer total straight to `bookings.total_price`.
+    let per_night =
+        crate::pricing::checked_mul_money(inputs.extra_person_fee, extra_guests, "extra_guest_charge")
+            .map_err(BookingError::validation)?;
+    let amount = crate::pricing::checked_mul_money(per_night, nights, "extra_guest_charge")
+        .map_err(BookingError::validation)?;
 
     Ok((extra_guests, amount))
 }
@@ -140,9 +142,8 @@ pub(crate) fn calculate_from_loaded_inputs(
             label: format!("Phụ thu {} khách", extra_guests),
             amount: extra_amount,
         });
-        result.total = result.total.checked_add(extra_amount).ok_or_else(|| {
-            BookingError::validation("stay total overflowed MoneyVnd".to_string())
-        })?;
+        result.total = crate::pricing::checked_add_money(result.total, extra_amount, "stay_total")
+            .map_err(BookingError::validation)?;
     }
 
     Ok(result)
@@ -155,6 +156,7 @@ mod tests {
         StayPricingInputs, StoredPricingRule,
     };
     use crate::domain::booking::BookingError;
+    use crate::money::MAX_TRANSPORT_SAFE_MONEY_VND;
 
     fn sample_inputs() -> StayPricingInputs {
         StayPricingInputs {
@@ -365,5 +367,44 @@ mod tests {
         assert_eq!(pricing.surcharge_amount, 100_000);
         assert_eq!(pricing.total, 1_200_000);
         assert_eq!(pricing.breakdown[2].amount, 100_000);
+    }
+
+    /// Một mốc khách hàng gõ nhầm (999_999_999) nhân với phụ thu 1 triệu, 30
+    /// đêm, cho ra khoảng 3e16 — vượt xa `MAX_TRANSPORT_SAFE_MONEY_VND`
+    /// (~9.007e15), mốc mà một số JS còn biểu diễn chính xác được. Trước bản
+    /// vá này, `extra_guest_charge` dùng `checked_mul`/`checked_add` thô: cả
+    /// hai phép tính đều "thành công" theo nghĩa không tràn số nguyên i64,
+    /// nên giá trị méo mó vẫn được ghi vào `bookings.total_price` và trả về
+    /// UI. Bài test này chứng minh giờ nó trả lỗi thay vì âm thầm ghi số sai.
+    #[test]
+    fn calculate_from_loaded_inputs_rejects_extra_guest_charge_beyond_transport_safe_ceiling() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.check_in = "2026-04-20".to_string();
+        inputs.check_out = "2026-05-20".to_string(); // 30 đêm
+        inputs.guests = Some(999_999_999);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 1_000_000;
+
+        let error = calculate_from_loaded_inputs(&inputs).unwrap_err();
+
+        assert!(matches!(error, BookingError::Validation(_)));
+    }
+
+    /// Bản thân phụ thu (trước khi cộng vào tổng) cũng phải bị chặn nếu nó
+    /// một mình đã vượt trần — không chỉ khi cộng dồn với `base_amount` mới lộ ra.
+    #[test]
+    fn calculate_from_loaded_inputs_rejects_when_extra_amount_alone_exceeds_the_ceiling() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(1);
+        inputs.check_in = "2026-04-20".to_string();
+        inputs.check_out = "2026-04-21".to_string(); // 1 đêm
+        inputs.guests = Some(2);
+        inputs.base_guests = 0;
+        inputs.extra_person_fee = MAX_TRANSPORT_SAFE_MONEY_VND;
+
+        let error = calculate_from_loaded_inputs(&inputs).unwrap_err();
+
+        assert!(matches!(error, BookingError::Validation(_)));
     }
 }

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -8,6 +8,7 @@
 
 use super::{BookingError, BookingResult};
 use crate::money::MoneyVnd;
+use chrono::NaiveDate;
 
 /// Everything the pricing rules need, already read out of the database.
 #[derive(Debug, Clone)]
@@ -19,6 +20,13 @@ pub(crate) struct StayPricingInputs {
     pub(crate) check_in: String,
     pub(crate) check_out: String,
     pub(crate) pricing_type: String,
+    /// Số khách trên booking. `None` là booking chưa khai số khách — booking cũ,
+    /// hoặc một nơi gọi không quan tâm — và có nghĩa là không phụ thu.
+    pub(crate) guests: Option<i32>,
+    /// `rooms.max_guests`: số khách đã nằm trong giá base.
+    pub(crate) base_guests: i32,
+    /// `rooms.extra_person_fee`: phụ thu mỗi khách vượt mốc, mỗi đêm.
+    pub(crate) extra_person_fee: MoneyVnd,
 }
 
 /// A row of `pricing_rules`, decoded but not yet interpreted.
@@ -75,19 +83,69 @@ pub(crate) fn build_effective_pricing_rule(
     }
 }
 
+/// Số đêm giữa hai mốc, chấp nhận cả `YYYY-MM-DD` lẫn RFC3339 (cắt 10 ký tự đầu).
+/// Trả 0 khi ngày đi không sau ngày đến — đúng lúc `calculate_price` cũng trả 0.
+fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
+    let parse = |value: &str| {
+        let head = &value[..value.len().min(10)];
+        NaiveDate::parse_from_str(head, "%Y-%m-%d")
+            .map_err(|error| BookingError::datetime_parse(error.to_string()))
+    };
+    Ok((parse(check_out)? - parse(check_in)?).num_days().max(0))
+}
+
+/// Phụ thu thêm người: khoản phẳng theo đêm.
+///
+/// Cố ý **không** đi qua `percentage_money_line` và cố ý nằm ngoài `base_amount`,
+/// nên uplift cuối tuần / ngày lễ không nhân lên nó. Thêm một người là thêm một
+/// khoản cố định, giải thích với khách được và dò ngược trên hoá đơn được.
+fn extra_guest_charge(inputs: &StayPricingInputs, nights: i64) -> BookingResult<(i64, MoneyVnd)> {
+    let Some(guests) = inputs.guests else {
+        return Ok((0, 0));
+    };
+    let extra_guests = i64::from(guests.saturating_sub(inputs.base_guests)).max(0);
+    if extra_guests == 0 || inputs.extra_person_fee <= 0 || nights <= 0 {
+        return Ok((0, 0));
+    }
+
+    let amount = inputs
+        .extra_person_fee
+        .checked_mul(extra_guests)
+        .and_then(|per_night| per_night.checked_mul(nights))
+        .ok_or_else(|| {
+            BookingError::validation("extra guest charge overflowed MoneyVnd".to_string())
+        })?;
+
+    Ok((extra_guests, amount))
+}
+
 pub(crate) fn calculate_from_loaded_inputs(
     inputs: &StayPricingInputs,
 ) -> BookingResult<crate::pricing::PricingResult> {
     let rule = build_effective_pricing_rule(inputs);
 
-    crate::pricing::calculate_price(
+    let mut result = crate::pricing::calculate_price(
         &rule,
         &inputs.check_in,
         &inputs.check_out,
         &inputs.pricing_type,
         inputs.special_uplift_pct,
     )
-    .map_err(BookingError::datetime_parse)
+    .map_err(BookingError::datetime_parse)?;
+
+    let nights = nights_between(&inputs.check_in, &inputs.check_out)?;
+    let (extra_guests, extra_amount) = extra_guest_charge(inputs, nights)?;
+    if extra_amount > 0 {
+        result.breakdown.push(crate::pricing::PricingLine {
+            label: format!("Phụ thu {} khách", extra_guests),
+            amount: extra_amount,
+        });
+        result.total = result.total.checked_add(extra_amount).ok_or_else(|| {
+            BookingError::validation("stay total overflowed MoneyVnd".to_string())
+        })?;
+    }
+
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -107,6 +165,9 @@ mod tests {
             check_in: "2026-04-20".to_string(),
             check_out: "2026-04-22".to_string(),
             pricing_type: "nightly".to_string(),
+            guests: None,
+            base_guests: 2,
+            extra_person_fee: 0,
         }
     }
 
@@ -213,5 +274,86 @@ mod tests {
             error,
             BookingError::DateTimeParse(message) if message.contains("Invalid check-in datetime")
         ));
+    }
+
+    /// 500.000₫ × 2 đêm = 1.000.000₫, cộng 2 khách vượt mốc × 50.000₫ × 2 đêm.
+    /// Đây đúng con số người dùng mô tả: 600.000₫/đêm cho 4 khách.
+    #[test]
+    fn calculate_from_loaded_inputs_adds_flat_extra_guest_line() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = Some(4);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.base_amount, 1_000_000);
+        assert_eq!(pricing.total, 1_200_000);
+        assert_eq!(pricing.breakdown.len(), 2);
+        assert_eq!(pricing.breakdown[1].label, "Phụ thu 2 khách");
+        assert_eq!(pricing.breakdown[1].amount, 200_000);
+    }
+
+    #[test]
+    fn calculate_from_loaded_inputs_charges_nothing_within_base_guests() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = Some(2);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.total, 1_000_000);
+        assert_eq!(pricing.breakdown.len(), 1);
+    }
+
+    /// Booking cũ: cột `guests` rỗng ⇒ giá y hệt trước khi có tính năng này.
+    /// Phòng chưa khai phụ thu ⇒ số khách bao nhiêu cũng không đổi giá.
+    #[test]
+    fn calculate_from_loaded_inputs_charges_nothing_when_fee_is_zero() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = Some(6);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 0;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.total, 1_000_000);
+        assert_eq!(pricing.breakdown.len(), 1);
+    }
+
+    #[test]
+    fn calculate_from_loaded_inputs_ignores_extra_fee_when_guests_unknown() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.guests = None;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.total, 1_000_000);
+        assert_eq!(pricing.breakdown.len(), 1);
+    }
+
+    /// Phụ thu là khoản phẳng: uplift ngày lễ chỉ ăn vào `base_amount`,
+    /// không nhân lên phần thêm người.
+    #[test]
+    fn extra_guest_line_is_not_multiplied_by_uplift() {
+        let mut inputs = sample_inputs();
+        inputs.fallback_base_price = Some(500_000);
+        inputs.special_uplift_pct = 10.0;
+        inputs.guests = Some(3);
+        inputs.base_guests = 2;
+        inputs.extra_person_fee = 50_000;
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.base_amount, 1_000_000);
+        assert_eq!(pricing.surcharge_amount, 100_000);
+        assert_eq!(pricing.total, 1_200_000);
+        assert_eq!(pricing.breakdown[2].amount, 100_000);
     }
 }

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -87,7 +87,7 @@ pub(crate) fn build_effective_pricing_rule(
 /// Trả 0 khi ngày đi không sau ngày đến — đúng lúc `calculate_price` cũng trả 0.
 fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
     let parse = |value: &str| {
-        let head = &value[..value.len().min(10)];
+        let head = value.get(..10).unwrap_or(value);
         NaiveDate::parse_from_str(head, "%Y-%m-%d")
             .map_err(|error| BookingError::datetime_parse(error.to_string()))
     };
@@ -151,8 +151,8 @@ pub(crate) fn calculate_from_loaded_inputs(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_effective_pricing_rule, calculate_from_loaded_inputs, StayPricingInputs,
-        StoredPricingRule,
+        build_effective_pricing_rule, calculate_from_loaded_inputs, nights_between,
+        StayPricingInputs, StoredPricingRule,
     };
     use crate::domain::booking::BookingError;
 
@@ -274,6 +274,16 @@ mod tests {
             error,
             BookingError::DateTimeParse(message) if message.contains("Invalid check-in datetime")
         ));
+    }
+
+    /// Byte 10 của chuỗi rơi giữa ký tự nhiều byte (emoji) — trước đây
+    /// `&value[..10]` panic "byte index 10 is not a char boundary"; nay
+    /// `get(..10)` trả `None` và hàm phải trả lỗi thay vì sập.
+    #[test]
+    fn nights_between_rejects_check_in_with_non_char_boundary_byte_ten_without_panicking() {
+        let error = nights_between("2026-04-2\u{1F600}x", "2026-04-22").unwrap_err();
+
+        assert!(matches!(error, BookingError::DateTimeParse(_)));
     }
 
     /// 500.000₫ × 2 đêm = 1.000.000₫, cộng 2 khách vượt mốc × 50.000₫ × 2 đêm.

--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -1407,6 +1407,7 @@ impl HotelTools {
             new_check_in_date: input.new_check_in_date,
             new_check_out_date: input.new_check_out_date,
             new_nights: input.new_nights,
+            new_guests: None,
         };
 
         match commands::do_modify_reservation(&self.pool, self.app_handle.as_ref(), &ctx, req).await

--- a/mhm/src-tauri/src/gateway/tools.rs
+++ b/mhm/src-tauri/src/gateway/tools.rs
@@ -1322,6 +1322,7 @@ impl HotelTools {
             deposit_amount,
             source: input.source.or(Some("ai-agent".to_string())),
             notes: input.notes,
+            guests: None,
         };
 
         match commands::do_create_reservation(&self.pool, self.app_handle.as_ref(), &ctx, req).await

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -320,6 +320,7 @@ pub fn run() {
             commands::rooms::get_rooms,
             commands::rooms::get_dashboard_stats,
             commands::rooms::check_in,
+            commands::rooms::backfill_stay,
             commands::rooms::get_room_detail,
             commands::rooms::check_out,
             commands::rooms::preview_checkout_settlement,

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -391,6 +391,7 @@ pub fn run() {
             commands::pricing::get_pricing_rules,
             commands::pricing::save_pricing_rule,
             commands::pricing::calculate_price_preview,
+            commands::pricing::calculate_room_price_preview,
             commands::pricing::get_special_dates,
             commands::pricing::save_special_date,
             // Folio/Billing

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -498,6 +498,9 @@ pub struct CreateReservationRequest {
     pub deposit_amount: Option<MoneyVnd>,
     pub source: Option<String>,
     pub notes: Option<String>,
+    /// Số khách ở thực tế. `None` ⇒ không phụ thu, giá giữ nguyên như cũ.
+    /// Kiểu `Option` để gateway và agent không phải sửa theo.
+    pub guests: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -359,6 +359,7 @@ pub struct BookingWithGuest {
     pub scheduled_checkin: Option<String>,
     pub scheduled_checkout: Option<String>,
     pub guest_phone: Option<String>,
+    pub guests: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -200,6 +200,23 @@ pub struct CheckInRequest {
     pub pricing_type: Option<String>,
 }
 
+/// Ghi bù một lượt khách đã ở nhưng chưa được nhập máy.
+#[derive(Debug, Deserialize)]
+pub struct BackfillStayRequest {
+    pub room_id: String,
+    pub guests: Vec<CreateGuestRequest>,
+    /// YYYY-MM-DD, bắt buộc trong quá khứ.
+    pub check_in_date: String,
+    /// YYYY-MM-DD; None = khách còn ở.
+    pub check_out_date: Option<String>,
+    /// YYYY-MM-DD; bắt buộc khi khách còn ở, phải sau hôm nay.
+    pub expected_checkout_date: Option<String>,
+    pub total_price: MoneyVnd,
+    pub paid_amount: MoneyVnd,
+    pub source: Option<String>,
+    pub notes: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckoutSettlementMode {

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -509,6 +509,9 @@ pub struct ModifyReservationRequest {
     pub new_check_in_date: String,
     pub new_check_out_date: String,
     pub new_nights: i32,
+    /// `None` ⇒ giữ nguyên số khách đang lưu. Đây **không** phải lệnh xoá:
+    /// muốn bỏ phụ thu thì gửi số khách mới nhỏ hơn hoặc bằng `max_guests`.
+    pub new_guests: Option<i32>,
 }
 
 #[derive(Debug, Serialize)]

--- a/mhm/src-tauri/src/pricing.rs
+++ b/mhm/src-tauri/src/pricing.rs
@@ -119,18 +119,18 @@ fn calculate_nightly(
         .map_err(|error| error.message)?;
 
     let mut breakdown = vec![PricingLine {
-        label: format!("{} night(s) x {}", nights, fmt_vnd(rule.daily_rate)),
+        label: format!("{} đêm x {}", nights, fmt_vnd(rule.daily_rate)),
         amount: base,
     }];
     if weekend > 0 {
         breakdown.push(PricingLine {
-            label: "Weekend surcharge".into(),
+            label: "Phụ thu cuối tuần".into(),
             amount: weekend,
         });
     }
     if special != 0 {
         breakdown.push(PricingLine {
-            label: "Holiday surcharge".into(),
+            label: "Phụ thu ngày lễ".into(),
             amount: special,
         });
     }
@@ -181,7 +181,7 @@ fn calculate_hourly(
     if capped {
         breakdown.push(PricingLine {
             label: format!(
-                "{}h x {} = {} -> Capped to {} rate",
+                "{}h x {} = {} -> Giới hạn theo giá {}",
                 hours,
                 fmt_vnd(rule.hourly_rate),
                 fmt_vnd(raw_hourly),
@@ -197,13 +197,13 @@ fn calculate_hourly(
     }
     if weekend > 0 {
         breakdown.push(PricingLine {
-            label: "Weekend surcharge".into(),
+            label: "Phụ thu cuối tuần".into(),
             amount: weekend,
         });
     }
     if special != 0 {
         breakdown.push(PricingLine {
-            label: "Holiday surcharge".into(),
+            label: "Phụ thu ngày lễ".into(),
             amount: special,
         });
     }
@@ -252,7 +252,7 @@ fn calculate_overnight(
     let base = checked_mul_money(rule.overnight_rate, nights, "overnight_rate")?;
     let mut surcharge = 0;
     let mut breakdown = vec![PricingLine {
-        label: format!("{} night(s) x {}", nights, fmt_vnd(rule.overnight_rate)),
+        label: format!("{} đêm x {}", nights, fmt_vnd(rule.overnight_rate)),
         amount: base,
     }];
 
@@ -267,7 +267,7 @@ fn calculate_overnight(
         surcharge = checked_add_money(surcharge, early_amount, "surcharge_amount")?;
         breakdown.push(PricingLine {
             label: format!(
-                "Early check-in surcharge ({}%)",
+                "Phụ thu nhận phòng sớm ({}%)",
                 rule.early_checkin_surcharge_pct
             ),
             amount: early_amount,
@@ -285,7 +285,7 @@ fn calculate_overnight(
         surcharge = checked_add_money(surcharge, late_amount, "surcharge_amount")?;
         breakdown.push(PricingLine {
             label: format!(
-                "Late check-out surcharge ({}%)",
+                "Phụ thu trả phòng muộn ({}%)",
                 rule.late_checkout_surcharge_pct
             ),
             amount: late_amount,
@@ -298,13 +298,13 @@ fn calculate_overnight(
 
     if weekend > 0 {
         breakdown.push(PricingLine {
-            label: "Weekend surcharge".into(),
+            label: "Phụ thu cuối tuần".into(),
             amount: weekend,
         });
     }
     if special != 0 {
         breakdown.push(PricingLine {
-            label: "Holiday surcharge".into(),
+            label: "Phụ thu ngày lễ".into(),
             amount: special,
         });
     }
@@ -344,7 +344,7 @@ fn calculate_daily(
 
     let mut surcharge = 0;
     let mut breakdown = vec![PricingLine {
-        label: format!("{} day(s) x {}", days, fmt_vnd(rule.daily_rate)),
+        label: format!("{} ngày x {}", days, fmt_vnd(rule.daily_rate)),
         amount: base,
     }];
 
@@ -359,7 +359,7 @@ fn calculate_daily(
         surcharge = checked_add_money(surcharge, early_amount, "surcharge_amount")?;
         breakdown.push(PricingLine {
             label: format!(
-                "Early check-in surcharge ({}%)",
+                "Phụ thu nhận phòng sớm ({}%)",
                 rule.early_checkin_surcharge_pct
             ),
             amount: early_amount,
@@ -377,7 +377,7 @@ fn calculate_daily(
         surcharge = checked_add_money(surcharge, late_amount, "surcharge_amount")?;
         breakdown.push(PricingLine {
             label: format!(
-                "Late check-out surcharge ({}%)",
+                "Phụ thu trả phòng muộn ({}%)",
                 rule.late_checkout_surcharge_pct
             ),
             amount: late_amount,
@@ -390,13 +390,13 @@ fn calculate_daily(
 
     if weekend > 0 {
         breakdown.push(PricingLine {
-            label: "Weekend surcharge".into(),
+            label: "Phụ thu cuối tuần".into(),
             amount: weekend,
         });
     }
     if special != 0 {
         breakdown.push(PricingLine {
-            label: "Holiday surcharge".into(),
+            label: "Phụ thu ngày lễ".into(),
             amount: special,
         });
     }

--- a/mhm/src-tauri/src/pricing.rs
+++ b/mhm/src-tauri/src/pricing.rs
@@ -179,13 +179,21 @@ fn calculate_hourly(
 
     let mut breakdown = vec![];
     if capped {
+        // Display-only Vietnamese wording for the cap kind; `cap_type` itself
+        // (and the `pricing_type` it feeds below) must stay the English
+        // machine value "overnight" / "daily".
+        let cap_label = match cap_type {
+            "overnight" => "qua đêm",
+            "daily" => "theo ngày",
+            other => other,
+        };
         breakdown.push(PricingLine {
             label: format!(
                 "{}h x {} = {} -> Giới hạn theo giá {}",
                 hours,
                 fmt_vnd(rule.hourly_rate),
                 fmt_vnd(raw_hourly),
-                cap_type
+                cap_label
             ),
             amount: base,
         });
@@ -616,6 +624,54 @@ mod tests {
         );
         assert!(r.capped);
         assert!(r.total <= 400_000 * 2);
+    }
+
+    #[test]
+    fn test_hourly_capping_to_overnight_label_is_vietnamese_but_pricing_type_stays_english() {
+        // 5h x 80k = 400k > overnight 300k -> capped to overnight
+        let r = p(
+            &std_rule(),
+            "2026-03-17T18:00:00",
+            "2026-03-17T23:00:00",
+            "hourly",
+            0.0,
+        );
+        assert!(r.capped);
+        let label = &r.breakdown[0].label;
+        assert!(
+            label.contains("qua đêm"),
+            "expected Vietnamese cap label 'qua đêm', got: {label}"
+        );
+        assert!(
+            !label.contains("overnight"),
+            "label leaked English machine value: {label}"
+        );
+        // Machine value must remain the English contract, untouched.
+        assert_eq!(r.pricing_type, "overnight");
+    }
+
+    #[test]
+    fn test_hourly_capping_to_daily_label_is_vietnamese_but_pricing_type_stays_english() {
+        // 20h x 80k = 1600k > daily 400k -> capped to daily
+        let r = p(
+            &std_rule(),
+            "2026-03-17T08:00:00",
+            "2026-03-18T04:00:00",
+            "hourly",
+            0.0,
+        );
+        assert!(r.capped);
+        let label = &r.breakdown[0].label;
+        assert!(
+            label.contains("theo ngày"),
+            "expected Vietnamese cap label 'theo ngày', got: {label}"
+        );
+        assert!(
+            !label.contains("daily"),
+            "label leaked English machine value: {label}"
+        );
+        // Machine value must remain the English contract, untouched.
+        assert_eq!(r.pricing_type, "daily");
     }
 
     #[test]

--- a/mhm/src-tauri/src/pricing.rs
+++ b/mhm/src-tauri/src/pricing.rs
@@ -454,14 +454,22 @@ fn calculate_weekend_uplift(
         .map_err(|error| error.message)
 }
 
-fn checked_mul_money(amount: MoneyVnd, multiplier: i64, field: &str) -> Result<MoneyVnd, String> {
+/// `pub(crate)`, not private: `domain::booking::pricing` reuses this so the
+/// flat extra-guest surcharge goes through the same transport-safe guard as
+/// every other money line here, instead of a raw `checked_mul`.
+pub(crate) fn checked_mul_money(
+    amount: MoneyVnd,
+    multiplier: i64,
+    field: &str,
+) -> Result<MoneyVnd, String> {
     let value = amount
         .checked_mul(multiplier)
         .ok_or_else(|| format!("{field} overflowed"))?;
     validate_transport_money_vnd(value, field).map_err(|error| error.message)
 }
 
-fn checked_add_money(a: MoneyVnd, b: MoneyVnd, field: &str) -> Result<MoneyVnd, String> {
+/// See `checked_mul_money` — same reasoning, `pub(crate)` for the same reason.
+pub(crate) fn checked_add_money(a: MoneyVnd, b: MoneyVnd, field: &str) -> Result<MoneyVnd, String> {
     let value = a
         .checked_add(b)
         .ok_or_else(|| format!("{field} overflowed"))?;

--- a/mhm/src-tauri/src/queries/booking/booking_list_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/booking_list_queries.rs
@@ -12,7 +12,7 @@ use crate::models::{BookingFilter, BookingWithGuest};
 const BOOKING_LIST_SQL: &str = "SELECT b.id, b.room_id, r.name as room_name, g.full_name as guest_name,
                 b.check_in_at, b.expected_checkout, b.actual_checkout,
                 b.nights, b.total_price, b.paid_amount, b.status, b.source,
-                b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout, b.guest_phone
+                b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout, b.guest_phone, b.guests
          FROM bookings b
          JOIN rooms r ON r.id = b.room_id
          JOIN guests g ON g.id = b.primary_guest_id
@@ -82,6 +82,7 @@ fn map_booking_with_guest(row: &sqlx::sqlite::SqliteRow) -> BookingWithGuest {
         scheduled_checkin: row.get("scheduled_checkin"),
         scheduled_checkout: row.get("scheduled_checkout"),
         guest_phone: row.get("guest_phone"),
+        guests: row.get("guests"),
     }
 }
 

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -219,6 +219,69 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
     })
 }
 
+/// Bản xem trước theo **mã phòng**. Khác `..._for_room_type` ở chỗ phụ thu thêm
+/// người là thuộc tính của từng phòng, nên phòng đã chọn rồi thì phải đọc đúng
+/// phòng đó — hai phòng cùng loại có thể đặt phụ thu khác nhau.
+///
+/// Đọc lệnh với ngày đặc biệt giống bản theo loại phòng: lỗi thì coi như 0%,
+/// vì đây là xem trước chứ chưa thu tiền.
+pub(crate) async fn load_stay_pricing_inputs_for_room(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<StayPricingInputs> {
+    let room_type = load_room_type(pool, room_id).await?;
+    let stored_rule = load_stored_pricing_rule(pool, &room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price(pool, &room_type).await?
+    } else {
+        None
+    };
+    let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+    let guest_pricing = load_room_guest_pricing(pool, room_id).await?;
+
+    Ok(StayPricingInputs {
+        room_type,
+        stored_rule,
+        fallback_base_price,
+        special_uplift_pct,
+        check_in: check_in.to_string(),
+        check_out: check_out.to_string(),
+        pricing_type: pricing_type.to_string(),
+        guests,
+        base_guests: guest_pricing.base_guests,
+        extra_person_fee: guest_pricing.extra_person_fee,
+    })
+}
+
+async fn load_room_type(pool: &Pool<Sqlite>, room_id: &str) -> BookingResult<String> {
+    sqlx::query_scalar::<_, String>(ROOM_TYPE_SQL)
+        .bind(room_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?
+        .ok_or_else(|| room_not_found(room_id))
+}
+
+async fn load_room_guest_pricing(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+) -> BookingResult<RoomGuestPricing> {
+    let row = sqlx::query(ROOM_GUEST_PRICING_SQL)
+        .bind(room_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row
+        .as_ref()
+        .map(room_guest_pricing_from_row)
+        .unwrap_or_default())
+}
+
 async fn load_stored_pricing_rule(
     pool: &Pool<Sqlite>,
     room_type: &str,

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -24,6 +24,14 @@ const ROOM_TYPE_SQL: &str = "SELECT type FROM rooms WHERE id = ? LIMIT 1";
 
 const FALLBACK_BASE_PRICE_SQL: &str = "SELECT base_price FROM rooms WHERE LOWER(type) = ? LIMIT 1";
 
+const ROOM_GUEST_PRICING_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_guests,
+            COALESCE(extra_person_fee, 0) AS extra_person_fee
+     FROM rooms WHERE id = ?";
+
+const ROOM_GUEST_PRICING_BY_TYPE_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_guests,
+            COALESCE(extra_person_fee, 0) AS extra_person_fee
+     FROM rooms WHERE LOWER(type) = ? LIMIT 1";
+
 const SPECIAL_UPLIFT_SQL: &str =
     "SELECT CAST(uplift_pct AS REAL) FROM special_dates WHERE date = ?";
 
@@ -69,6 +77,61 @@ fn date_key(date_str: &str) -> &str {
     }
 }
 
+/// Mốc tính giá của một phòng. Phòng không tìm thấy thì dùng mặc định của schema
+/// (`max_guests` mặc định 2, `extra_person_fee` mặc định 0) — tức không phụ thu.
+struct RoomGuestPricing {
+    base_guests: i32,
+    extra_person_fee: MoneyVnd,
+}
+
+impl Default for RoomGuestPricing {
+    fn default() -> Self {
+        Self {
+            base_guests: 2,
+            extra_person_fee: 0,
+        }
+    }
+}
+
+fn room_guest_pricing_from_row(row: &sqlx::sqlite::SqliteRow) -> RoomGuestPricing {
+    RoomGuestPricing {
+        base_guests: row.get("max_guests"),
+        extra_person_fee: get_money_vnd(row, "extra_person_fee"),
+    }
+}
+
+async fn load_room_guest_pricing_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    room_id: &str,
+) -> BookingResult<RoomGuestPricing> {
+    let row = sqlx::query(ROOM_GUEST_PRICING_SQL)
+        .bind(room_id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row
+        .as_ref()
+        .map(room_guest_pricing_from_row)
+        .unwrap_or_default())
+}
+
+async fn load_room_guest_pricing_for_type(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+) -> BookingResult<RoomGuestPricing> {
+    let row = sqlx::query(ROOM_GUEST_PRICING_BY_TYPE_SQL)
+        .bind(room_type.to_lowercase())
+        .fetch_optional(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(row
+        .as_ref()
+        .map(room_guest_pricing_from_row)
+        .unwrap_or_default())
+}
+
 pub(crate) fn stored_rule_from_row(row: &sqlx::sqlite::SqliteRow) -> StoredPricingRule {
     StoredPricingRule {
         room_type: row.get("room_type"),
@@ -91,6 +154,7 @@ pub(crate) async fn load_stay_pricing_inputs_tx(
     check_in: &str,
     check_out: &str,
     pricing_type: &str,
+    guests: Option<i32>,
 ) -> BookingResult<StayPricingInputs> {
     let room_type = load_room_type_tx(tx, room_id).await?;
     let stored_rule = load_stored_pricing_rule_tx(tx, &room_type).await?;
@@ -100,6 +164,7 @@ pub(crate) async fn load_stay_pricing_inputs_tx(
         None
     };
     let special_uplift_pct = load_special_uplift_tx(tx, check_in).await?;
+    let guest_pricing = load_room_guest_pricing_tx(tx, room_id).await?;
 
     Ok(StayPricingInputs {
         room_type,
@@ -109,6 +174,9 @@ pub(crate) async fn load_stay_pricing_inputs_tx(
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
         pricing_type: pricing_type.to_string(),
+        guests,
+        base_guests: guest_pricing.base_guests,
+        extra_person_fee: guest_pricing.extra_person_fee,
     })
 }
 
@@ -126,6 +194,7 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
     check_in: &str,
     check_out: &str,
     pricing_type: &str,
+    guests: Option<i32>,
 ) -> BookingResult<StayPricingInputs> {
     let stored_rule = load_stored_pricing_rule(pool, room_type).await?;
     let fallback_base_price = if stored_rule.is_none() {
@@ -134,6 +203,7 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
         None
     };
     let special_uplift_pct = load_special_uplift(pool, check_in).await.unwrap_or(0.0);
+    let guest_pricing = load_room_guest_pricing_for_type(pool, room_type).await?;
 
     Ok(StayPricingInputs {
         room_type: room_type.to_string(),
@@ -143,6 +213,9 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
         pricing_type: pricing_type.to_string(),
+        guests,
+        base_guests: guest_pricing.base_guests,
+        extra_person_fee: guest_pricing.extra_person_fee,
     })
 }
 
@@ -314,7 +387,13 @@ mod tests {
             .unwrap();
 
         pool.execute(
-            "CREATE TABLE rooms (id TEXT PRIMARY KEY, type TEXT NOT NULL, base_price INTEGER)",
+            "CREATE TABLE rooms (
+                id TEXT PRIMARY KEY,
+                type TEXT NOT NULL,
+                base_price INTEGER,
+                max_guests INTEGER NOT NULL DEFAULT 2,
+                extra_person_fee INTEGER NOT NULL DEFAULT 0
+            )",
         )
         .await
         .unwrap();
@@ -347,9 +426,16 @@ mod tests {
         let pool = setup_loader_pool().await;
 
         pool.execute("DROP TABLE rooms").await.unwrap();
-        pool.execute("CREATE TABLE rooms (id TEXT PRIMARY KEY, type TEXT NOT NULL)")
-            .await
-            .unwrap();
+        pool.execute(
+            "CREATE TABLE rooms (
+                id TEXT PRIMARY KEY,
+                type TEXT NOT NULL,
+                max_guests INTEGER NOT NULL DEFAULT 2,
+                extra_person_fee INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .await
+        .unwrap();
         sqlx::query("INSERT INTO rooms (id, type) VALUES (?, ?)")
             .bind("room-1")
             .bind("deluxe")
@@ -391,6 +477,7 @@ mod tests {
             "2026-04-20T14:00:00+07:00",
             "2026-04-21T12:00:00+07:00",
             "nightly",
+            None,
         )
         .await
         .unwrap();
@@ -422,6 +509,7 @@ mod tests {
             "2026-04-21T14:00:00+07:00",
             "2026-04-22T12:00:00+07:00",
             "nightly",
+            None,
         )
         .await
         .unwrap();

--- a/mhm/src-tauri/src/queries/groups/group_queries.rs
+++ b/mhm/src-tauri/src/queries/groups/group_queries.rs
@@ -14,7 +14,7 @@ const GROUP_BOOKINGS_SQL: &str =
             b.check_in_at, b.expected_checkout, b.actual_checkout, b.nights,
             b.total_price, b.paid_amount, b.status, b.source,
             b.booking_type, b.deposit_amount, b.scheduled_checkin, b.scheduled_checkout,
-            b.guest_phone
+            b.guest_phone, b.guests
      FROM bookings b
      JOIN rooms r ON r.id = b.room_id
      JOIN guests g ON g.id = b.primary_guest_id
@@ -144,6 +144,7 @@ fn map_group_booking(row: &sqlx::sqlite::SqliteRow) -> BookingWithGuest {
         scheduled_checkin: row.get("scheduled_checkin"),
         scheduled_checkout: row.get("scheduled_checkout"),
         guest_phone: row.get("guest_phone"),
+        guests: row.get("guests"),
     }
 }
 
@@ -201,6 +202,7 @@ mod tests {
             scheduled_checkin: None,
             scheduled_checkout: None,
             guest_phone: None,
+            guests: None,
         }
     }
 

--- a/mhm/src-tauri/src/services/booking/backfill.rs
+++ b/mhm/src-tauri/src/services/booking/backfill.rs
@@ -279,8 +279,6 @@ fn backfill_lock_keys_from_payload(hash_payload: &serde_json::Value) -> CommandR
     Ok(vec![crate::aggregate_locks::room_key(room_id)?])
 }
 
-// Lệnh Tauri gọi hàm này được nối ở bước sau; hiện chỉ có test gọi tới.
-#[allow(dead_code)]
 pub async fn backfill_stay_idempotent(
     pool: &Pool<Sqlite>,
     ctx: &WriteCommandContext,

--- a/mhm/src-tauri/src/services/booking/backfill.rs
+++ b/mhm/src-tauri/src/services/booking/backfill.rs
@@ -1,0 +1,350 @@
+//! Ghi bù một lượt khách đã ở nhưng chưa được nhập máy.
+//!
+//! Chủ nhà quên nhập khách vãng lai thì phải ghi lại sau: hoặc khách đã trả
+//! phòng, hoặc khách vẫn còn nằm trong phòng. Cả hai trường hợp đều ghi trọn
+//! một lượt ở (booking, sổ tiền, lịch phòng, hồ sơ khách) trong một giao dịch.
+
+use chrono::{Local, NaiveDate, TimeZone};
+use serde_json::json;
+use sqlx::{Pool, Row, Sqlite, Transaction};
+
+use crate::{
+    app_error::CommandResult,
+    command_idempotency::{
+        system_error, CommandLedgerResultSummary, CommandLedgerSummary, IdempotentCommandResult,
+        SanitizedLedgerIntent, WriteCommandContext, WriteCommandExecutor, WriteCommandRequest,
+    },
+    domain::booking::{BookingError, BookingResult, OriginSideEffect},
+    models::{status, BackfillStayRequest, Booking},
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
+};
+
+use super::{
+    billing_service::{record_charge_with_origin_tx, record_payment_with_origin_tx},
+    guest_service::{create_guest_manifest, guest_hash_payload_entries, link_booking_guests},
+    stay_lifecycle::{fetch_booking_tx, map_check_in_command_error, mark_write_db_error},
+    support::{
+        ensure_one_row_affected, insert_room_calendar_rows, validate_non_negative_booking_money,
+    },
+};
+
+struct BackfillDates {
+    check_in: NaiveDate,
+    /// Ngày ra thực tế (đã trả) hoặc ngày ra dự kiến (còn ở).
+    end: NaiveDate,
+    still_staying: bool,
+}
+
+fn parse_iso_date(value: &str, label: &str) -> BookingResult<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| BookingError::validation(format!("{} không đúng định dạng YYYY-MM-DD", label)))
+}
+
+fn validate_backfill_request(
+    req: &BackfillStayRequest,
+    today: NaiveDate,
+) -> BookingResult<BackfillDates> {
+    if req.guests.is_empty() {
+        return Err(BookingError::validation(
+            "Phải có ít nhất 1 khách".to_string(),
+        ));
+    }
+    validate_non_negative_booking_money(req.total_price, "total_price")?;
+    validate_non_negative_booking_money(req.paid_amount, "paid_amount")?;
+    if req.paid_amount > req.total_price {
+        return Err(BookingError::validation(
+            "Số tiền đã thu không được vượt quá tiền phòng".to_string(),
+        ));
+    }
+
+    let check_in = parse_iso_date(&req.check_in_date, "Ngày vào")?;
+    if check_in >= today {
+        return Err(BookingError::validation(
+            "Ngày vào của ghi bù phải trong quá khứ".to_string(),
+        ));
+    }
+
+    match (&req.check_out_date, &req.expected_checkout_date) {
+        (Some(check_out_date), _) => {
+            let end = parse_iso_date(check_out_date, "Ngày ra")?;
+            if end <= check_in {
+                return Err(BookingError::validation(
+                    "Ngày ra phải sau ngày vào".to_string(),
+                ));
+            }
+            if end > today {
+                return Err(BookingError::validation(
+                    "Khách đã trả phòng thì ngày ra không được ở tương lai".to_string(),
+                ));
+            }
+            Ok(BackfillDates {
+                check_in,
+                end,
+                still_staying: false,
+            })
+        }
+        (None, Some(expected)) => {
+            let end = parse_iso_date(expected, "Ngày ra dự kiến")?;
+            if end <= today {
+                return Err(BookingError::validation(
+                    "Ngày ra dự kiến phải sau hôm nay".to_string(),
+                ));
+            }
+            Ok(BackfillDates {
+                check_in,
+                end,
+                still_staying: true,
+            })
+        }
+        (None, None) => Err(BookingError::validation(
+            "Thiếu ngày ra dự kiến cho khách còn ở".to_string(),
+        )),
+    }
+}
+
+fn local_datetime_rfc3339(date: NaiveDate, hour: u32) -> BookingResult<String> {
+    let naive = date
+        .and_hms_opt(hour, 0, 0)
+        .ok_or_else(|| BookingError::datetime_parse(format!("invalid time {hour}:00")))?;
+    match Local.from_local_datetime(&naive) {
+        chrono::LocalResult::Single(dt) | chrono::LocalResult::Ambiguous(dt, _) => {
+            Ok(dt.to_rfc3339())
+        }
+        chrono::LocalResult::None => Err(BookingError::datetime_parse(format!(
+            "invalid local datetime {naive}"
+        ))),
+    }
+}
+
+async fn backfill_stay_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    req: &BackfillStayRequest,
+    user_id: Option<&str>,
+    origin_key: &str,
+) -> BookingResult<Booking> {
+    let today = Local::now().date_naive();
+    let dates = validate_backfill_request(req, today)?;
+
+    // Quy ước giờ chuẩn khách sạn: nhận 14:00, trả 12:00.
+    let check_in_at = local_datetime_rfc3339(dates.check_in, 14)?;
+    let end_at = local_datetime_rfc3339(dates.end, 12)?;
+    let nights = (dates.end - dates.check_in).num_days() as i32;
+
+    let room = sqlx::query("SELECT id, status FROM rooms WHERE id = ?")
+        .bind(&req.room_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy phòng {}", req.room_id)))?;
+    let room_status: String = room.get("status");
+    if dates.still_staying && room_status != status::room::VACANT {
+        return Err(BookingError::conflict(format!(
+            "Phòng {} đang có khách, không thể ghi bù khách còn ở",
+            req.room_id
+        )));
+    }
+
+    let conflicts = sqlx::query(
+        "SELECT rc.date, COALESCE(g.full_name, '') AS guest_name
+         FROM room_calendar rc
+         LEFT JOIN bookings b ON b.id = rc.booking_id
+         LEFT JOIN guests g ON g.id = b.primary_guest_id
+         WHERE rc.room_id = ? AND rc.date >= ? AND rc.date < ?
+         ORDER BY rc.date ASC",
+    )
+    .bind(&req.room_id)
+    .bind(dates.check_in.format("%Y-%m-%d").to_string())
+    .bind(dates.end.format("%Y-%m-%d").to_string())
+    .fetch_all(&mut **tx)
+    .await?;
+    if let Some(first) = conflicts.first() {
+        let date: String = first.get("date");
+        let guest_name: String = first.get("guest_name");
+        return Err(BookingError::conflict(format!(
+            "Phòng {} đã có khách ngày {} ({})",
+            req.room_id, date, guest_name
+        )));
+    }
+
+    let booking_id = uuid::Uuid::new_v4().to_string();
+    let guest_manifest = create_guest_manifest(tx, &req.guests, &check_in_at)
+        .await
+        .map_err(mark_write_db_error)?;
+
+    let (booking_status, actual_checkout) = if dates.still_staying {
+        (status::booking::ACTIVE, None)
+    } else {
+        (status::booking::CHECKED_OUT, Some(end_at.clone()))
+    };
+
+    sqlx::query(
+        "INSERT INTO bookings (
+            id, room_id, primary_guest_id, check_in_at, expected_checkout,
+            actual_checkout, nights, total_price, paid_amount, status, source,
+            notes, created_by, booking_type, pricing_type, pricing_snapshot, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, 'walk-in', 'nightly', NULL, ?)",
+    )
+    .bind(&booking_id)
+    .bind(&req.room_id)
+    .bind(&guest_manifest.primary_guest_id)
+    .bind(&check_in_at)
+    .bind(&end_at)
+    .bind(&actual_checkout)
+    .bind(nights)
+    .bind(req.total_price)
+    .bind(booking_status)
+    .bind(req.source.as_deref().unwrap_or("walk-in"))
+    .bind(&req.notes)
+    .bind(user_id)
+    .bind(&check_in_at)
+    .execute(&mut **tx)
+    .await
+    .map_err(BookingError::from)
+    .map_err(mark_write_db_error)?;
+
+    link_booking_guests(tx, &booking_id, &guest_manifest.guest_ids)
+        .await
+        .map_err(mark_write_db_error)?;
+
+    let charge_origin = OriginSideEffect::new(origin_key, 0)?;
+    record_charge_with_origin_tx(
+        tx,
+        &booking_id,
+        req.total_price,
+        "Tiền phòng (ghi bù)",
+        check_in_at.clone(),
+        &charge_origin,
+    )
+    .await
+    .map_err(mark_write_db_error)?;
+
+    if req.paid_amount > 0 {
+        let payment_origin = OriginSideEffect::new(origin_key, 1)?;
+        record_payment_with_origin_tx(
+            tx,
+            &booking_id,
+            req.paid_amount,
+            "Thanh toán (ghi bù)",
+            &payment_origin,
+        )
+        .await
+        .map_err(mark_write_db_error)?;
+    }
+
+    insert_room_calendar_rows(
+        tx,
+        &req.room_id,
+        &booking_id,
+        dates.check_in,
+        dates.end,
+        status::calendar::OCCUPIED,
+    )
+    .await
+    .map_err(mark_write_db_error)?;
+
+    if dates.still_staying {
+        let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status = ?")
+            .bind(status::room::OCCUPIED)
+            .bind(&req.room_id)
+            .bind(status::room::VACANT)
+            .execute(&mut **tx)
+            .await
+            .map_err(BookingError::from)
+            .map_err(mark_write_db_error)?;
+        ensure_one_row_affected(result, format!("room {} is no longer vacant", req.room_id))?;
+    }
+
+    fetch_booking_tx(tx, &booking_id).await
+}
+
+fn build_backfill_hash_payload(req: &BackfillStayRequest) -> serde_json::Value {
+    json!({
+        "schema": "stay.backfill.v1",
+        "room_id": req.room_id.clone(),
+        "guests": guest_hash_payload_entries(&req.guests),
+        "check_in_date": req.check_in_date.clone(),
+        "check_out_date": req.check_out_date.clone(),
+        "expected_checkout_date": req.expected_checkout_date.clone(),
+        "total_price": req.total_price,
+        "paid_amount": req.paid_amount,
+        "source": req.source.clone(),
+        "notes": req.notes.clone(),
+    })
+}
+
+fn backfill_lock_keys_from_payload(hash_payload: &serde_json::Value) -> CommandResult<Vec<String>> {
+    let room_id = hash_payload
+        .get("room_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| system_error("backfill lock payload missing room_id"))?;
+    Ok(vec![crate::aggregate_locks::room_key(room_id)?])
+}
+
+// Lệnh Tauri gọi hàm này được nối ở bước sau; hiện chỉ có test gọi tới.
+#[allow(dead_code)]
+pub async fn backfill_stay_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    req: BackfillStayRequest,
+    user_id: Option<String>,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let today = Local::now().date_naive();
+    validate_backfill_request(&req, today).map_err(|error| {
+        map_check_in_command_error(error).with_request_id(ctx.request_id.clone())
+    })?;
+
+    let hash_payload = build_backfill_hash_payload(&req);
+    let still_staying = req.check_out_date.is_none();
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("stay.backfill.v1")),
+        ("room_present", json!(true)),
+        ("guest_count", json!(req.guests.len())),
+        ("still_staying", json!(still_staying)),
+        ("total_price_vnd", json!(req.total_price)),
+        ("paid_amount_vnd", json!(req.paid_amount)),
+        ("source_present", json!(req.source.is_some())),
+    ])?;
+    let summary = CommandLedgerSummary::new("Backfill stay")?.with_aggregate_ref(
+        "room",
+        "room",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload.clone(), ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("room:{}", req.room_id))
+        .with_lock_key_deriver(backfill_lock_keys_from_payload)
+        .with_success_summary(CommandLedgerResultSummary::success("Backfilled")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.backfilled",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms", "folio"],
+        )?);
+
+    let runtime_lock_keys = backfill_lock_keys_from_payload(&hash_payload)?;
+    let origin_key = format!("{}:{}", ctx.command_name, ctx.idempotency_key);
+    let req_for_service = req;
+    let user_id_for_service = user_id;
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_pre_transaction_guard(
+            ctx,
+            request,
+            move || async move {
+                crate::aggregate_locks::global_manager()
+                    .acquire(runtime_lock_keys)
+                    .await
+            },
+            move |tx| {
+                Box::pin(async move {
+                    let booking = backfill_stay_tx(
+                        tx,
+                        &req_for_service,
+                        user_id_for_service.as_deref(),
+                        origin_key.as_str(),
+                    )
+                    .await
+                    .map_err(map_check_in_command_error)?;
+                    serde_json::to_value(&booking).map_err(system_error)
+                })
+            },
+        )
+        .await
+}

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -452,6 +452,7 @@ async fn group_checkin_tx(
                 &booking_checkout_at
             },
             "nightly",
+            None,
         )
         .await?;
         let total_price = pricing.total;

--- a/mhm/src-tauri/src/services/booking/guest_service.rs
+++ b/mhm/src-tauri/src/services/booking/guest_service.rs
@@ -11,6 +11,30 @@ pub struct GuestManifest {
     pub guest_ids: Vec<String>,
 }
 
+/// Ánh xạ khách sang JSON dùng cho request hash của các lệnh ghi.
+///
+/// Sống cạnh `create_guest_manifest` để mọi hiểu biết về các trường của
+/// `CreateGuestRequest` nằm chung một chỗ: thêm một trường thì chỉ sửa ở đây.
+pub(super) fn guest_hash_payload_entries(guests: &[CreateGuestRequest]) -> Vec<serde_json::Value> {
+    guests
+        .iter()
+        .map(|guest| {
+            serde_json::json!({
+                "guest_type": guest.guest_type.clone(),
+                "full_name": guest.full_name.clone(),
+                "doc_number": guest.doc_number.clone(),
+                "dob": guest.dob.clone(),
+                "gender": guest.gender.clone(),
+                "nationality": guest.nationality.clone(),
+                "address": guest.address.clone(),
+                "visa_expiry": guest.visa_expiry.clone(),
+                "scan_path": guest.scan_path.clone(),
+                "phone": guest.phone.clone(),
+            })
+        })
+        .collect()
+}
+
 struct GuestRecordInput<'a> {
     guest_type: &'a str,
     full_name: &'a str,

--- a/mhm/src-tauri/src/services/booking/guest_service.rs
+++ b/mhm/src-tauri/src/services/booking/guest_service.rs
@@ -14,7 +14,12 @@ pub struct GuestManifest {
 /// Ánh xạ khách sang JSON dùng cho request hash của các lệnh ghi.
 ///
 /// Sống cạnh `create_guest_manifest` để mọi hiểu biết về các trường của
-/// `CreateGuestRequest` nằm chung một chỗ: thêm một trường thì chỉ sửa ở đây.
+/// `CreateGuestRequest` nằm chung một chỗ. Đây là điểm sửa duy nhất cho check-in
+/// (`stay_lifecycle::build_check_in_hash_payload`) và ghi bù
+/// (`backfill::build_backfill_hash_payload`) — nhưng KHÔNG phải điểm sửa duy nhất cho toàn bộ
+/// hệ thống: `group_lifecycle::build_group_checkin_hash_payload` vẫn tự ánh xạ từng trường một
+/// cách độc lập (chưa gọi hàm này), nên thêm một trường mới ở đây sẽ không tự động phản ánh
+/// sang lệnh check-in nhóm.
 pub(super) fn guest_hash_payload_entries(guests: &[CreateGuestRequest]) -> Vec<serde_json::Value> {
     guests
         .iter()

--- a/mhm/src-tauri/src/services/booking/mod.rs
+++ b/mhm/src-tauri/src/services/booking/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_service;
+pub mod backfill;
 pub mod billing_service;
 pub mod group_lifecycle;
 pub mod group_service_management;

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -69,15 +69,9 @@ pub async fn calculate_room_price_preview(
     pricing_type: &str,
     guests: Option<i32>,
 ) -> BookingResult<crate::pricing::PricingResult> {
-    let inputs = load_stay_pricing_inputs_for_room(
-        pool,
-        room_id,
-        check_in,
-        check_out,
-        pricing_type,
-        guests,
-    )
-    .await?;
+    let inputs =
+        load_stay_pricing_inputs_for_room(pool, room_id, check_in, check_out, pricing_type, guests)
+            .await?;
     calculate_from_loaded_inputs(&inputs)
 }
 

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -29,9 +29,10 @@ pub async fn calculate_stay_price_tx(
     check_in: &str,
     check_out: &str,
     pricing_type: &str,
+    guests: Option<i32>,
 ) -> BookingResult<crate::pricing::PricingResult> {
     let inputs =
-        load_stay_pricing_inputs_tx(tx, room_id, check_in, check_out, pricing_type).await?;
+        load_stay_pricing_inputs_tx(tx, room_id, check_in, check_out, pricing_type, guests).await?;
     calculate_from_loaded_inputs(&inputs)
 }
 
@@ -43,10 +44,17 @@ pub async fn calculate_price_preview(
     check_in: &str,
     check_out: &str,
     pricing_type: &str,
+    guests: Option<i32>,
 ) -> BookingResult<crate::pricing::PricingResult> {
-    let inputs =
-        load_stay_pricing_inputs_for_room_type(pool, room_type, check_in, check_out, pricing_type)
-            .await?;
+    let inputs = load_stay_pricing_inputs_for_room_type(
+        pool,
+        room_type,
+        check_in,
+        check_out,
+        pricing_type,
+        guests,
+    )
+    .await?;
     calculate_from_loaded_inputs(&inputs)
 }
 
@@ -207,14 +215,16 @@ mod tests {
         seed_room(&pool, "R-BASE", "derived", 620_000).await;
 
         for (room_id, room_type) in [("R-CONF", "configured"), ("R-BASE", "derived")] {
-            let preview = calculate_price_preview(&pool, room_type, CHECK_IN, CHECK_OUT, "nightly")
-                .await
-                .unwrap_or_else(|error| panic!("preview for {room_type}: {error}"));
+            let preview =
+                calculate_price_preview(&pool, room_type, CHECK_IN, CHECK_OUT, "nightly", None)
+                    .await
+                    .unwrap_or_else(|error| panic!("preview for {room_type}: {error}"));
 
             let mut tx = pool.begin().await.expect("begin");
-            let charged = calculate_stay_price_tx(&mut tx, room_id, CHECK_IN, CHECK_OUT, "nightly")
-                .await
-                .unwrap_or_else(|error| panic!("charge for {room_type}: {error}"));
+            let charged =
+                calculate_stay_price_tx(&mut tx, room_id, CHECK_IN, CHECK_OUT, "nightly", None)
+                    .await
+                    .unwrap_or_else(|error| panic!("charge for {room_type}: {error}"));
             tx.rollback().await.expect("rollback");
 
             assert_eq!(preview.total, charged.total, "total for {room_type}");
@@ -245,12 +255,14 @@ mod tests {
         let pool = migrated_pool().await;
         seed_room(&pool, "R-BASE", "derived", 350_000).await;
 
-        let house = calculate_price_preview(&pool, "no-such-type", CHECK_IN, CHECK_OUT, "nightly")
-            .await
-            .expect("house preview");
-        let derived = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
-            .await
-            .expect("derived preview");
+        let house =
+            calculate_price_preview(&pool, "no-such-type", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("house preview");
+        let derived =
+            calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("derived preview");
 
         // The house default *is* 350k, so a room priced at 350k must quote the same.
         assert_eq!(house.total, derived.total);
@@ -286,15 +298,17 @@ mod tests {
         seed_room(&pool, "R-BASE", "derived", 620_000).await;
 
         let configured =
-            calculate_price_preview(&pool, "configured", CHECK_IN, CHECK_OUT, "nightly")
+            calculate_price_preview(&pool, "configured", CHECK_IN, CHECK_OUT, "nightly", None)
                 .await
                 .expect("configured preview");
-        let derived = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
-            .await
-            .expect("derived preview");
-        let house = calculate_price_preview(&pool, "no-such-type", CHECK_IN, CHECK_OUT, "nightly")
-            .await
-            .expect("house preview");
+        let derived =
+            calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("derived preview");
+        let house =
+            calculate_price_preview(&pool, "no-such-type", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("house preview");
 
         assert_ne!(configured.total, derived.total);
         assert_ne!(derived.total, house.total);
@@ -306,7 +320,7 @@ mod tests {
         let pool = migrated_pool().await;
         seed_room(&pool, "R-SPECIAL", "derived", 500_000).await;
 
-        let plain = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
+        let plain = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly", None)
             .await
             .expect("plain preview");
 
@@ -320,9 +334,10 @@ mod tests {
             .await
             .expect("seed special date");
 
-        let uplifted = calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly")
-            .await
-            .expect("uplifted preview");
+        let uplifted =
+            calculate_price_preview(&pool, "derived", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("uplifted preview");
 
         assert!(uplifted.surcharge_amount > plain.surcharge_amount);
         assert!(uplifted.total > plain.total);

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -17,7 +17,8 @@ use crate::domain::booking::pricing::calculate_from_loaded_inputs;
 use crate::domain::booking::BookingResult;
 use crate::money::{validate_non_negative_money_vnd, MoneyVnd};
 use crate::queries::booking::pricing_queries::{
-    load_stay_pricing_inputs_for_room_type, load_stay_pricing_inputs_tx,
+    load_stay_pricing_inputs_for_room, load_stay_pricing_inputs_for_room_type,
+    load_stay_pricing_inputs_tx,
 };
 use crate::repositories::booking::pricing_repository::{self, PricingRuleUpsert};
 
@@ -49,6 +50,28 @@ pub async fn calculate_price_preview(
     let inputs = load_stay_pricing_inputs_for_room_type(
         pool,
         room_type,
+        check_in,
+        check_out,
+        pricing_type,
+        guests,
+    )
+    .await?;
+    calculate_from_loaded_inputs(&inputs)
+}
+
+/// Bản xem trước mà form đặt phòng dùng: keyed theo phòng đã chọn, nên con số
+/// nó trả về đúng bằng con số `calculate_stay_price_tx` sẽ tính khi ghi sổ.
+pub async fn calculate_room_price_preview(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    check_in: &str,
+    check_out: &str,
+    pricing_type: &str,
+    guests: Option<i32>,
+) -> BookingResult<crate::pricing::PricingResult> {
+    let inputs = load_stay_pricing_inputs_for_room(
+        pool,
+        room_id,
         check_in,
         check_out,
         pricing_type,

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -614,7 +614,7 @@ pub async fn confirm_reservation_tx(
         &today.format("%Y-%m-%d").to_string(),
         &effective_checkout,
         &reservation.pricing_type,
-        None,
+        reservation.guests,
     )
     .await?;
     let total_price = pricing.total;
@@ -758,20 +758,21 @@ pub async fn modify_reservation_tx(
         )));
     }
 
+    let effective_guests = req.new_guests.or(reservation.guests);
     let pricing = calculate_stay_price_tx(
         tx,
         &reservation.room_id,
         &req.new_check_in_date,
         &req.new_check_out_date,
         &reservation.pricing_type,
-        None,
+        effective_guests,
     )
     .await?;
     let total_price = pricing.total;
 
     let result = sqlx::query(
         "UPDATE bookings
-         SET check_in_at = ?, expected_checkout = ?, scheduled_checkin = ?, scheduled_checkout = ?, nights = ?, total_price = ?
+         SET check_in_at = ?, expected_checkout = ?, scheduled_checkin = ?, scheduled_checkout = ?, nights = ?, total_price = ?, guests = ?
          WHERE id = ? AND status = ? AND room_id = ?",
     )
     .bind(&req.new_check_in_date)
@@ -780,6 +781,7 @@ pub async fn modify_reservation_tx(
     .bind(&req.new_check_out_date)
     .bind(derived_nights)
     .bind(total_price)
+    .bind(effective_guests)
     .bind(&req.booking_id)
     .bind(status::booking::BOOKED)
     .bind(locked_room_id)
@@ -1049,7 +1051,7 @@ async fn load_booked_reservation(
     booking_id: &str,
 ) -> BookingResult<BookedReservation> {
     let row = sqlx::query(
-        "SELECT room_id, status, paid_amount, scheduled_checkout, pricing_type
+        "SELECT room_id, status, paid_amount, scheduled_checkout, pricing_type, guests
          FROM bookings
          WHERE id = ?",
     )
@@ -1079,6 +1081,7 @@ async fn load_booked_reservation(
         pricing_type: row
             .get::<Option<String>, _>("pricing_type")
             .unwrap_or_else(|| "nightly".to_string()),
+        guests: row.get("guests"),
     })
 }
 
@@ -1109,6 +1112,7 @@ struct BookedReservation {
     paid_amount: MoneyVnd,
     scheduled_checkout: String,
     pricing_type: String,
+    guests: Option<i32>,
 }
 
 fn parse_date(value: &str) -> BookingResult<NaiveDate> {

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -243,6 +243,7 @@ pub async fn create_reservation_tx(
         &req.check_in_date,
         &req.check_out_date,
         "nightly",
+        None,
     )
     .await?;
     let total_price = pricing.total;
@@ -612,6 +613,7 @@ pub async fn confirm_reservation_tx(
         &today.format("%Y-%m-%d").to_string(),
         &effective_checkout,
         &reservation.pricing_type,
+        None,
     )
     .await?;
     let total_price = pricing.total;
@@ -761,6 +763,7 @@ pub async fn modify_reservation_tx(
         &req.new_check_in_date,
         &req.new_check_out_date,
         &reservation.pricing_type,
+        None,
     )
     .await?;
     let total_price = pricing.total;

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -243,7 +243,7 @@ pub async fn create_reservation_tx(
         &req.check_in_date,
         &req.check_out_date,
         "nightly",
-        None,
+        req.guests,
     )
     .await?;
     let total_price = pricing.total;
@@ -264,8 +264,8 @@ pub async fn create_reservation_tx(
             id, room_id, primary_guest_id, check_in_at, expected_checkout, actual_checkout,
             nights, total_price, paid_amount, status, source, notes, created_by,
             booking_type, pricing_type, deposit_amount, guest_phone, scheduled_checkin,
-            scheduled_checkout, pricing_snapshot, created_at
-         ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, 0, ?, ?, ?, NULL, 'reservation', 'nightly', ?, ?, ?, ?, NULL, ?)",
+            scheduled_checkout, pricing_snapshot, guests, created_at
+         ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, 0, ?, ?, ?, NULL, 'reservation', 'nightly', ?, ?, ?, ?, NULL, ?, ?)",
     )
     .bind(&booking_id)
     .bind(&req.room_id)
@@ -281,6 +281,7 @@ pub async fn create_reservation_tx(
     .bind(req.guest_phone.as_deref())
     .bind(&req.check_in_date)
     .bind(&req.check_out_date)
+    .bind(req.guests)
     .bind(&now)
     .execute(&mut **tx)
     .await

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -994,6 +994,14 @@ pub async fn modify_reservation_idempotent(
         .await
 }
 
+/// Trần số đêm cho một đặt phòng. Trước nhánh này, ngày đi chỉ đọc được (suy
+/// ra từ một ô số đêm mang `max={90}`), nên 90 đêm là trần cứng theo cấu trúc.
+/// Nhánh này cho gõ tay ngày đi trực tiếp và xoá ô số đêm đó — nhưng không có
+/// gì thay thế trần cũ, nên một lỗi gõ năm (`2036` thay vì `2026`) tạo ra một
+/// đặt phòng khoảng 3650 đêm, khoá phòng đó cả thập kỷ trong `room_calendar`.
+/// Đây là khôi phục lại trần cũ, không phải đặt ra chính sách mới.
+const MAX_RESERVATION_NIGHTS: i64 = 90;
+
 fn validate_requested_nights(
     check_in_date: &str,
     check_out_date: &str,
@@ -1006,6 +1014,12 @@ fn validate_requested_nights(
         return Err(BookingError::validation(
             "Check-out date must be after check-in date".to_string(),
         ));
+    }
+    if derived_nights > MAX_RESERVATION_NIGHTS {
+        return Err(BookingError::validation(format!(
+            "Number of nights must not exceed {}",
+            MAX_RESERVATION_NIGHTS
+        )));
     }
     if requested_nights != derived_nights as i32 {
         return Err(BookingError::validation(format!(

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -24,7 +24,7 @@ use super::{
         record_charge_tx, record_charge_with_origin_tx, record_payment_tx,
         record_payment_with_origin_tx,
     },
-    guest_service::{create_guest_manifest, link_booking_guests},
+    guest_service::{create_guest_manifest, guest_hash_payload_entries, link_booking_guests},
     pricing_service::calculate_stay_price_tx,
     support::{
         begin_tx, ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
@@ -36,7 +36,7 @@ use super::{
 #[cfg(test)]
 use super::support::{begin_immediate_tx, fetch_booking};
 
-fn mark_write_db_error(error: BookingError) -> BookingError {
+pub(super) fn mark_write_db_error(error: BookingError) -> BookingError {
     match error {
         BookingError::Database(message) => BookingError::database_write(message),
         other => other,
@@ -139,29 +139,10 @@ pub(super) fn map_extend_stay_command_error(error: BookingError) -> CommandError
 }
 
 fn build_check_in_hash_payload(req: &CheckInRequest) -> serde_json::Value {
-    let guests = req
-        .guests
-        .iter()
-        .map(|guest| {
-            json!({
-                "guest_type": guest.guest_type.clone(),
-                "full_name": guest.full_name.clone(),
-                "doc_number": guest.doc_number.clone(),
-                "dob": guest.dob.clone(),
-                "gender": guest.gender.clone(),
-                "nationality": guest.nationality.clone(),
-                "address": guest.address.clone(),
-                "visa_expiry": guest.visa_expiry.clone(),
-                "scan_path": guest.scan_path.clone(),
-                "phone": guest.phone.clone(),
-            })
-        })
-        .collect::<Vec<_>>();
-
     json!({
         "schema": "stay.check_in.v1",
         "room_id": req.room_id.clone(),
-        "guests": guests,
+        "guests": guest_hash_payload_entries(&req.guests),
         "nights": req.nights,
         "source": req.source.clone(),
         "notes": req.notes.clone(),
@@ -221,7 +202,7 @@ fn extend_stay_initial_lock_keys_from_payload(
     ])
 }
 
-async fn fetch_booking_tx(
+pub(super) async fn fetch_booking_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,
 ) -> BookingResult<Booking> {

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -645,7 +645,7 @@ async fn preview_checkout_settlement_tx(
 ) -> BookingResult<CheckoutSettlementComputation> {
     let booking = sqlx::query(
         "SELECT room_id, check_in_at, nights, total_price, paid_amount,
-                COALESCE(pricing_type, 'nightly') AS pricing_type, status
+                COALESCE(pricing_type, 'nightly') AS pricing_type, guests, status
          FROM bookings WHERE id = ?",
     )
     .bind(&req.booking_id)
@@ -671,6 +671,7 @@ async fn preview_checkout_settlement_tx(
     let pricing_type: String = booking.get("pricing_type");
     let original_nights: i32 = booking.get("nights");
     let original_total = read_money_vnd_or_zero(&booking, "total_price");
+    let guests: Option<i32> = booking.get("guests");
     let already_paid = read_money_vnd_or_zero(&booking, "paid_amount");
     let actual_nights = actual_nights_for_checkout(&check_in_at, now)?;
 
@@ -684,7 +685,7 @@ async fn preview_checkout_settlement_tx(
                 &check_in_at,
                 &settlement_boundary,
                 &pricing_type,
-                None,
+                guests,
             )
             .await?;
             (settled_nights, pricing.total)
@@ -1010,7 +1011,7 @@ async fn extend_stay_tx(
     origin_key: Option<String>,
 ) -> BookingResult<Booking> {
     let booking = sqlx::query(
-        "SELECT room_id, nights, total_price, expected_checkout, pricing_type, status
+        "SELECT room_id, nights, total_price, expected_checkout, pricing_type, guests, status
          FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
@@ -1040,6 +1041,7 @@ async fn extend_stay_tx(
     let pricing_type = booking
         .get::<Option<String>, _>("pricing_type")
         .unwrap_or_else(|| "nightly".to_string());
+    let guests: Option<i32> = booking.get("guests");
 
     let old_expected = parse_booking_datetime(&old_expected_checkout)?;
     let new_expected = old_expected + Duration::days(1);
@@ -1079,7 +1081,7 @@ async fn extend_stay_tx(
         &old_expected_checkout,
         &new_expected.to_rfc3339(),
         &pricing_type,
-        None,
+        guests,
     )
     .await?;
     let incremental_total = incremental_pricing.total;

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -321,6 +321,7 @@ async fn check_in_tx(
         &check_in_at,
         &expected_checkout,
         &pricing_type,
+        None,
     )
     .await?;
     let total_price = pricing.total;
@@ -683,6 +684,7 @@ async fn preview_checkout_settlement_tx(
                 &check_in_at,
                 &settlement_boundary,
                 &pricing_type,
+                None,
             )
             .await?;
             (settled_nights, pricing.total)
@@ -1077,6 +1079,7 @@ async fn extend_stay_tx(
         &old_expected_checkout,
         &new_expected.to_rfc3339(),
         &pricing_type,
+        None,
     )
     .await?;
     let incremental_total = incremental_pricing.total;

--- a/mhm/src-tauri/src/services/booking/tests/backfill.rs
+++ b/mhm/src-tauri/src/services/booking/tests/backfill.rs
@@ -1,0 +1,297 @@
+use super::prelude::*;
+
+fn day(offset: i64) -> String {
+    (Local::now().date_naive() + Duration::days(offset))
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+fn guest(name: &str) -> CreateGuestRequest {
+    CreateGuestRequest {
+        guest_type: Some("domestic".to_string()),
+        full_name: name.to_string(),
+        doc_number: "012345678901".to_string(),
+        dob: None,
+        gender: Some("Nam".to_string()),
+        nationality: Some("VN".to_string()),
+        address: None,
+        visa_expiry: None,
+        scan_path: None,
+        phone: Some("0900000001".to_string()),
+    }
+}
+
+fn req(room: &str, cin: i64, cout: Option<i64>, expected: Option<i64>) -> BackfillStayRequest {
+    BackfillStayRequest {
+        room_id: room.to_string(),
+        guests: vec![guest("Khách Ghi Bù")],
+        check_in_date: day(cin),
+        check_out_date: cout.map(day),
+        expected_checkout_date: expected.map(day),
+        total_price: 600_000,
+        paid_amount: 600_000,
+        source: Some("walk-in".to_string()),
+        notes: None,
+    }
+}
+
+async fn count(pool: &sqlx::Pool<sqlx::Sqlite>, sql: &str) -> i64 {
+    sqlx::query_scalar(sql).fetch_one(pool).await.unwrap()
+}
+
+#[tokio::test]
+async fn backfill_checked_out_stay_records_full_history() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF1").await.unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-1", "idem-bf-1");
+
+    let result =
+        backfill::backfill_stay_idempotent(&pool, &ctx, req("R-BF1", -3, Some(-1), None), None)
+            .await
+            .unwrap();
+    let booking: crate::models::Booking = serde_json::from_value(result.response).unwrap();
+
+    assert_eq!(booking.status, "checked_out");
+    assert_eq!(booking.nights, 2);
+    assert!(booking.actual_checkout.is_some());
+    assert_eq!(booking.total_price, 600_000);
+    assert_eq!(booking.paid_amount, 600_000);
+
+    // Trạng thái thật trong DB, không chỉ struct trả về.
+    let row = sqlx::query(
+        "SELECT status, nights, total_price, paid_amount, actual_checkout, check_in_at,
+                expected_checkout, source
+         FROM bookings WHERE id = ?",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.get::<String, _>("status"), "checked_out");
+    assert_eq!(row.get::<i32, _>("nights"), 2);
+    assert_eq!(row.get::<i64, _>("total_price"), 600_000);
+    assert_eq!(row.get::<i64, _>("paid_amount"), 600_000);
+    assert_eq!(row.get::<String, _>("source"), "walk-in");
+    // Giờ chuẩn khách sạn: nhận 14:00 ngày vào, trả 12:00 ngày ra.
+    assert!(row.get::<String, _>("check_in_at").contains(&day(-3)));
+    assert!(row.get::<String, _>("check_in_at").contains("T14:00:00"));
+    let actual_checkout: String = row.get::<Option<String>, _>("actual_checkout").unwrap();
+    assert!(actual_checkout.contains(&day(-1)));
+    assert!(actual_checkout.contains("T12:00:00"));
+    assert_eq!(
+        row.get::<String, _>("expected_checkout"),
+        actual_checkout,
+        "khách đã trả thì ngày ra dự kiến trùng ngày ra thực tế"
+    );
+
+    let cal: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM room_calendar WHERE room_id = 'R-BF1' AND booking_id = ?",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(cal, 2);
+
+    // Sổ tiền: 1 dòng thu tiền phòng + 1 dòng thanh toán.
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let payments: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'payment'",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!((charges, payments), (1, 1));
+
+    let linked: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
+            .bind(&booking.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(linked, 1);
+
+    // Khách đã trả → phòng vẫn trống.
+    let room_status: String = sqlx::query_scalar("SELECT status FROM rooms WHERE id = 'R-BF1'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(room_status, "vacant");
+}
+
+#[tokio::test]
+async fn backfill_still_staying_marks_room_occupied() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF2").await.unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-2", "idem-bf-2");
+
+    let result =
+        backfill::backfill_stay_idempotent(&pool, &ctx, req("R-BF2", -1, None, Some(2)), None)
+            .await
+            .unwrap();
+    let booking: crate::models::Booking = serde_json::from_value(result.response).unwrap();
+
+    assert_eq!(booking.status, "active");
+    assert_eq!(booking.nights, 3);
+    assert!(booking.actual_checkout.is_none());
+
+    let row =
+        sqlx::query("SELECT status, actual_checkout, expected_checkout FROM bookings WHERE id = ?")
+            .bind(&booking.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(row.get::<String, _>("status"), "active");
+    assert!(row.get::<Option<String>, _>("actual_checkout").is_none());
+    assert!(row.get::<String, _>("expected_checkout").contains(&day(2)));
+
+    let cal: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM room_calendar WHERE room_id = 'R-BF2' AND booking_id = ?",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(cal, 3);
+
+    let room_status: String = sqlx::query_scalar("SELECT status FROM rooms WHERE id = 'R-BF2'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(room_status, "occupied");
+}
+
+#[tokio::test]
+async fn backfill_still_staying_rejects_room_that_is_not_vacant() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF7").await.unwrap();
+    sqlx::query("UPDATE rooms SET status = 'occupied' WHERE id = 'R-BF7'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-7", "idem-bf-7");
+
+    let error =
+        backfill::backfill_stay_idempotent(&pool, &ctx, req("R-BF7", -1, None, Some(2)), None)
+            .await
+            .unwrap_err();
+    assert!(
+        error.message.contains("đang có khách"),
+        "unexpected: {}",
+        error.message
+    );
+
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 0);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM guests").await, 0);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM room_calendar").await, 0);
+}
+
+#[tokio::test]
+async fn backfill_rejects_check_in_today_or_future() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF3").await.unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-3", "idem-bf-3");
+
+    let error =
+        backfill::backfill_stay_idempotent(&pool, &ctx, req("R-BF3", 0, Some(1), None), None)
+            .await
+            .unwrap_err();
+    assert!(
+        error.message.contains("quá khứ"),
+        "unexpected: {}",
+        error.message
+    );
+
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 0);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM guests").await, 0);
+}
+
+#[tokio::test]
+async fn backfill_rejects_overlapping_stay() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF4").await.unwrap();
+    let first = cmd_with_request("backfill_stay", "req-bf-4a", "idem-bf-4a");
+    backfill::backfill_stay_idempotent(&pool, &first, req("R-BF4", -5, Some(-3), None), None)
+        .await
+        .unwrap();
+
+    let second = cmd_with_request("backfill_stay", "req-bf-4b", "idem-bf-4b");
+    let error =
+        backfill::backfill_stay_idempotent(&pool, &second, req("R-BF4", -4, Some(-2), None), None)
+            .await
+            .unwrap_err();
+    assert!(
+        error.message.contains("đã có khách"),
+        "unexpected: {}",
+        error.message
+    );
+
+    // Lần ghi bù hỏng không được để lại mảnh dữ liệu nào.
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 1);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM guests").await, 1);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM room_calendar").await, 2);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM transactions").await, 2);
+}
+
+#[tokio::test]
+async fn backfill_rejects_paid_above_total() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF5").await.unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-5", "idem-bf-5");
+    let mut request = req("R-BF5", -2, Some(-1), None);
+    request.paid_amount = 700_000;
+
+    let error = backfill::backfill_stay_idempotent(&pool, &ctx, request, None)
+        .await
+        .unwrap_err();
+    assert!(
+        error.message.contains("vượt quá"),
+        "unexpected: {}",
+        error.message
+    );
+
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 0);
+}
+
+#[tokio::test]
+async fn backfill_idempotent_retry_replays_without_duplicates() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF6").await.unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-6", "idem-bf-6");
+
+    let first =
+        backfill::backfill_stay_idempotent(&pool, &ctx, req("R-BF6", -3, Some(-1), None), None)
+            .await
+            .unwrap();
+    let second =
+        backfill::backfill_stay_idempotent(&pool, &ctx, req("R-BF6", -3, Some(-1), None), None)
+            .await
+            .unwrap();
+    assert_replayed_pair(&first, &second);
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bookings WHERE room_id = 'R-BF6'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1);
+
+    let calendar_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE room_id = 'R-BF6'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(calendar_rows, 2);
+
+    let transactions: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(transactions, 2);
+}

--- a/mhm/src-tauri/src/services/booking/tests/backfill.rs
+++ b/mhm/src-tauri/src/services/booking/tests/backfill.rs
@@ -188,6 +188,8 @@ async fn backfill_still_staying_rejects_room_that_is_not_vacant() {
         error.message
     );
 
+    // Guards ordering, not rollback: the room-status guard runs before any write, so this
+    // rejected call never wrote a row (see `backfill_rejects_overlapping_stay` for detail).
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 0);
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM guests").await, 0);
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM room_calendar").await, 0);
@@ -209,6 +211,8 @@ async fn backfill_rejects_check_in_today_or_future() {
         error.message
     );
 
+    // Guards ordering, not rollback: validation runs before any write, so this rejected call
+    // never wrote a row (see `backfill_rejects_overlapping_stay` for detail).
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 0);
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM guests").await, 0);
 }
@@ -233,7 +237,16 @@ async fn backfill_rejects_overlapping_stay() {
         error.message
     );
 
-    // Lần ghi bù hỏng không được để lại mảnh dữ liệu nào.
+    // These counts show only the first (successful) stay's rows remain: 1 booking, 1 guest,
+    // 2 calendar rows, 2 transactions — nothing extra from the second, rejected call.
+    //
+    // What this does NOT prove: that a write started and was then rolled back. The overlap
+    // check runs *before* `create_guest_manifest` (the first write) in `backfill_stay_tx`, so
+    // the rejected call never writes a row in the first place — there is nothing to roll back.
+    // These assertions guard against a future reordering that moved a write ahead of the
+    // guards; they are not evidence that transactional rollback itself works. That guarantee
+    // is structural: every mutation in `backfill_stay_tx` runs on the single `Transaction` the
+    // executor commits only on `Ok`, and no test here exercises a failure after a real write.
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 1);
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM guests").await, 1);
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM room_calendar").await, 2);
@@ -257,7 +270,53 @@ async fn backfill_rejects_paid_above_total() {
         error.message
     );
 
+    // Guards ordering, not rollback: money validation runs before any write, so this rejected
+    // call never wrote a row (see `backfill_rejects_overlapping_stay` for detail).
     assert_eq!(count(&pool, "SELECT COUNT(*) FROM bookings").await, 0);
+}
+
+#[tokio::test]
+async fn backfill_with_zero_paid_amount_writes_no_payment_row() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-BF8").await.unwrap();
+    let ctx = cmd_with_request("backfill_stay", "req-bf-8", "idem-bf-8");
+    let mut request = req("R-BF8", -3, Some(-1), None);
+    request.paid_amount = 0;
+
+    let result = backfill::backfill_stay_idempotent(&pool, &ctx, request, None)
+        .await
+        .unwrap();
+    let booking: crate::models::Booking = serde_json::from_value(result.response).unwrap();
+
+    assert_eq!(booking.paid_amount, 0);
+
+    // Money path: `paid_amount > 0` guards whether a payment row is written at all. This is
+    // the only test in the suite where `paid_amount` is 0, so it is the only one that exercises
+    // the "no payment" branch.
+    let row = sqlx::query("SELECT paid_amount FROM bookings WHERE id = ?")
+        .bind(&booking.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("paid_amount"), 0);
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 1, "charge row must still be written");
+
+    let payments: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'payment'",
+    )
+    .bind(&booking.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(payments, 0, "no payment row when nothing was paid");
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs
+++ b/mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs
@@ -40,6 +40,43 @@ async fn check_out_booking_at(
 }
 
 #[tokio::test]
+async fn actual_nights_settlement_keeps_the_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R330", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+    // Zero out the weekend uplift the fallback pricing rule would otherwise
+    // apply — without this, the assertion below is only correct on days whose
+    // check-in date (today minus 2) does not land on a Sat/Sun.
+    seed_pricing_rule(&pool, "standard", 500_000).await.unwrap();
+    let booking_id = uuid::Uuid::new_v4().to_string();
+    seed_active_booking(&pool, &booking_id, "R330").await.unwrap();
+
+    let check_in = Local::now() - Duration::days(2);
+    sqlx::query(
+        "UPDATE bookings SET guests = 4, nights = 3, total_price = 1800000, check_in_at = ? WHERE id = ?",
+    )
+    .bind(check_in.to_rfc3339())
+    .bind(&booking_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let settlement = stay_lifecycle::preview_checkout_settlement(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: booking_id.clone(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Ở 2 đêm thật × 600.000₫, không phải × 500.000₫.
+    assert_eq!(settlement.recommended_total, 1_200_000);
+}
+
+#[tokio::test]
 async fn check_out_settles_same_day_actual_nights_to_minimum_one_night() {
     let pool = test_pool().await;
     seed_room(&pool, "R410").await.unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs
+++ b/mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs
@@ -50,7 +50,9 @@ async fn actual_nights_settlement_keeps_the_guest_charge() {
     // check-in date (today minus 2) does not land on a Sat/Sun.
     seed_pricing_rule(&pool, "standard", 500_000).await.unwrap();
     let booking_id = uuid::Uuid::new_v4().to_string();
-    seed_active_booking(&pool, &booking_id, "R330").await.unwrap();
+    seed_active_booking(&pool, &booking_id, "R330")
+        .await
+        .unwrap();
 
     let check_in = Local::now() - Duration::days(2);
     sqlx::query(

--- a/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
@@ -1,6 +1,27 @@
 use super::prelude::*;
 
 #[tokio::test]
+async fn extend_stay_prices_the_extra_night_with_the_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R320", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+    let booking_id = uuid::Uuid::new_v4().to_string();
+    seed_active_booking(&pool, &booking_id, "R320").await.unwrap();
+
+    sqlx::query("UPDATE bookings SET guests = 4, total_price = 1200000, nights = 2 WHERE id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let booking = stay_lifecycle::extend_stay(&pool, &booking_id).await.unwrap();
+
+    // 1.200.000₫ cũ + 600.000₫ cho đêm thêm, không phải + 500.000₫.
+    assert_eq!(booking.total_price, 1_800_000);
+}
+
+#[tokio::test]
 async fn extend_stay_uses_existing_expected_checkout() {
     let pool = test_pool().await;
     seed_room(&pool, "R203").await.unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
@@ -7,7 +7,9 @@ async fn extend_stay_prices_the_extra_night_with_the_guest_charge() {
         .await
         .unwrap();
     let booking_id = uuid::Uuid::new_v4().to_string();
-    seed_active_booking(&pool, &booking_id, "R320").await.unwrap();
+    seed_active_booking(&pool, &booking_id, "R320")
+        .await
+        .unwrap();
 
     sqlx::query("UPDATE bookings SET guests = 4, total_price = 1200000, nights = 2 WHERE id = ?")
         .bind(&booking_id)
@@ -15,7 +17,9 @@ async fn extend_stay_prices_the_extra_night_with_the_guest_charge() {
         .await
         .unwrap();
 
-    let booking = stay_lifecycle::extend_stay(&pool, &booking_id).await.unwrap();
+    let booking = stay_lifecycle::extend_stay(&pool, &booking_id)
+        .await
+        .unwrap();
 
     // 1.200.000₫ cũ + 600.000₫ cho đêm thêm, không phải + 500.000₫.
     assert_eq!(booking.total_price, 1_800_000);

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -20,7 +20,7 @@ mod prelude {
         commands::reservations,
         domain::booking::{BookingError, OriginSideEffect},
         models::{
-            AddGroupServiceRequest, CheckOutRequest, CheckoutSettlementMode,
+            AddGroupServiceRequest, BackfillStayRequest, CheckOutRequest, CheckoutSettlementMode,
             CheckoutSettlementPreviewRequest, CreateGuestRequest, CreateReservationRequest,
             GroupCheckoutRequest, ModifyReservationRequest,
         },
@@ -29,7 +29,7 @@ mod prelude {
     };
 
     pub(crate) use crate::services::booking::{
-        audit_service,
+        audit_service, backfill,
         billing_service::{
             add_folio_line, add_folio_line_idempotent, record_cancellation_fee_tx,
             record_deposit_tx, record_deposit_with_origin_tx, record_payment,
@@ -42,6 +42,7 @@ mod prelude {
     };
 }
 
+mod backfill;
 mod checkout_settlement;
 mod extend_stay;
 mod folio;

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -36,7 +36,7 @@ mod prelude {
             record_payment_idempotent, record_payment_returning_id_tx, record_payment_tx,
             record_payment_with_origin_tx,
         },
-        group_lifecycle, group_service_management, guest_service,
+        group_lifecycle, group_service_management, guest_service, pricing_service,
         pricing_service::calculate_stay_price_tx,
         reservation_lifecycle, stay_lifecycle,
     };

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -22,7 +22,7 @@ mod prelude {
         models::{
             AddGroupServiceRequest, CheckOutRequest, CheckoutSettlementMode,
             CheckoutSettlementPreviewRequest, CreateGuestRequest, CreateReservationRequest,
-            GroupCheckoutRequest,
+            GroupCheckoutRequest, ModifyReservationRequest,
         },
         money::MAX_TRANSPORT_SAFE_MONEY_VND,
         queries::booking::{audit_queries, billing_queries, revenue_queries},

--- a/mhm/src-tauri/src/services/booking/tests/pricing.rs
+++ b/mhm/src-tauri/src/services/booking/tests/pricing.rs
@@ -200,6 +200,65 @@ async fn room_price_preview_uses_its_own_rooms_surcharge_not_a_same_type_sibling
     assert_eq!(preview.breakdown[1].amount, 200_000);
 }
 
+/// Cái toàn bộ thiết kế của nhánh này đặt cược vào: bản xem trước theo phòng
+/// (`calculate_room_price_preview`) phải trả đúng con số sẽ bị tính khi ghi
+/// sổ (`calculate_stay_price_tx`) — kể cả khi có phụ thu thêm khách, không
+/// chỉ khi `guests: None`. Hai bài `room_price_preview_matches_...` ở trên chỉ
+/// so `preview.total` với một con số hằng (`1_200_000`); bài
+/// `the_preview_and_the_lifecycle_charge_agree_on_every_reachable_rule_source`
+/// trong `pricing_service.rs` so cấu trúc thật nhưng chỉ chạy với
+/// `guests: None`. Bài này là bài giữ lời hứa đó khỏi mục rữa: so cấu trúc
+/// (breakdown nhãn + số tiền, không chỉ tổng) với `guests: Some(4)`.
+#[tokio::test]
+async fn room_price_preview_matches_the_lifecycle_charge_structurally_with_extra_guests() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R341", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let preview = pricing_service::calculate_room_price_preview(
+        &pool,
+        "R341",
+        "2026-08-06",
+        "2026-08-08",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let charged = calculate_stay_price_tx(
+        &mut tx,
+        "R341",
+        "2026-08-06",
+        "2026-08-08",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .unwrap();
+    tx.rollback().await.unwrap();
+
+    assert_eq!(preview.total, charged.total);
+    assert_eq!(preview.base_amount, charged.base_amount);
+    assert_eq!(preview.surcharge_amount, charged.surcharge_amount);
+    assert_eq!(preview.weekend_amount, charged.weekend_amount);
+    assert_eq!(preview.breakdown.len(), charged.breakdown.len());
+    for (preview_line, charged_line) in preview.breakdown.iter().zip(charged.breakdown.iter()) {
+        assert_eq!(preview_line.label, charged_line.label);
+        assert_eq!(preview_line.amount, charged_line.amount);
+    }
+
+    // Con số thật phải khác 0 và có mặt dòng phụ thu — nếu không, so sánh
+    // cấu trúc ở trên có thể trùng khớp một cách vô nghĩa (cả hai đều rỗng).
+    assert!(charged.total > 0);
+    assert!(charged
+        .breakdown
+        .iter()
+        .any(|line| line.label.contains("khách")));
+}
+
 #[tokio::test]
 async fn calculate_stay_price_tx_reads_uncommitted_special_date() {
     let pool = test_pool().await;

--- a/mhm/src-tauri/src/services/booking/tests/pricing.rs
+++ b/mhm/src-tauri/src/services/booking/tests/pricing.rs
@@ -15,6 +15,7 @@ async fn calculate_stay_price_tx_reads_uncommitted_pricing_rule() {
         "2026-04-15T10:00:00+07:00",
         "2026-04-17T10:00:00+07:00",
         "nightly",
+        None,
     )
     .await
     .unwrap();
@@ -37,6 +38,7 @@ async fn calculate_stay_price_tx_applies_special_date_uplift() {
         "2026-04-20T10:00:00+07:00",
         "2026-04-22T10:00:00+07:00",
         "nightly",
+        None,
     )
     .await
     .unwrap();
@@ -68,6 +70,7 @@ async fn calculate_stay_price_tx_returns_not_found_for_missing_room() {
         "2026-04-20T10:00:00+07:00",
         "2026-04-22T10:00:00+07:00",
         "nightly",
+        None,
     )
     .await
     .unwrap_err();
@@ -92,6 +95,7 @@ async fn calculate_stay_price_tx_returns_datetime_parse_for_invalid_check_in() {
         "not-a-datetime",
         "2026-04-22T10:00:00+07:00",
         "nightly",
+        None,
     )
     .await
     .unwrap_err();
@@ -123,6 +127,7 @@ async fn calculate_stay_price_tx_reads_uncommitted_room_base_price() {
         "2026-04-20T10:00:00+07:00",
         "2026-04-22T10:00:00+07:00",
         "nightly",
+        None,
     )
     .await
     .unwrap();
@@ -148,6 +153,7 @@ async fn calculate_stay_price_tx_reads_uncommitted_special_date() {
         "2026-04-20T10:00:00+07:00",
         "2026-04-22T10:00:00+07:00",
         "nightly",
+        None,
     )
     .await
     .unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/pricing.rs
+++ b/mhm/src-tauri/src/services/booking/tests/pricing.rs
@@ -160,6 +160,46 @@ async fn room_price_preview_matches_what_the_reservation_will_be_charged() {
     assert_eq!(preview.breakdown[1].label, "Phụ thu 2 khách");
 }
 
+/// Two rooms of the same type with different surcharges. The room-keyed
+/// preview must quote the room actually asked for, not whichever same-type
+/// row a bare `LIMIT 1` would happen to return.
+///
+/// `R339` is seeded first so it lands on the lower rowid: `rooms` has no
+/// index on `type`, so `WHERE LOWER(type) = ? LIMIT 1` (the type-keyed query)
+/// resolves via a full table scan in rowid order and would return `R339` —
+/// not `R340`, the room the preview is actually for. If the room-keyed loader
+/// were ever swapped to the type-keyed query, this test would silently start
+/// quoting `R339`'s surcharge for a preview requested against `R340`.
+#[tokio::test]
+async fn room_price_preview_uses_its_own_rooms_surcharge_not_a_same_type_sibling() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R339", 500_000, 2, 900_000)
+        .await
+        .unwrap();
+    seed_room_with_guest_pricing(&pool, "R340", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let preview = pricing_service::calculate_room_price_preview(
+        &pool,
+        "R340",
+        "2026-08-06",
+        "2026-08-08",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .unwrap();
+
+    // base: 500_000 * 2 nights = 1_000_000
+    // surcharge: R340's own 50_000/night/extra-guest * 2 extra guests * 2 nights = 200_000
+    // If R339's 900_000 fee leaked in instead, surcharge would be 3_600_000 and total 4_600_000.
+    assert_eq!(preview.total, 1_200_000);
+    assert_eq!(preview.breakdown.len(), 2);
+    assert_eq!(preview.breakdown[1].label, "Phụ thu 2 khách");
+    assert_eq!(preview.breakdown[1].amount, 200_000);
+}
+
 #[tokio::test]
 async fn calculate_stay_price_tx_reads_uncommitted_special_date() {
     let pool = test_pool().await;

--- a/mhm/src-tauri/src/services/booking/tests/pricing.rs
+++ b/mhm/src-tauri/src/services/booking/tests/pricing.rs
@@ -138,6 +138,29 @@ async fn calculate_stay_price_tx_reads_uncommitted_room_base_price() {
 }
 
 #[tokio::test]
+async fn room_price_preview_matches_what_the_reservation_will_be_charged() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R340", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let preview = pricing_service::calculate_room_price_preview(
+        &pool,
+        "R340",
+        "2026-08-06",
+        "2026-08-08",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.total, 1_200_000);
+    assert_eq!(preview.breakdown.len(), 2);
+    assert_eq!(preview.breakdown[1].label, "Phụ thu 2 khách");
+}
+
+#[tokio::test]
 async fn calculate_stay_price_tx_reads_uncommitted_special_date() {
     let pool = test_pool().await;
     seed_room_with_price(&pool, "R152", 600_000).await.unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/pricing.rs
+++ b/mhm/src-tauri/src/services/booking/tests/pricing.rs
@@ -50,11 +50,11 @@ async fn calculate_stay_price_tx_applies_special_date_uplift() {
     assert_eq!(pricing.weekend_amount, 0);
     assert_eq!(pricing.breakdown.len(), 2);
     assert_eq!(pricing.breakdown[0].amount, 1_200_000);
-    assert!(pricing.breakdown[0].label.contains("night(s)"));
+    assert!(pricing.breakdown[0].label.contains("đêm"));
     assert!(pricing
         .breakdown
         .iter()
-        .any(|line| line.label == "Holiday surcharge"));
+        .any(|line| line.label == "Phụ thu ngày lễ"));
 
     tx.rollback().await.unwrap();
 }

--- a/mhm/src-tauri/src/services/booking/tests/reservation_idempotency.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservation_idempotency.rs
@@ -174,6 +174,7 @@ async fn reservation_command_idempotency_create_hashes_deposit_as_integer_vnd_un
         source: Some("phone".to_string()),
         notes: None,
         deposit_amount: Some(500_000),
+        guests: None,
     };
 
     reservation_lifecycle::create_reservation_idempotent(&pool, &ctx, request)

--- a/mhm/src-tauri/src/services/booking/tests/reservation_idempotency.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservation_idempotency.rs
@@ -474,6 +474,7 @@ async fn reservation_command_idempotency_modify_cancel_confirm_same_key_differen
             new_check_in_date: "2026-04-23".to_string(),
             new_check_out_date: "2026-04-25".to_string(),
             new_nights: 2,
+            new_guests: None,
         },
     )
     .await
@@ -486,6 +487,7 @@ async fn reservation_command_idempotency_modify_cancel_confirm_same_key_differen
             new_check_in_date: "2026-04-23".to_string(),
             new_check_out_date: "2026-04-25".to_string(),
             new_nights: 2,
+            new_guests: None,
         },
     )
     .await

--- a/mhm/src-tauri/src/services/booking/tests/reservations.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservations.rs
@@ -54,6 +54,7 @@ async fn create_reservation_rejects_inconsistent_nights_input() {
             deposit_amount: Some(50_000),
             source: Some("phone".to_string()),
             notes: Some("test reservation".to_string()),
+            guests: None,
         },
     )
     .await
@@ -87,6 +88,7 @@ async fn reservation_lifecycle_smoke_covers_confirm_and_cancel_paths() {
             deposit_amount: Some(50_000),
             source: Some("phone".to_string()),
             notes: Some("reservation smoke".to_string()),
+            guests: None,
         }
     };
 
@@ -693,4 +695,83 @@ async fn do_modify_reservation_returns_service_booking_without_app_handle() {
     assert_eq!(booking.total_price, 1_200_000);
 
     assert_calendar_rows(&pool, "B167", "booked", 2).await;
+}
+
+#[tokio::test]
+async fn create_reservation_charges_extra_guests() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R300", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R300".to_string(),
+            guest_name: "Nguyễn Nhật Huy".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: Some("phone".to_string()),
+            notes: None,
+            guests: Some(4),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let row = sqlx::query("SELECT total_price, guests FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<i64, _>("total_price"), 1_200_000);
+    assert_eq!(row.get::<Option<i32>, _>("guests"), Some(4));
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn create_reservation_without_guests_prices_like_before() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R301", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R301".to_string(),
+            guest_name: "Khách cũ".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: None,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+
+    assert_eq!(total, 1_000_000);
+
+    tx.rollback().await.unwrap();
 }

--- a/mhm/src-tauri/src/services/booking/tests/reservations.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservations.rs
@@ -66,6 +66,62 @@ async fn create_reservation_rejects_inconsistent_nights_input() {
     ));
 }
 
+/// Trước đây ngày đi chỉ đọc được, suy từ một ô số đêm mang `max={90}` — 90
+/// đêm là trần cứng theo cấu trúc. Ô đó bị xoá để cho gõ tay ngày đi, và
+/// không gì thay thế trần cũ ở tầng service: một lỗi gõ năm (`2036` thay vì
+/// `2026`) tạo ra một đặt phòng khoảng 3650 đêm, khoá phòng đó cả thập kỷ.
+/// Test này khôi phục kỳ vọng: vượt trần phải bị từ chối, bất kể ai gọi vào
+/// (form, gateway, agent).
+#[tokio::test]
+async fn create_reservation_rejects_nights_beyond_the_ceiling() {
+    let pool = test_pool().await;
+    seed_room_with_price(&pool, "R160B", 600_000).await.unwrap();
+
+    let error = reservation_lifecycle::create_reservation(
+        &pool,
+        CreateReservationRequest {
+            room_id: "R160B".to_string(),
+            guest_name: "Nguyen Van C".to_string(),
+            guest_phone: Some("0900000002".to_string()),
+            guest_doc_number: Some("079000000002".to_string()),
+            check_in_date: "2026-08-08".to_string(),
+            check_out_date: "2036-08-08".to_string(), // ~3650 đêm — lỗi gõ năm
+            nights: 3653,
+            deposit_amount: None,
+            source: Some("phone".to_string()),
+            notes: None,
+            guests: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::domain::booking::BookingError::Validation(_)
+    ));
+}
+
+#[tokio::test]
+async fn modify_reservation_rejects_nights_beyond_the_ceiling() {
+    let pool = test_pool().await;
+    seed_booked_reservation_with_price(&pool, "B166B", "R166B", 600_000)
+        .await
+        .unwrap();
+
+    let error = reservation_lifecycle::modify_reservation(
+        &pool,
+        reservation_modify_request("B166B", "2026-08-08", "2036-08-08", 3653),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::domain::booking::BookingError::Validation(_)
+    ));
+}
+
 #[tokio::test]
 async fn reservation_lifecycle_smoke_covers_confirm_and_cancel_paths() {
     let pool = test_pool().await;

--- a/mhm/src-tauri/src/services/booking/tests/reservations.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservations.rs
@@ -866,3 +866,126 @@ async fn confirm_reservation_keeps_the_extra_guest_charge() {
 
     tx.rollback().await.unwrap();
 }
+
+#[tokio::test]
+async fn modify_reservation_prefers_explicit_new_guests_over_stored_count() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R320", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R320".to_string(),
+            guest_name: "Trần Thị Mai".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            // Stored count starts within max_guests (2), so no extra-person fee applies yet.
+            guests: Some(2),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Explicit new_guests (4) differs from the stored count (2). If `.or()` were
+    // reversed to `reservation.guests.or(req.new_guests)`, the stored 2 would win
+    // and the total would stay at 1_000_000 instead of reflecting the caller's 4.
+    let booking = reservation_lifecycle::modify_reservation_tx(
+        &mut tx,
+        ModifyReservationRequest {
+            booking_id: booking_id.clone(),
+            new_check_in_date: "2026-08-10".to_string(),
+            new_check_out_date: "2026-08-12".to_string(),
+            new_nights: 2,
+            new_guests: Some(4),
+        },
+        "R320",
+    )
+    .await
+    .unwrap();
+
+    // (500.000₫ base + 2 khách vượt mốc × 50.000₫)/đêm × 2 đêm = 1.200.000₫.
+    assert_eq!(booking.total_price, 1_200_000);
+
+    let row = sqlx::query("SELECT total_price, guests FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("total_price"), 1_200_000);
+    assert_eq!(row.get::<Option<i32>, _>("guests"), Some(4));
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn modify_reservation_keeps_null_guests_null() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R321", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R321".to_string(),
+            guest_name: "Lê Văn Nam".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: None,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let created_row = sqlx::query("SELECT total_price, guests FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+    assert_eq!(created_row.get::<i64, _>("total_price"), 1_000_000);
+    assert_eq!(created_row.get::<Option<i32>, _>("guests"), None);
+
+    let booking = reservation_lifecycle::modify_reservation_tx(
+        &mut tx,
+        ModifyReservationRequest {
+            booking_id: booking_id.clone(),
+            new_check_in_date: "2026-08-10".to_string(),
+            new_check_out_date: "2026-08-12".to_string(),
+            new_nights: 2,
+            new_guests: None,
+        },
+        "R321",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(booking.total_price, 1_000_000);
+
+    let row = sqlx::query("SELECT total_price, guests FROM bookings WHERE id = ?")
+        .bind(&booking_id)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("total_price"), 1_000_000);
+    assert_eq!(row.get::<Option<i32>, _>("guests"), None);
+
+    tx.rollback().await.unwrap();
+}

--- a/mhm/src-tauri/src/services/booking/tests/reservations.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservations.rs
@@ -634,6 +634,7 @@ async fn modify_reservation_rejects_inconsistent_nights_input() {
             new_check_in_date: "2026-04-23".to_string(),
             new_check_out_date: "2026-04-26".to_string(),
             new_nights: 2,
+            new_guests: None,
         },
     )
     .await
@@ -772,6 +773,96 @@ async fn create_reservation_without_guests_prices_like_before() {
         .unwrap();
 
     assert_eq!(total, 1_000_000);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn modify_reservation_keeps_the_extra_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R310", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R310".to_string(),
+            guest_name: "Nguyễn Nhật Huy".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: "2026-08-06".to_string(),
+            check_out_date: "2026-08-08".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: Some(4),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Dời sang 3 đêm, không nói gì về số khách.
+    let booking = reservation_lifecycle::modify_reservation_tx(
+        &mut tx,
+        ModifyReservationRequest {
+            booking_id: booking_id.clone(),
+            new_check_in_date: "2026-08-10".to_string(),
+            new_check_out_date: "2026-08-13".to_string(),
+            new_nights: 3,
+            new_guests: None,
+        },
+        "R310",
+    )
+    .await
+    .unwrap();
+
+    // 600.000₫/đêm × 3 đêm — không tụt về 500.000₫.
+    assert_eq!(booking.total_price, 1_800_000);
+
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn confirm_reservation_keeps_the_extra_guest_charge() {
+    let pool = test_pool().await;
+    seed_room_with_guest_pricing(&pool, "R311", 500_000, 2, 50_000)
+        .await
+        .unwrap();
+
+    let today = Local::now().date_naive();
+    let check_in = today.format("%Y-%m-%d").to_string();
+    let check_out = (today + Duration::days(2)).format("%Y-%m-%d").to_string();
+
+    let mut tx = pool.begin().await.unwrap();
+    let booking_id = reservation_lifecycle::create_reservation_tx(
+        &mut tx,
+        CreateReservationRequest {
+            room_id: "R311".to_string(),
+            guest_name: "Nguyễn Nhật Huy".to_string(),
+            guest_phone: None,
+            guest_doc_number: None,
+            check_in_date: check_in,
+            check_out_date: check_out,
+            nights: 2,
+            deposit_amount: None,
+            source: None,
+            notes: None,
+            guests: Some(4),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let booking = reservation_lifecycle::confirm_reservation_tx(&mut tx, &booking_id, "R311", None)
+        .await
+        .unwrap();
+
+    assert_eq!(booking.total_price, 1_200_000);
 
     tx.rollback().await.unwrap();
 }

--- a/mhm/src-tauri/src/services/booking/tests/support/db.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/db.rs
@@ -79,6 +79,7 @@ pub async fn test_pool() -> Pool<Sqlite> {
             is_master_room INTEGER NOT NULL DEFAULT 0,
             is_audited INTEGER NOT NULL DEFAULT 0,
             pricing_snapshot TEXT,
+            guests INTEGER,
             created_at TEXT NOT NULL
         )",
     )

--- a/mhm/src-tauri/src/services/booking/tests/support/request.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/request.rs
@@ -56,6 +56,7 @@ pub fn reservation_modify_request(
         new_check_in_date: check_in.to_string(),
         new_check_out_date: check_out.to_string(),
         new_nights: nights,
+        new_guests: None,
     }
 }
 

--- a/mhm/src-tauri/src/services/booking/tests/support/request.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/request.rs
@@ -41,6 +41,7 @@ pub fn minimal_reservation_request(room_id: &str) -> CreateReservationRequest {
         deposit_amount: Some(50_000),
         source: Some("phone".to_string()),
         notes: Some("test reservation".to_string()),
+        guests: None,
     }
 }
 

--- a/mhm/src-tauri/src/services/booking/tests/support/seed.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/seed.rs
@@ -449,3 +449,29 @@ pub async fn seed_booked_reservation_with_price(
     seed_booked_reservation(pool, booking_id, room_id).await?;
     Ok(())
 }
+
+/// Phòng có mốc tính giá theo số khách: `max_guests` là số khách nằm trong giá
+/// base, `extra_person_fee` là phụ thu mỗi khách vượt mốc mỗi đêm.
+pub async fn seed_room_with_guest_pricing(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    base_price: MoneyVnd,
+    max_guests: i32,
+    extra_person_fee: MoneyVnd,
+) -> BookingResult<()> {
+    sqlx::query(
+        "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+         VALUES (?, ?, ?, ?, 0, ?, ?, ?, 'vacant')",
+    )
+    .bind(room_id)
+    .bind(format!("Room {}", room_id))
+    .bind("standard")
+    .bind(1_i32)
+    .bind(base_price)
+    .bind(max_guests)
+    .bind(extra_person_fee)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/mhm/src/app/MainShell.tsx
+++ b/mhm/src/app/MainShell.tsx
@@ -75,7 +75,7 @@ const PAGE_TITLES: Record<string, string> = {
 };
 
 export function MainShell() {
-  const { activeTab, setTab, setCheckinOpen, setGroupCheckinOpen, checkinRoomId } = useHotelStore();
+  const { activeTab, setTab, setCheckinOpen, setGroupCheckinOpen, checkinRoomId, checkinNights } = useHotelStore();
   const { user, logout } = useAuthStore();
   const { collapsed, toggleCollapse } = useSidebarCollapse();
 
@@ -348,7 +348,7 @@ export function MainShell() {
         </div>
       </main>
 
-      <CheckinSheet preSelectedRoomId={checkinRoomId ?? undefined} />
+      <CheckinSheet preSelectedRoomId={checkinRoomId ?? undefined} preSelectedNights={checkinNights ?? undefined} />
       <GroupCheckinSheet />
       <AppToaster />
     </div>

--- a/mhm/src/components/BackfillSheet.test.tsx
+++ b/mhm/src/components/BackfillSheet.test.tsx
@@ -228,6 +228,11 @@ describe("BackfillSheet", () => {
             />,
         );
         await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Còn Ở");
+        // `canSubmit` đòi total > 0, nên phải chờ gợi ý giá về (hoặc gõ tay)
+        // trước khi bấm — một lượt 0₫ không còn gửi đi được.
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Tiền phòng/i)).not.toHaveValue(0);
+        });
         await user.click(screen.getByRole("button", { name: /Ghi bù/ }));
 
         await waitFor(() => {
@@ -502,6 +507,115 @@ describe("BackfillSheet", () => {
         await user.click(stayingCheckbox);
         await waitFor(() => {
             expect(select).toHaveValue("");
+        });
+    });
+
+    // Spec §4: bật "Khách còn ở" thì ngày ra lấy theo cuối vùng kéo NẾU vùng đó
+    // chạm tương lai, còn không thì mặc định ngày mai. Nửa sau chưa từng được
+    // làm: bật toggle chỉ đổi nhãn và min/max, `checkOutDate` giữ nguyên giá
+    // trị quá khứ, `datesValid` chỉ soi nights > 0 nên nút gửi vẫn sáng và chủ
+    // ăn nguyên toast của backend "Ngày ra dự kiến phải sau hôm nay."
+    it("vùng kéo toàn quá khứ: bật 'Khách còn ở' đẩy ngày ra về ngày mai", async () => {
+        const today = localDateIso(new Date());
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{
+                    roomId: "R101",
+                    checkInDate: addDaysIso(today, -3),
+                    checkOutDate: addDaysIso(today, -1),
+                    stillStaying: false,
+                }}
+            />,
+        );
+        expect(await screen.findByLabelText("Ngày ra")).toHaveValue(addDaysIso(today, -1));
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+
+        await user.click(screen.getByRole("checkbox", { name: /Khách còn ở/ }));
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Ngày ra dự kiến")).toHaveValue(addDaysIso(today, 1));
+        });
+        // Ngày đã hợp lệ thì nút gửi phải sáng — nếu ngày vẫn là quá khứ, cái
+        // sáng lên chỉ dẫn tới một cú từ chối ở backend.
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /Ghi bù/ })).not.toBeDisabled();
+        });
+    });
+
+    it("không đè ngày ra tương lai đã có sẵn khi bật 'Khách còn ở'", async () => {
+        const today = localDateIso(new Date());
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{
+                    roomId: "R101",
+                    checkInDate: addDaysIso(today, -3),
+                    checkOutDate: addDaysIso(today, 5),
+                    stillStaying: false,
+                }}
+            />,
+        );
+        expect(await screen.findByLabelText("Ngày ra")).toHaveValue(addDaysIso(today, 5));
+
+        await user.click(screen.getByRole("checkbox", { name: /Khách còn ở/ }));
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Ngày ra dự kiến")).toHaveValue(addDaysIso(today, 5));
+        });
+    });
+
+    // Chiều ngược lại, mở ra bởi chính cú nhảy ở trên: "đã trả phòng" mà ngày
+    // ra nằm ở tương lai cũng bị backend từ chối.
+    it("tắt 'Khách còn ở' kéo ngày ra tương lai về hôm nay", async () => {
+        const today = localDateIso(new Date());
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{
+                    roomId: "R101",
+                    checkInDate: addDaysIso(today, -3),
+                    checkOutDate: addDaysIso(today, 5),
+                    stillStaying: true,
+                }}
+            />,
+        );
+        expect(await screen.findByLabelText("Ngày ra dự kiến")).toHaveValue(addDaysIso(today, 5));
+
+        await user.click(screen.getByRole("checkbox", { name: /Khách còn ở/ }));
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Ngày ra")).toHaveValue(today);
+        });
+    });
+
+    it("không cho ghi bù một lượt 0₫", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /Ghi bù/ })).not.toBeDisabled();
+        });
+
+        // Bảng giá hỏng thì `total` đứng ở 0 — một lượt lưu trú 0₫ không phải
+        // dữ liệu sổ sách thật, và nó cũng làm hỏng luôn cả doanh thu.
+        const totalInput = screen.getByLabelText(/Tiền phòng/i);
+        await user.clear(totalInput);
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /Ghi bù/ })).toBeDisabled();
         });
     });
 

--- a/mhm/src/components/BackfillSheet.test.tsx
+++ b/mhm/src/components/BackfillSheet.test.tsx
@@ -595,6 +595,42 @@ describe("BackfillSheet", () => {
         });
     });
 
+    // Bug thật: chủ kéo từ 3 hôm trước đến hôm qua (khách đã trả phòng), lỡ tay
+    // tick "Khách còn ở" (ngày ra dự kiến nhảy sang ngày mai — đúng), rồi tắt
+    // lại ngay. Trước đây nhánh tắt chỉ biết chốt về `todayIso` khi ngày ra
+    // đang ở tương lai — nó xoá mất luôn ngày "hôm qua" chủ đã kéo thật, âm
+    // thầm biến một lượt ở đúng thành một lượt dài thêm một đêm mà nút gửi vẫn
+    // sáng và giá vẫn tính lại êm ru, chủ không hề hay biết.
+    it("kéo từ quá khứ, bật rồi tắt 'Khách còn ở' thì ngày ra trở lại đúng ngày đã kéo (không bị chốt về hôm nay)", async () => {
+        const today = localDateIso(new Date());
+        const draggedCheckOut = addDaysIso(today, -1);
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{
+                    roomId: "R101",
+                    checkInDate: addDaysIso(today, -3),
+                    checkOutDate: draggedCheckOut,
+                    stillStaying: false,
+                }}
+            />,
+        );
+        expect(await screen.findByLabelText("Ngày ra")).toHaveValue(draggedCheckOut);
+
+        const stayingCheckbox = screen.getByRole("checkbox", { name: /Khách còn ở/ });
+        await user.click(stayingCheckbox);
+        await waitFor(() => {
+            expect(screen.getByLabelText("Ngày ra dự kiến")).toHaveValue(addDaysIso(today, 1));
+        });
+
+        await user.click(stayingCheckbox);
+        await waitFor(() => {
+            expect(screen.getByLabelText("Ngày ra")).toHaveValue(draggedCheckOut);
+        });
+    });
+
     it("không cho ghi bù một lượt 0₫", async () => {
         const user = userEvent.setup();
         render(

--- a/mhm/src/components/BackfillSheet.test.tsx
+++ b/mhm/src/components/BackfillSheet.test.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -178,6 +178,44 @@ describe("BackfillSheet", () => {
                 expect.objectContaining({ correlationId: "COR-BACKFILL01" }),
             );
         });
+    });
+
+    it("gõ tiền lẻ (500000.5) vào ô tiền thì số gửi lên backend vẫn là số nguyên", async () => {
+        // Money là MoneyVnd (số nguyên) ở backend. step="1" không chặn được gì
+        // vì form không có thẻ <form> nên constraint validation của trình
+        // duyệt (stepMismatch) không bao giờ chạy — submit chỉ là
+        // onClick={handleSubmit}. Test này gõ thẳng một giá trị thập phân hợp
+        // lệ với input type="number" và buộc component tự làm tròn, không dựa
+        // vào step.
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+
+        const totalInput = screen.getByLabelText(/Tiền phòng/i);
+        fireEvent.change(totalInput, { target: { value: "500000.5" } });
+        const paidInput = screen.getByLabelText("Đã thu");
+        fireEvent.change(paidInput, { target: { value: "300000.5" } });
+
+        await user.click(screen.getByRole("button", { name: /Ghi bù/ }));
+
+        await waitFor(() => {
+            expect(invokeWriteCommand).toHaveBeenCalled();
+        });
+        const [, payload] = invokeWriteCommand.mock.calls[0];
+        const req = (payload as { req: { total_price: number; paid_amount: number } }).req;
+        expect(Number.isInteger(req.total_price)).toBe(true);
+        expect(Number.isInteger(req.paid_amount)).toBe(true);
+        expect(req.total_price).toBe(500001);
+        expect(req.paid_amount).toBe(300001);
     });
 
     it("khách còn ở: gửi expected_checkout_date, để trống check_out_date", async () => {

--- a/mhm/src/components/BackfillSheet.test.tsx
+++ b/mhm/src/components/BackfillSheet.test.tsx
@@ -69,7 +69,19 @@ vi.mock("sonner", () => ({
     },
 }));
 
+import { addDaysIso, localDateIso } from "@/lib/timelineSelection";
 import BackfillSheet from "./BackfillSheet";
+
+// FormField/FormFieldSelect (shared) chỉ đặt <label> cạnh <input>/<select>,
+// không có htmlFor/id liên kết (xem CheckinSheet.test.tsx) — nên
+// getByLabelText không tìm ra các trường Ngày sinh/Giới tính/Quốc tịch/Địa
+// chỉ. Đây là control nằm ngay sau <label> có cùng text, trong cùng div cha.
+function controlAfterLabel(labelText: string): HTMLElement {
+    const label = screen.getByText(labelText);
+    const el = label.parentElement?.querySelector("input, select");
+    if (!el) throw new Error(`Không tìm thấy control cạnh nhãn "${labelText}"`);
+    return el as HTMLElement;
+}
 
 describe("BackfillSheet", () => {
     beforeEach(() => {
@@ -116,6 +128,11 @@ describe("BackfillSheet", () => {
         await waitFor(() => {
             expect(screen.getAllByDisplayValue("500000").length).toBe(2);
         });
+
+        // step="1" trên hai ô tiền — thiếu nó, một giá trị như 500000.5 được
+        // gửi lên như float thay vì bị chặn ngay trong form.
+        expect(screen.getByLabelText(/Tiền phòng/i)).toHaveAttribute("step", "1");
+        expect(screen.getByLabelText("Đã thu")).toHaveAttribute("step", "1");
     });
 
     it("khách còn ở: đổi nhãn ngày ra thành dự kiến", async () => {
@@ -300,5 +317,177 @@ describe("BackfillSheet", () => {
 
         expect(screen.getByPlaceholderText("Họ và tên *")).toHaveValue("");
         expect(await screen.findByDisplayValue("2026-07-10")).toBeInTheDocument();
+    });
+
+    it("bật rồi tắt 'Khách còn ở' thì Đã thu đổi theo đúng chiều (không bị kẹt)", async () => {
+        // Mở từ một vùng kéo đã trả phòng: total → 500000, "Đã thu" tự nạp
+        // theo total. Tick "Khách còn ở": phải về 0 (khách chưa trả phòng,
+        // không được gửi paid_amount=500000 cho khách chưa trả). Untick lại:
+        // phải nạp lại total. Bug cũ: guard `!paidDirty && !stillStaying` chỉ
+        // đúng chiều untick→total, còn tick→0 bị bỏ sót nên giá trị cũ dính lại.
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await waitFor(() => {
+            expect(screen.getByLabelText("Đã thu")).toHaveValue(500000);
+        });
+
+        const stayingCheckbox = screen.getByRole("checkbox", { name: /Khách còn ở/ });
+        await user.click(stayingCheckbox);
+        await waitFor(() => {
+            expect(screen.getByLabelText("Đã thu")).toHaveValue(0);
+        });
+
+        await user.click(stayingCheckbox);
+        await waitFor(() => {
+            expect(screen.getByLabelText("Đã thu")).toHaveValue(500000);
+        });
+    });
+
+    it("ngày vào không được chọn tương lai; ngày ra bị giới hạn theo chế độ", async () => {
+        const todayIso = localDateIso(new Date());
+        const { rerender } = render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        const checkIn = await screen.findByLabelText("Ngày vào");
+        expect(checkIn).toHaveAttribute("max", todayIso);
+
+        // Đã trả phòng: ngày ra không được sau hôm nay, không có min.
+        const checkOutDone = screen.getByLabelText(/^Ngày ra$/);
+        expect(checkOutDone).toHaveAttribute("max", todayIso);
+        expect(checkOutDone).not.toHaveAttribute("min");
+
+        rerender(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-27", checkOutDate: "2026-07-31", stillStaying: true }}
+            />,
+        );
+        // Còn ở: ngày ra dự kiến phải sau hôm nay, không có max.
+        const checkOutStaying = await screen.findByLabelText("Ngày ra dự kiến");
+        expect(checkOutStaying).toHaveAttribute("min", addDaysIso(todayIso, 1));
+        expect(checkOutStaying).not.toHaveAttribute("max");
+    });
+
+    it("nhập ngày sinh/giới tính/quốc tịch/địa chỉ thật thì gửi đúng giá trị đã nhập", async () => {
+        // Trước đây các trường này bị hardcode (dob rỗng, gender "Nam",
+        // nationality "Việt Nam", address rỗng) bất kể chủ gõ gì — dữ liệu này
+        // feed thẳng vào khai báo tạm trú nộp công an nên không được bịa.
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+        await user.type(controlAfterLabel("Ngày sinh"), "1990-01-01");
+        await user.selectOptions(controlAfterLabel("Giới tính"), "Nữ");
+        const nationalityInput = controlAfterLabel("Quốc tịch");
+        await user.clear(nationalityInput);
+        await user.type(nationalityInput, "Hàn Quốc");
+        await user.type(controlAfterLabel("Địa chỉ"), "123 Lê Lợi");
+
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+        await user.click(screen.getByRole("button", { name: /Ghi bù/ }));
+
+        await waitFor(() => {
+            expect(invokeWriteCommand).toHaveBeenCalledWith(
+                "backfill_stay",
+                expect.objectContaining({
+                    req: expect.objectContaining({
+                        guests: [
+                            expect.objectContaining({
+                                full_name: "Nguyễn Văn Bù",
+                                dob: "1990-01-01",
+                                gender: "Nữ",
+                                nationality: "Hàn Quốc",
+                                address: "123 Lê Lợi",
+                            }),
+                        ],
+                    }),
+                }),
+                expect.anything(),
+            );
+        });
+    });
+
+    it("chọn phòng rồi bật 'Khách còn ở' làm phòng biến khỏi danh sách thì tự bỏ chọn", async () => {
+        rooms = [
+            ...ORIGINAL_ROOMS,
+            {
+                id: "R102",
+                name: "R102",
+                type: "deluxe",
+                floor: 2,
+                has_balcony: true,
+                base_price: 800000,
+                max_guests: 3,
+                extra_person_fee: 80000,
+                status: "occupied",
+            },
+        ];
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R102", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        const select = (await screen.findByLabelText(/^Phòng$/)) as HTMLSelectElement;
+        expect(select).toHaveValue("R102");
+
+        const stayingCheckbox = screen.getByRole("checkbox", { name: /Khách còn ở/ });
+        await user.click(stayingCheckbox);
+        await waitFor(() => {
+            expect(select).toHaveValue("");
+        });
+
+        // Chỉ hiện blank vì option biến mất chưa chứng minh được gì — nếu state
+        // `roomId` chưa thực sự bị xoá, bật lại (option quay lại danh sách) sẽ
+        // hiện lại "R102" dù chủ chưa hề chọn lại nó. Untick lại để chứng minh
+        // state đã bị xoá thật, không phải chỉ DOM ẩn option đi tạm thời.
+        await user.click(stayingCheckbox);
+        await waitFor(() => {
+            expect(select).toHaveValue("");
+        });
+    });
+
+    it("backend báo lỗi: báo toast, giữ sheet mở và giữ nguyên dữ liệu đã nhập", async () => {
+        invokeWriteCommand.mockRejectedValueOnce(new Error("boom"));
+        const onOpenChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={onOpenChange}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+        await user.click(screen.getByRole("button", { name: /Ghi bù/ }));
+
+        await waitFor(() => {
+            expect(toastError).toHaveBeenCalled();
+        });
+        expect(onOpenChange).not.toHaveBeenCalledWith(false);
+        expect(screen.getByPlaceholderText("Họ và tên *")).toHaveValue("Nguyễn Văn Bù");
     });
 });

--- a/mhm/src/components/BackfillSheet.test.tsx
+++ b/mhm/src/components/BackfillSheet.test.tsx
@@ -1,0 +1,304 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.hoisted(() => vi.fn());
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
+const createCorrelationId = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+const fetchRooms = vi.hoisted(() => vi.fn());
+
+// Chỉ một phòng, đang trống — đúng như brief yêu cầu (rooms: một phòng trống
+// R101 loại standard). status "vacant" khớp với backend status::room::VACANT.
+const ORIGINAL_ROOMS = vi.hoisted(() => [
+    {
+        id: "R101",
+        name: "R101",
+        type: "standard",
+        floor: 1,
+        has_balcony: false,
+        base_price: 250000,
+        max_guests: 2,
+        extra_person_fee: 50000,
+        status: "vacant",
+    },
+]);
+let rooms = ORIGINAL_ROOMS;
+
+vi.mock("@tauri-apps/api/core", () => ({
+    invoke,
+}));
+
+vi.mock("@/lib/invokeCommand", () => ({
+    invokeWriteCommand,
+}));
+
+vi.mock("@/lib/correlationId", () => ({
+    createCorrelationId,
+}));
+
+vi.mock("@/stores/useHotelStore", () => ({
+    useHotelStore: () => ({
+        rooms,
+        fetchRooms,
+    }),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+    Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SheetContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+        <div {...props}>{children}</div>
+    ),
+    SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+    Button: ({
+        children,
+        ...props
+    }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("sonner", () => ({
+    toast: {
+        error: toastError,
+        success: toastSuccess,
+    },
+}));
+
+import BackfillSheet from "./BackfillSheet";
+
+describe("BackfillSheet", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        rooms = ORIGINAL_ROOMS;
+        invokeWriteCommand.mockResolvedValue({});
+        createCorrelationId.mockReturnValue("COR-BACKFILL01");
+        // Xác thực đúng phòng/ngày được truyền vào engine giá — nếu component
+        // tính sai nights hoặc gửi sai roomId/checkIn/checkOut, mock trả về một
+        // tổng khác hẳn (999999) và các assertion về "500000" bên dưới sẽ rớt.
+        // Một mock luôn trả cùng một hằng số bất kể input sẽ không chứng minh
+        // được gì — đây buộc phải khớp đúng tham số thật.
+        invoke.mockImplementation(async (command: string, args: unknown) => {
+            if (command === "calculate_room_price_preview") {
+                const a = args as { roomId?: string; checkIn?: string; checkOut?: string };
+                const matches =
+                    a.roomId === "R101" && a.checkIn === "2026-07-26" && a.checkOut === "2026-07-28";
+                return {
+                    pricing_type: "nightly",
+                    base_amount: matches ? 500000 : 999999,
+                    surcharge_amount: 0,
+                    weekend_amount: 0,
+                    total: matches ? 500000 : 999999,
+                    capped: false,
+                    breakdown: [{ label: "2 đêm x 250.000", amount: matches ? 500000 : 999999 }],
+                };
+            }
+            return null;
+        });
+    });
+
+    it("điền sẵn theo vùng kéo và gợi ý tiền phòng", async () => {
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        expect(await screen.findByDisplayValue("2026-07-26")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("2026-07-28")).toBeInTheDocument();
+
+        // Gợi ý từ bảng giá, và "Đã thu" mặc định bằng tiền phòng khi khách đã trả.
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+    });
+
+    it("khách còn ở: đổi nhãn ngày ra thành dự kiến", async () => {
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-27", checkOutDate: "2026-07-31", stillStaying: true }}
+            />,
+        );
+        expect(await screen.findByText("Ngày ra dự kiến")).toBeInTheDocument();
+        expect(screen.queryByText(/^Ngày ra$/)).not.toBeInTheDocument();
+    });
+
+    it("gửi đúng request backfill_stay", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+        await user.click(screen.getByRole("button", { name: /Ghi bù/ }));
+
+        await waitFor(() => {
+            expect(invokeWriteCommand).toHaveBeenCalledWith(
+                "backfill_stay",
+                expect.objectContaining({
+                    req: expect.objectContaining({
+                        room_id: "R101",
+                        check_in_date: "2026-07-26",
+                        check_out_date: "2026-07-28",
+                        expected_checkout_date: null,
+                        total_price: 500000,
+                        paid_amount: 500000,
+                    }),
+                }),
+                expect.objectContaining({ correlationId: "COR-BACKFILL01" }),
+            );
+        });
+    });
+
+    it("khách còn ở: gửi expected_checkout_date, để trống check_out_date", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-20", checkOutDate: "2026-08-05", stillStaying: true }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Còn Ở");
+        await user.click(screen.getByRole("button", { name: /Ghi bù/ }));
+
+        await waitFor(() => {
+            expect(invokeWriteCommand).toHaveBeenCalledWith(
+                "backfill_stay",
+                expect.objectContaining({
+                    req: expect.objectContaining({
+                        room_id: "R101",
+                        check_in_date: "2026-07-20",
+                        check_out_date: null,
+                        expected_checkout_date: "2026-08-05",
+                    }),
+                }),
+                expect.anything(),
+            );
+        });
+    });
+
+    it("chặn đã thu vượt tiền phòng", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyễn Văn Bù");
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+        const paidInput = screen.getByLabelText("Đã thu");
+        await user.clear(paidInput);
+        await user.type(paidInput, "600000");
+        expect(screen.getByRole("button", { name: /Ghi bù/ })).toBeDisabled();
+        expect(screen.getByText(/không được vượt quá/i)).toBeInTheDocument();
+    });
+
+    it("sửa tay tiền phòng thì gợi ý từ engine không còn ghi đè", async () => {
+        // Nếu effect nạp gợi ý không tôn trọng cờ "đã sửa tay", một cập nhật giá
+        // sau đó (vd đổi ngày) sẽ ghi đè số chủ vừa gõ — test này bắt lỗi đó.
+        const user = userEvent.setup();
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await waitFor(() => {
+            expect(screen.getAllByDisplayValue("500000").length).toBe(2);
+        });
+
+        const totalInput = screen.getByLabelText(/Tiền phòng/i);
+        await user.clear(totalInput);
+        await user.type(totalInput, "700000");
+        expect(totalInput).toHaveValue(700000);
+
+        // Đổi ngày ra — kích hoạt việc engine tính lại giá (dù mock vẫn trả một
+        // giá trị "khác" vì thay đổi tham số, total do chủ gõ vẫn phải giữ nguyên).
+        const checkOutInput = screen.getByLabelText(/^Ngày ra$/);
+        await user.clear(checkOutInput);
+        await user.type(checkOutInput, "2026-07-29");
+
+        await waitFor(() => {
+            expect(invoke).toHaveBeenCalledWith(
+                "calculate_room_price_preview",
+                expect.objectContaining({ checkOut: "2026-07-29" }),
+            );
+        });
+        expect(totalInput).toHaveValue(700000);
+    });
+
+    it("chỉ liệt kê phòng trống khi ghi bù khách còn ở", async () => {
+        rooms = [
+            ...ORIGINAL_ROOMS,
+            {
+                id: "R102",
+                name: "R102",
+                type: "deluxe",
+                floor: 2,
+                has_balcony: true,
+                base_price: 800000,
+                max_guests: 3,
+                extra_person_fee: 80000,
+                status: "occupied",
+            },
+        ];
+        render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-27", checkOutDate: "2026-07-31", stillStaying: true }}
+            />,
+        );
+        const select = screen.getByLabelText(/^Phòng$/) as HTMLSelectElement;
+        const optionValues = Array.from(select.options).map((o) => o.value);
+        expect(optionValues).toContain("R101");
+        expect(optionValues).not.toContain("R102");
+    });
+
+    it("reset form khi mở lại sheet với vùng kéo khác", async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-26", checkOutDate: "2026-07-28", stillStaying: false }}
+            />,
+        );
+        await user.type(screen.getByPlaceholderText("Họ và tên *"), "Khách Cũ");
+        expect(screen.getByPlaceholderText("Họ và tên *")).toHaveValue("Khách Cũ");
+
+        // Đóng rồi mở lại với một vùng kéo khác (roomId, ngày khác) — mô phỏng
+        // đúng luồng thật: cha đặt backfillPrefill=null lúc đóng rồi set giá trị
+        // mới khi người dùng kéo chọn ô khác.
+        rerender(<BackfillSheet open={false} onOpenChange={() => {}} prefill={undefined} />);
+        rerender(
+            <BackfillSheet
+                open
+                onOpenChange={() => {}}
+                prefill={{ roomId: "R101", checkInDate: "2026-07-10", checkOutDate: "2026-07-12", stillStaying: false }}
+            />,
+        );
+
+        expect(screen.getByPlaceholderText("Họ và tên *")).toHaveValue("");
+        expect(await screen.findByDisplayValue("2026-07-10")).toBeInTheDocument();
+    });
+});

--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -3,12 +3,14 @@ import { useHotelStore } from "../stores/useHotelStore";
 import { History } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
+import { FormField, FormFieldSelect } from "@/components/shared/FormField";
 import { usePricePreview } from "@/hooks/usePricePreview";
 import { formatAppError } from "@/lib/appError";
 import { createCorrelationId } from "@/lib/correlationId";
 import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtNumber } from "@/lib/format";
+import { addDaysIso, localDateIso, nightsBetween } from "@/lib/timelineSelection";
 import { toast } from "sonner";
 
 export interface BackfillPrefill {
@@ -24,23 +26,19 @@ interface Props {
     prefill?: BackfillPrefill;
 }
 
-// Ngày dạng "YYYY-MM-DD" (không giờ) được JS phân giải theo UTC — dùng nguyên
-// dạng đó (không thêm "T00:00:00") để tránh lệch ngày ở múi giờ dương như
-// Asia/Ho_Chi_Minh khi quy đổi qua toISOString(). Cùng cách làm với
-// ReservationSheet.tsx.
-function nightsBetween(checkIn: string, checkOut: string): number {
-    if (!checkIn || !checkOut) return 0;
-    const ms = new Date(checkOut).getTime() - new Date(checkIn).getTime();
-    if (Number.isNaN(ms)) return 0;
-    return Math.round(ms / 86_400_000);
-}
-
 export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
     const { rooms, fetchRooms } = useHotelStore();
     const [roomId, setRoomId] = useState("");
     const [guestName, setGuestName] = useState("");
     const [guestPhone, setGuestPhone] = useState("");
     const [guestDoc, setGuestDoc] = useState("");
+    // Feed thẳng vào danh sách khai báo tạm trú nộp công an — không được bịa,
+    // nên có input thật (giá trị dưới đây chỉ là gợi ý ban đầu trong ô, chủ
+    // thấy và có thể sửa; những gì gửi đi là những gì chủ thực sự nhập).
+    const [guestDob, setGuestDob] = useState("");
+    const [guestGender, setGuestGender] = useState("Nam");
+    const [guestNationality, setGuestNationality] = useState("Việt Nam");
+    const [guestAddress, setGuestAddress] = useState("");
     const [checkInDate, setCheckInDate] = useState("");
     const [checkOutDate, setCheckOutDate] = useState("");
     const [stillStaying, setStillStaying] = useState(false);
@@ -67,6 +65,10 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
         setGuestName("");
         setGuestPhone("");
         setGuestDoc("");
+        setGuestDob("");
+        setGuestGender("Nam");
+        setGuestNationality("Việt Nam");
+        setGuestAddress("");
         setTotal(0);
         setTotalDirty(false);
         setPaid(0);
@@ -97,14 +99,33 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
     }, [preview, totalDirty]);
 
     // Khách đã trả phòng: mặc định đã thu đủ, cho tới khi chủ sửa tay.
-    // Khách còn ở: không giả định đã thu đủ (khách chưa trả phòng).
+    // Khách còn ở: mặc định 0 — khách chưa trả phòng nên không giả định đã
+    // thu đủ. Guard cũ là `!paidDirty && !stillStaying`: đúng chiều untick
+    // (còn ở → đã trả) nhưng bỏ sót chiều tick (đã trả → còn ở) vì điều kiện
+    // hoá false ngay khi stillStaying thành true, nên "Đã thu" bị kẹt ở giá
+    // trị total cũ và gửi đi paid_amount sai cho một khách chưa trả phòng.
     useEffect(() => {
-        if (!paidDirty && !stillStaying) setPaid(total);
+        if (!paidDirty) setPaid(stillStaying ? 0 : total);
     }, [total, paidDirty, stillStaying]);
 
     // Khách còn ở chỉ ghi bù được vào phòng đang trống — backend enforce lại
     // rule này, đây chỉ là phản ánh lên danh sách chọn cho khỏi chọn nhầm.
     const selectableRooms = stillStaying ? rooms.filter((r) => r.status === "vacant") : rooms;
+
+    // Bật "Khách còn ở" có thể lọc mất phòng đang chọn (không còn vacant) —
+    // <select> khi đó không có option khớp và hiện trống, nhưng state vẫn giữ
+    // (và vẫn gửi đi) roomId đó nếu không xoá ở đây.
+    useEffect(() => {
+        if (roomId && !selectableRooms.some((r) => r.id === roomId)) {
+            setRoomId("");
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [stillStaying, rooms]);
+
+    // Backend vẫn validate lại — đây chỉ là rào chắn trong form cho khỏi chọn
+    // nhầm một ngày rõ ràng vô lý (ghi bù mà ngày vào ở tương lai, hoặc ngày
+    // ra "đã trả phòng" lại nằm sau hôm nay).
+    const todayIso = localDateIso(new Date());
 
     const paidTooHigh = paid > total;
     const paidNegative = paid < 0;
@@ -133,10 +154,10 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 full_name: guestName,
                                 doc_number: guestDoc,
                                 phone: guestPhone,
-                                dob: "",
-                                gender: "Nam",
-                                nationality: "Việt Nam",
-                                address: "",
+                                dob: guestDob,
+                                gender: guestGender,
+                                nationality: guestNationality,
+                                address: guestAddress,
                             },
                         ],
                         check_in_date: checkInDate,
@@ -211,6 +232,7 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 type="date"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
                                 value={checkInDate}
+                                max={todayIso}
                                 onChange={(e) => setCheckInDate(e.target.value)}
                             />
                         </div>
@@ -223,6 +245,8 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 type="date"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
                                 value={checkOutDate}
+                                min={stillStaying ? addDaysIso(todayIso, 1) : undefined}
+                                max={stillStaying ? undefined : todayIso}
                                 onChange={(e) => setCheckOutDate(e.target.value)}
                             />
                         </div>
@@ -256,6 +280,22 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 onChange={(e) => setGuestDoc(e.target.value)}
                             />
                         </div>
+                        {/* Feed thẳng vào khai báo tạm trú nộp công an — cùng bộ
+                            trường và cách dùng FormField/FormFieldSelect như chế
+                            độ "Đầy đủ" của CheckinSheet.tsx, cho hai form cùng một
+                            "cảm giác sản phẩm". Giá trị mặc định chỉ là gợi ý ban
+                            đầu trong ô; chủ thấy và có thể sửa trước khi gửi. */}
+                        <div className="grid grid-cols-2 gap-3">
+                            <FormField label="Ngày sinh" value={guestDob} onChange={setGuestDob} />
+                            <FormFieldSelect
+                                label="Giới tính"
+                                value={guestGender}
+                                options={["Nam", "Nữ"]}
+                                onChange={setGuestGender}
+                            />
+                            <FormField label="Quốc tịch" value={guestNationality} onChange={setGuestNationality} />
+                            <FormField label="Địa chỉ" value={guestAddress} onChange={setGuestAddress} />
+                        </div>
                     </div>
 
                     <div className="grid grid-cols-2 gap-3">
@@ -266,6 +306,7 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                             <input
                                 id="backfill-total"
                                 type="number"
+                                step="1"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
                                 value={total}
                                 onChange={(e) => {
@@ -287,6 +328,7 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                             <input
                                 id="backfill-paid"
                                 type="number"
+                                step="1"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
                                 value={paid}
                                 onChange={(e) => {

--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useState } from "react";
+import { useHotelStore } from "../stores/useHotelStore";
+import { History } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { usePricePreview } from "@/hooks/usePricePreview";
+import { formatAppError } from "@/lib/appError";
+import { createCorrelationId } from "@/lib/correlationId";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
+import { getRoomTypeLabel } from "@/lib/constants";
+import { fmtNumber } from "@/lib/format";
+import { toast } from "sonner";
+
+export interface BackfillPrefill {
+    roomId: string;
+    checkInDate: string;
+    checkOutDate: string;
+    stillStaying: boolean;
+}
+
+interface Props {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    prefill?: BackfillPrefill;
+}
+
+// Ngày dạng "YYYY-MM-DD" (không giờ) được JS phân giải theo UTC — dùng nguyên
+// dạng đó (không thêm "T00:00:00") để tránh lệch ngày ở múi giờ dương như
+// Asia/Ho_Chi_Minh khi quy đổi qua toISOString(). Cùng cách làm với
+// ReservationSheet.tsx.
+function nightsBetween(checkIn: string, checkOut: string): number {
+    if (!checkIn || !checkOut) return 0;
+    const ms = new Date(checkOut).getTime() - new Date(checkIn).getTime();
+    if (Number.isNaN(ms)) return 0;
+    return Math.round(ms / 86_400_000);
+}
+
+export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
+    const { rooms, fetchRooms } = useHotelStore();
+    const [roomId, setRoomId] = useState("");
+    const [guestName, setGuestName] = useState("");
+    const [guestPhone, setGuestPhone] = useState("");
+    const [guestDoc, setGuestDoc] = useState("");
+    const [checkInDate, setCheckInDate] = useState("");
+    const [checkOutDate, setCheckOutDate] = useState("");
+    const [stillStaying, setStillStaying] = useState(false);
+    const [total, setTotal] = useState(0);
+    const [totalDirty, setTotalDirty] = useState(false);
+    const [paid, setPaid] = useState(0);
+    const [paidDirty, setPaidDirty] = useState(false);
+    const [source, setSource] = useState("walk-in");
+    const [notes, setNotes] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    // Không phụ thuộc vào *reference* của `prefill` — cha (Reservations.tsx)
+    // dựng object này inline mỗi lần render, nên phụ thuộc vào các trường
+    // nguyên thuỷ bên trong mới tránh được việc effect chạy lại (và xoá dữ
+    // liệu người dùng vừa gõ) chỉ vì cha re-render vì lý do khác. Cùng bài
+    // học đã áp dụng cho prefillDates ở ReservationSheet.tsx.
+    useEffect(() => {
+        if (!open) return;
+        fetchRooms();
+        setRoomId(prefill?.roomId ?? "");
+        setCheckInDate(prefill?.checkInDate ?? "");
+        setCheckOutDate(prefill?.checkOutDate ?? "");
+        setStillStaying(prefill?.stillStaying ?? false);
+        setGuestName("");
+        setGuestPhone("");
+        setGuestDoc("");
+        setTotal(0);
+        setTotalDirty(false);
+        setPaid(0);
+        setPaidDirty(false);
+        setSource("walk-in");
+        setNotes("");
+        setSubmitting(false);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, prefill?.roomId, prefill?.checkInDate, prefill?.checkOutDate, prefill?.stillStaying]);
+
+    const nights = nightsBetween(checkInDate, checkOutDate);
+    const datesValid = nights > 0;
+
+    // Form ghi bù chỉ có một khách chính (không có ô "số khách" như
+    // ReservationSheet) — engine giá được gọi với guests: 1 cho đúng số
+    // người thực sự ở, không phải một hằng số bịa ra.
+    const { preview, loading: pricingLoading, error: pricingError } = usePricePreview({
+        roomId,
+        checkIn: checkInDate,
+        checkOut: checkOutDate,
+        guests: 1,
+        debounceMs: 200,
+    });
+
+    // Gợi ý theo bảng giá cho tới khi chủ sửa tay ô Tiền phòng.
+    useEffect(() => {
+        if (!totalDirty && preview) setTotal(preview.total);
+    }, [preview, totalDirty]);
+
+    // Khách đã trả phòng: mặc định đã thu đủ, cho tới khi chủ sửa tay.
+    // Khách còn ở: không giả định đã thu đủ (khách chưa trả phòng).
+    useEffect(() => {
+        if (!paidDirty && !stillStaying) setPaid(total);
+    }, [total, paidDirty, stillStaying]);
+
+    // Khách còn ở chỉ ghi bù được vào phòng đang trống — backend enforce lại
+    // rule này, đây chỉ là phản ánh lên danh sách chọn cho khỏi chọn nhầm.
+    const selectableRooms = stillStaying ? rooms.filter((r) => r.status === "vacant") : rooms;
+
+    const paidTooHigh = paid > total;
+    const paidNegative = paid < 0;
+    const canSubmit =
+        !!roomId &&
+        guestName.trim().length > 0 &&
+        !!checkInDate &&
+        !!checkOutDate &&
+        datesValid &&
+        !paidTooHigh &&
+        !paidNegative &&
+        !submitting;
+
+    async function handleSubmit() {
+        if (!canSubmit) return;
+        setSubmitting(true);
+        try {
+            const correlationId = createCorrelationId();
+            await invokeWriteCommand(
+                "backfill_stay",
+                {
+                    req: {
+                        room_id: roomId,
+                        guests: [
+                            {
+                                full_name: guestName,
+                                doc_number: guestDoc,
+                                phone: guestPhone,
+                                dob: "",
+                                gender: "Nam",
+                                nationality: "Việt Nam",
+                                address: "",
+                            },
+                        ],
+                        check_in_date: checkInDate,
+                        check_out_date: stillStaying ? null : checkOutDate,
+                        expected_checkout_date: stillStaying ? checkOutDate : null,
+                        total_price: total,
+                        paid_amount: paid,
+                        source,
+                        notes: notes || null,
+                    },
+                },
+                { correlationId },
+            );
+            toast.success(stillStaying ? "Đã ghi bù khách đang ở!" : "Đã ghi bù khách đã trả phòng!");
+            onOpenChange(false);
+            fetchRooms();
+        } catch (e) {
+            toast.error(formatAppError(e));
+        }
+        setSubmitting(false);
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent side="right" className="w-[480px] sm:w-[520px] overflow-y-auto p-0">
+                <SheetHeader className="p-6 pb-4 border-b border-slate-100">
+                    <SheetTitle className="flex items-center gap-2 text-lg">
+                        <History size={20} className="text-amber-600" />
+                        Ghi bù sổ khách
+                    </SheetTitle>
+                    <p className="text-sm text-slate-500">
+                        Ghi lại khách đã ở mà quên nhập — khách sẽ vào danh sách khai báo tạm trú.
+                    </p>
+                </SheetHeader>
+
+                <div className="p-6 space-y-5">
+                    <div className="space-y-1.5">
+                        <label htmlFor="backfill-room" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                            Phòng
+                        </label>
+                        <select
+                            id="backfill-room"
+                            className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                            value={roomId}
+                            onChange={(e) => setRoomId(e.target.value)}
+                        >
+                            <option value="">— Chọn phòng —</option>
+                            {selectableRooms.map((r) => (
+                                <option key={r.id} value={r.id}>
+                                    {r.name} ({getRoomTypeLabel(r.type)})
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <label className="flex items-center gap-2 text-sm font-medium text-slate-700 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            checked={stillStaying}
+                            onChange={(e) => setStillStaying(e.target.checked)}
+                        />
+                        Khách còn ở (chưa trả phòng)
+                    </label>
+
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <label htmlFor="backfill-checkin" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                                Ngày vào
+                            </label>
+                            <input
+                                id="backfill-checkin"
+                                type="date"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={checkInDate}
+                                onChange={(e) => setCheckInDate(e.target.value)}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <label htmlFor="backfill-checkout" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                                {stillStaying ? "Ngày ra dự kiến" : "Ngày ra"}
+                            </label>
+                            <input
+                                id="backfill-checkout"
+                                type="date"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={checkOutDate}
+                                onChange={(e) => setCheckOutDate(e.target.value)}
+                            />
+                        </div>
+                    </div>
+
+                    {checkInDate && checkOutDate && !datesValid && (
+                        <div className="rounded-xl p-3 text-sm bg-red-50 text-red-700 border border-red-200">
+                            Ngày ra phải sau ngày vào ít nhất 1 đêm.
+                        </div>
+                    )}
+
+                    <div className="space-y-3">
+                        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Thông tin khách</h3>
+                        <input
+                            placeholder="Họ và tên *"
+                            className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                            value={guestName}
+                            onChange={(e) => setGuestName(e.target.value)}
+                        />
+                        <div className="grid grid-cols-2 gap-3">
+                            <input
+                                placeholder="Số điện thoại"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={guestPhone}
+                                onChange={(e) => setGuestPhone(e.target.value)}
+                            />
+                            <input
+                                placeholder="Số CCCD (tùy chọn)"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={guestDoc}
+                                onChange={(e) => setGuestDoc(e.target.value)}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <label htmlFor="backfill-total" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                                Tiền phòng ({nights} đêm)
+                            </label>
+                            <input
+                                id="backfill-total"
+                                type="number"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={total}
+                                onChange={(e) => {
+                                    setTotal(Number(e.target.value) || 0);
+                                    setTotalDirty(true);
+                                }}
+                            />
+                            {pricingLoading && !preview && (
+                                <p className="text-xs text-slate-400">Đang tính giá gợi ý...</p>
+                            )}
+                            {pricingError && (
+                                <p className="text-xs text-red-500">Không tính được giá gợi ý — có thể sửa tay.</p>
+                            )}
+                        </div>
+                        <div className="space-y-1.5">
+                            <label htmlFor="backfill-paid" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                                Đã thu
+                            </label>
+                            <input
+                                id="backfill-paid"
+                                type="number"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={paid}
+                                onChange={(e) => {
+                                    setPaid(Number(e.target.value) || 0);
+                                    setPaidDirty(true);
+                                }}
+                            />
+                        </div>
+                    </div>
+                    {(paidTooHigh || paidNegative) && (
+                        <p className="text-xs text-red-600 font-medium">
+                            {paidTooHigh
+                                ? `Đã thu (${fmtNumber(paid)}₫) không được vượt quá tiền phòng (${fmtNumber(total)}₫).`
+                                : "Đã thu không được nhỏ hơn 0."}
+                        </p>
+                    )}
+
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <label htmlFor="backfill-source" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                                Nguồn
+                            </label>
+                            <select
+                                id="backfill-source"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={source}
+                                onChange={(e) => setSource(e.target.value)}
+                            >
+                                <option value="walk-in">Walk-in</option>
+                                <option value="phone">Điện thoại</option>
+                                <option value="zalo">Zalo</option>
+                                <option value="agoda">Agoda</option>
+                                <option value="booking.com">Booking.com</option>
+                                <option value="other">Khác</option>
+                            </select>
+                        </div>
+                        <div className="space-y-1.5">
+                            <label htmlFor="backfill-notes" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                                Ghi chú
+                            </label>
+                            <input
+                                id="backfill-notes"
+                                className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
+                                value={notes}
+                                onChange={(e) => setNotes(e.target.value)}
+                            />
+                        </div>
+                    </div>
+
+                    <Button
+                        className="w-full h-12 rounded-xl bg-amber-600 hover:bg-amber-700 text-white font-semibold text-sm cursor-pointer"
+                        onClick={handleSubmit}
+                        disabled={!canSubmit}
+                    >
+                        {submitting ? "Đang xử lý..." : "Ghi bù vào sổ"}
+                    </Button>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -42,6 +42,12 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
     const [checkInDate, setCheckInDate] = useState("");
     const [checkOutDate, setCheckOutDate] = useState("");
     const [stillStaying, setStillStaying] = useState(false);
+    // Nhớ ngày ra *trước khi* tick "Khách còn ở", để tắt lại trả nó về đúng
+    // ngày chủ đã kéo — thay vì chốt cứng về hôm nay. `null` nghĩa là không
+    // còn giá trị đáng tin để phục hồi (sheet mở sẵn ở chế độ còn ở, hoặc chủ
+    // đã tự sửa ô ngày ra trong lúc toggle đang bật) — khi đó rơi về nhánh
+    // chốt-hôm-nay cũ như trước.
+    const [preToggleCheckOutDate, setPreToggleCheckOutDate] = useState<string | null>(null);
     const [total, setTotal] = useState(0);
     const [totalDirty, setTotalDirty] = useState(false);
     const [paid, setPaid] = useState(0);
@@ -62,6 +68,7 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
         setCheckInDate(prefill?.checkInDate ?? "");
         setCheckOutDate(prefill?.checkOutDate ?? "");
         setStillStaying(prefill?.stillStaying ?? false);
+        setPreToggleCheckOutDate(null);
         setGuestName("");
         setGuestPhone("");
         setGuestDoc("");
@@ -238,6 +245,10 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 const nextStillStaying = e.target.checked;
                                 setStillStaying(nextStillStaying);
                                 if (nextStillStaying) {
+                                    // Nhớ lại ngày ra hiện tại (ngày chủ thực sự đã kéo/nhập)
+                                    // trước khi ghi đè nó, để tắt toggle sau này biết phục hồi
+                                    // đúng giá trị thay vì chốt cứng về hôm nay.
+                                    setPreToggleCheckOutDate(checkOutDate || null);
                                     // §4: ngày ra dự kiến lấy theo cuối vùng kéo khi vùng đó
                                     // chạm tương lai, còn không thì mặc định NGÀY MAI. Đổi nhãn
                                     // và min/max thôi là chưa đủ: `datesValid` chỉ soi nights > 0
@@ -249,11 +260,28 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                     if (!checkOutDate || checkOutDate <= todayIso) {
                                         setCheckOutDate(addDaysIso(todayIso, 1));
                                     }
-                                } else if (checkOutDate > todayIso) {
-                                    // Chiều ngược lại, mở ra bởi chính cú nhảy ở trên: "đã trả
-                                    // phòng" mà ngày ra ở tương lai cũng bị backend từ chối. Kéo
-                                    // về hôm nay — đúng `max` của ô ở chế độ này.
-                                    setCheckOutDate(todayIso);
+                                } else {
+                                    if (preToggleCheckOutDate && preToggleCheckOutDate <= todayIso) {
+                                        // Bug thật đã sửa: trước đây nhánh này chỉ biết chốt về
+                                        // `todayIso` khi ngày ra đang ở tương lai — nó xoá mất
+                                        // ngày chủ đã kéo thật (vd "hôm qua") và âm thầm biến
+                                        // một lượt ở đúng thành dài thêm một đêm mà không ai
+                                        // hay biết. Còn giá trị nhớ được (và nó hợp lệ cho chế
+                                        // độ "đã trả phòng", tức không nằm ở tương lai) thì
+                                        // phục hồi đúng ngày đó.
+                                        setCheckOutDate(preToggleCheckOutDate);
+                                    } else if (checkOutDate > todayIso) {
+                                        // Không có gì đáng tin để phục hồi (sheet mở sẵn ở chế
+                                        // độ còn ở, hoặc chủ đã tự sửa ô ngày ra trong lúc
+                                        // toggle đang bật) — rơi về hành vi cũ: "đã trả phòng"
+                                        // mà ngày ra ở tương lai cũng bị backend từ chối, kéo
+                                        // về hôm nay — đúng `max` của ô ở chế độ này.
+                                        setCheckOutDate(todayIso);
+                                    }
+                                    // Chỉ dọn giá trị nhớ được ở nhánh tắt toggle — nhánh bật
+                                    // toggle ở trên vừa mới ghi nó, xoá ngay tại đây (thay vì
+                                    // chỉ trong nhánh tắt) sẽ xoá mất giá trị vừa ghi đó.
+                                    setPreToggleCheckOutDate(null);
                                 }
                             }}
                         />
@@ -285,7 +313,14 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 value={checkOutDate}
                                 min={stillStaying ? addDaysIso(todayIso, 1) : undefined}
                                 max={stillStaying ? undefined : todayIso}
-                                onChange={(e) => setCheckOutDate(e.target.value)}
+                                onChange={(e) => {
+                                    setCheckOutDate(e.target.value);
+                                    // Chủ tự sửa ngày trong lúc toggle đang bật: giá trị nhớ
+                                    // trước-toggle không còn đáng tin để phục hồi khi tắt lại
+                                    // (chủ vừa đổi ý) — bỏ nó, tắt toggle sẽ rơi về nhánh chốt
+                                    // hôm nay như hành vi cũ.
+                                    if (stillStaying) setPreToggleCheckOutDate(null);
+                                }}
                             />
                         </div>
                     </div>

--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -114,13 +114,23 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
 
     // Bật "Khách còn ở" có thể lọc mất phòng đang chọn (không còn vacant) —
     // <select> khi đó không có option khớp và hiện trống, nhưng state vẫn giữ
-    // (và vẫn gửi đi) roomId đó nếu không xoá ở đây.
+    // (và vẫn gửi đi) roomId đó nếu không xoá ở đây. Trước đây deps chỉ có
+    // [stillStaying, rooms], thiếu roomId — nếu sheet mở lại với prefill mới
+    // (roomId khác) trong khi stillStaying đã sẵn true và rooms không đổi
+    // reference, effect không chạy lại và không dọn roomId cũ. Depend thẳng
+    // vào roomId và selectableRooms (danh sách đã lọc, đúng những gì effect
+    // dùng) để effect luôn thấy đúng giá trị mới nhất. Không lặp vô hạn: khi
+    // effect tự setRoomId(""), lần chạy kế tiếp roomId rỗng nên `if (roomId
+    // && ...)` chặn ngay ở điều kiện đầu — no-op. Khi roomId đang hợp lệ
+    // (có trong selectableRooms), `!selectableRooms.some(...)` là false nên
+    // cũng no-op — dù selectableRooms là mảng mới mỗi lần stillStaying=true
+    // khiến effect chạy lại nhiều hơn cần thiết, nó không bao giờ gọi
+    // setRoomId khi không cần, nên không thể lặp.
     useEffect(() => {
         if (roomId && !selectableRooms.some((r) => r.id === roomId)) {
             setRoomId("");
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [stillStaying, rooms]);
+    }, [roomId, selectableRooms]);
 
     // Backend vẫn validate lại — đây chỉ là rào chắn trong form cho khỏi chọn
     // nhầm một ngày rõ ràng vô lý (ghi bù mà ngày vào ở tương lai, hoặc ngày
@@ -310,7 +320,11 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
                                 value={total}
                                 onChange={(e) => {
-                                    setTotal(Number(e.target.value) || 0);
+                                    // Money là MoneyVnd (số nguyên) ở backend. Không có <form> bao
+                                    // quanh nên constraint validation của trình duyệt (stepMismatch
+                                    // từ step="1") không bao giờ chạy trước khi handleSubmit gọi API
+                                    // — phải tự làm tròn ở đây, không được dựa vào step.
+                                    setTotal(Math.round(Number(e.target.value) || 0));
                                     setTotalDirty(true);
                                 }}
                             />
@@ -332,7 +346,9 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-amber-200"
                                 value={paid}
                                 onChange={(e) => {
-                                    setPaid(Number(e.target.value) || 0);
+                                    // Cùng lý do với ô Tiền phòng ở trên — làm tròn ở đây thay vì
+                                    // trông cậy vào step="1" (không có tác dụng khi không có <form>).
+                                    setPaid(Math.round(Number(e.target.value) || 0));
                                     setPaidDirty(true);
                                 }}
                             />

--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -145,6 +145,9 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
         !!checkInDate &&
         !!checkOutDate &&
         datesValid &&
+        // Bảng giá hỏng thì `total` đứng nguyên ở 0 và không gì chặn một lượt
+        // lưu trú 0₫ đi vào sổ — vừa sai sổ sách, vừa kéo lệch doanh thu.
+        total > 0 &&
         !paidTooHigh &&
         !paidNegative &&
         !submitting;
@@ -227,7 +230,28 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
                         <input
                             type="checkbox"
                             checked={stillStaying}
-                            onChange={(e) => setStillStaying(e.target.checked)}
+                            onChange={(e) => {
+                                const nextStillStaying = e.target.checked;
+                                setStillStaying(nextStillStaying);
+                                if (nextStillStaying) {
+                                    // §4: ngày ra dự kiến lấy theo cuối vùng kéo khi vùng đó
+                                    // chạm tương lai, còn không thì mặc định NGÀY MAI. Đổi nhãn
+                                    // và min/max thôi là chưa đủ: `datesValid` chỉ soi nights > 0
+                                    // nên nút gửi vẫn sáng với một ngày ra trong quá khứ, và
+                                    // backend từ chối bằng "Ngày ra dự kiến phải sau hôm nay."
+                                    // `min` không cứu được — không có <form> bao quanh và nút
+                                    // không phải submit, đúng lý do đã áp cho step="1" ở ô tiền.
+                                    // Ngày tương lai chủ đã chọn thì giữ nguyên, không đè.
+                                    if (!checkOutDate || checkOutDate <= todayIso) {
+                                        setCheckOutDate(addDaysIso(todayIso, 1));
+                                    }
+                                } else if (checkOutDate > todayIso) {
+                                    // Chiều ngược lại, mở ra bởi chính cú nhảy ở trên: "đã trả
+                                    // phòng" mà ngày ra ở tương lai cũng bị backend từ chối. Kéo
+                                    // về hôm nay — đúng `max` của ô ở chế độ này.
+                                    setCheckOutDate(todayIso);
+                                }
+                            }}
                         />
                         Khách còn ở (chưa trả phòng)
                     </label>

--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -127,10 +127,14 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
     // khiến effect chạy lại nhiều hơn cần thiết, nó không bao giờ gọi
     // setRoomId khi không cần, nên không thể lặp.
     useEffect(() => {
-        if (roomId && !selectableRooms.some((r) => r.id === roomId)) {
+        // `rooms.length > 0`: các sheet này gọi fetchRooms() lúc mở, nên có một
+        // khoảnh khắc danh sách còn rỗng. Không có vế này, một phòng hợp lệ
+        // truyền vào bị xoá ngay trước khi rooms kịp về, và effect nạp
+        // preSelected không chạy lại để đặt lại nó.
+        if (rooms.length > 0 && roomId && !selectableRooms.some((r) => r.id === roomId)) {
             setRoomId("");
         }
-    }, [roomId, selectableRooms]);
+    }, [rooms, roomId, selectableRooms]);
 
     // Backend vẫn validate lại — đây chỉ là rào chắn trong form cho khỏi chọn
     // nhầm một ngày rõ ràng vô lý (ghi bù mà ngày vào ở tương lai, hoặc ngày

--- a/mhm/src/components/CheckinSheet.test.tsx
+++ b/mhm/src/components/CheckinSheet.test.tsx
@@ -1,0 +1,41 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useHotelStore } from "@/stores/useHotelStore";
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import CheckinSheet from "./CheckinSheet";
+
+describe("CheckinSheet", () => {
+  it("điền sẵn số đêm khi mở từ calendar", async () => {
+    useHotelStore.setState({ isCheckinOpen: true });
+    render(<CheckinSheet preSelectedRoomId="1A" preSelectedNights={3} />);
+
+    // FormField (shared) chỉ đặt <label> cạnh <input>, không có htmlFor/id
+    // liên kết chúng — nên getByLabelText("Số đêm") không tìm ra input này
+    // dù component đã prefill đúng. Đây là lối thoát chính brief cho phép:
+    // xác minh qua display value của input số đêm.
+    expect(await screen.findByDisplayValue("3")).toBeInTheDocument();
+  });
+});

--- a/mhm/src/components/CheckinSheet.test.tsx
+++ b/mhm/src/components/CheckinSheet.test.tsx
@@ -1,8 +1,10 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { clearMockResponses, setMockResponse } from "@test-mocks/tauri-core";
 import { useHotelStore } from "@/stores/useHotelStore";
+import type { Room, RoomStatus } from "@/types";
 
 vi.mock("@/components/ui/sheet", () => ({
   Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -27,7 +29,35 @@ vi.mock("sonner", () => ({
 
 import CheckinSheet from "./CheckinSheet";
 
+function room(id: string, status: RoomStatus): Room {
+  return {
+    id,
+    name: id,
+    type: "standard",
+    floor: 1,
+    has_balcony: false,
+    base_price: 250000,
+    max_guests: 2,
+    extra_person_fee: 50000,
+    status,
+  };
+}
+
+// Ô "Phòng *" là <select> trần, nhãn không có htmlFor/id liên kết — cùng lý do
+// đã ghi ở BackfillSheet.test.tsx.
+function roomSelect(): HTMLSelectElement {
+  const label = screen.getByText("Phòng *");
+  const el = label.parentElement?.querySelector("select");
+  if (!el) throw new Error('Không tìm thấy <select> cạnh nhãn "Phòng *"');
+  return el;
+}
+
 describe("CheckinSheet", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    useHotelStore.setState({ isCheckinOpen: false, rooms: [] });
+  });
+
   it("điền sẵn số đêm khi mở từ calendar", async () => {
     useHotelStore.setState({ isCheckinOpen: true });
     render(<CheckinSheet preSelectedRoomId="1A" preSelectedNights={3} />);
@@ -37,5 +67,44 @@ describe("CheckinSheet", () => {
     // dù component đã prefill đúng. Đây là lối thoát chính brief cho phép:
     // xác minh qua display value của input số đêm.
     expect(await screen.findByDisplayValue("3")).toBeInTheDocument();
+  });
+
+  // Ô lịch của một phòng ĐANG CÓ KHÁCH vẫn kéo được (hôm nay khách sắp trả),
+  // và cú kéo đó truyền thẳng roomId vào đây mà không ai kiểm tra nó có nằm
+  // trong danh sách phòng trống hay không. Trước nhánh này mọi caller đều đã
+  // gác sẵn trên "vacant" nên tình huống không tới được.
+  it("bỏ chọn phòng khi phòng truyền vào không nằm trong danh sách phòng trống", async () => {
+    setMockResponse("get_rooms", () => [room("R101", "occupied")]);
+    useHotelStore.setState({ isCheckinOpen: true });
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => {
+      expect(roomSelect()).toHaveValue("");
+    });
+
+    // Ô select trống chưa chứng minh được gì: jsdom cũng hiện trống khi state
+    // vẫn giữ R101 mà option đã bị lọc mất. Cho R101 trở lại danh sách — nếu
+    // state chưa thực sự bị xoá, select sẽ tự nhảy về "R101" dù chủ chưa hề
+    // chọn lại nó.
+    act(() => {
+      useHotelStore.setState({ rooms: [room("R101", "vacant")] });
+    });
+
+    await waitFor(() => {
+      expect(
+        Array.from(roomSelect().options).map((o) => o.value),
+      ).toContain("R101");
+    });
+    expect(roomSelect()).toHaveValue("");
+  });
+
+  it("giữ nguyên phòng truyền vào khi phòng đó đang trống", async () => {
+    setMockResponse("get_rooms", () => [room("R101", "vacant")]);
+    useHotelStore.setState({ isCheckinOpen: true });
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await waitFor(() => {
+      expect(roomSelect()).toHaveValue("R101");
+    });
   });
 });

--- a/mhm/src/components/CheckinSheet.tsx
+++ b/mhm/src/components/CheckinSheet.tsx
@@ -24,7 +24,7 @@ const emptyGuest = (): GuestInput => ({
     address: "",
 });
 
-export default function CheckinSheet({ preSelectedRoomId }: { preSelectedRoomId?: string } = {}) {
+export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: { preSelectedRoomId?: string; preSelectedNights?: number } = {}) {
     const { rooms, checkIn, fetchRooms, isCheckinOpen, setCheckinOpen } = useHotelStore();
 
     const [guests, setGuests] = useState<GuestInput[]>([emptyGuest()]);
@@ -46,6 +46,13 @@ export default function CheckinSheet({ preSelectedRoomId }: { preSelectedRoomId?
             setSelectedRoom(preSelectedRoomId);
         }
     }, [isCheckinOpen, preSelectedRoomId]);
+
+    // Auto-fill nights when pre-selected
+    useEffect(() => {
+        if (isCheckinOpen && preSelectedNights) {
+            setNights(preSelectedNights);
+        }
+    }, [isCheckinOpen, preSelectedNights]);
 
     // Listen for OCR results from background watcher
     useEffect(() => {

--- a/mhm/src/components/CheckinSheet.tsx
+++ b/mhm/src/components/CheckinSheet.tsx
@@ -126,6 +126,25 @@ export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: {
     }, [isCheckinOpen]);
 
     const vacantRooms = rooms.filter((r) => r.status === "vacant");
+
+    // Kéo một ô lịch của phòng ĐANG CÓ KHÁCH vẫn mở được sheet này với đúng
+    // roomId đó, mà danh sách chỉ liệt kê phòng trống — <select> không có
+    // option nào khớp nên hiện trống, trong khi state vẫn giữ (và vẫn gửi đi)
+    // id vô hình kia. Trước nhánh này mọi caller đều đã gác sẵn trên "vacant"
+    // nên tình huống không tới được. Cùng cách xử lý như BackfillSheet.tsx:
+    // depend thẳng vào selectedRoom và vacantRooms để effect luôn thấy giá trị
+    // mới nhất. Không lặp vô hạn: sau khi tự xoá, `selectedRoom` rỗng nên điều
+    // kiện đầu chặn ngay; còn khi phòng đang hợp lệ thì vế sau là false.
+    useEffect(() => {
+        // `rooms.length > 0`: các sheet này gọi fetchRooms() lúc mở, nên có một
+        // khoảnh khắc danh sách còn rỗng. Không có vế này, một phòng hợp lệ
+        // truyền vào bị xoá ngay trước khi rooms kịp về, và effect nạp
+        // preSelected không chạy lại để đặt lại nó.
+        if (rooms.length > 0 && selectedRoom && !vacantRooms.some((r) => r.id === selectedRoom)) {
+            setSelectedRoom("");
+        }
+    }, [rooms, selectedRoom, vacantRooms]);
+
     const selectedRoomData = rooms.find((r) => r.id === selectedRoom);
     const totalPrice = selectedRoomData
         ? selectedRoomData.base_price * nights

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -341,6 +341,25 @@ describe("ReservationSheet", () => {
   });
 
   it("để người dùng chọn ngày đi và không còn ô số đêm", async () => {
+    // Dòng tổng tiền giờ đến từ engine (calculate_room_price_preview) chứ
+    // không còn tự nhân trong component — nạp một breakdown giả phản ánh
+    // đúng số đêm đã chọn, để chứng minh ngày tự suy ra số đêm mà không cần
+    // ô nhập riêng.
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "calculate_room_price_preview") {
+        return {
+          pricing_type: "nightly",
+          base_amount: 1_500_000,
+          surcharge_amount: 0,
+          weekend_amount: 0,
+          total: 1_500_000,
+          capped: false,
+          breakdown: [{ label: "3 night(s) x 500.000", amount: 1_500_000 }],
+        };
+      }
+      return { available: true, conflicts: [], max_nights: null };
+    });
+
     render(<ReservationSheet open onOpenChange={vi.fn()} />);
 
     expect(screen.queryByLabelText(/số đêm/i)).not.toBeInTheDocument();
@@ -356,7 +375,7 @@ describe("ReservationSheet", () => {
     fireEvent.change(checkOut, { target: { value: "2026-08-09" } });
 
     await waitFor(() => {
-      expect(screen.getByText(/3 đêm/i)).toBeInTheDocument();
+      expect(screen.getByText(/3 night\(s\)/i)).toBeInTheDocument();
     });
   });
 
@@ -428,6 +447,35 @@ describe("ReservationSheet", () => {
     fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R102" } });
 
     await waitFor(() => expect(guests.value).toBe("5"));
+  });
+
+  it("hiện tổng tiền do engine trả về, kèm dòng phụ thu", async () => {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "calculate_room_price_preview") {
+        return {
+          pricing_type: "nightly",
+          base_amount: 1_000_000,
+          surcharge_amount: 0,
+          weekend_amount: 0,
+          total: 1_200_000,
+          capped: false,
+          breakdown: [
+            { label: "2 night(s) x 500.000", amount: 1_000_000 },
+            { label: "Phụ thu 2 khách", amount: 200_000 },
+          ],
+        };
+      }
+      return { available: true, conflicts: [], max_nights: null };
+    });
+
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+    fireEvent.change(screen.getByLabelText(/số khách/i), { target: { value: "4" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Phụ thu 2 khách")).toBeInTheDocument();
+      expect(screen.getByText("1.200.000₫")).toBeInTheDocument();
+    });
   });
 
   it("một fetchRooms() không liên quan (mảng rooms mới, cùng dữ liệu) không được xoá số khách đã gõ tay", async () => {

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -809,4 +809,44 @@ describe("ReservationSheet", () => {
     expect(checkIn.value).toBe("2026-04-20");
     expect(checkOut.value).toBe("2026-04-22");
   });
+
+  it("một re-render không liên quan với prefillDates object mới (cùng nội dung) không được xoá ngày người dùng vừa sửa", async () => {
+    // prefillDates đến từ kéo-thả trên lịch (Task 8) và được component cha
+    // dựng inline trong JSX (`prefillDates={... ? { checkIn, checkOut } : undefined}`),
+    // nên mỗi lần cha re-render vì lý do bất kỳ sẽ tạo ra một object mới có
+    // cùng nội dung. Nếu effect phụ thuộc vào *reference* của prefillDates,
+    // nó sẽ chạy lại, rơi vào nhánh `else if (prefillDates)`, và ghi đè ngày
+    // người dùng vừa gõ tay trở lại giá trị prefill ban đầu.
+    const { rerender } = render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        preSelectedRoomId="R101"
+        prefillDates={{ checkIn: "2026-08-02", checkOut: "2026-08-05" }}
+      />,
+    );
+
+    const checkIn = screen.getByLabelText(/ngày đến/i) as HTMLInputElement;
+    await waitFor(() => {
+      expect(checkIn.value).toBe("2026-08-02");
+    });
+
+    // Người dùng tự sửa ngày đến sau khi sheet đã mở.
+    fireEvent.change(checkIn, { target: { value: "2026-08-10" } });
+    expect(checkIn.value).toBe("2026-08-10");
+
+    // Re-render với một object prefillDates MỚI nhưng cùng nội dung — đúng
+    // những gì component cha (calendar kéo-thả) tạo ra ở mỗi lần render.
+    rerender(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        preSelectedRoomId="R101"
+        prefillDates={{ checkIn: "2026-08-02", checkOut: "2026-08-05" }}
+      />,
+    );
+
+    const checkInAfterRerender = screen.getByLabelText(/ngày đến/i) as HTMLInputElement;
+    expect(checkInAfterRerender.value).toBe("2026-08-10");
+  });
 });

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -122,14 +122,17 @@ describe("ReservationSheet", () => {
     });
 
     const [roomSelect, sourceSelect] = screen.getAllByRole("combobox");
-    const [nightsInput, depositInput] = screen.getAllByRole("spinbutton");
+    const depositInput = screen.getByRole("spinbutton");
 
     fireEvent.change(roomSelect, {
       target: { value: "R101" },
     });
     await user.type(screen.getByPlaceholderText("Họ và tên *"), "Nguyen Van A");
-    fireEvent.change(nightsInput, {
-      target: { value: "2" },
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-06" },
+    });
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2026-08-08" },
     });
     fireEvent.change(depositInput, {
       target: { value: "250000" },
@@ -203,9 +206,8 @@ describe("ReservationSheet", () => {
       expect(fetchRooms).toHaveBeenCalledTimes(1);
     });
 
-    const [nightsInput] = screen.getAllByRole("spinbutton");
-    fireEvent.change(nightsInput, {
-      target: { value: "3" },
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2026-04-23" },
     });
 
     await user.click(screen.getByRole("button", { name: /lưu thay đổi/i }));
@@ -289,7 +291,7 @@ describe("ReservationSheet", () => {
     });
 
     const [roomSelect] = screen.getAllByRole("combobox");
-    const [, depositInput] = screen.getAllByRole("spinbutton");
+    const depositInput = screen.getByRole("spinbutton");
 
     fireEvent.change(roomSelect, {
       target: { value: "R101" },
@@ -309,5 +311,51 @@ describe("ReservationSheet", () => {
     expect(toastError).toHaveBeenCalledWith(
       "deposit_amount must be a safe integer VND value",
     );
+  });
+
+  it("để người dùng chọn ngày đi và không còn ô số đêm", async () => {
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    expect(screen.queryByLabelText(/số đêm/i)).not.toBeInTheDocument();
+
+    const checkOut = screen.getByLabelText(/ngày đi/i) as HTMLInputElement;
+    expect(checkOut.readOnly).toBe(false);
+
+    // Dòng tổng tiền chỉ hiện khi đã chọn phòng — đó là chỗ số đêm hiện ra.
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-06" },
+    });
+    fireEvent.change(checkOut, { target: { value: "2026-08-09" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/3 đêm/i)).toBeInTheDocument();
+    });
+  });
+
+  it("khoá nút đặt phòng khi ngày đi không sau ngày đến", async () => {
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    // Điền đủ phòng và tên khách trước, để nút bị khoá *chỉ vì* ngày sai —
+    // không điền thì nút vốn đã khoá và test không chứng minh được gì.
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+    fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
+      target: { value: "Nguyễn Nhật Huy" },
+    });
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-06" },
+    });
+
+    const submit = screen.getByRole("button", { name: /đặt phòng/i });
+    await waitFor(() => expect(submit).toBeEnabled());
+
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2026-08-06" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/ngày đi phải sau ngày đến/i)).toBeInTheDocument();
+    });
+    expect(submit).toBeDisabled();
   });
 });

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -18,10 +18,16 @@ const fetchRooms = vi.hoisted(() => vi.fn());
 const openInvoice = vi.hoisted(() => vi.fn());
 const closeInvoice = vi.hoisted(() => vi.fn());
 const resetAvailability = vi.hoisted(() => vi.fn());
-// A stable reference, like the real Zustand store returns — recreating this
-// array on every render would spuriously refire the room-reload effect that
-// depends on it and clobber whatever guest count the user just typed.
-const rooms = vi.hoisted(() => [
+// The real Zustand store is NOT always a stable reference: fetchRooms() does
+// `set({ rooms })` with a brand-new array from a fresh `invoke("get_rooms")`
+// call, and it's wired up to fire on unrelated events (any "db-updated" event,
+// the MCP agent booking path, etc — see useHotelStore.ts / RuntimeStateProvider).
+// ORIGINAL_ROOMS is an immutable snapshot; `rooms` is what the mocked hook
+// currently returns. Tests reassign `rooms` to model either case:
+//   - untouched (same reference across renders), or
+//   - `ORIGINAL_ROOMS.map((r) => ({ ...r }))` (new array, new room objects,
+//     equal contents — exactly what a fetchRooms() refresh produces).
+const ORIGINAL_ROOMS = vi.hoisted(() => [
   {
     id: "R101",
     name: "R101",
@@ -34,7 +40,20 @@ const rooms = vi.hoisted(() => [
     extra_person_fee: 50000,
     status: "vacant",
   },
+  {
+    id: "R102",
+    name: "R102",
+    type: "deluxe",
+    room_type: "deluxe",
+    floor: 2,
+    has_balcony: true,
+    base_price: 800000,
+    max_guests: 5,
+    extra_person_fee: 80000,
+    status: "vacant",
+  },
 ]);
+let rooms = ORIGINAL_ROOMS;
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke,
@@ -115,6 +134,7 @@ describe("ReservationSheet", () => {
     invoke.mockResolvedValue(undefined);
     invokeWriteCommand.mockResolvedValue(undefined);
     createCorrelationId.mockReturnValue("COR-5E6F7A8B");
+    rooms = ORIGINAL_ROOMS;
   });
 
   it("uses invokeWriteCommand with scrubbed monitoring context for the create flow", async () => {
@@ -389,5 +409,47 @@ describe("ReservationSheet", () => {
         expect.anything(),
       );
     });
+  });
+
+  it("đổi sang phòng khác thì nạp lại số khách theo phòng mới, dù đã gõ tay số khác", async () => {
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+
+    const guests = screen.getByLabelText(/số khách/i) as HTMLInputElement;
+    await waitFor(() => expect(guests.value).toBe("2"));
+
+    // Người dùng gõ tay một số khách khác với max_guests của phòng đang chọn.
+    fireEvent.change(guests, { target: { value: "9" } });
+    expect(guests.value).toBe("9");
+
+    // Đổi sang phòng khác — đây LÀ một lựa chọn phòng mới của người dùng,
+    // nên số khách phải được nạp lại theo phòng mới (ghi đè số đã gõ tay).
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R102" } });
+
+    await waitFor(() => expect(guests.value).toBe("5"));
+  });
+
+  it("một fetchRooms() không liên quan (mảng rooms mới, cùng dữ liệu) không được xoá số khách đã gõ tay", async () => {
+    const { rerender } = render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+
+    const guests = screen.getByLabelText(/số khách/i) as HTMLInputElement;
+    await waitFor(() => expect(guests.value).toBe("2"));
+
+    // Người dùng gõ tay một số khách khác với max_guests của phòng đang chọn.
+    fireEvent.change(guests, { target: { value: "9" } });
+    expect(guests.value).toBe("9");
+
+    // Mô phỏng đúng những gì fetchRooms() thật làm khi một sự kiện không liên
+    // quan xảy ra ở nơi khác (dọn phòng khác, checkout phòng khác, AI agent
+    // đặt một phòng khác...): store trả về một mảng rooms MỚI (identity mới)
+    // nhưng cùng nội dung — roomId đang chọn không đổi.
+    rooms = ORIGINAL_ROOMS.map((r) => ({ ...r }));
+    rerender(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    const guestsAfterRefresh = screen.getByLabelText(/số khách/i) as HTMLInputElement;
+    expect(guestsAfterRefresh.value).toBe("9");
   });
 });

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -846,4 +846,93 @@ describe("ReservationSheet", () => {
     const checkInAfterRerender = screen.getByLabelText(/ngày đến/i) as HTMLInputElement;
     expect(checkInAfterRerender.value).toBe("2026-08-10");
   });
+
+  // Ô lịch tương lai của một phòng ĐANG CÓ KHÁCH vẫn kéo được (khách rời sau
+  // hai hôm), và cú kéo truyền thẳng roomId vào đây. Danh sách chỉ liệt kê
+  // vacant/booked, nên phòng đó không có option nào khớp: ô "Phòng" hiện
+  // trống trong khi state vẫn giữ id — và nút gửi vẫn sáng, vì nó gác trên
+  // `!roomId`, mà id vô hình kia là truthy.
+  it("bỏ chọn phòng khi phòng kéo từ lịch không nằm trong danh sách chọn được", async () => {
+    rooms = [
+      ORIGINAL_ROOMS[0],
+      { ...ORIGINAL_ROOMS[1], status: "occupied" },
+    ];
+    const { rerender } = render(
+      <ReservationSheet open onOpenChange={vi.fn()} preSelectedRoomId="R102" />,
+    );
+
+    const roomSelect = screen.getByLabelText(/^Phòng$/) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(roomSelect).toHaveValue("");
+    });
+    // Nút gửi phải tắt: bật lên với một phòng vô hình chỉ dẫn tới một cú từ
+    // chối ở backend.
+    expect(screen.getByRole("button", { name: /Đặt phòng/ })).toBeDisabled();
+
+    // Ô trống chưa chứng minh gì — jsdom cũng hiện trống khi state còn giữ
+    // R102 mà option đã bị lọc mất. Cho R102 trở lại danh sách: state chưa bị
+    // xoá thật thì select tự nhảy về "R102" dù chủ chưa hề chọn lại.
+    rooms = ORIGINAL_ROOMS.map((r) => ({ ...r }));
+    rerender(<ReservationSheet open onOpenChange={vi.fn()} preSelectedRoomId="R102" />);
+
+    await waitFor(() => {
+      expect(
+        Array.from((screen.getByLabelText(/^Phòng$/) as HTMLSelectElement).options).map(
+          (o) => o.value,
+        ),
+      ).toContain("R102");
+    });
+    expect(screen.getByLabelText(/^Phòng$/)).toHaveValue("");
+  });
+
+  // Chế độ sửa: phòng lấy từ chính booking đang sửa, ô select bị disable, và
+  // phòng đó rất có thể không còn vacant/booked — nó đang có khách. Ô select
+  // hiện trống ở cả hai đời code (không có option khớp), nên chỉ soi DOM là
+  // không phân biệt được; đường lưu thay đổi mới là thứ chứng minh state còn
+  // nguyên: `handleSubmit` chặn ngay ở `!roomId`.
+  it("không bỏ chọn phòng của booking đang sửa dù phòng đó đang có khách", async () => {
+    rooms = [
+      ORIGINAL_ROOMS[0],
+      { ...ORIGINAL_ROOMS[1], status: "occupied" },
+    ];
+    const user = userEvent.setup();
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        editBooking={{
+          id: "B-EDIT",
+          room_id: "R102",
+          guest_name: "Nguyen Van A",
+          guest_phone: "0900000000",
+          check_in_at: "2026-08-02T14:00:00+07:00",
+          expected_checkout: "2026-08-05T12:00:00+07:00",
+          scheduled_checkin: "2026-08-02",
+          scheduled_checkout: "2026-08-05",
+          nights: 3,
+          guests: 2,
+          total_price: 1000000,
+          deposit_amount: 0,
+          source: "phone",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchRooms).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: /lưu thay đổi/i }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "modify_reservation",
+        expect.objectContaining({
+          req: expect.objectContaining({ booking_id: "B-EDIT" }),
+        }),
+        expect.anything(),
+      );
+    });
+    expect(toastError).not.toHaveBeenCalled();
+  });
 });

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -354,7 +354,7 @@ describe("ReservationSheet", () => {
           weekend_amount: 0,
           total: 1_500_000,
           capped: false,
-          breakdown: [{ label: "3 night(s) x 500.000", amount: 1_500_000 }],
+          breakdown: [{ label: "3 đêm x 500.000", amount: 1_500_000 }],
         };
       }
       return { available: true, conflicts: [], max_nights: null };
@@ -375,7 +375,7 @@ describe("ReservationSheet", () => {
     fireEvent.change(checkOut, { target: { value: "2026-08-09" } });
 
     await waitFor(() => {
-      expect(screen.getByText(/3 night\(s\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/3 đêm/i)).toBeInTheDocument();
     });
   });
 
@@ -460,7 +460,7 @@ describe("ReservationSheet", () => {
           total: 1_200_000,
           capped: false,
           breakdown: [
-            { label: "2 night(s) x 500.000", amount: 1_000_000 },
+            { label: "2 đêm x 500.000", amount: 1_000_000 },
             { label: "Phụ thu 2 khách", amount: 200_000 },
           ],
         };
@@ -493,7 +493,7 @@ describe("ReservationSheet", () => {
           total: 1_000_000,
           capped: true,
           breakdown: [
-            { label: "2 night(s) x 1.000.000", amount: 2_000_000 },
+            { label: "2 đêm x 1.000.000", amount: 2_000_000 },
             { label: "Phụ thu 3 khách", amount: 3_000_000 },
           ],
         };
@@ -530,7 +530,7 @@ describe("ReservationSheet", () => {
             total: 600_000,
             capped: false,
             breakdown: [
-              { label: "1 night(s) x 500.000", amount: 500_000 },
+              { label: "1 đêm x 500.000", amount: 500_000 },
               { label: "Phụ thu 1 khách", amount: 100_000 },
             ],
           };

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -865,6 +865,14 @@ describe("ReservationSheet", () => {
     await waitFor(() => {
       expect(roomSelect).toHaveValue("");
     });
+    // Điền tên khách trước — nút gửi cũng khoá bởi `!isEditMode && !guestName`
+    // (xem disabled expression trong ReservationSheet.tsx), nên nếu bỏ qua
+    // bước này, assertion dưới đúng bất kể roomId có bị xoá hay không và
+    // không chứng minh được gì cho chính bug đang test. Điền tên vào rồi thì
+    // việc phòng bị xoá mới là lý do DUY NHẤT còn giữ nút tắt.
+    fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
+      target: { value: "Nguyễn Nhật Huy" },
+    });
     // Nút gửi phải tắt: bật lên với một phòng vô hình chỉ dẫn tới một cú từ
     // chối ở backend.
     expect(screen.getByRole("button", { name: /Đặt phòng/ })).toBeDisabled();

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -735,4 +735,78 @@ describe("ReservationSheet", () => {
     const guestsAfterRefresh = screen.getByLabelText(/số khách/i) as HTMLInputElement;
     expect(guestsAfterRefresh.value).toBe("9");
   });
+
+  it("điền sẵn ngày và số đêm khi mở từ calendar (prefillDates)", async () => {
+    // Không còn ô "số đêm" riêng (đã bỏ, xem test "để người dùng chọn ngày
+    // đi..." phía trên) — số đêm giờ luôn suy ra từ checkIn/checkOut qua
+    // nightsBetween(). Nạp breakdown giả phản ánh đúng 3 đêm để chứng minh
+    // nights được tính đúng từ cặp ngày prefill, không phải qua ô nhập riêng.
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "calculate_room_price_preview") {
+        return {
+          pricing_type: "nightly",
+          base_amount: 1_500_000,
+          surcharge_amount: 0,
+          weekend_amount: 0,
+          total: 1_500_000,
+          capped: false,
+          breakdown: [{ label: "3 đêm x 500.000", amount: 1_500_000 }],
+        };
+      }
+      return { available: true, conflicts: [], max_nights: null };
+    });
+
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        preSelectedRoomId="R101"
+        prefillDates={{ checkIn: "2026-08-02", checkOut: "2026-08-05" }}
+      />,
+    );
+
+    const checkIn = screen.getByLabelText(/ngày đến/i) as HTMLInputElement;
+    const checkOut = screen.getByLabelText(/ngày đi/i) as HTMLInputElement;
+    await waitFor(() => {
+      expect(checkIn.value).toBe("2026-08-02");
+      expect(checkOut.value).toBe("2026-08-05");
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/3 đêm/i)).toBeInTheDocument();
+    });
+  });
+
+  it("editBooking thắng prefillDates khi component nhận cả hai (edit mode ưu tiên)", async () => {
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        prefillDates={{ checkIn: "2026-08-02", checkOut: "2026-08-05" }}
+        editBooking={{
+          id: "B999",
+          room_id: "R101",
+          guest_name: "Existing Guest",
+          guest_phone: "0900000000",
+          check_in_at: "2026-04-20",
+          expected_checkout: "2026-04-22",
+          scheduled_checkin: "2026-04-20",
+          scheduled_checkout: "2026-04-22",
+          nights: 2,
+          guests: 2,
+          total_price: 1000000,
+          source: "phone",
+          deposit_amount: 50000,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchRooms).toHaveBeenCalledTimes(1);
+    });
+
+    const checkIn = screen.getByLabelText(/ngày đến/i) as HTMLInputElement;
+    const checkOut = screen.getByLabelText(/ngày đi/i) as HTMLInputElement;
+    expect(checkIn.value).toBe("2026-04-20");
+    expect(checkOut.value).toBe("2026-04-22");
+  });
 });

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -220,7 +220,12 @@ describe("ReservationSheet", () => {
           scheduled_checkin: "2026-04-20",
           scheduled_checkout: "2026-04-22",
           nights: 2,
-          guests: 2,
+          // Cố ý KHÁC max_guests của R101 (2) — nếu guard `isEditMode` trên
+          // effect nạp lại số khách theo phòng (guestsLoadedForRoomId) bị gỡ,
+          // effect đó sẽ nạp đè guests = 2 (max_guests của R101), và bài test
+          // này sẽ bắt được ngay vì 2 khác 4. Trùng giá trị với max_guests sẽ
+          // che mất một guard bị gỡ mất — xem finding 4 của lượt review.
+          guests: 4,
           total_price: 1000000,
           source: "phone",
           deposit_amount: 50000,
@@ -248,7 +253,7 @@ describe("ReservationSheet", () => {
             new_check_in_date: "2026-04-20",
             new_check_out_date: "2026-04-23",
             new_nights: 3,
-            new_guests: 2,
+            new_guests: 4,
           },
         },
         {
@@ -263,6 +268,109 @@ describe("ReservationSheet", () => {
       );
     });
     expect(invoke).not.toHaveBeenCalledWith("modify_reservation", expect.anything());
+  });
+
+  it("sửa một đặt phòng cũ (guests NULL) mà không đụng ô số khách thì gửi new_guests: null, giữ nguyên giá cũ", async () => {
+    // Trước bản vá: prefill effect làm `setGuests(editBooking.guests ?? 2)`,
+    // nên guests NULL biến thành số 2 trên form, và submit gửi thẳng số đó —
+    // một đặt phòng cũ chưa từng có phụ thu bỗng bị tính thêm người. Backend
+    // đọc `new_guests: null` là "giữ nguyên số đã lưu"
+    // (modify_reservation_tx: `req.new_guests.or(reservation.guests)`), nên
+    // gửi null mới đúng là "không đụng gì" khi người dùng không đụng ô này.
+    const user = userEvent.setup();
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        editBooking={{
+          id: "B-LEGACY",
+          room_id: "R101",
+          guest_name: "Nguyen Van Legacy",
+          guest_phone: "0900000000",
+          check_in_at: "2026-04-20",
+          expected_checkout: "2026-04-22",
+          scheduled_checkin: "2026-04-20",
+          scheduled_checkout: "2026-04-22",
+          nights: 2,
+          guests: null,
+          total_price: 1000000,
+          source: "phone",
+          deposit_amount: 50000,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchRooms).toHaveBeenCalledTimes(1);
+    });
+
+    // Chỉ đổi ngày — không đụng vào ô số khách.
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2026-04-23" },
+    });
+
+    await user.click(screen.getByRole("button", { name: /lưu thay đổi/i }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "modify_reservation",
+        expect.objectContaining({
+          req: expect.objectContaining({
+            booking_id: "B-LEGACY",
+            new_guests: null,
+          }),
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("sửa một đặt phòng cũ (guests NULL) và CÓ đụng ô số khách thì gửi đúng số vừa gõ", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        editBooking={{
+          id: "B-LEGACY-2",
+          room_id: "R101",
+          guest_name: "Nguyen Van Legacy",
+          guest_phone: "0900000000",
+          check_in_at: "2026-04-20",
+          expected_checkout: "2026-04-22",
+          scheduled_checkin: "2026-04-20",
+          scheduled_checkout: "2026-04-22",
+          nights: 2,
+          guests: null,
+          total_price: 1000000,
+          source: "phone",
+          deposit_amount: 50000,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchRooms).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByLabelText(/số khách/i), {
+      target: { value: "3" },
+    });
+
+    await user.click(screen.getByRole("button", { name: /lưu thay đổi/i }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "modify_reservation",
+        expect.objectContaining({
+          req: expect.objectContaining({
+            booking_id: "B-LEGACY-2",
+            new_guests: 3,
+          }),
+        }),
+        expect.anything(),
+      );
+    });
   });
 
   it("formats create flow failures with formatAppError", async () => {
@@ -403,6 +511,47 @@ describe("ReservationSheet", () => {
       expect(screen.getByText(/ngày đi phải sau ngày đến/i)).toBeInTheDocument();
     });
     expect(submit).toBeDisabled();
+  });
+
+  it("đặt ô ngày đi max = 90 đêm sau ngày đến", async () => {
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-06" },
+    });
+
+    const checkOut = screen.getByLabelText(/ngày đi/i) as HTMLInputElement;
+    // 90 đêm sau 2026-08-06.
+    expect(checkOut.max).toBe("2026-11-04");
+  });
+
+  it("từ chối đặt phòng vượt quá 90 đêm dù ô ngày đi cho gõ tay bỏ qua max", async () => {
+    // Ô ngày đi cho gõ tay trực tiếp (không còn suy từ ô số đêm có max={90}
+    // như trước), nên thuộc tính `max` trên input không chặn được input giả
+    // lập qua fireEvent — đúng như một lỗi gõ năm thật (2036 thay vì 2026)
+    // sẽ đi vòng qua trình duyệt. handleSubmit phải tự chặn.
+    const user = userEvent.setup();
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+    await user.type(screen.getByPlaceholderText(/họ và tên/i), "Nguyen Van A");
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-08" },
+    });
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2036-08-08" },
+    });
+
+    await user.click(screen.getByRole("button", { name: /đặt phòng/i }));
+
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringMatching(/90 đêm/),
+    );
+    expect(invokeWriteCommand).not.toHaveBeenCalledWith(
+      "create_reservation",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it("nạp số khách theo phòng và gửi nó khi đặt phòng", async () => {

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -18,6 +18,23 @@ const fetchRooms = vi.hoisted(() => vi.fn());
 const openInvoice = vi.hoisted(() => vi.fn());
 const closeInvoice = vi.hoisted(() => vi.fn());
 const resetAvailability = vi.hoisted(() => vi.fn());
+// A stable reference, like the real Zustand store returns — recreating this
+// array on every render would spuriously refire the room-reload effect that
+// depends on it and clobber whatever guest count the user just typed.
+const rooms = vi.hoisted(() => [
+  {
+    id: "R101",
+    name: "R101",
+    type: "standard",
+    room_type: "standard",
+    floor: 1,
+    has_balcony: false,
+    base_price: 500000,
+    max_guests: 2,
+    extra_person_fee: 50000,
+    status: "vacant",
+  },
+]);
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke,
@@ -33,20 +50,7 @@ vi.mock("@/lib/correlationId", () => ({
 
 vi.mock("@/stores/useHotelStore", () => ({
   useHotelStore: () => ({
-    rooms: [
-      {
-        id: "R101",
-        name: "R101",
-        type: "standard",
-        room_type: "standard",
-        floor: 1,
-        has_balcony: false,
-        base_price: 500000,
-        max_guests: 2,
-        extra_person_fee: 0,
-        status: "vacant",
-      },
-    ],
+    rooms,
     fetchRooms,
   }),
 }));
@@ -122,7 +126,7 @@ describe("ReservationSheet", () => {
     });
 
     const [roomSelect, sourceSelect] = screen.getAllByRole("combobox");
-    const depositInput = screen.getByRole("spinbutton");
+    const depositInput = screen.getByPlaceholderText("0");
 
     fireEvent.change(roomSelect, {
       target: { value: "R101" },
@@ -160,6 +164,7 @@ describe("ReservationSheet", () => {
             check_in_date: expect.any(String),
             check_out_date: expect.any(String),
             nights: 2,
+            guests: 2,
             deposit_amount: 250000,
             source: "zalo",
             notes: "Khách thích tầng cao",
@@ -195,6 +200,7 @@ describe("ReservationSheet", () => {
           scheduled_checkin: "2026-04-20",
           scheduled_checkout: "2026-04-22",
           nights: 2,
+          guests: 2,
           total_price: 1000000,
           source: "phone",
           deposit_amount: 50000,
@@ -222,6 +228,7 @@ describe("ReservationSheet", () => {
             new_check_in_date: "2026-04-20",
             new_check_out_date: "2026-04-23",
             new_nights: 3,
+            new_guests: 2,
           },
         },
         {
@@ -291,7 +298,7 @@ describe("ReservationSheet", () => {
     });
 
     const [roomSelect] = screen.getAllByRole("combobox");
-    const depositInput = screen.getByRole("spinbutton");
+    const depositInput = screen.getByPlaceholderText("0");
 
     fireEvent.change(roomSelect, {
       target: { value: "R101" },
@@ -357,5 +364,30 @@ describe("ReservationSheet", () => {
       expect(screen.getByText(/ngày đi phải sau ngày đến/i)).toBeInTheDocument();
     });
     expect(submit).toBeDisabled();
+  });
+
+  it("nạp số khách theo phòng và gửi nó khi đặt phòng", async () => {
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+
+    const guests = screen.getByLabelText(/số khách/i) as HTMLInputElement;
+    await waitFor(() => expect(guests.value).toBe("2"));
+
+    fireEvent.change(guests, { target: { value: "4" } });
+    fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
+      target: { value: "Nguyễn Nhật Huy" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /đặt phòng/i }));
+
+    await waitFor(() => {
+      expect(invokeWriteCommand).toHaveBeenCalledWith(
+        "create_reservation",
+        expect.objectContaining({
+          req: expect.objectContaining({ guests: 4 }),
+        }),
+        expect.anything(),
+      );
+    });
   });
 });

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -478,6 +478,92 @@ describe("ReservationSheet", () => {
     });
   });
 
+  it("hiện đúng preview.total do engine trả về, không phải tổng cộng dồn breakdown khi bị cap", async () => {
+    // total (1.000.000) cố tình khác xa tổng breakdown (2.000.000 + 3.000.000
+    // = 5.000.000) — mô phỏng một trường hợp bị cap/rounding ở engine. Nếu
+    // component lỡ tự cộng dồn breakdown thay vì dùng preview.total, test này
+    // phải bắt được ngay vì hai con số cách nhau rất xa.
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "calculate_room_price_preview") {
+        return {
+          pricing_type: "nightly",
+          base_amount: 2_000_000,
+          surcharge_amount: 3_000_000,
+          weekend_amount: 0,
+          total: 1_000_000,
+          capped: true,
+          breakdown: [
+            { label: "2 night(s) x 1.000.000", amount: 2_000_000 },
+            { label: "Phụ thu 3 khách", amount: 3_000_000 },
+          ],
+        };
+      }
+      return { available: true, conflicts: [], max_nights: null };
+    });
+
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-06" },
+    });
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2026-08-08" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("1.000.000₫")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("5.000.000₫")).not.toBeInTheDocument();
+  });
+
+  it("báo lỗi rõ ràng khi tính giá thất bại, và không còn hiện giá cũ bên cạnh thông báo lỗi", async () => {
+    let calls = 0;
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "calculate_room_price_preview") {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            pricing_type: "nightly",
+            base_amount: 500_000,
+            surcharge_amount: 100_000,
+            weekend_amount: 0,
+            total: 600_000,
+            capped: false,
+            breakdown: [
+              { label: "1 night(s) x 500.000", amount: 500_000 },
+              { label: "Phụ thu 1 khách", amount: 100_000 },
+            ],
+          };
+        }
+        throw new Error("IPC lỗi giả lập");
+      }
+      return { available: true, conflicts: [], max_nights: null };
+    });
+
+    render(<ReservationSheet open onOpenChange={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/^phòng$/i), { target: { value: "R101" } });
+    fireEvent.change(screen.getByLabelText(/ngày đến/i), {
+      target: { value: "2026-08-06" },
+    });
+    fireEvent.change(screen.getByLabelText(/ngày đi/i), {
+      target: { value: "2026-08-07" },
+    });
+
+    // Lượt gọi đầu tiên thành công — giá hiện lên bình thường.
+    await waitFor(() => {
+      expect(screen.getByText("600.000₫")).toBeInTheDocument();
+    });
+
+    // Đổi số khách để kích hoạt một lượt gọi mới, lượt này thất bại.
+    fireEvent.change(screen.getByLabelText(/số khách/i), { target: { value: "4" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/không tính được giá/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("600.000₫")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tổng")).not.toBeInTheDocument();
+  });
+
   it("một fetchRooms() không liên quan (mảng rooms mới, cùng dữ liệu) không được xoá số khách đã gõ tay", async () => {
     const { rerender } = render(<ReservationSheet open onOpenChange={vi.fn()} />);
 

--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -771,9 +771,6 @@ describe("ReservationSheet", () => {
       expect(checkIn.value).toBe("2026-08-02");
       expect(checkOut.value).toBe("2026-08-05");
     });
-    await waitFor(() => {
-      expect(screen.getByText(/3 đêm/i)).toBeInTheDocument();
-    });
   });
 
   it("editBooking thắng prefillDates khi component nhận cả hai (edit mode ưu tiên)", async () => {

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -20,6 +20,7 @@ interface Props {
     onOpenChange: (v: boolean) => void;
     preSelectedRoomId?: string;
     editBooking?: EditableBooking;
+    prefillDates?: { checkIn: string; checkOut: string };
 }
 
 function nightsBetween(checkIn: string, checkOut: string): number {
@@ -45,7 +46,7 @@ function addDays(date: string, days: number): string {
 // Đây là khôi phục lại trần cũ, không phải đặt ra chính sách mới.
 const MAX_RESERVATION_NIGHTS = 90;
 
-export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId, editBooking }: Props) {
+export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId, editBooking, prefillDates }: Props) {
     const { rooms, fetchRooms } = useHotelStore();
     const [roomId, setRoomId] = useState(preSelectedRoomId || "");
     const [guestName, setGuestName] = useState("");
@@ -109,6 +110,13 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 // (input có `min={1}`) cho khoảnh khắc trước khi effect đó chạy.
                 setGuests(editBooking.guests ?? 1);
                 setGuestsTouched(false);
+            } else if (prefillDates) {
+                // Đến từ kéo-thả trên lịch (Task 8): số đêm không cần tính ở
+                // đây — `nights` luôn được suy ra từ checkInDate/checkOutDate
+                // qua nightsBetween() ở trên, múi giờ-an toàn như mọi nơi khác
+                // trong file này.
+                setCheckInDate(prefillDates.checkIn);
+                setCheckOutDate(prefillDates.checkOut);
             } else {
                 // Mặc định: nhận phòng ngày mai, ở 1 đêm.
                 const tomorrow = addDays(new Date().toISOString().split("T")[0], 1);
@@ -116,7 +124,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 setCheckOutDate(addDays(tomorrow, 1));
             }
         }
-    }, [open, editBooking]);
+    }, [open, editBooking, prefillDates]);
 
     useEffect(() => {
         if (preSelectedRoomId) setRoomId(preSelectedRoomId);

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useHotelStore } from "../stores/useHotelStore";
 import { CalendarDays, User, Phone, CreditCard, AlertTriangle, FileText } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -96,10 +96,29 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         if (preSelectedRoomId) setRoomId(preSelectedRoomId);
     }, [preSelectedRoomId]);
 
+    // Tracks the room the guest count was last loaded for, so this effect only
+    // reloads on an actual room *change* — not merely because `rooms` got a
+    // new array identity (fetchRooms() re-`set`s a fresh array on every
+    // unrelated DB write; see useHotelStore.fetchRooms and the
+    // "db-updated"/"mcp_reservation_created" listeners in RuntimeStateProvider).
+    // Without this guard, any unrelated write elsewhere silently wipes out a
+    // guest count the user had just typed in this form.
+    const guestsLoadedForRoomId = useRef<string | null>(null);
+
     useEffect(() => {
-        if (isEditMode || !roomId) return;
+        if (isEditMode) return;
+        if (!roomId) {
+            // Cleared selection: forget what we loaded, so re-picking the same
+            // room later is treated as a fresh choice and reloads again.
+            guestsLoadedForRoomId.current = null;
+            return;
+        }
+        if (guestsLoadedForRoomId.current === roomId) return;
         const room = rooms.find((r) => r.id === roomId);
-        if (room) setGuests(room.max_guests);
+        if (room) {
+            setGuests(room.max_guests);
+            guestsLoadedForRoomId.current = roomId;
+        }
     }, [roomId, rooms, isEditMode]);
 
     async function handleSubmit() {

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -124,7 +124,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 setCheckOutDate(addDays(tomorrow, 1));
             }
         }
-    }, [open, editBooking, prefillDates]);
+    }, [open, editBooking, prefillDates?.checkIn, prefillDates?.checkOut]);
 
     useEffect(() => {
         if (preSelectedRoomId) setRoomId(preSelectedRoomId);

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -38,6 +38,13 @@ function addDays(date: string, days: number): string {
     return d.toISOString().split("T")[0];
 }
 
+// Trần số đêm cho một đặt phòng. Trước đây ngày đi chỉ đọc được, suy ra từ
+// một ô số đêm mang `max={90}` — 90 đêm là trần cứng theo cấu trúc. Ô đó bị
+// xoá để cho gõ tay ngày đi trực tiếp, và không gì thay thế trần cũ ở đây:
+// một lỗi gõ năm (2036 thay vì 2026) tạo ra một đặt phòng khoảng 3650 đêm.
+// Đây là khôi phục lại trần cũ, không phải đặt ra chính sách mới.
+const MAX_RESERVATION_NIGHTS = 90;
+
 export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId, editBooking }: Props) {
     const { rooms, fetchRooms } = useHotelStore();
     const [roomId, setRoomId] = useState(preSelectedRoomId || "");
@@ -47,6 +54,11 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
     const [checkInDate, setCheckInDate] = useState("");
     const [checkOutDate, setCheckOutDate] = useState("");
     const [guests, setGuests] = useState(2);
+    // Chỉ có ý nghĩa ở edit mode: người dùng đã đụng vào ô số khách trong lần
+    // sửa này chưa. Dùng để phân biệt "chưa đụng tới" (giữ nguyên số đã lưu,
+    // kể cả khi số đã lưu là NULL) với "đã chọn một số khách mới" — xem
+    // handleSubmit và effect nạp placeholder bên dưới.
+    const [guestsTouched, setGuestsTouched] = useState(false);
     const nights = nightsBetween(checkInDate, checkOutDate);
     const datesValid = nights > 0;
     const [deposit, setDeposit] = useState("");
@@ -90,7 +102,13 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 setCheckOutDate(cout);
                 setDeposit(editBooking.deposit_amount ? String(editBooking.deposit_amount) : "");
                 setSource(editBooking.source || "phone");
-                setGuests(editBooking.guests ?? 2);
+                // Giá trị tạm: nếu `editBooking.guests` là NULL (booking cũ,
+                // chưa khai số khách), placeholder trung tính đúng đắn là
+                // `max_guests` của phòng — effect bên dưới sẽ nạp lại ngay khi
+                // `rooms` có phòng này. `?? 1` chỉ là chỗ giữ chỗ tối thiểu
+                // (input có `min={1}`) cho khoảnh khắc trước khi effect đó chạy.
+                setGuests(editBooking.guests ?? 1);
+                setGuestsTouched(false);
             } else {
                 // Mặc định: nhận phòng ngày mai, ở 1 đêm.
                 const tomorrow = addDays(new Date().toISOString().split("T")[0], 1);
@@ -129,6 +147,20 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         }
     }, [roomId, rooms, isEditMode]);
 
+    // Edit mode, riêng trường hợp booking cũ (guests NULL): hiện max_guests
+    // của phòng làm placeholder trung tính, chứ không phải số 2 hardcode.
+    // Vô hại về giá — chỉ hiện lên, không tự gửi: handleSubmit chỉ gửi giá
+    // trị này khi `guestsTouched`, còn không thì gửi `null` để giữ nguyên
+    // NULL đã lưu. Chỉ chạy khi thực sự cần: guests đã lưu là NULL và người
+    // dùng chưa đụng vào ô này trong lần sửa này.
+    useEffect(() => {
+        if (!isEditMode || !editBooking) return;
+        if (editBooking.guests != null) return;
+        if (guestsTouched) return;
+        const room = rooms.find((r) => r.id === editBooking.room_id);
+        if (room) setGuests(room.max_guests);
+    }, [isEditMode, editBooking, rooms, guestsTouched]);
+
     async function handleSubmit() {
         if (!roomId || !checkInDate || !checkOutDate) {
             toast.error("Vui lòng điền đầy đủ thông tin");
@@ -136,6 +168,12 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         }
         if (nights <= 0) {
             toast.error("Ngày đi phải sau ngày đến");
+            return;
+        }
+        if (nights > MAX_RESERVATION_NIGHTS) {
+            // Ô ngày đi cho gõ tay trực tiếp, nên `max` trên input không chặn
+            // được — chặn ở đây để một lỗi gõ năm không khoá phòng cả thập kỷ.
+            toast.error(`Số đêm không được vượt quá ${MAX_RESERVATION_NIGHTS} đêm`);
             return;
         }
         if (!isEditMode && !guestName) {
@@ -150,13 +188,21 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         try {
             const correlationId = createCorrelationId();
             if (isEditMode && editBooking) {
+                // Booking cũ (guests NULL) mà người dùng chưa đụng vào ô số
+                // khách trong lần sửa này: gửi `null`, không phải một số bịa
+                // ra. Backend đọc `new_guests: null` là "giữ nguyên số đã
+                // lưu" (modify_reservation_tx: `req.new_guests.or(reservation.guests)`),
+                // nên NULL vẫn ở lại NULL và giá không đổi. Người dùng có gõ
+                // một số khách mới thì gửi đúng số đó.
+                const newGuests =
+                    editBooking.guests == null && !guestsTouched ? null : guests;
                 await invokeWriteCommand("modify_reservation", {
                     req: {
                         booking_id: editBooking.id,
                         new_check_in_date: checkInDate,
                         new_check_out_date: checkOutDate,
                         new_nights: nights,
-                        new_guests: guests,
+                        new_guests: newGuests,
                     },
                 }, {
                     correlationId,
@@ -214,6 +260,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         setSource("phone");
         setNotes("");
         setGuests(2);
+        setGuestsTouched(false);
         resetAvailability();
     }
 
@@ -277,6 +324,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                                 value={checkOutDate}
                                 min={checkInDate ? addDays(checkInDate, 1) : undefined}
+                                max={checkInDate ? addDays(checkInDate, MAX_RESERVATION_NIGHTS) : undefined}
                                 onChange={(e) => setCheckOutDate(e.target.value)}
                             />
                         </div>
@@ -291,7 +339,10 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                             min={1}
                             className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                             value={guests}
-                            onChange={(e) => setGuests(Math.max(1, parseInt(e.target.value) || 1))}
+                            onChange={(e) => {
+                                setGuests(Math.max(1, parseInt(e.target.value) || 1));
+                                setGuestsTouched(true);
+                            }}
                         />
                     </div>
 

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -68,7 +68,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         disabled: isEditMode,
         debounceMs: 300,
     });
-    const { preview, loading: pricing } = usePricePreview({
+    const { preview, loading: pricing, error: pricingError } = usePricePreview({
         roomId,
         checkIn: checkInDate,
         checkOut: checkOutDate,
@@ -412,7 +412,11 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                     {/* Price Estimate — con số do engine tính, không phải phép nhân ở đây */}
                     {roomId && datesValid && (
                         <div className="bg-blue-50 rounded-xl p-4 space-y-1">
-                            {pricing && !preview ? (
+                            {pricingError ? (
+                                <div className="text-sm text-red-600">
+                                    Không tính được giá — vui lòng thử lại.
+                                </div>
+                            ) : pricing && !preview ? (
                                 <div className="text-sm text-slate-500">Đang tính giá...</div>
                             ) : preview ? (
                                 <>

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -11,6 +11,7 @@ import { createCorrelationId } from "@/lib/correlationId";
 import { fmtNumber } from "@/lib/format";
 import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { optionalMoneyVnd } from "@/lib/money";
+import { nightsBetween } from "@/lib/timelineSelection";
 import { toast } from "sonner";
 import InvoiceDialog from "./InvoiceDialog";
 import type { EditableBooking } from "@/types";
@@ -21,16 +22,6 @@ interface Props {
     preSelectedRoomId?: string;
     editBooking?: EditableBooking;
     prefillDates?: { checkIn: string; checkOut: string };
-}
-
-function nightsBetween(checkIn: string, checkOut: string): number {
-    if (!checkIn || !checkOut) return 0;
-    // Ngày dạng "YYYY-MM-DD" (không có giờ) được JS phân giải theo UTC — dùng
-    // nguyên dạng đó (không thêm "T00:00:00") để tránh lệch ngày ở múi giờ
-    // dương như Asia/Ho_Chi_Minh (UTC+7) khi quy đổi qua toISOString().
-    const ms = new Date(checkOut).getTime() - new Date(checkIn).getTime();
-    if (Number.isNaN(ms)) return 0;
-    return Math.round(ms / 86_400_000);
 }
 
 function addDays(date: string, days: number): string {

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -11,7 +11,7 @@ import { createCorrelationId } from "@/lib/correlationId";
 import { fmtNumber } from "@/lib/format";
 import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { optionalMoneyVnd } from "@/lib/money";
-import { nightsBetween } from "@/lib/timelineSelection";
+import { addDaysIso, localDateIso, nightsBetween } from "@/lib/timelineSelection";
 import { toast } from "sonner";
 import InvoiceDialog from "./InvoiceDialog";
 import type { EditableBooking } from "@/types";
@@ -22,12 +22,6 @@ interface Props {
     preSelectedRoomId?: string;
     editBooking?: EditableBooking;
     prefillDates?: { checkIn: string; checkOut: string };
-}
-
-function addDays(date: string, days: number): string {
-    const d = new Date(date);
-    d.setDate(d.getDate() + days);
-    return d.toISOString().split("T")[0];
 }
 
 // Trần số đêm cho một đặt phòng. Trước đây ngày đi chỉ đọc được, suy ra từ
@@ -110,9 +104,9 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 setCheckOutDate(prefillDates.checkOut);
             } else {
                 // Mặc định: nhận phòng ngày mai, ở 1 đêm.
-                const tomorrow = addDays(new Date().toISOString().split("T")[0], 1);
+                const tomorrow = addDaysIso(localDateIso(new Date()), 1);
                 setCheckInDate(tomorrow);
-                setCheckOutDate(addDays(tomorrow, 1));
+                setCheckOutDate(addDaysIso(tomorrow, 1));
             }
         }
     }, [open, editBooking, prefillDates?.checkIn, prefillDates?.checkOut]);
@@ -159,6 +153,28 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         const room = rooms.find((r) => r.id === editBooking.room_id);
         if (room) setGuests(room.max_guests);
     }, [isEditMode, editBooking, rooms, guestsTouched]);
+
+    const vacantRooms = rooms.filter((r) => r.status === "vacant" || r.status === "booked");
+
+    // Kéo một ô lịch TƯƠNG LAI của phòng đang có khách (khách rời sau hai hôm)
+    // mở sheet này với đúng roomId đó, mà danh sách chỉ liệt kê vacant/booked —
+    // <select> không có option khớp nên hiện trống, còn state vẫn giữ id đó và
+    // nút gửi vẫn sáng vì nó gác trên `!roomId`, mà id vô hình kia là truthy.
+    // Cùng cách xử lý như BackfillSheet.tsx.
+    //
+    // Chế độ sửa được miễn: phòng ở đó lấy từ chính booking đang sửa và ô
+    // select bị disable — phòng đang có khách là chuyện bình thường, xoá đi sẽ
+    // chặn luôn việc lưu thay đổi.
+    useEffect(() => {
+        if (isEditMode) return;
+        // `rooms.length > 0`: các sheet này gọi fetchRooms() lúc mở, nên có một
+        // khoảnh khắc danh sách còn rỗng. Không có vế này, một phòng hợp lệ
+        // truyền vào bị xoá ngay trước khi rooms kịp về, và effect nạp
+        // preSelected không chạy lại để đặt lại nó.
+        if (rooms.length > 0 && roomId && !vacantRooms.some((r) => r.id === roomId)) {
+            setRoomId("");
+        }
+    }, [isEditMode, rooms, roomId, vacantRooms]);
 
     async function handleSubmit() {
         if (!roomId || !checkInDate || !checkOutDate) {
@@ -263,8 +279,6 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         resetAvailability();
     }
 
-    const vacantRooms = rooms.filter((r) => r.status === "vacant" || r.status === "booked");
-
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>
             <SheetContent side="right" className="w-[480px] sm:w-[520px] overflow-y-auto p-0">
@@ -304,13 +318,13 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                                 type="date"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                                 value={checkInDate}
-                                min={new Date().toISOString().split("T")[0]}
+                                min={localDateIso(new Date())}
                                 onChange={(e) => {
                                     const nextCheckIn = e.target.value;
                                     setCheckInDate(nextCheckIn);
                                     // Giữ ngày đi hợp lệ: đẩy nó ra sau ngày đến mới.
                                     if (nextCheckIn && nightsBetween(nextCheckIn, checkOutDate) <= 0) {
-                                        setCheckOutDate(addDays(nextCheckIn, 1));
+                                        setCheckOutDate(addDaysIso(nextCheckIn, 1));
                                     }
                                 }}
                             />
@@ -322,8 +336,8 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                                 type="date"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                                 value={checkOutDate}
-                                min={checkInDate ? addDays(checkInDate, 1) : undefined}
-                                max={checkInDate ? addDays(checkInDate, MAX_RESERVATION_NIGHTS) : undefined}
+                                min={checkInDate ? addDaysIso(checkInDate, 1) : undefined}
+                                max={checkInDate ? addDaysIso(checkInDate, MAX_RESERVATION_NIGHTS) : undefined}
                                 onChange={(e) => setCheckOutDate(e.target.value)}
                             />
                         </div>

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -21,6 +21,22 @@ interface Props {
     editBooking?: EditableBooking;
 }
 
+function nightsBetween(checkIn: string, checkOut: string): number {
+    if (!checkIn || !checkOut) return 0;
+    // Ngày dạng "YYYY-MM-DD" (không có giờ) được JS phân giải theo UTC — dùng
+    // nguyên dạng đó (không thêm "T00:00:00") để tránh lệch ngày ở múi giờ
+    // dương như Asia/Ho_Chi_Minh (UTC+7) khi quy đổi qua toISOString().
+    const ms = new Date(checkOut).getTime() - new Date(checkIn).getTime();
+    if (Number.isNaN(ms)) return 0;
+    return Math.round(ms / 86_400_000);
+}
+
+function addDays(date: string, days: number): string {
+    const d = new Date(date);
+    d.setDate(d.getDate() + days);
+    return d.toISOString().split("T")[0];
+}
+
 export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId, editBooking }: Props) {
     const { rooms, fetchRooms } = useHotelStore();
     const [roomId, setRoomId] = useState(preSelectedRoomId || "");
@@ -29,7 +45,8 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
     const [guestDoc, setGuestDoc] = useState("");
     const [checkInDate, setCheckInDate] = useState("");
     const [checkOutDate, setCheckOutDate] = useState("");
-    const [nights, setNights] = useState(1);
+    const nights = nightsBetween(checkInDate, checkOutDate);
+    const datesValid = nights > 0;
     const [deposit, setDeposit] = useState("");
     const [source, setSource] = useState("phone");
     const [notes, setNotes] = useState("");
@@ -62,15 +79,13 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 const cout = editBooking.scheduled_checkout || editBooking.expected_checkout.split("T")[0];
                 setCheckInDate(cin);
                 setCheckOutDate(cout);
-                setNights(editBooking.nights);
                 setDeposit(editBooking.deposit_amount ? String(editBooking.deposit_amount) : "");
                 setSource(editBooking.source || "phone");
             } else {
-                // Set default check-in date to tomorrow
-                const tomorrow = new Date();
-                tomorrow.setDate(tomorrow.getDate() + 1);
-                setCheckInDate(tomorrow.toISOString().split("T")[0]);
-                updateCheckout(tomorrow.toISOString().split("T")[0], 1);
+                // Mặc định: nhận phòng ngày mai, ở 1 đêm.
+                const tomorrow = addDays(new Date().toISOString().split("T")[0], 1);
+                setCheckInDate(tomorrow);
+                setCheckOutDate(addDays(tomorrow, 1));
             }
         }
     }, [open, editBooking]);
@@ -79,16 +94,13 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         if (preSelectedRoomId) setRoomId(preSelectedRoomId);
     }, [preSelectedRoomId]);
 
-    function updateCheckout(cin: string, n: number) {
-        if (!cin) return;
-        const d = new Date(cin);
-        d.setDate(d.getDate() + n);
-        setCheckOutDate(d.toISOString().split("T")[0]);
-    }
-
     async function handleSubmit() {
         if (!roomId || !checkInDate || !checkOutDate) {
             toast.error("Vui lòng điền đầy đủ thông tin");
+            return;
+        }
+        if (nights <= 0) {
+            toast.error("Ngày đi phải sau ngày đến");
             return;
         }
         if (!isEditMode && !guestName) {
@@ -164,7 +176,6 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         setDeposit("");
         setSource("phone");
         setNotes("");
-        setNights(1);
         resetAvailability();
     }
 
@@ -183,8 +194,9 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 <div className="p-6 space-y-5">
                     {/* Room Selection */}
                     <div className="space-y-1.5">
-                        <label className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Phòng</label>
+                        <label htmlFor="reservation-room" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Phòng</label>
                         <select
+                            id="reservation-room"
                             className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
                             value={roomId}
                             onChange={(e) => setRoomId(e.target.value)}
@@ -202,45 +214,41 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                     {/* Dates */}
                     <div className="grid grid-cols-2 gap-3">
                         <div className="space-y-1.5">
-                            <label className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Ngày đến</label>
+                            <label htmlFor="reservation-check-in" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Ngày đến</label>
                             <input
+                                id="reservation-check-in"
                                 type="date"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                                 value={checkInDate}
                                 min={new Date().toISOString().split("T")[0]}
                                 onChange={(e) => {
-                                    setCheckInDate(e.target.value);
-                                    updateCheckout(e.target.value, nights);
+                                    const nextCheckIn = e.target.value;
+                                    setCheckInDate(nextCheckIn);
+                                    // Giữ ngày đi hợp lệ: đẩy nó ra sau ngày đến mới.
+                                    if (nextCheckIn && nightsBetween(nextCheckIn, checkOutDate) <= 0) {
+                                        setCheckOutDate(addDays(nextCheckIn, 1));
+                                    }
                                 }}
                             />
                         </div>
                         <div className="space-y-1.5">
-                            <label className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Ngày đi</label>
+                            <label htmlFor="reservation-check-out" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Ngày đi</label>
                             <input
+                                id="reservation-check-out"
                                 type="date"
                                 className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                                 value={checkOutDate}
-                                readOnly
+                                min={checkInDate ? addDays(checkInDate, 1) : undefined}
+                                onChange={(e) => setCheckOutDate(e.target.value)}
                             />
                         </div>
                     </div>
 
-                    {/* Nights */}
-                    <div className="space-y-1.5">
-                        <label className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Số đêm</label>
-                        <input
-                            type="number"
-                            min={1}
-                            max={90}
-                            className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
-                            value={nights}
-                            onChange={(e) => {
-                                const n = Math.max(1, parseInt(e.target.value) || 1);
-                                setNights(n);
-                                updateCheckout(checkInDate, n);
-                            }}
-                        />
-                    </div>
+                    {checkInDate && checkOutDate && !datesValid && (
+                        <div className="rounded-xl p-3 text-sm bg-red-50 text-red-700 border border-red-200">
+                            Ngày đi phải sau ngày đến ít nhất 1 đêm.
+                        </div>
+                    )}
 
                     {/* Availability Status */}
                     {!isEditMode && roomId && checkInDate && checkOutDate && (
@@ -385,7 +393,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                     <Button
                         className="w-full h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold text-sm cursor-pointer"
                         onClick={handleSubmit}
-                        disabled={loading || (!isEditMode && !guestName) || !roomId || (availability !== null && !availability.available)}
+                        disabled={loading || (!isEditMode && !guestName) || !roomId || !datesValid || (availability !== null && !availability.available)}
                     >
                         {loading ? "Đang xử lý..." : isEditMode ? "💾 Lưu thay đổi" : "📅 Đặt phòng"}
                     </Button>

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -45,6 +45,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
     const [guestDoc, setGuestDoc] = useState("");
     const [checkInDate, setCheckInDate] = useState("");
     const [checkOutDate, setCheckOutDate] = useState("");
+    const [guests, setGuests] = useState(2);
     const nights = nightsBetween(checkInDate, checkOutDate);
     const datesValid = nights > 0;
     const [deposit, setDeposit] = useState("");
@@ -81,6 +82,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                 setCheckOutDate(cout);
                 setDeposit(editBooking.deposit_amount ? String(editBooking.deposit_amount) : "");
                 setSource(editBooking.source || "phone");
+                setGuests(editBooking.guests ?? 2);
             } else {
                 // Mặc định: nhận phòng ngày mai, ở 1 đêm.
                 const tomorrow = addDays(new Date().toISOString().split("T")[0], 1);
@@ -93,6 +95,12 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
     useEffect(() => {
         if (preSelectedRoomId) setRoomId(preSelectedRoomId);
     }, [preSelectedRoomId]);
+
+    useEffect(() => {
+        if (isEditMode || !roomId) return;
+        const room = rooms.find((r) => r.id === roomId);
+        if (room) setGuests(room.max_guests);
+    }, [roomId, rooms, isEditMode]);
 
     async function handleSubmit() {
         if (!roomId || !checkInDate || !checkOutDate) {
@@ -121,6 +129,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                         new_check_in_date: checkInDate,
                         new_check_out_date: checkOutDate,
                         new_nights: nights,
+                        new_guests: guests,
                     },
                 }, {
                     correlationId,
@@ -144,6 +153,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                         check_in_date: checkInDate,
                         check_out_date: checkOutDate,
                         nights,
+                        guests,
                         deposit_amount: depositAmount,
                         source,
                         notes: notes || null,
@@ -176,6 +186,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         setDeposit("");
         setSource("phone");
         setNotes("");
+        setGuests(2);
         resetAvailability();
     }
 
@@ -242,6 +253,19 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                                 onChange={(e) => setCheckOutDate(e.target.value)}
                             />
                         </div>
+                    </div>
+
+                    {/* Guests */}
+                    <div className="space-y-1.5">
+                        <label htmlFor="reservation-guests" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Số khách</label>
+                        <input
+                            id="reservation-guests"
+                            type="number"
+                            min={1}
+                            className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            value={guests}
+                            onChange={(e) => setGuests(Math.max(1, parseInt(e.target.value) || 1))}
+                        />
                     </div>
 
                     {checkInDate && checkOutDate && !datesValid && (

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -4,6 +4,7 @@ import { CalendarDays, User, Phone, CreditCard, AlertTriangle, FileText } from "
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { useAvailability } from "@/hooks/useAvailability";
+import { usePricePreview } from "@/hooks/usePricePreview";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { createCorrelationId } from "@/lib/correlationId";
@@ -65,6 +66,13 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         fromDate: checkInDate,
         toDate: checkOutDate,
         disabled: isEditMode,
+        debounceMs: 300,
+    });
+    const { preview, loading: pricing } = usePricePreview({
+        roomId,
+        checkIn: checkInDate,
+        checkOut: checkOutDate,
+        guests,
         debounceMs: 300,
     });
 
@@ -401,21 +409,31 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                         />
                     </div>
 
-                    {/* Price Estimate */}
-                    {roomId && nights > 0 && (
+                    {/* Price Estimate — con số do engine tính, không phải phép nhân ở đây */}
+                    {roomId && datesValid && (
                         <div className="bg-blue-50 rounded-xl p-4 space-y-1">
-                            <div className="flex justify-between text-sm">
-                                <span className="text-slate-600">Giá phòng × {nights} đêm</span>
-                                <span className="font-bold text-slate-800">
-                                    {fmtNumber((rooms.find((r) => r.id === roomId)?.base_price || 0) * nights)}₫
-                                </span>
-                            </div>
-                            {deposit && parseFloat(deposit) > 0 && (
-                                <div className="flex justify-between text-sm">
-                                    <span className="text-slate-600">Tiền cọc</span>
-                                    <span className="font-semibold text-emerald-700">-{fmtNumber(parseFloat(deposit))}₫</span>
-                                </div>
-                            )}
+                            {pricing && !preview ? (
+                                <div className="text-sm text-slate-500">Đang tính giá...</div>
+                            ) : preview ? (
+                                <>
+                                    {preview.breakdown.map((line, i) => (
+                                        <div key={i} className="flex justify-between text-sm">
+                                            <span className="text-slate-600">{line.label}</span>
+                                            <span className="text-slate-700">{fmtNumber(line.amount)}₫</span>
+                                        </div>
+                                    ))}
+                                    <div className="flex justify-between text-sm pt-1 border-t border-blue-100">
+                                        <span className="text-slate-600">Tổng</span>
+                                        <span className="font-bold text-slate-800">{fmtNumber(preview.total)}₫</span>
+                                    </div>
+                                    {deposit && parseFloat(deposit) > 0 && (
+                                        <div className="flex justify-between text-sm">
+                                            <span className="text-slate-600">Tiền cọc</span>
+                                            <span className="font-semibold text-emerald-700">-{fmtNumber(parseFloat(deposit))}₫</span>
+                                        </div>
+                                    )}
+                                </>
+                            ) : null}
                         </div>
                     )}
 

--- a/mhm/src/components/RoomDetailPanel.test.tsx
+++ b/mhm/src/components/RoomDetailPanel.test.tsx
@@ -51,6 +51,8 @@ describe("RoomDetailPanel checkout settlement", () => {
                         floor: 1,
                         has_balcony: false,
                         base_price: 500000,
+                        max_guests: 2,
+                        extra_person_fee: 0,
                         status: "occupied",
                     },
                     booking: {

--- a/mhm/src/hooks/usePricePreview.ts
+++ b/mhm/src/hooks/usePricePreview.ts
@@ -22,6 +22,9 @@ export function usePricePreview({
 }: UsePricePreviewOptions) {
     const [preview, setPreview] = useState<PricingResult | null>(null);
     const [loading, setLoading] = useState(false);
+    // Simple boolean, no error taxonomy — the box only needs to know whether
+    // the last lookup failed so it can stop rendering an empty/misleading box.
+    const [error, setError] = useState(false);
     const requestIdRef = useRef(0);
 
     useEffect(() => {
@@ -29,6 +32,7 @@ export function usePricePreview({
             requestIdRef.current += 1;
             setPreview(null);
             setLoading(false);
+            setError(false);
             return;
         }
 
@@ -38,6 +42,7 @@ export function usePricePreview({
 
         const run = async () => {
             setLoading(true);
+            setError(false);
             try {
                 const result = await invoke<PricingResult>("calculate_room_price_preview", {
                     roomId,
@@ -52,6 +57,7 @@ export function usePricePreview({
             } catch {
                 if (active && requestIdRef.current === requestId) {
                     setPreview(null);
+                    setError(true);
                 }
             } finally {
                 if (active && requestIdRef.current === requestId) {
@@ -73,5 +79,5 @@ export function usePricePreview({
         };
     }, [checkIn, checkOut, debounceMs, guests, roomId]);
 
-    return { preview, loading };
+    return { preview, loading, error };
 }

--- a/mhm/src/hooks/usePricePreview.ts
+++ b/mhm/src/hooks/usePricePreview.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import type { PricingResult } from "@/types";
+
+interface UsePricePreviewOptions {
+    roomId: string;
+    checkIn: string;
+    checkOut: string;
+    guests: number;
+    debounceMs?: number;
+}
+
+/// Con số hiển thị phải do engine trả về, không phải do giao diện tự nhân —
+/// đó là cách duy nhất để số trên màn hình bằng số ghi vào sổ.
+export function usePricePreview({
+    roomId,
+    checkIn,
+    checkOut,
+    guests,
+    debounceMs = 0,
+}: UsePricePreviewOptions) {
+    const [preview, setPreview] = useState<PricingResult | null>(null);
+    const [loading, setLoading] = useState(false);
+    const requestIdRef = useRef(0);
+
+    useEffect(() => {
+        if (!roomId || !checkIn || !checkOut) {
+            requestIdRef.current += 1;
+            setPreview(null);
+            setLoading(false);
+            return;
+        }
+
+        const requestId = requestIdRef.current + 1;
+        requestIdRef.current = requestId;
+        let active = true;
+
+        const run = async () => {
+            setLoading(true);
+            try {
+                const result = await invoke<PricingResult>("calculate_room_price_preview", {
+                    roomId,
+                    checkIn,
+                    checkOut,
+                    pricingType: "nightly",
+                    guests,
+                });
+                if (active && requestIdRef.current === requestId) {
+                    setPreview(result);
+                }
+            } catch {
+                if (active && requestIdRef.current === requestId) {
+                    setPreview(null);
+                }
+            } finally {
+                if (active && requestIdRef.current === requestId) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        const timer = debounceMs > 0 ? window.setTimeout(run, debounceMs) : null;
+        if (timer == null) {
+            void run();
+        }
+
+        return () => {
+            active = false;
+            if (timer != null) {
+                clearTimeout(timer);
+            }
+        };
+    }, [checkIn, checkOut, debounceMs, guests, roomId]);
+
+    return { preview, loading };
+}

--- a/mhm/src/lib/timelineSelection.test.ts
+++ b/mhm/src/lib/timelineSelection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { addDaysIso, localDateIso, resolveSelection } from "./timelineSelection";
+import { addDaysIso, localDateIso, nightsBetween, resolveSelection } from "./timelineSelection";
 
 const days = Array.from({ length: 16 }, (_, i) => ({
     // cột 0 = 26/07, cột 3 = hôm nay 29/07 (khớp layout thật: today − 3)
@@ -55,5 +55,18 @@ describe("date helpers", () => {
     });
     it("localDateIso định dạng YYYY-MM-DD", () => {
         expect(localDateIso(new Date(2026, 6, 29))).toBe("2026-07-29");
+    });
+});
+
+describe("nightsBetween", () => {
+    it("tính đúng số đêm giữa hai ngày", () => {
+        expect(nightsBetween("2026-07-26", "2026-07-28")).toBe(2);
+    });
+    it("ngày ra trước ngày vào → số âm", () => {
+        expect(nightsBetween("2026-07-28", "2026-07-26")).toBe(-2);
+    });
+    it("thiếu ngày vào hoặc ngày ra → 0", () => {
+        expect(nightsBetween("", "2026-07-28")).toBe(0);
+        expect(nightsBetween("2026-07-26", "")).toBe(0);
     });
 });

--- a/mhm/src/lib/timelineSelection.test.ts
+++ b/mhm/src/lib/timelineSelection.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { addDaysIso, localDateIso, resolveSelection } from "./timelineSelection";
+
+const days = Array.from({ length: 16 }, (_, i) => ({
+    // cột 0 = 26/07, cột 3 = hôm nay 29/07 (khớp layout thật: today − 3)
+    fullDate: addDaysIso("2026-07-26", i),
+}));
+const todayKey = "2026-07-29";
+
+describe("resolveSelection", () => {
+    it("bấm 1 ô hôm nay → check-in 1 đêm", () => {
+        const r = resolveSelection({ roomId: "1A", startIndex: 3, endIndex: 3 }, days, todayKey);
+        expect(r).toEqual({
+            kind: "checkin", roomId: "1A", checkInDate: "2026-07-29",
+            checkOutDate: "2026-07-30", nights: 1, stillStaying: false,
+        });
+    });
+
+    it("kéo 3 ô tương lai → reservation 3 đêm", () => {
+        const r = resolveSelection({ roomId: "2B", startIndex: 5, endIndex: 7 }, days, todayKey);
+        expect(r.kind).toBe("reservation");
+        expect(r.checkInDate).toBe("2026-07-31");
+        expect(r.checkOutDate).toBe("2026-08-03");
+        expect(r.nights).toBe(3);
+    });
+
+    it("kéo ngược (phải sang trái) chuẩn hoá lại", () => {
+        const r = resolveSelection({ roomId: "2B", startIndex: 7, endIndex: 5 }, days, todayKey);
+        expect(r.checkInDate).toBe("2026-07-31");
+        expect(r.nights).toBe(3);
+    });
+
+    it("ô quá khứ, kết thúc trước hôm nay → backfill đã trả", () => {
+        const r = resolveSelection({ roomId: "3B", startIndex: 0, endIndex: 1 }, days, todayKey);
+        expect(r.kind).toBe("backfill");
+        expect(r.checkInDate).toBe("2026-07-26");
+        expect(r.checkOutDate).toBe("2026-07-28");
+        expect(r.stillStaying).toBe(false);
+    });
+
+    it("kéo từ quá khứ vắt qua hôm nay → backfill khách còn ở", () => {
+        const r = resolveSelection({ roomId: "3B", startIndex: 1, endIndex: 4 }, days, todayKey);
+        expect(r.kind).toBe("backfill");
+        expect(r.checkInDate).toBe("2026-07-27");
+        expect(r.checkOutDate).toBe("2026-07-31");
+        expect(r.nights).toBe(4);
+        expect(r.stillStaying).toBe(true);
+    });
+});
+
+describe("date helpers", () => {
+    it("addDaysIso vượt tháng", () => {
+        expect(addDaysIso("2026-07-30", 3)).toBe("2026-08-02");
+        expect(addDaysIso("2026-08-02", -3)).toBe("2026-07-30");
+    });
+    it("localDateIso định dạng YYYY-MM-DD", () => {
+        expect(localDateIso(new Date(2026, 6, 29))).toBe("2026-07-29");
+    });
+});

--- a/mhm/src/lib/timelineSelection.ts
+++ b/mhm/src/lib/timelineSelection.ts
@@ -26,6 +26,18 @@ export function addDaysIso(date: string, days: number): string {
     return localDateIso(new Date(y, m - 1, d + days));
 }
 
+// Ngày dạng "YYYY-MM-DD" (không giờ) được JS phân giải theo UTC — dùng nguyên
+// dạng đó (không thêm "T00:00:00") để tránh lệch ngày ở múi giờ dương như
+// Asia/Ho_Chi_Minh khi quy đổi qua toISOString(). Dùng chung cho
+// BackfillSheet.tsx và ReservationSheet.tsx — trước đây mỗi nơi tự giữ một
+// bản sao y hệt, giờ chỉ còn một chỗ để sửa nếu logic múi giờ đổi.
+export function nightsBetween(checkIn: string, checkOut: string): number {
+    if (!checkIn || !checkOut) return 0;
+    const ms = new Date(checkOut).getTime() - new Date(checkIn).getTime();
+    if (Number.isNaN(ms)) return 0;
+    return Math.round(ms / 86_400_000);
+}
+
 /** Mỗi ô được chọn = một đêm ở; ngày ra = ngày bắt đầu + số ô. */
 export function resolveSelection(
     range: TimelineSelectionRange,

--- a/mhm/src/lib/timelineSelection.ts
+++ b/mhm/src/lib/timelineSelection.ts
@@ -1,0 +1,52 @@
+export interface TimelineSelectionRange {
+    roomId: string;
+    startIndex: number;
+    endIndex: number;
+}
+
+export type SelectionKind = "checkin" | "reservation" | "backfill";
+
+export interface ResolvedSelection {
+    kind: SelectionKind;
+    roomId: string;
+    checkInDate: string;
+    checkOutDate: string;
+    nights: number;
+    stillStaying: boolean;
+}
+
+export function localDateIso(d: Date): string {
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+export function addDaysIso(date: string, days: number): string {
+    const [y, m, d] = date.split("-").map(Number);
+    return localDateIso(new Date(y, m - 1, d + days));
+}
+
+/** Mỗi ô được chọn = một đêm ở; ngày ra = ngày bắt đầu + số ô. */
+export function resolveSelection(
+    range: TimelineSelectionRange,
+    days: { fullDate: string }[],
+    todayKey: string,
+): ResolvedSelection {
+    const lo = Math.min(range.startIndex, range.endIndex);
+    const hi = Math.max(range.startIndex, range.endIndex);
+    const nights = hi - lo + 1;
+    const checkInDate = days[lo].fullDate;
+    const checkOutDate = addDaysIso(checkInDate, nights);
+    const kind: SelectionKind =
+        checkInDate === todayKey ? "checkin"
+        : checkInDate > todayKey ? "reservation"
+        : "backfill";
+    return {
+        kind,
+        roomId: range.roomId,
+        checkInDate,
+        checkOutDate,
+        nights,
+        stillStaying: kind === "backfill" && checkOutDate > todayKey,
+    };
+}

--- a/mhm/src/pages/Reservations.test.tsx
+++ b/mhm/src/pages/Reservations.test.tsx
@@ -69,6 +69,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
+import { emitTestEvent, resetEventMocks } from "@test-mocks/tauri-event";
 import Reservations from "./Reservations";
 
 function formatLocalDate(date: Date): string {
@@ -339,6 +340,49 @@ describe("Reservations date navigation", () => {
 
     // Lùi 7 ngày: lưới phủ hôm nay - 10 đến hôm nay + 5, hôm nay vẫn nằm trong.
     expect(screen.getByTestId("timeline-today-marker")).toBeTruthy();
+  });
+});
+
+describe("Reservations timeline refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetEventMocks();
+    invokeWriteCommand.mockResolvedValue(undefined);
+    createCorrelationId.mockReturnValue("COR-5E6F7A8B");
+  });
+
+  // Đường check-in kéo từ lịch bàn giao hẳn cho CheckinSheet ở MainShell —
+  // không có onOpenChange nào quay về trang này, nên trước đây check-in xong
+  // là lịch đứng im và ô vừa kéo trông như vẫn trống. Sự kiện "db-updated" là
+  // thứ backend phát sau MỌI lệnh ghi, kể cả check_in.
+  it("nạp lại bookings khi backend báo dữ liệu đổi", async () => {
+    let bookings: unknown[] = [];
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_all_bookings") return bookings;
+      return undefined;
+    });
+
+    render(<Reservations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Room R101")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("booking-bar-B-CHECKIN")).toBeNull();
+
+    // Khách vừa được check-in từ ô lịch: booking chỉ tồn tại sau lần nạp sau.
+    bookings = [
+      bookingAt({
+        id: "B-CHECKIN",
+        guest_name: "Khách vãng lai",
+        status: "active",
+        scheduled_checkin: dateOffsetFromToday(0),
+        scheduled_checkout: dateOffsetFromToday(2),
+      }),
+    ];
+
+    await emitTestEvent("db-updated", { entity: "rooms" });
+
+    expect(await screen.findByTestId("booking-bar-B-CHECKIN")).toBeTruthy();
   });
 });
 

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -267,11 +267,14 @@ export default function Reservations() {
         const onKeyDown = (event: KeyboardEvent) => {
             if (event.key === "Escape") setDragSel(null);
         };
+        const onBlur = () => setDragSel(null);
         window.addEventListener("mouseup", onMouseUp);
         window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("blur", onBlur);
         return () => {
             window.removeEventListener("mouseup", onMouseUp);
             window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("blur", onBlur);
         };
     }, [dragSel, DAYS]);
 
@@ -405,7 +408,7 @@ export default function Reservations() {
                                             })}
 
                                             {DAYS.some(d => d.isToday) && (
-                                                <div data-testid="timeline-today-marker" className="absolute top-0 bottom-0 w-[2px] bg-brand-primary/60 z-20" style={{ left: `${DAYS.findIndex(d => d.isToday) * COL_WIDTH + COL_WIDTH / 2}px` }} />
+                                                <div data-testid="timeline-today-marker" className="absolute top-0 bottom-0 w-[2px] bg-brand-primary/60 z-20 pointer-events-none" style={{ left: `${DAYS.findIndex(d => d.isToday) * COL_WIDTH + COL_WIDTH / 2}px` }} />
                                             )}
 
                                             {bars.map((bar) => (

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent } from "react";
 import { Search, ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +15,7 @@ import InvoiceDialog from "@/components/InvoiceDialog";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import ReservationSheet from "@/components/ReservationSheet";
 import RoomDrawer from "@/components/RoomDrawer";
+import { resolveSelection, localDateIso, type TimelineSelectionRange } from "@/lib/timelineSelection";
 import type { BookingStatus, BookingWithGuest } from "@/types";
 
 type BookingBar = BookingWithGuest & {
@@ -116,7 +117,7 @@ function getStatusLabel(status: BookingStatus): string {
 }
 
 export default function Reservations() {
-    const { rooms, fetchRooms } = useHotelStore();
+    const { rooms, fetchRooms, setCheckinOpen } = useHotelStore();
     const [bookings, setBookings] = useState<BookingWithGuest[]>([]);
     const [searchQuery, setSearchQuery] = useState("");
     const [dateOffset, setDateOffset] = useState(0);
@@ -124,9 +125,11 @@ export default function Reservations() {
     const [selectedBooking, setSelectedBooking] = useState<BookingWithGuest | null>(null);
     const [editBooking, setEditBooking] = useState<BookingWithGuest | null>(null);
     const [drawerRoomId, setDrawerRoomId] = useState<string | null>(null);
+    const [dragSel, setDragSel] = useState<TimelineSelectionRange | null>(null);
+    const [reservationPrefill, setReservationPrefill] = useState<{ roomId: string; checkIn: string; checkOut: string } | null>(null);
     const { invoiceOpen, invoiceData, invoiceLoading, viewInvoice, closeInvoice } = useInvoiceDialog();
 
-    const DAYS = getDateRange(dateOffset);
+    const DAYS = useMemo(() => getDateRange(dateOffset), [dateOffset]);
     const rangeLabel = formatRangeLabel(DAYS);
 
     useEffect(() => { fetchRooms(); }, []);
@@ -237,6 +240,40 @@ export default function Reservations() {
             toast.error(formatAppError(e));
         }
     }
+
+    function handleCellMouseDown(roomId: string, colIndex: number, event: ReactMouseEvent) {
+        if (event.button !== 0) return;
+        event.preventDefault(); // chặn select text khi kéo
+        setDragSel({ roomId, startIndex: colIndex, endIndex: colIndex });
+    }
+
+    function handleCellMouseEnter(roomId: string, colIndex: number) {
+        setDragSel((prev) => (prev && prev.roomId === roomId ? { ...prev, endIndex: colIndex } : prev));
+    }
+
+    useEffect(() => {
+        if (!dragSel) return;
+        const onMouseUp = () => {
+            const resolved = resolveSelection(dragSel, DAYS, localDateIso(new Date()));
+            setDragSel(null);
+            if (resolved.kind === "checkin") {
+                setCheckinOpen(true, resolved.roomId, resolved.nights);
+            } else if (resolved.kind === "reservation") {
+                setReservationPrefill({ roomId: resolved.roomId, checkIn: resolved.checkInDate, checkOut: resolved.checkOutDate });
+                setSheetOpen(true);
+            }
+            // "backfill": nối ở task BackfillSheet — tới lúc đó bấm ngày quá khứ chưa làm gì.
+        };
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") setDragSel(null);
+        };
+        window.addEventListener("mouseup", onMouseUp);
+        window.addEventListener("keydown", onKeyDown);
+        return () => {
+            window.removeEventListener("mouseup", onMouseUp);
+            window.removeEventListener("keydown", onKeyDown);
+        };
+    }, [dragSel, DAYS]);
 
     return (
         <div className="flex flex-col h-full bg-white rounded-3xl shadow-soft overflow-hidden">
@@ -351,9 +388,21 @@ export default function Reservations() {
                                         </div>
 
                                         <div className="flex relative w-max">
-                                            {DAYS.map((d, colIndex) => (
-                                                <div key={colIndex} className={`w-[80px] shrink-0 border-r border-slate-200 ${d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30 transition-colors`} />
-                                            ))}
+                                            {DAYS.map((d, colIndex) => {
+                                                const inSelection = dragSel !== null
+                                                    && dragSel.roomId === room.id
+                                                    && colIndex >= Math.min(dragSel.startIndex, dragSel.endIndex)
+                                                    && colIndex <= Math.max(dragSel.startIndex, dragSel.endIndex);
+                                                return (
+                                                    <div
+                                                        key={colIndex}
+                                                        data-testid={`cell-${room.id}-${colIndex}`}
+                                                        onMouseDown={(event) => handleCellMouseDown(room.id, colIndex, event)}
+                                                        onMouseEnter={() => handleCellMouseEnter(room.id, colIndex)}
+                                                        className={`w-[80px] shrink-0 border-r border-slate-200 select-none cursor-pointer ${inSelection ? "bg-blue-100/70" : d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30 transition-colors`}
+                                                    />
+                                                );
+                                            })}
 
                                             {DAYS.some(d => d.isToday) && (
                                                 <div data-testid="timeline-today-marker" className="absolute top-0 bottom-0 w-[2px] bg-brand-primary/60 z-20" style={{ left: `${DAYS.findIndex(d => d.isToday) * COL_WIDTH + COL_WIDTH / 2}px` }} />
@@ -437,9 +486,11 @@ export default function Reservations() {
                 open={sheetOpen || !!editBooking}
                 onOpenChange={(v) => {
                     setSheetOpen(v);
-                    if (!v) { setEditBooking(null); loadBookings(); }
+                    if (!v) { setEditBooking(null); setReservationPrefill(null); loadBookings(); }
                 }}
                 editBooking={editBooking || undefined}
+                preSelectedRoomId={reservationPrefill?.roomId}
+                prefillDates={reservationPrefill ? { checkIn: reservationPrefill.checkIn, checkOut: reservationPrefill.checkOut } : undefined}
             />
         </div>
     );

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -14,6 +14,7 @@ import BookingDetailPopup from "@/components/BookingDetailPopup";
 import InvoiceDialog from "@/components/InvoiceDialog";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import ReservationSheet from "@/components/ReservationSheet";
+import BackfillSheet, { type BackfillPrefill } from "@/components/BackfillSheet";
 import RoomDrawer from "@/components/RoomDrawer";
 import { resolveSelection, localDateIso, type TimelineSelectionRange } from "@/lib/timelineSelection";
 import type { BookingStatus, BookingWithGuest } from "@/types";
@@ -127,6 +128,7 @@ export default function Reservations() {
     const [drawerRoomId, setDrawerRoomId] = useState<string | null>(null);
     const [dragSel, setDragSel] = useState<TimelineSelectionRange | null>(null);
     const [reservationPrefill, setReservationPrefill] = useState<{ roomId: string; checkIn: string; checkOut: string } | null>(null);
+    const [backfillPrefill, setBackfillPrefill] = useState<BackfillPrefill | null>(null);
     const { invoiceOpen, invoiceData, invoiceLoading, viewInvoice, closeInvoice } = useInvoiceDialog();
 
     const DAYS = useMemo(() => getDateRange(dateOffset), [dateOffset]);
@@ -261,8 +263,14 @@ export default function Reservations() {
             } else if (resolved.kind === "reservation") {
                 setReservationPrefill({ roomId: resolved.roomId, checkIn: resolved.checkInDate, checkOut: resolved.checkOutDate });
                 setSheetOpen(true);
+            } else {
+                setBackfillPrefill({
+                    roomId: resolved.roomId,
+                    checkInDate: resolved.checkInDate,
+                    checkOutDate: resolved.checkOutDate,
+                    stillStaying: resolved.stillStaying,
+                });
             }
-            // "backfill": nối ở task BackfillSheet — tới lúc đó bấm ngày quá khứ chưa làm gì.
         };
         const onKeyDown = (event: KeyboardEvent) => {
             if (event.key === "Escape") setDragSel(null);
@@ -494,6 +502,15 @@ export default function Reservations() {
                 editBooking={editBooking || undefined}
                 preSelectedRoomId={reservationPrefill?.roomId}
                 prefillDates={reservationPrefill ? { checkIn: reservationPrefill.checkIn, checkOut: reservationPrefill.checkOut } : undefined}
+            />
+
+            {/* Backfill Sheet — ghi bù khách đã ở nhưng chưa nhập, mở từ ô ngày quá khứ */}
+            <BackfillSheet
+                open={!!backfillPrefill}
+                onOpenChange={(v) => {
+                    if (!v) { setBackfillPrefill(null); loadBookings(); fetchRooms(); }
+                }}
+                prefill={backfillPrefill ?? undefined}
             />
         </div>
     );

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { Search, ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -8,6 +9,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { createCorrelationId } from "@/lib/correlationId";
 import { formatAppError } from "@/lib/appError";
+import { createDeferredCleanup } from "@/lib/deferredCleanup";
 import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { toast } from "sonner";
 import BookingDetailPopup from "@/components/BookingDetailPopup";
@@ -41,13 +43,6 @@ function startOfLocalDay(date: Date): Date {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-function formatLocalDate(date: Date): string {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}-${month}-${day}`;
-}
-
 function differenceInCalendarDays(left: Date, right: Date): number {
     const leftUtc = Date.UTC(left.getFullYear(), left.getMonth(), left.getDate());
     const rightUtc = Date.UTC(right.getFullYear(), right.getMonth(), right.getDate());
@@ -56,11 +51,11 @@ function differenceInCalendarDays(left: Date, right: Date): number {
 
 function getDateRange(offset: number) {
     const today = startOfLocalDay(new Date());
-    const todayKey = formatLocalDate(today);
+    const todayKey = localDateIso(today);
     return Array.from({ length: VISIBLE_DAYS }, (_, i) => {
         const d = new Date(today);
         d.setDate(today.getDate() + i - 3 + offset);
-        const fullDate = formatLocalDate(d);
+        const fullDate = localDateIso(d);
         return {
             day: d.toLocaleDateString("vi-VN", { weekday: "short" }).replace(".", ""),
             date: d.getDate(),
@@ -144,6 +139,26 @@ export default function Reservations() {
 
     useEffect(() => { loadBookings(); }, []);
 
+    // `bookings` là state cục bộ của trang này, và listener toàn cục ở
+    // RuntimeStateProvider chỉ làm mới rooms/stats — không ai làm mới bookings.
+    // Đường check-in kéo từ lịch bàn giao hẳn cho CheckinSheet ở MainShell nên
+    // cũng không có callback nào quay về đây: check-in xong, lịch đứng im,
+    // không có bar nào hiện ra, và chủ kéo lại đúng ô đó thì ăn lỗi "phòng
+    // không còn trống". Backend phát "db-updated" sau MỌI lệnh ghi
+    // (commands/mod.rs::emit_db_update), nên nghe đúng một chỗ này là ba đường
+    // kéo (check-in / đặt trước / ghi bù) làm mới giống hệt nhau.
+    //
+    // Vì mọi lệnh ghi đều đi qua đây, các lời gọi loadBookings() rải trong
+    // handler đóng sheet / confirm / cancel đã được bỏ: giữ lại chúng sẽ nạp
+    // hai lần cho cùng một thao tác. Lần nạp lúc mount ở trên vẫn cần — không
+    // có sự kiện nào phát khi trang vừa mở.
+    useEffect(() => {
+        const cleanup = createDeferredCleanup(
+            listen<{ entity: string }>("db-updated", () => { loadBookings(); }),
+        );
+        return cleanup;
+    }, []);
+
     const roomGroups = Object.values(
         rooms.reduce<Record<string, { name: string; rooms: { id: string; type: string }[] }>>((groups, room) => {
             const existing = groups[room.type] ?? {
@@ -222,8 +237,6 @@ export default function Reservations() {
         try {
             await invokeWriteCommand("confirm_reservation", { bookingId }, { correlationId });
             toast.success("Check-in reservation thành công!");
-            loadBookings();
-            fetchRooms();
             setSelectedBooking(null);
         } catch (e) {
             toast.error(formatAppError(e));
@@ -235,8 +248,6 @@ export default function Reservations() {
         try {
             await invokeWriteCommand("cancel_reservation", { bookingId }, { correlationId });
             toast.success("Đã hủy reservation. Tiền cọc được giữ lại.");
-            loadBookings();
-            fetchRooms();
             setSelectedBooking(null);
         } catch (e) {
             toast.error(formatAppError(e));
@@ -480,7 +491,7 @@ export default function Reservations() {
             {/* Room Drawer for active bookings */}
             <RoomDrawer
                 open={!!drawerRoomId}
-                onClose={() => { setDrawerRoomId(null); loadBookings(); fetchRooms(); }}
+                onClose={() => setDrawerRoomId(null)}
                 roomId={drawerRoomId}
             />
 
@@ -497,7 +508,7 @@ export default function Reservations() {
                 open={sheetOpen || !!editBooking}
                 onOpenChange={(v) => {
                     setSheetOpen(v);
-                    if (!v) { setEditBooking(null); setReservationPrefill(null); loadBookings(); }
+                    if (!v) { setEditBooking(null); setReservationPrefill(null); }
                 }}
                 editBooking={editBooking || undefined}
                 preSelectedRoomId={reservationPrefill?.roomId}
@@ -508,7 +519,7 @@ export default function Reservations() {
             <BackfillSheet
                 open={!!backfillPrefill}
                 onOpenChange={(v) => {
-                    if (!v) { setBackfillPrefill(null); loadBookings(); fetchRooms(); }
+                    if (!v) setBackfillPrefill(null);
                 }}
                 prefill={backfillPrefill ?? undefined}
             />

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -179,7 +179,12 @@ export default function Reservations() {
             .filter(b => b.room_id === roomId && b.status !== "cancelled")
             .flatMap((b): BookingBar[] => {
                 const checkIn = parseDate(b.scheduled_checkin || b.check_in_at);
-                const checkOut = parseDate(b.scheduled_checkout || b.expected_checkout);
+                // Booking đã trả: bar dừng đúng lúc trả phòng thực tế, kể cả khi trước đó lỡ extend.
+                const checkOut = parseDate(
+                    b.status === "checked_out" && b.actual_checkout
+                        ? b.actual_checkout
+                        : b.scheduled_checkout || b.expected_checkout,
+                );
                 const startDay = DAYS[0].dateObj;
 
                 const rawStart = differenceInCalendarDays(checkIn, startDay) + HALF_DAY;

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -320,7 +320,7 @@ export default function Reservations() {
                     </div>
 
                     {DAYS.map((d, i) => (
-                        <div key={i} className={`w-[80px] shrink-0 border-r border-slate-50 flex flex-col items-center justify-center py-2.5 ${d.isToday ? "bg-blue-50/40" : ""}`}>
+                        <div key={i} className={`w-[80px] shrink-0 border-r border-slate-200 flex flex-col items-center justify-center py-2.5 ${d.isToday ? "bg-blue-50/40" : ""}`}>
                             <span className={`text-[10px] font-semibold uppercase ${d.isToday ? "text-brand-primary" : "text-slate-400"}`}>{d.day}</span>
                             <span className={`text-sm font-bold ${d.isToday ? "text-brand-primary" : "text-slate-700"}`}>{d.date}</span>
                         </div>
@@ -337,7 +337,7 @@ export default function Reservations() {
                                 </div>
                                 <div className="flex">
                                     {DAYS.map((d, i) => (
-                                        <div key={i} className={`w-[80px] shrink-0 border-r border-slate-50 ${d.isToday ? "bg-blue-50/20" : ""}`} />
+                                        <div key={i} className={`w-[80px] shrink-0 border-r border-slate-200 ${d.isToday ? "bg-blue-50/20" : ""}`} />
                                     ))}
                                 </div>
                             </div>
@@ -345,14 +345,14 @@ export default function Reservations() {
                             {group.rooms.map((room) => {
                                 const bars = getBookingBars(room.id);
                                 return (
-                                    <div key={room.id} className="flex group border-b border-slate-50 h-[64px]">
+                                    <div key={room.id} className="flex group border-b border-slate-100 h-[64px]">
                                         <div className="w-[140px] shrink-0 border-r border-slate-100 bg-white shadow-[2px_0_10px_rgba(0,0,0,0.02)] sticky left-0 z-10 flex items-center px-4 group-hover:bg-slate-50/50 transition-colors">
                                             <span className="font-bold text-sm text-slate-700">Room {room.id}</span>
                                         </div>
 
                                         <div className="flex relative w-max">
                                             {DAYS.map((d, colIndex) => (
-                                                <div key={colIndex} className={`w-[80px] shrink-0 border-r border-slate-50 ${d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30 transition-colors`} />
+                                                <div key={colIndex} className={`w-[80px] shrink-0 border-r border-slate-200 ${d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30 transition-colors`} />
                                             ))}
 
                                             {DAYS.some(d => d.isToday) && (

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -31,6 +31,7 @@ interface HotelStore {
   loading: boolean;
   isCheckinOpen: boolean;
   checkinRoomId: string | null;
+  checkinNights: number | null;
   isGroupCheckinOpen: boolean;
   groups: BookingGroup[];
 
@@ -38,7 +39,7 @@ interface HotelStore {
   fetchStats: () => Promise<void>;
   markDashboardDataChanged: () => void;
   setTab: (tab: HotelTab) => void;
-  setCheckinOpen: (open: boolean, roomId?: string | null) => void;
+  setCheckinOpen: (open: boolean, roomId?: string | null, nights?: number | null) => void;
   checkIn: (roomId: string, guests: CheckInGuestInput[], nights: number, paidAmount?: MoneyVnd, source?: string, notes?: string) => Promise<void>;
   checkOut: (
     bookingId: string,
@@ -83,6 +84,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     loading: false,
     isCheckinOpen: false,
     checkinRoomId: null,
+    checkinNights: null,
     isGroupCheckinOpen: false,
     groups: [],
 
@@ -102,10 +104,11 @@ export const useHotelStore = create<HotelStore>((set, get) => {
       })),
 
     setTab: (tab) => set({ activeTab: tab }),
-    setCheckinOpen: (open, roomId = null) =>
+    setCheckinOpen: (open, roomId = null, nights = null) =>
       set({
         isCheckinOpen: open,
         checkinRoomId: open ? roomId : null,
+        checkinNights: open ? nights : null,
       }),
 
     checkIn: async (roomId, guests, nights, paidAmount, source, notes) => {

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -176,6 +176,21 @@ export interface AvailabilityResult {
   max_nights: number | null;
 }
 
+export interface PricingLine {
+  label: string;
+  amount: MoneyVnd;
+}
+
+export interface PricingResult {
+  pricing_type: string;
+  base_amount: MoneyVnd;
+  surcharge_amount: MoneyVnd;
+  weekend_amount: MoneyVnd;
+  total: MoneyVnd;
+  breakdown: PricingLine[];
+  capped: boolean;
+}
+
 export interface EditableBooking {
   id: string;
   room_id: string;

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -22,6 +22,8 @@ export interface Room {
   floor: number;
   has_balcony: boolean;
   base_price: MoneyVnd;
+  max_guests: number;
+  extra_person_fee: MoneyVnd;
   status: RoomStatus;
 }
 
@@ -184,6 +186,7 @@ export interface EditableBooking {
   check_in_at: string;
   expected_checkout: string;
   nights: number;
+  guests: number | null;
   total_price: MoneyVnd;
   deposit_amount: MoneyVnd | null;
   source: string | null;
@@ -281,6 +284,7 @@ export interface BookingWithGuest {
   scheduled_checkin: string | null;
   scheduled_checkout: string | null;
   guest_phone: string | null;
+  guests: number | null;
 }
 
 export interface ActivityItem {

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -147,4 +147,29 @@ describe("09 — Reservations", () => {
         expect(bookingBar).toHaveStyle({ left: "280px" });
         expect(bookingBar).not.toHaveStyle({ left: "200px" });
     });
+
+    it("cắt bar của booking đã trả tại ngày trả thực tế", async () => {
+        const dayMs = 86400000;
+        const base = new Date();
+        setMockResponse("get_all_bookings", () => [
+            createBookingWithGuest({
+                id: "b-early",
+                room_id: "1A",
+                guest_name: "Khách Trả Sớm",
+                status: "checked_out",
+                check_in_at: new Date(base.getTime() - 2 * dayMs).toISOString(),
+                expected_checkout: new Date(base.getTime() + 2 * dayMs).toISOString(),
+                actual_checkout: base.toISOString(),
+            }),
+        ]);
+
+        render(<Reservations />);
+
+        const bar = await screen.findByTestId("booking-bar-b-early");
+        // Cột đầu = hôm nay − 3. Check-in cách đây 2 ngày → cột 1 → left (1 + 0.5) × 80 = 120px.
+        // Kết thúc tại actual_checkout (hôm nay, cột 3) → width (3.5 − 1.5) × 80 = 160px,
+        // KHÔNG phải kéo tới expected_checkout (cột 5, width 320px).
+        expect(bar.style.left).toBe("120px");
+        expect(bar.style.width).toBe("160px");
+    });
 });

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -246,6 +246,14 @@ describe("09 — Reservations", () => {
         expect(screen.queryByText("Đặt phòng trước")).not.toBeInTheDocument();
     });
 
+    it("bấm ô quá khứ mở form ghi bù", async () => {
+        render(<Reservations />);
+        const cell = await screen.findByTestId("cell-1A-0"); // cột 0 = hôm nay − 3
+        fireEvent.mouseDown(cell, { button: 0 });
+        fireEvent.mouseUp(window);
+        expect(await screen.findByText("Ghi bù sổ khách")).toBeInTheDocument();
+    });
+
     it("thả chuột ngoài cửa sổ (window blur) huỷ selection đang kéo", async () => {
         render(<Reservations />);
         const start = await screen.findByTestId("cell-1A-5");

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -49,7 +49,12 @@ describe("09 — Reservations", () => {
         invoke.mockClear();
 
         // Reservations page needs rooms for the timeline grid
-        useHotelStore.setState({ rooms: mockRooms });
+        useHotelStore.setState({
+            rooms: mockRooms,
+            isCheckinOpen: false,
+            checkinRoomId: null,
+            checkinNights: null,
+        });
         setMockResponse("get_rooms", () => mockRooms);
         setMockResponse("get_all_bookings", () => mockBookings);
         setMockResponse("check_availability", () => ({ available: true, conflicts: [], max_nights: null }));
@@ -190,13 +195,69 @@ describe("09 — Reservations", () => {
         const start = await screen.findByTestId("cell-1A-5");
         const end = await screen.findByTestId("cell-1A-6");
         fireEvent.mouseDown(start, { button: 0 });
-        fireEvent.mouseEnter(end);
+        // React derives onMouseEnter from the mouseout/mouseover pair at its root —
+        // testing-library's mouseEnter dispatches a non-bubbling event React never
+        // sees there. mouseOver is what actually reaches handleCellMouseEnter.
+        fireEvent.mouseOver(end);
         fireEvent.mouseUp(window);
 
         expect(await screen.findByText("Đặt phòng trước")).toBeInTheDocument();
-        const expectedCheckIn = new Date(Date.now() + 2 * 86400000);
         const iso = (d: Date) =>
             `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        const expectedCheckIn = new Date(Date.now() + 2 * 86400000);
+        const expectedCheckOut = new Date(Date.now() + 4 * 86400000);
         expect(screen.getByDisplayValue(iso(expectedCheckIn))).toBeInTheDocument();
+        expect(screen.getByDisplayValue(iso(expectedCheckOut))).toBeInTheDocument();
+    });
+
+    it("bấm vào bar booking mở popup chi tiết mà không bắt đầu kéo chọn", async () => {
+        render(<Reservations />);
+        const bar = await screen.findByTestId("booking-bar-b3"); // status: checked_out
+        fireEvent.click(bar);
+
+        // Popup mở
+        expect(await screen.findByText("Đã trả — Lê Văn C")).toBeInTheDocument();
+
+        // Không có selection/form nào khác bị kích hoạt bởi cú click này
+        expect(useHotelStore.getState().isCheckinOpen).toBe(false);
+        expect(screen.queryByText("Đặt phòng trước")).not.toBeInTheDocument();
+    });
+
+    it("nhấn chuột phải trên ô không bắt đầu kéo chọn", async () => {
+        render(<Reservations />);
+        const cell = await screen.findByTestId("cell-1A-3");
+        fireEvent.mouseDown(cell, { button: 2 });
+        fireEvent.mouseUp(window);
+
+        expect(useHotelStore.getState().isCheckinOpen).toBe(false);
+        expect(screen.queryByText("Đặt phòng trước")).not.toBeInTheDocument();
+    });
+
+    it("nhấn Escape khi đang kéo sẽ huỷ selection, không mở form nào", async () => {
+        render(<Reservations />);
+        const start = await screen.findByTestId("cell-1A-5");
+        const end = await screen.findByTestId("cell-1A-6");
+        fireEvent.mouseDown(start, { button: 0 });
+        fireEvent.mouseOver(end);
+        fireEvent.keyDown(window, { key: "Escape" });
+        fireEvent.mouseUp(window);
+
+        expect(useHotelStore.getState().isCheckinOpen).toBe(false);
+        expect(screen.queryByText("Đặt phòng trước")).not.toBeInTheDocument();
+    });
+
+    it("thả chuột ngoài cửa sổ (window blur) huỷ selection đang kéo", async () => {
+        render(<Reservations />);
+        const start = await screen.findByTestId("cell-1A-5");
+        const end = await screen.findByTestId("cell-1A-6");
+        fireEvent.mouseDown(start, { button: 0 });
+        fireEvent.mouseOver(end);
+        fireEvent(window, new Event("blur"));
+        // mouseUp xảy ra sau khi quay lại cửa sổ — selection phải đã bị xoá từ blur,
+        // nên mouseUp này không được mở form nào.
+        fireEvent.mouseUp(window);
+
+        expect(useHotelStore.getState().isCheckinOpen).toBe(false);
+        expect(screen.queryByText("Đặt phòng trước")).not.toBeInTheDocument();
     });
 });

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, waitFor } from "../helpers/render-app";
+import { render, screen, waitFor, fireEvent } from "../helpers/render-app";
 import userEvent from "@testing-library/user-event";
 import Reservations from "@/pages/Reservations";
 import { setMockResponse, clearMockResponses, invoke } from "@test-mocks/tauri-core";
@@ -171,5 +171,32 @@ describe("09 — Reservations", () => {
         // KHÔNG phải kéo tới expected_checkout (cột 5, width 320px).
         expect(bar.style.left).toBe("120px");
         expect(bar.style.width).toBe("160px");
+    });
+
+    it("bấm ô hôm nay mở check-in với phòng và số đêm", async () => {
+        render(<Reservations />);
+        const cell = await screen.findByTestId("cell-1A-3"); // cột 3 = hôm nay
+        fireEvent.mouseDown(cell, { button: 0 });
+        fireEvent.mouseUp(window);
+
+        const state = useHotelStore.getState();
+        expect(state.isCheckinOpen).toBe(true);
+        expect(state.checkinRoomId).toBe("1A");
+        expect(state.checkinNights).toBe(1);
+    });
+
+    it("kéo 2 ô tương lai mở form đặt phòng với ngày điền sẵn", async () => {
+        render(<Reservations />);
+        const start = await screen.findByTestId("cell-1A-5");
+        const end = await screen.findByTestId("cell-1A-6");
+        fireEvent.mouseDown(start, { button: 0 });
+        fireEvent.mouseEnter(end);
+        fireEvent.mouseUp(window);
+
+        expect(await screen.findByText("Đặt phòng trước")).toBeInTheDocument();
+        const expectedCheckIn = new Date(Date.now() + 2 * 86400000);
+        const iso = (d: Date) =>
+            `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        expect(screen.getByDisplayValue(iso(expectedCheckIn))).toBeInTheDocument();
     });
 });

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -19,6 +19,7 @@ const PMS_WRITE_COMMANDS_REQUIRING_WRAPPER = new Set([
 
 const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
   backup_database: "system backup/export action, not a PMS business write wrapper target",
+  calculate_room_price_preview: "read-only pricing preview lookup",
   check_availability: "read-only reservation availability lookup",
   complete_onboarding: "bootstrap setup command excluded from Batch 1 PMS wrapper scope",
   export_bookings_csv: "system export action, not a PMS business write wrapper target",

--- a/mhm/tests/helpers/mock-data.ts
+++ b/mhm/tests/helpers/mock-data.ts
@@ -20,6 +20,8 @@ export function createRoom(overrides: Partial<Room> = {}): Room {
         floor: overrides.floor ?? 1,
         has_balcony: overrides.has_balcony ?? true,
         base_price: overrides.base_price ?? 350000,
+        max_guests: overrides.max_guests ?? 2,
+        extra_person_fee: overrides.extra_person_fee ?? 0,
         status: overrides.status ?? "vacant",
         ...overrides,
     };


### PR DESCRIPTION
Cải thiện phần đặt phòng trên trang Reservations theo 3 góp ý của chủ khách sạn.

## Vấn đề

1. Khách trả phòng sớm (hoặc lỡ bấm Gia hạn rồi checkout) mà bar trên calendar vẫn kéo dài tới ngày trả dự kiến.
2. Vạch chia ngày quá mờ, gần như không thấy.
3. Ô trống trên calendar không bấm được — muốn bấm/kéo một vùng ngày là mở đúng form.

## Thay đổi

**Hiển thị**
- Booking đã trả vẽ bar tới `actual_checkout` thay vì ngày trả dự kiến (có fallback cho dữ liệu cũ).
- Vạch chia ngày đậm lên (`slate-50` → `slate-200`), vạch ngang giữa phòng lên `slate-100`.

**Bấm/kéo trên calendar**
- Nhấn giữ và kéo ngang trong một hàng phòng để chọn số đêm. Kéo ngược, Escape, và thả chuột ngoài cửa sổ đều xử lý đúng.
- Thả chuột mở form theo ngày bắt đầu: hôm nay → Check-in walk-in; tương lai → Đặt phòng; quá khứ → form **Ghi bù** mới.
- Bấm lên bar khách có sẵn vẫn mở popup chi tiết, không kích hoạt kéo chọn.

**Ghi bù khách quên nhập (mới)**
- Form `BackfillSheet` với 2 chế độ: khách đã trả phòng, và khách còn đang ở.
- Lệnh `backfill_stay` mới ở backend, theo đúng khuôn idempotent-write sẵn có (ledger, outbox, khoá aggregate, origin-keyed side effects). Chặn trùng lịch, kiểm tra ngày và tiền, ghi trong một transaction.
- Phân loại `backfill_stay` là lệnh rủi ro cao trong `command_recovery` — thao tác khôi phục phải xác nhận và nêu lý do.
- Form thu thập nhân thân thật (giới tính, ngày sinh, quốc tịch, địa chỉ) thay vì điền cứng, vì các bản ghi này nộp cho công an qua danh sách khai báo tạm trú.

## Sửa từ review toàn nhánh

Bốn lỗi ở chỗ nối giữa các phần, mà review từng task không thể thấy:

1. Check-in từ calendar không làm mới timeline — không hiện bar, kéo lại ô đó thì báo "phòng không còn trống". Nay làm mới qua sự kiện `db-updated`; đã kiểm mọi lệnh ghi booking đều phát sự kiện này.
2. Khách ghi bù đã trả phòng không hiện trong danh sách Khai báo tạm trú dù form hứa là có (query chỉ lấy `status = 'active'`). Đã mở rộng phạm vi cho khách vừa trả phòng trong 30 ngày, dùng chung một predicate để danh sách và badge không lệch nhau.
3. Kéo ô của phòng mà form đích lọc mất khiến ô "Phòng" trống trơn nhưng nút gửi vẫn bật. Đã áp cách xử lý sẵn có của `BackfillSheet` sang `CheckinSheet` và `ReservationSheet`.
4. Bấm "Khách còn ở" trên vùng chọn toàn quá khứ chắc chắn bị backend từ chối. Nay mặc định sang ngày mai; bỏ tick thì trả lại đúng ngày đã kéo.

Dọn kèm: gỡ helper ngày trùng lặp, thay một `addDays` không an toàn múi giờ, chặn ghi bù 0₫, ép tiền về số nguyên.

## Kiểm thử

- Frontend: 416 test pass, `tsc --noEmit` sạch
- Backend: 948 test pass, `clippy --all-targets` và `fmt --check` sạch

## Lưu ý khi triển khai

Badge Khai báo tạm trú giờ đếm cả khách đã trả phòng trong 30 ngày chưa khai báo, nên con số sẽ nhảy lên ở lần chạy đầu sau khi cập nhật.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
