### PR TITLE
feat(restore-drill): assert freshness, schema version, and row baseline

### DIFF
--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -141,6 +141,11 @@ async fn ensure_setting_default(
 
 // ─── Versioned Inline Migrations ───
 
+/// Schema version a database reaches after `run_migrations` finishes on this
+/// build. Bump this together with every new migration block below; the
+/// `migrations_run_to_latest_schema_version` test fails otherwise.
+pub(crate) const LATEST_SCHEMA_VERSION: i32 = 22;
+
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS schema_version (
@@ -852,7 +857,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, super::LATEST_SCHEMA_VERSION);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/restore_drill.rs
+++ b/mhm/src-tauri/src/restore_drill.rs
@@ -757,35 +757,42 @@ fn push_core_count_baseline_check(
     }
 }
 
-/// Newest existing report in `restore-drills/`, with its core-table counts.
-/// The current run has not written its own report yet, so the newest file on
-/// disk is the previous drill.
+/// Most recent report in `restore-drills/` that actually carries core-table
+/// counts, with those counts. The current run has not written its own report
+/// yet, so every report on disk is a previous drill.
+///
+/// Reports are searched newest-first rather than reading only the newest one:
+/// a drill that failed before it could count anything (no backup found, bad
+/// integrity, missing tables) writes a report with no counts row, and letting
+/// that blind the comparison would drop the baseline exactly when something
+/// has already gone wrong.
 fn previous_core_counts(runtime_root: &Path) -> Option<(String, Vec<(String, i64)>)> {
     let report_dir = runtime_root.join("restore-drills");
-    let mut newest: Option<String> = None;
+    let mut file_names = Vec::new();
     for entry in fs::read_dir(&report_dir).ok()? {
-        let entry = entry.ok()?;
-        if !entry.file_type().ok()?.is_file() {
+        // One unreadable entry must not hide every other report.
+        let Ok(entry) = entry else { continue };
+        if !entry
+            .file_type()
+            .map(|kind| kind.is_file())
+            .unwrap_or(false)
+        {
             continue;
         }
         let file_name = entry.file_name().to_string_lossy().into_owned();
-        if !file_name.starts_with(REPORT_PREFIX) || !file_name.ends_with(REPORT_SUFFIX) {
-            continue;
-        }
-        // Report names embed a zero-padded timestamp, so byte order is time order.
-        let is_newer = match newest.as_ref() {
-            Some(current) => &file_name > current,
-            None => true,
-        };
-        if is_newer {
-            newest = Some(file_name);
+        if file_name.starts_with(REPORT_PREFIX) && file_name.ends_with(REPORT_SUFFIX) {
+            file_names.push(file_name);
         }
     }
 
-    let file_name = newest?;
-    let contents = fs::read_to_string(report_dir.join(&file_name)).ok()?;
-    let counts = parse_core_counts(&contents)?;
-    Some((file_name, counts))
+    // Report names embed a zero-padded timestamp, so byte order is time order.
+    file_names.sort_unstable_by(|left, right| right.cmp(left));
+
+    file_names.into_iter().find_map(|file_name| {
+        let contents = fs::read_to_string(report_dir.join(&file_name)).ok()?;
+        let counts = parse_core_counts(&contents)?;
+        Some((file_name, counts))
+    })
 }
 
 fn parse_core_counts(report: &str) -> Option<Vec<(String, i64)>> {
@@ -1288,6 +1295,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drill_warns_but_does_not_fail_on_a_backup_timestamped_in_the_future() {
+        let temp = make_temp_dir("restore-drill-future");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260501_110000.db")).await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 0, 0)),
+        })
+        .await;
+
+        // A skewed clock is not a broken backup.
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("| Backup freshness | WARN |"));
+        assert!(report.contains("check the system clock"));
+    }
+
+    #[tokio::test]
     async fn drill_exempts_an_explicitly_named_backup_from_the_age_limit() {
         let temp = make_temp_dir("restore-drill-explicit-age");
         let backup_dir = temp.path().join("backups");
@@ -1506,6 +1534,29 @@ mod tests {
         let (file_name, counts) = previous_core_counts(temp.path()).expect("finds a report");
         assert_eq!(file_name, "restore-drill-20260425_110000.md");
         assert_eq!(counts, vec![("guests".to_string(), 11)]);
+    }
+
+    #[test]
+    fn previous_core_counts_skips_a_failed_report_with_no_counts() {
+        let temp = make_temp_dir("restore-drill-baseline-skip-failed");
+        let report_dir = temp.path().join("restore-drills");
+        fs::create_dir_all(&report_dir).unwrap();
+        fs::write(
+            report_dir.join("restore-drill-20260419_110000.md"),
+            "| Core tables readable | PASS | guests=9 |\n",
+        )
+        .unwrap();
+        // A drill that failed before it could count anything.
+        fs::write(
+            report_dir.join("restore-drill-20260425_110000.md"),
+            "Status: FAIL\n\n| Backup selection | FAIL | no managed CapyInn backup found |\n",
+        )
+        .unwrap();
+
+        let (file_name, counts) = previous_core_counts(temp.path())
+            .expect("falls back to the newest report that has counts");
+        assert_eq!(file_name, "restore-drill-20260419_110000.md");
+        assert_eq!(counts, vec![("guests".to_string(), 9)]);
     }
 
     #[test]

--- a/mhm/src-tauri/src/restore_drill.rs
+++ b/mhm/src-tauri/src/restore_drill.rs
@@ -1,4 +1,4 @@
-use chrono::{NaiveDateTime, Utc};
+use chrono::{Duration, NaiveDateTime, Utc};
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     Sqlite,
@@ -23,6 +23,11 @@ const REQUIRED_TABLES: [&str; 6] = [
     "audit_logs",
     "schema_version",
 ];
+/// A drill that only proves some ancient file still opens is not proving the
+/// backup chain is alive. Auto-selected backups older than this fail the drill.
+const MAX_BACKUP_AGE_DAYS: i64 = 7;
+/// Name of the check row the baseline comparison reads out of the previous report.
+const CORE_COUNTS_CHECK: &str = "Core tables readable";
 const BACKUP_REASONS: [&str; 7] = [
     "settings",
     "checkout",
@@ -106,6 +111,10 @@ struct ManagedBackup {
     timestamp: NaiveDateTime,
     collision_index: u64,
     file_name: String,
+    /// True when the caller named the file. An explicitly chosen backup is
+    /// exempt from the freshness check — inspecting an old backup on purpose
+    /// is a legitimate use of the drill.
+    explicit: bool,
 }
 
 #[derive(Debug)]
@@ -173,7 +182,10 @@ pub async fn run_restore_drill(options: RestoreDrillOptions) -> RestoreDrillRun 
         format!("selected {}", selected.path.display()),
     ));
 
-    let (copied_path, failure) = validate_selected_backup(&selected.path, &mut checks, now).await;
+    let freshness_failure = push_freshness_check(&selected, now, &mut checks);
+
+    let (copied_path, failure) =
+        validate_selected_backup(&selected.path, &runtime_root, &mut checks, now).await;
 
     finish_run(FinishRunInput {
         runtime_root,
@@ -181,8 +193,60 @@ pub async fn run_restore_drill(options: RestoreDrillOptions) -> RestoreDrillRun 
         backup_path: Some(selected.path),
         copied_path,
         checks,
-        failure,
+        failure: failure.or(freshness_failure),
     })
+}
+
+/// A stale backup still gets fully validated — knowing whether the old file is
+/// at least readable is worth having — but the run fails either way.
+fn push_freshness_check(
+    selected: &ManagedBackup,
+    now: NaiveDateTime,
+    checks: &mut Vec<RestoreDrillCheck>,
+) -> Option<String> {
+    if selected.explicit {
+        checks.push(pass_check(
+            "Backup freshness",
+            "skipped: backup was named explicitly",
+        ));
+        return None;
+    }
+
+    let age = now.signed_duration_since(selected.timestamp);
+    if age < Duration::zero() {
+        checks.push(warn_check(
+            "Backup freshness",
+            format!(
+                "backup is timestamped {} in the future; check the system clock",
+                format_age(-age)
+            ),
+        ));
+        return None;
+    }
+
+    if age > Duration::days(MAX_BACKUP_AGE_DAYS) {
+        let failure = format!(
+            "newest backup is {} old, over the {MAX_BACKUP_AGE_DAYS}-day limit; the backup chain has stopped",
+            format_age(age)
+        );
+        checks.push(fail_check("Backup freshness", failure.clone()));
+        return Some(failure);
+    }
+
+    checks.push(pass_check(
+        "Backup freshness",
+        format!("{} old, within {MAX_BACKUP_AGE_DAYS} days", format_age(age)),
+    ));
+    None
+}
+
+fn format_age(age: Duration) -> String {
+    let hours = age.num_hours();
+    if hours < 48 {
+        format!("{hours}h")
+    } else {
+        format!("{}d", age.num_days())
+    }
 }
 
 struct FinishRunInput {
@@ -258,6 +322,7 @@ fn select_backup(
                 timestamp: drill_timestamp_now(),
                 collision_index: 0,
                 file_name,
+                explicit: true,
             })
         }
         None => select_newest_managed_backup(runtime_root),
@@ -290,6 +355,7 @@ fn select_newest_managed_backup(runtime_root: &Path) -> Result<ManagedBackup, St
             timestamp: metadata.timestamp,
             collision_index: metadata.collision_index,
             file_name,
+            explicit: false,
         };
 
         if newest
@@ -363,6 +429,7 @@ fn parse_managed_backup_file_name(name: &str) -> Option<ParsedBackupName> {
 
 async fn validate_selected_backup(
     backup_path: &Path,
+    runtime_root: &Path,
     checks: &mut Vec<RestoreDrillCheck>,
     now: NaiveDateTime,
 ) -> (Option<PathBuf>, Option<String>) {
@@ -432,12 +499,13 @@ async fn validate_selected_backup(
         }
     }
 
-    let validation_failure = validate_copied_database(&copied_path, checks).await;
+    let validation_failure = validate_copied_database(&copied_path, runtime_root, checks).await;
     (Some(copied_path), validation_failure)
 }
 
 async fn validate_copied_database(
     copied_path: &Path,
+    runtime_root: &Path,
     checks: &mut Vec<RestoreDrillCheck>,
 ) -> Option<String> {
     let options = SqliteConnectOptions::new()
@@ -542,32 +610,68 @@ async fn validate_copied_database(
             .fetch_one(&pool)
             .await
         {
-            Ok(count) => counts.push(format!("{table}={count}")),
+            Ok(count) => counts.push((table, count)),
             Err(error) => {
                 let failure = format!("core table {table} cannot be read: {error}");
-                checks.push(fail_check("Core tables readable", failure.clone()));
+                checks.push(fail_check(CORE_COUNTS_CHECK, failure.clone()));
                 return Some(failure);
             }
         }
     }
-    checks.push(pass_check("Core tables readable", counts.join(", ")));
+    checks.push(pass_check(CORE_COUNTS_CHECK, render_core_counts(&counts)));
 
-    match sqlx::query_scalar::<Sqlite, i64>("SELECT COUNT(*) FROM schema_version;")
-        .fetch_one(&pool)
-        .await
+    push_core_count_baseline_check(runtime_root, &counts, checks);
+
+    push_schema_version_check(&pool, checks).await
+}
+
+/// The row count alone cannot tell a good backup from one written by a build
+/// this binary cannot read, so report the version *value* and compare it with
+/// the version this build migrates to.
+async fn push_schema_version_check(
+    pool: &sqlx::Pool<Sqlite>,
+    checks: &mut Vec<RestoreDrillCheck>,
+) -> Option<String> {
+    let version = match sqlx::query_scalar::<Sqlite, i64>(
+        "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1;",
+    )
+    .fetch_optional(pool)
+    .await
     {
-        Ok(count) => {
-            checks.push(pass_check(
-                "Schema version readable",
-                format!("{count} rows"),
-            ));
-            None
+        Ok(Some(version)) => version,
+        Ok(None) => {
+            let failure = "schema_version table has no row".to_string();
+            checks.push(fail_check("Schema version", failure.clone()));
+            return Some(failure);
         }
         Err(error) => {
             let failure = format!("schema_version cannot be read: {error}");
-            checks.push(fail_check("Schema version readable", failure.clone()));
-            Some(failure)
+            checks.push(fail_check("Schema version", failure.clone()));
+            return Some(failure);
         }
+    };
+
+    let expected = i64::from(crate::db::LATEST_SCHEMA_VERSION);
+    if version == expected {
+        checks.push(pass_check(
+            "Schema version",
+            format!("{version}, matches this build"),
+        ));
+        None
+    } else if version < expected {
+        // Normal for an older backup: the app migrates it forward on restore.
+        checks.push(pass_check(
+            "Schema version",
+            format!("{version}, older than this build ({expected}); restore migrates it forward"),
+        ));
+        None
+    } else {
+        let failure = format!(
+            "backup schema is {version} but this build only migrates to {expected}; \
+             this build cannot restore the backup without losing data"
+        );
+        checks.push(fail_check("Schema version", failure.clone()));
+        Some(failure)
     }
 }
 
@@ -589,6 +693,114 @@ fn create_temp_workspace(now: NaiveDateTime) -> io::Result<TempWorkspace> {
         io::ErrorKind::AlreadyExists,
         "cannot allocate unique temporary drill workspace",
     ))
+}
+
+fn render_core_counts(counts: &[(&str, i64)]) -> String {
+    counts
+        .iter()
+        .map(|(table, count)| format!("{table}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// "Opens cleanly" says nothing about whether the backup still holds the data
+/// it held last week. Compare against the previous drill so a truncated or
+/// reset database is visible instead of silently passing every check.
+///
+/// A drop is a WARN, not a FAIL: rooms and guests legitimately shrink when the
+/// hotel is reconfigured, and a drill that goes red on ordinary edits is a
+/// drill people learn to ignore.
+fn push_core_count_baseline_check(
+    runtime_root: &Path,
+    counts: &[(&str, i64)],
+    checks: &mut Vec<RestoreDrillCheck>,
+) {
+    let Some((previous_report, previous)) = previous_core_counts(runtime_root) else {
+        checks.push(pass_check(
+            "Core table baseline",
+            "no previous drill report to compare against",
+        ));
+        return;
+    };
+
+    let mut drops = Vec::new();
+    let mut compared = 0usize;
+    for (table, count) in counts {
+        let Some(before) = previous
+            .iter()
+            .find(|(name, _)| name == table)
+            .map(|(_, value)| *value)
+        else {
+            continue;
+        };
+        compared += 1;
+        if *count < before {
+            drops.push(format!("{table} {before}->{count}"));
+        }
+    }
+
+    if compared == 0 {
+        checks.push(pass_check(
+            "Core table baseline",
+            format!("no comparable counts in {previous_report}"),
+        ));
+    } else if drops.is_empty() {
+        checks.push(pass_check(
+            "Core table baseline",
+            format!("no table shrank since {previous_report}"),
+        ));
+    } else {
+        checks.push(warn_check(
+            "Core table baseline",
+            format!("shrank since {previous_report}: {}", drops.join(", ")),
+        ));
+    }
+}
+
+/// Newest existing report in `restore-drills/`, with its core-table counts.
+/// The current run has not written its own report yet, so the newest file on
+/// disk is the previous drill.
+fn previous_core_counts(runtime_root: &Path) -> Option<(String, Vec<(String, i64)>)> {
+    let report_dir = runtime_root.join("restore-drills");
+    let mut newest: Option<String> = None;
+    for entry in fs::read_dir(&report_dir).ok()? {
+        let entry = entry.ok()?;
+        if !entry.file_type().ok()?.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        if !file_name.starts_with(REPORT_PREFIX) || !file_name.ends_with(REPORT_SUFFIX) {
+            continue;
+        }
+        // Report names embed a zero-padded timestamp, so byte order is time order.
+        let is_newer = match newest.as_ref() {
+            Some(current) => &file_name > current,
+            None => true,
+        };
+        if is_newer {
+            newest = Some(file_name);
+        }
+    }
+
+    let file_name = newest?;
+    let contents = fs::read_to_string(report_dir.join(&file_name)).ok()?;
+    let counts = parse_core_counts(&contents)?;
+    Some((file_name, counts))
+}
+
+fn parse_core_counts(report: &str) -> Option<Vec<(String, i64)>> {
+    let row = report
+        .lines()
+        .find(|line| line.starts_with(&format!("| {CORE_COUNTS_CHECK} |")))?;
+    let detail = row.split('|').nth(3)?.trim();
+    let counts = detail
+        .split(',')
+        .filter_map(|pair| {
+            let (table, count) = pair.trim().split_once('=')?;
+            Some((table.to_string(), count.trim().parse::<i64>().ok()?))
+        })
+        .collect::<Vec<_>>();
+    (!counts.is_empty()).then_some(counts)
 }
 
 fn write_report(runtime_root: &Path, now: NaiveDateTime, report: &str) -> io::Result<PathBuf> {
@@ -781,6 +993,10 @@ mod tests {
     }
 
     async fn create_valid_backup(path: &Path) {
+        create_valid_backup_with_version(path, 10).await;
+    }
+
+    async fn create_valid_backup_with_version(path: &Path, schema_version: i64) {
         let options = SqliteConnectOptions::new()
             .filename(path)
             .create_if_missing(true);
@@ -798,10 +1014,15 @@ mod tests {
             "CREATE TABLE audit_logs (id TEXT PRIMARY KEY, action TEXT NOT NULL)",
             "CREATE TABLE schema_version (version INTEGER NOT NULL DEFAULT 0)",
             "INSERT INTO guests (id, full_name) VALUES ('guest-1', 'Alice Example')",
-            "INSERT INTO schema_version (version) VALUES (10)",
         ] {
             sqlx::query(statement).execute(&pool).await.unwrap();
         }
+
+        sqlx::query("INSERT INTO schema_version (version) VALUES (?)")
+            .bind(schema_version)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     async fn create_incomplete_backup(path: &Path) {
@@ -1002,5 +1223,293 @@ mod tests {
             fs::read_to_string(existing_report).unwrap(),
             "existing report"
         );
+    }
+
+    #[tokio::test]
+    async fn drill_fails_when_newest_backup_is_older_than_the_age_limit() {
+        let temp = make_temp_dir("restore-drill-stale");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260401_110000.db")).await;
+
+        // 25 days after the newest backup: the backup chain has clearly stopped.
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 0, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Fail);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("Backup freshness"));
+        assert!(report.contains("25d old"));
+        // The stale file is still validated, so its readability is on record.
+        assert!(report.contains("| Integrity check | PASS"));
+    }
+
+    #[tokio::test]
+    async fn drill_passes_when_newest_backup_is_within_the_age_limit() {
+        let temp = make_temp_dir("restore-drill-fresh");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260425_110000.db")).await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 0, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("| Backup freshness | PASS | 24h old, within 7 days |"));
+    }
+
+    #[tokio::test]
+    async fn drill_passes_on_the_last_day_inside_the_age_limit() {
+        let temp = make_temp_dir("restore-drill-fresh-boundary");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        // Exactly seven days old: at the limit, not over it.
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260419_110000.db")).await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 0, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("| Backup freshness | PASS | 7d old"));
+    }
+
+    #[tokio::test]
+    async fn drill_exempts_an_explicitly_named_backup_from_the_age_limit() {
+        let temp = make_temp_dir("restore-drill-explicit-age");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        let ancient = backup_dir.join("capyinn_backup_manual_20260101_110000.db");
+        create_valid_backup(&ancient).await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: Some(ancient),
+            now: Some(fixed_time(2026, 4, 26, 11, 0, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("skipped: backup was named explicitly"));
+    }
+
+    #[tokio::test]
+    async fn drill_reports_the_schema_version_value_not_the_row_count() {
+        let temp = make_temp_dir("restore-drill-schema-value");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup_with_version(
+            &backup_dir.join("capyinn_backup_scheduled_20260426_110000.db"),
+            i64::from(crate::db::LATEST_SCHEMA_VERSION),
+        )
+        .await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains(&format!(
+            "| Schema version | PASS | {}, matches this build |",
+            crate::db::LATEST_SCHEMA_VERSION
+        )));
+    }
+
+    #[tokio::test]
+    async fn drill_passes_when_backup_schema_is_older_than_this_build() {
+        let temp = make_temp_dir("restore-drill-schema-older");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup_with_version(
+            &backup_dir.join("capyinn_backup_scheduled_20260426_110000.db"),
+            1,
+        )
+        .await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("restore migrates it forward"));
+    }
+
+    #[tokio::test]
+    async fn drill_fails_when_backup_schema_is_newer_than_this_build() {
+        let temp = make_temp_dir("restore-drill-schema-newer");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup_with_version(
+            &backup_dir.join("capyinn_backup_scheduled_20260426_110000.db"),
+            i64::from(crate::db::LATEST_SCHEMA_VERSION) + 1,
+        )
+        .await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Fail);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("cannot restore the backup without losing data"));
+    }
+
+    #[tokio::test]
+    async fn drill_fails_when_schema_version_table_is_empty() {
+        let temp = make_temp_dir("restore-drill-schema-empty");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        let backup = backup_dir.join("capyinn_backup_scheduled_20260426_110000.db");
+        create_valid_backup(&backup).await;
+
+        let options = SqliteConnectOptions::new().filename(&backup);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM schema_version")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Fail);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("schema_version table has no row"));
+    }
+
+    #[tokio::test]
+    async fn drill_warns_when_a_core_table_shrank_since_the_previous_drill() {
+        let temp = make_temp_dir("restore-drill-baseline-shrink");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260426_110000.db")).await;
+
+        let report_dir = temp.path().join("restore-drills");
+        fs::create_dir_all(&report_dir).unwrap();
+        fs::write(
+            report_dir.join("restore-drill-20260419_110000.md"),
+            "| Core tables readable | PASS | settings=0, rooms=0, guests=9, bookings=0, audit_logs=0, schema_version=1 |\n",
+        )
+        .unwrap();
+
+        // The fixture backup holds a single guest, down from nine.
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        // A shrinking table is worth a human glance, not a red drill.
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("| Core table baseline | WARN |"));
+        assert!(report.contains("guests 9->1"));
+    }
+
+    #[tokio::test]
+    async fn drill_passes_the_baseline_check_when_nothing_shrank() {
+        let temp = make_temp_dir("restore-drill-baseline-steady");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260426_110000.db")).await;
+
+        let report_dir = temp.path().join("restore-drills");
+        fs::create_dir_all(&report_dir).unwrap();
+        fs::write(
+            report_dir.join("restore-drill-20260419_110000.md"),
+            "| Core tables readable | PASS | guests=1, bookings=0 |\n",
+        )
+        .unwrap();
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("| Core table baseline | PASS | no table shrank since restore-drill-20260419_110000.md |"));
+    }
+
+    #[tokio::test]
+    async fn drill_notes_when_there_is_no_previous_drill_to_compare() {
+        let temp = make_temp_dir("restore-drill-baseline-first");
+        let backup_dir = temp.path().join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        create_valid_backup(&backup_dir.join("capyinn_backup_scheduled_20260426_110000.db")).await;
+
+        let result = run_restore_drill(RestoreDrillOptions {
+            runtime_root: Some(temp.path().to_path_buf()),
+            backup_path: None,
+            now: Some(fixed_time(2026, 4, 26, 11, 30, 0)),
+        })
+        .await;
+
+        assert_eq!(result.status, RestoreDrillStatus::Pass);
+        let report = fs::read_to_string(result.report_path.expect("writes report")).unwrap();
+        assert!(report.contains("no previous drill report to compare against"));
+    }
+
+    #[test]
+    fn previous_core_counts_reads_the_newest_report() {
+        let temp = make_temp_dir("restore-drill-baseline-newest");
+        let report_dir = temp.path().join("restore-drills");
+        fs::create_dir_all(&report_dir).unwrap();
+        fs::write(
+            report_dir.join("restore-drill-20260419_110000.md"),
+            "| Core tables readable | PASS | guests=9 |\n",
+        )
+        .unwrap();
+        fs::write(
+            report_dir.join("restore-drill-20260425_110000.md"),
+            "| Core tables readable | PASS | guests=11 |\n",
+        )
+        .unwrap();
+
+        let (file_name, counts) = previous_core_counts(temp.path()).expect("finds a report");
+        assert_eq!(file_name, "restore-drill-20260425_110000.md");
+        assert_eq!(counts, vec![("guests".to_string(), 11)]);
+    }
+
+    #[test]
+    fn parse_core_counts_ignores_a_report_without_the_row() {
+        assert!(parse_core_counts("# Restore Drill Report\n\nStatus: PASS\n").is_none());
     }
 }


### PR DESCRIPTION
## Vì sao

Drill hiện tại chứng minh **một file backup nào đó mở được**. Nó không chứng minh **chuỗi backup còn sống** hay **bản build này phục hồi được file đó**. Chạy thật ngày 30/07 ra PASS, nhưng cái PASS đó sẽ y hệt nếu app đã ngừng backup ba tuần trước.

Ba lỗ hổng, ba assertion.

## Thay đổi

**1. Tuổi backup (`Backup freshness`)** — backup tự chọn mà cũ hơn 7 ngày thì FAIL. Trước đây drill lấy file mới nhất bất kể nó cũ cỡ nào. File cũ vẫn được validate đầy đủ để biết nó có đọc được không, nhưng run vẫn đỏ. Backup chỉ định thẳng bằng tham số thì được miễn — soi một file cũ có chủ đích là việc hợp lệ.

**2. Phiên bản schema (`Schema version`)** — báo cáo cũ in `schema_version=1`, đó là **số dòng**, không phải số phiên bản. Giờ đọc đúng giá trị và so với version mà build này migrate tới:

| Tình huống | Kết quả |
|---|---|
| bằng nhau | PASS |
| backup **cũ hơn** build | PASS — restore sẽ migrate tiến lên, đây là bình thường |
| backup **mới hơn** build | FAIL — build này phục hồi sẽ mất dữ liệu |

**3. Baseline số dòng (`Core table baseline`)** — so số dòng các bảng lõi với báo cáo drill trước đó. Trước đây không có gì so sánh, nên một DB bị cắt cụt hay reset vẫn qua sạch mọi check.

Bảng co lại là **WARN, không phải FAIL** — `rooms`/`guests` co lại là chuyện thường khi cấu hình lại khách sạn, và một drill đỏ vì thao tác bình thường là drill người ta tập cho mình thói quen bỏ qua.

`LATEST_SCHEMA_VERSION` thay số 22 hardcode trong test migration, nên thêm migration mới là buộc phải bump — chính con số drill đọc.

## Kết quả chạy thật

Chạy trên dữ liệu thật, PR này **FAIL** — và đó là một phát hiện đúng:

```
| Backup freshness      | PASS | 16h old, within 7 days
| Core table baseline   | PASS | no table shrank since restore-drill-20260730_005820.md
| Schema version        | FAIL | backup schema is 23 but this build only
                                 migrates to 22; this build cannot restore
                                 the backup without losing data
```

Migration v23 hiện chỉ nằm trên nhánh chưa merge `design/kbtt-ux-simplify`. Nghĩa là **app đang chạy phục vụ khách sạn đi trước `main` một migration, và mọi backup sinh ra lúc này không bản build nào từ `main` phục hồi được.** Đây đúng là loại rủi ro drill sinh ra để bắt. Drill sẽ xanh trở lại khi v23 về `main`.

## Kiểm chứng

- `cargo test` — 963 pass, 0 fail
- `cargo clippy --all-targets -- -D warnings` — sạch
- `cargo fmt --check` — sạch
- 12 test mới; mỗi assertion đã mutation-test: tắt từng điều kiện thì **đúng** test tương ứng đỏ, không lan sang test khác

🤖 Generated with [Claude Code](https://claude.com/claude-code)
