### PR TITLE
Mùa cao điểm: khai theo khoảng ngày, và tính đúng từng đêm

### DIFF
--- a/docs/superpowers/plans/2026-07-29-mua-cao-diem.md
+++ b/docs/superpowers/plans/2026-07-29-mua-cao-diem.md
@@ -1,0 +1,2371 @@
+# Mùa cao điểm — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Chủ khách sạn khai được mùa cao điểm theo khoảng ngày, và engine tính phụ thu đúng theo từng đêm nằm trong mùa thay vì nhìn mỗi ngày nhận phòng.
+
+**Architecture:** Engine giữ nguyên `crate::pricing::calculate_price` với tham số `f64` cũ; tầng `domain` quy đổi danh sách ngày lễ của kỳ ở thành **một mức bình quân** rồi truyền vào. Tầng `queries` đọc cả khoảng thay vì một ngày. Đường ghi mới đi `command → service → repository` trong một transaction. Giao diện là một mục Cài đặt mới, gom ngày liền nhau thành khoảng khi hiển thị.
+
+**Tech Stack:** Rust + sqlx/SQLite + Tauri 2 (backend); React 18 + TypeScript + Vitest + shadcn/ui + sonner (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md` — đọc trước khi làm task đầu tiên.
+
+**Worktree:** `/Users/binhan/HotelManager/.worktrees/peak-season`, nhánh `feature/peak-season`. Mọi đường dẫn dưới đây tính từ `mhm/` trong worktree đó.
+
+## Global Constraints
+
+- **Tiền là số nguyên VND.** `MoneyVnd = i64`. Không có `f64` nào chạm vào tiền. `uplift_pct` là phần trăm, **không phải tiền** — nó vẫn là `f64` như hiện tại.
+- **Tầng lối đi cho ghi:** `UI → command → service → repository → SQLite`. Không lệnh nào được cầm `Transaction<'_, Sqlite>`. `architecture_guard.rs:244` **không** bắt được vi phạm này, nên đừng lấy test xanh làm bằng chứng.
+- **Tầng lối đi cho đọc:** `UI → command → query → SQLite`.
+- **`domain/`, `queries/`, `repositories/`, `services/` không bao giờ import `crate::commands`.**
+- **Ngày dạng `YYYY-MM-DD` so sánh bằng chuỗi.** Không dùng `new Date("2026-02-14T00:00:00")` ở TypeScript — nó phân tích theo giờ địa phương rồi in ra UTC, lệch một ngày ở UTC+7.
+- **Cắt chuỗi ngày bằng `get(..10)`**, không bao giờ `&s[..10]` — cắt theo byte sẽ panic với ký tự nhiều byte.
+- **Chặn đầu vào nằm ở service**, trả `CommandError::user(codes::VALIDATION_INVALID_INPUT, …)` với thông điệp tiếng Việt.
+- **Trần:** khoảng ≤ 366 ngày; `0 <= uplift_pct <= 500`.
+- **Test Rust khẳng định trên `surcharge_amount`**, không phải `total`, và fixture phải đặt `weekend_uplift_pct = 0` — xem Task 2 Bước 1.
+- **Chạy `cargo fmt` trước mỗi lần commit backend.** CI gác `cargo fmt --check` nhưng `verify:full` không chạy nó.
+
+---
+
+## File Structure
+
+| File | Trách nhiệm | Task |
+|---|---|---|
+| `src-tauri/src/queries/booking/pricing_queries.rs` | `date_key` an toàn; đọc ngày lễ cả khoảng | 1, 2 |
+| `src-tauri/src/domain/booking/pricing.rs` | kiểu `SpecialDay`; quy tắc bình quân | 2 |
+| `src-tauri/src/repositories/booking/pricing_repository.rs` | ghi/xoá một dòng `special_dates` trong transaction | 3 |
+| `src-tauri/src/services/booking/pricing_service.rs` | chặn đầu vào, mở transaction, trải khoảng | 4, 5 |
+| `src-tauri/src/commands/pricing.rs` | `require_admin`, sinh `id`/`now`, `emit_db_update` | 3, 4, 5 |
+| `src-tauri/src/lib.rs` | đăng ký lệnh | 3, 4, 5 |
+| `src/lib/specialDateRanges.ts` | **mới** — gom cụm và dò trùng, thuần, không React | 6 |
+| `src/pages/settings/SpecialDatesSection.tsx` | **mới** — màn hình khai báo | 7 |
+| `src/pages/settings/index.tsx` | thêm mục vào thanh bên | 7 |
+| `src/__mocks__/tauri-core.ts` | mock hai lệnh mới | 7 |
+| `tests/frontend-invoke-wrapper-guardrails.test.ts` | cho phép `get_special_dates` gọi trần | 7 |
+
+---
+
+### Task 1: `date_key` không được panic
+
+Task nhỏ nhất và độc lập nhất. Làm trước vì Task 2 cho `date_key` ăn **hai** chuỗi thay vì một, tăng gấp đôi phơi nhiễm với lỗi này.
+
+**Files:**
+- Modify: `src-tauri/src/queries/booking/pricing_queries.rs:72-78`
+- Test: cùng file, trong `mod tests`
+
+**Interfaces:**
+- Consumes: không có
+- Produces: `fn date_key(date_str: &str) -> &str` — chữ ký không đổi, chỉ đổi ruột
+
+- [ ] **Bước 1: Thêm test đỏ**
+
+Thêm vào `mod tests` ở cuối `pricing_queries.rs`. Trong khối `use super::{…}` của module test, thêm `date_key` vào danh sách import.
+
+```rust
+    #[test]
+    fn date_key_does_not_panic_when_byte_ten_splits_a_character() {
+        // Chín ký tự ASCII rồi một ký tự hai byte: byte thứ 10 rơi vào giữa
+        // ký tự ấy. `&value[..10]` sẽ panic ở đây.
+        let value = "123456789é";
+
+        assert_eq!(date_key(value), value);
+    }
+```
+
+- [ ] **Bước 2: Chạy test cho thấy nó đỏ**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib date_key_does_not_panic -- --nocapture
+```
+
+Kỳ vọng: **FAIL**, panic với thông điệp kiểu `byte index 10 is not a char boundary`.
+
+- [ ] **Bước 3: Sửa `date_key`**
+
+Thay toàn bộ thân hàm ở `pricing_queries.rs:72-78`:
+
+```rust
+/// `special_dates.date` is a bare `YYYY-MM-DD`, so an RFC3339 check-in has to
+/// be truncated before it will match.
+///
+/// Cắt bằng `get` chứ không phải `&value[..10]`: chuỗi đến từ dữ liệu người
+/// dùng, và cắt theo byte sẽ panic nếu byte thứ mười rơi vào giữa một ký tự
+/// nhiều byte. Tầng domain đã vá đúng lỗi này ở `nights_between`.
+fn date_key(date_str: &str) -> &str {
+    date_str.get(..10).unwrap_or(date_str)
+}
+```
+
+- [ ] **Bước 4: Chạy lại cho xanh**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib date_key_does_not_panic
+```
+
+Kỳ vọng: **PASS**, `test result: ok. 1 passed`.
+
+- [ ] **Bước 5: Chạy cả module để chắc không vỡ gì**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib pricing_queries
+```
+
+Kỳ vọng: PASS toàn bộ, không có warning mới.
+
+- [ ] **Bước 6: Commit**
+
+```bash
+cd mhm/src-tauri && cargo fmt
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src-tauri/src/queries/booking/pricing_queries.rs
+git commit -m "fix(pricing): stop date_key panicking on a multi-byte boundary
+
+It byte-sliced a string that comes from user data. The domain layer was
+hardened against exactly this; the query layer was not, and the peak-season
+change is about to feed it a second string."
+```
+
+---
+
+### Task 2: Phụ thu ngày lễ tính theo từng đêm
+
+Đây là **toàn bộ** thay đổi luật giá, trong một đơn vị biên dịch được. Đổi kiểu trong `domain` thì `queries` phải đổi theo cùng lúc, không tách được.
+
+**Files:**
+- Modify: `src-tauri/src/domain/booking/pricing.rs` (struct `StayPricingInputs`, `nights_between`, `calculate_from_loaded_inputs`, `mod tests`)
+- Modify: `src-tauri/src/queries/booking/pricing_queries.rs` (hằng SQL, hai loader, ba chỗ dựng `StayPricingInputs`, `mod tests`)
+
+**Interfaces:**
+- Consumes: `date_key` từ Task 1
+- Produces:
+  - `pub(crate) struct SpecialDay { pub(crate) date: String, pub(crate) uplift_pct: f64 }` trong `domain::booking::pricing`
+  - `StayPricingInputs.special_days: Vec<SpecialDay>` thay cho `special_uplift_pct: f64`
+  - `fn date_only(value: &str) -> BookingResult<NaiveDate>` (riêng tư trong domain)
+  - `fn effective_special_uplift(inputs: &StayPricingInputs) -> BookingResult<f64>` (riêng tư trong domain)
+
+- [ ] **Bước 1: Sửa fixture test trước, và hiểu vì sao**
+
+Trong `domain/booking/pricing.rs`, `mod tests`, hàm `sample_inputs()`: đổi `special_uplift_pct: 0.0` thành `special_days: Vec::new()`, và **thêm** một `stored_rule` có `weekend_uplift_pct: 0.0`.
+
+Vì sao phải thêm `stored_rule`: `sample_inputs()` đang để `stored_rule: None`, nên `build_effective_pricing_rule` rơi xuống `..Default::default()`, tức `weekend_uplift_pct: 20.0` (`pricing.rs:46`). Mà **mọi** ngày trong các test dưới đây đều đụng cuối tuần — 14/02 và 15/02/2026 là thứ Bảy và Chủ nhật, 21/02 và 22/02 cũng vậy. Để mặc 20% thì `total` gánh thêm phụ thu cuối tuần và mọi con số sai hết.
+
+```rust
+    /// Giá 500k một đêm, **không** phụ thu cuối tuần. Bỏ `weekend_uplift_pct`
+    /// đi là mọi con số trong các test ngày lễ dưới đây sai, vì `sample_inputs`
+    /// không có `stored_rule` sẽ rơi xuống mặc định 20% của `PricingRule`.
+    fn holiday_rule() -> StoredPricingRule {
+        StoredPricingRule {
+            room_type: "standard".to_string(),
+            hourly_rate: 20_000,
+            overnight_rate: 300_000,
+            daily_rate: 500_000,
+            overnight_start: "22:00".to_string(),
+            overnight_end: "11:00".to_string(),
+            daily_checkin: "14:00".to_string(),
+            daily_checkout: "12:00".to_string(),
+            early_checkin_surcharge_pct: 0.0,
+            late_checkout_surcharge_pct: 0.0,
+            weekend_uplift_pct: 0.0,
+        }
+    }
+
+    fn special(date: &str, uplift_pct: f64) -> SpecialDay {
+        SpecialDay { date: date.to_string(), uplift_pct }
+    }
+
+    /// Tết 14/02–22/02 +40%, đúng khai báo dùng chung cho các test dưới.
+    fn tet_2026() -> Vec<SpecialDay> {
+        (14..=22)
+            .map(|day| special(&format!("2026-02-{day:02}"), 40.0))
+            .collect()
+    }
+```
+
+Sửa `sample_inputs()`:
+
+```rust
+    fn sample_inputs() -> StayPricingInputs {
+        StayPricingInputs {
+            room_type: "standard".to_string(),
+            stored_rule: None,
+            fallback_base_price: None,
+            special_days: Vec::new(),
+            check_in: "2026-04-20".to_string(),
+            check_out: "2026-04-22".to_string(),
+            pricing_type: "nightly".to_string(),
+            guests: None,
+            base_guests: 2,
+            extra_person_fee: 0,
+        }
+    }
+```
+
+Trong `use super::{…}` của `mod tests`, thêm `SpecialDay`.
+
+Hai test cũ đang gán `inputs.special_uplift_pct = 10.0` (`domain/booking/pricing.rs:256` và `:362`) — đổi thành:
+
+```rust
+        inputs.special_days = vec![special("2026-04-20", 10.0), special("2026-04-21", 10.0)];
+```
+
+Kỳ ở của `sample_inputs` là 20/04→22/04, tức hai đêm 20 và 21. Khai cả hai đêm ở 10% cho mức bình quân đúng bằng 10%, nên hai test cũ giữ nguyên con số kỳ vọng.
+
+- [ ] **Bước 2: Viết các test đỏ cho luật mới**
+
+Thêm vào `mod tests` của `domain/booking/pricing.rs`:
+
+```rust
+    #[test]
+    fn special_uplift_covers_only_the_nights_inside_the_season() {
+        // 12/02→16/02 là bốn đêm 12,13,14,15. Tết phủ 14 và 15.
+        // Hôm nay engine nhìn mỗi ngày đến 12/02 rồi báo 0₫.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.check_in = "2026-02-12".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 2 đêm × 500.000 × 40% = 400.000
+        assert_eq!(pricing.surcharge_amount, 400_000);
+    }
+
+    #[test]
+    fn special_uplift_stops_at_the_end_of_the_season() {
+        // 22/02→25/02 là ba đêm 22,23,24. Chỉ đêm 22 còn trong Tết.
+        // Hôm nay engine thấy ngày đến 22/02 là lễ rồi tính 40% cho cả ba đêm.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.check_in = "2026-02-22".to_string();
+        inputs.check_out = "2026-02-25".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 1 đêm × 500.000 × 40% = 200.000, không phải 600.000
+        assert_eq!(pricing.surcharge_amount, 200_000);
+    }
+
+    #[test]
+    fn special_uplift_spans_two_different_seasons() {
+        // 20/02→25/02 là năm đêm. Tết +40% ba đêm 20,21,22; Hè +25% hai đêm 23,24.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026()
+            .into_iter()
+            .chain([special("2026-02-23", 25.0), special("2026-02-24", 25.0)])
+            .collect();
+        inputs.check_in = "2026-02-20".to_string();
+        inputs.check_out = "2026-02-25".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // Mức bình quân (40×3 + 25×2)/5 = 34%. base = 5 × 500.000 = 2.500.000.
+        // 2.500.000 × 34% = 850.000 = 3×200.000 + 2×125.000.
+        assert_eq!(pricing.base_amount, 2_500_000);
+        assert_eq!(pricing.surcharge_amount, 850_000);
+    }
+
+    #[test]
+    fn special_uplift_is_unchanged_for_a_stay_entirely_inside_the_season() {
+        // Chống hồi quy: kỳ ở nằm trọn trong mùa phải ra y như luật cũ.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.check_in = "2026-02-15".to_string();
+        inputs.check_out = "2026-02-18".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // Cả ba đêm 15,16,17 đều là Tết → vẫn đúng 40% trên toàn bộ base.
+        assert_eq!(pricing.base_amount, 1_500_000);
+        assert_eq!(pricing.surcharge_amount, 600_000);
+    }
+
+    #[test]
+    fn no_special_days_means_no_surcharge() {
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.check_in = "2026-02-12".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.surcharge_amount, 0);
+    }
+
+    #[test]
+    fn hourly_stay_within_one_day_is_unchanged() {
+        // N = 1, mức bình quân bằng đúng mức của ngày ấy. Kết quả như luật cũ.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.pricing_type = "hourly".to_string();
+        inputs.check_in = "2026-02-14T08:00:00".to_string();
+        inputs.check_out = "2026-02-14T13:00:00".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 5 giờ × 20.000 = 100.000; 100.000 × 40% = 40.000.
+        assert_eq!(pricing.base_amount, 100_000);
+        assert_eq!(pricing.surcharge_amount, 40_000);
+    }
+
+    #[test]
+    fn hourly_stay_across_two_days_is_prorated_and_this_is_a_deliberate_change() {
+        // Ngoại lệ đã ghi trong spec: `base` của kiểu giờ không tính theo đêm,
+        // nên chia đều theo ngày là cách phân bổ duy nhất có nghĩa. Trước khi
+        // sửa, kỳ ở này ra 0₫ vì ngày đến 13/02 chưa khai.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.pricing_type = "hourly".to_string();
+        inputs.check_in = "2026-02-13T20:00:00".to_string();
+        inputs.check_out = "2026-02-15T02:00:00".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 30 giờ × 20.000 = 600.000, không chạm trần nào.
+        // Hai ngày lịch 13 và 14; (0 + 40)/2 = 20% → 120.000.
+        assert_eq!(pricing.base_amount, 600_000);
+        assert_eq!(pricing.surcharge_amount, 120_000);
+    }
+
+    #[test]
+    fn a_holiday_that_falls_on_a_weekend_still_charges_both() {
+        // Khoá hành vi hiện có: hai phụ thu cộng dồn, không cái nào nuốt cái
+        // nào. Đây là quyết định về giá, đổi nó không thuộc phạm vi đợt này.
+        // Chú ý fixture: test này là chỗ DUY NHẤT cố ý bật phụ thu cuối tuần.
+        let mut rule = holiday_rule();
+        rule.weekend_uplift_pct = 20.0;
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(rule);
+        inputs.special_days = tet_2026();
+        // 14/02/2026 là thứ Bảy, 15/02 là Chủ nhật — hai đêm, cả hai đều cuối
+        // tuần và cả hai đều trong Tết.
+        inputs.check_in = "2026-02-14".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.base_amount, 1_000_000);
+        assert_eq!(pricing.weekend_amount, 200_000, "2 đêm × 500.000 × 20%");
+        assert_eq!(pricing.surcharge_amount, 400_000, "2 đêm × 500.000 × 40%");
+        assert_eq!(pricing.total, 1_600_000, "cả hai phụ thu đều được cộng");
+    }
+
+    #[test]
+    fn a_malformed_stored_date_simply_never_matches() {
+        // Cột `date` không có ràng buộc CHECK, nên rác là có thật. Tính chất
+        // "coi như không khai" tự có từ việc so sánh chuỗi — đừng thêm đường
+        // phân tích-rồi-báo-lỗi, làm thế là đổi đúng hành vi test này khoá.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = vec![special("khong-phai-ngay", 40.0)];
+        inputs.check_in = "2026-02-12".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.surcharge_amount, 0);
+    }
+```
+
+- [ ] **Bước 3: Chạy cho thấy đỏ vì lý do đúng**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib domain::booking::pricing 2>&1 | head -40
+```
+
+Kỳ vọng: **FAIL biên dịch** — `no field 'special_days' on type 'StayPricingInputs'`, `cannot find function 'special'`, `cannot find type 'SpecialDay'`. Đây là đỏ đúng: kiểu chưa tồn tại.
+
+- [ ] **Bước 4: Thêm kiểu `SpecialDay` và đổi trường**
+
+Trong `domain/booking/pricing.rs`, trong `struct StayPricingInputs`, thay dòng `pub(crate) special_uplift_pct: f64,` bằng:
+
+```rust
+    /// Những ngày trong khoảng kỳ ở đã được khai là mùa cao điểm. Ngày không
+    /// khai thì không có mặt. Rỗng nghĩa là không phụ thu.
+    pub(crate) special_days: Vec<SpecialDay>,
+```
+
+Ngay sau `struct StayPricingInputs`, thêm:
+
+```rust
+/// Một ngày đã khai là mùa cao điểm.
+///
+/// Định nghĩa ở đây chứ không mượn `queries::booking::pricing_queries::SpecialDate`:
+/// chiều phụ thuộc là queries → domain, và `architecture_guard` giữ chiều ấy.
+#[derive(Debug, Clone)]
+pub(crate) struct SpecialDay {
+    /// `YYYY-MM-DD` đúng như nằm trong cột `special_dates.date`.
+    pub(crate) date: String,
+    pub(crate) uplift_pct: f64,
+}
+```
+
+- [ ] **Bước 5: Tách `date_only` rồi viết `effective_special_uplift`**
+
+Thay `nights_between` (hiện ở `domain/booking/pricing.rs:86-95`) bằng hai hàm:
+
+```rust
+/// Ngày lịch của một mốc thời gian.
+///
+/// Cắt bằng `get` chứ không phải `&value[..10]`: một chuỗi nhiều byte sẽ làm
+/// bản cắt theo byte panic.
+fn date_only(value: &str) -> BookingResult<NaiveDate> {
+    let head = value.get(..10).unwrap_or(value);
+    NaiveDate::parse_from_str(head, "%Y-%m-%d")
+        .map_err(|error| BookingError::datetime_parse(error.to_string()))
+}
+
+pub(crate) fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
+    Ok((date_only(check_out)? - date_only(check_in)?)
+        .num_days()
+        .max(0))
+}
+```
+
+Thêm ngay sau đó:
+
+```rust
+/// Mức uplift bình quân trên số ngày của kỳ ở.
+///
+/// Nhân mức này với `base` là chia đều `base` cho từng ngày rồi cho mỗi ngày
+/// chịu mức của riêng nó: `base × (Σ pct_d / N) = Σ ((base/N) × pct_d)`.
+///
+/// Với `nightly`/`overnight`/`daily`, `base/N` đúng bằng giá một đêm đã cấu
+/// hình, nên kết quả **là** "từng đêm chịu mức của nó". Với `hourly` thì `base`
+/// không tính theo đêm và đây là phép phân bổ theo ngày — cố ý, xem spec
+/// `2026-07-29-mua-cao-diem-design.md`.
+///
+/// Đi từng ngày y hệt `crate::pricing::calculate_weekend_uplift`, nên phụ thu
+/// cuối tuần và phụ thu ngày lễ không bao giờ bất đồng về việc một kỳ ở gồm
+/// những ngày nào.
+fn effective_special_uplift(inputs: &StayPricingInputs) -> BookingResult<f64> {
+    if inputs.special_days.is_empty() {
+        return Ok(0.0);
+    }
+
+    let check_in = date_only(&inputs.check_in)?;
+    let check_out = date_only(&inputs.check_out)?;
+    let total_days = (check_out - check_in).num_days().max(1);
+
+    let mut total_pct = 0.0;
+    let mut date = check_in;
+    for _ in 0..total_days {
+        let key = date.format("%Y-%m-%d").to_string();
+        if let Some(day) = inputs.special_days.iter().find(|day| day.date == key) {
+            total_pct += day.uplift_pct;
+        }
+        date = date.succ_opt().unwrap_or(date);
+    }
+
+    Ok(total_pct / total_days as f64)
+}
+```
+
+Trong `calculate_from_loaded_inputs`, đổi đối số cuối của `crate::pricing::calculate_price` từ `inputs.special_uplift_pct` thành `effective_special_uplift(inputs)?`:
+
+```rust
+    let mut result = crate::pricing::calculate_price(
+        &rule,
+        &inputs.check_in,
+        &inputs.check_out,
+        &inputs.pricing_type,
+        effective_special_uplift(inputs)?,
+    )
+    .map_err(BookingError::datetime_parse)?;
+```
+
+- [ ] **Bước 6: Đổi tầng đọc**
+
+Trong `queries/booking/pricing_queries.rs`:
+
+Thay hằng `SPECIAL_UPLIFT_SQL` (`:41-42`) bằng:
+
+```rust
+const SPECIAL_DAYS_IN_RANGE_SQL: &str =
+    "SELECT date, CAST(uplift_pct AS REAL) AS uplift_pct
+     FROM special_dates WHERE date >= ? AND date <= ? ORDER BY date";
+```
+
+Trong khối `use crate::domain::booking::pricing::{…}` ở đầu file, thêm `SpecialDay`.
+
+Thay `load_special_uplift` (`:311`) và `load_special_uplift_tx` (`:391`) bằng:
+
+```rust
+/// Ngày lễ trong khoảng kỳ ở.
+///
+/// Cận trên **bao gồm** ngày trả phòng. Đọc dư một ngày là cố ý: quyết định
+/// "ngày nào là một đêm" thuộc về `domain`, tầng đọc không được tự cắt.
+async fn load_special_days(
+    pool: &Pool<Sqlite>,
+    check_in: &str,
+    check_out: &str,
+) -> BookingResult<Vec<SpecialDay>> {
+    let rows: Vec<(String, f64)> = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
+        .bind(date_key(check_in))
+        .bind(date_key(check_out))
+        .fetch_all(pool)
+        .await
+        .map_err(database_error)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(date, uplift_pct)| SpecialDay { date, uplift_pct })
+        .collect())
+}
+
+async fn load_special_days_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    check_in: &str,
+    check_out: &str,
+) -> BookingResult<Vec<SpecialDay>> {
+    let rows: Vec<(String, f64)> = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
+        .bind(date_key(check_in))
+        .bind(date_key(check_out))
+        .fetch_all(&mut **tx)
+        .await
+        .map_err(database_error)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(date, uplift_pct)| SpecialDay { date, uplift_pct })
+        .collect())
+}
+```
+
+Sửa ba chỗ dựng `StayPricingInputs`, **giữ nguyên** cách xử lỗi của từng chỗ:
+
+- `load_stay_pricing_inputs_tx` (`:166`) — đường thu tiền thật, ném lỗi:
+```rust
+    let special_days = load_special_days_tx(tx, check_in, check_out).await?;
+```
+- `load_stay_pricing_inputs_for_room_type` (`:205`) — chỉ xem trước, khoan dung:
+```rust
+    let special_days = load_special_days(pool, check_in, check_out)
+        .await
+        .unwrap_or_default();
+```
+- `load_stay_pricing_inputs_for_room` (`:243`) — như trên, chép y hệt.
+
+Ở cả ba, trong phần dựng struct, đổi `special_uplift_pct,` thành `special_days,`.
+
+- [ ] **Bước 7: Chạy test domain cho xanh**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib domain::booking::pricing
+```
+
+Kỳ vọng: **PASS**, kể cả tám test mới. Nếu `special_uplift_spans_two_different_seasons` đỏ ở 199.999 thay vì 200.000, dừng lại và báo — con số ấy phụ thuộc vào chế độ làm tròn ở `money.rs:58`.
+
+- [ ] **Bước 8: Thêm test cho tầng đọc**
+
+Trong `mod tests` của `pricing_queries.rs`. Hai test hiện có đang khẳng định `inputs.special_uplift_pct` (`:551`, `:583`) — đổi chúng sang `special_days`. Bảng dựng trong test hiện là `CREATE TABLE special_dates (date TEXT PRIMARY KEY, uplift_pct REAL)` (`:365`), đủ dùng.
+
+```rust
+    #[tokio::test]
+    async fn load_special_days_returns_only_the_days_inside_the_stay() {
+        let pool = test_pool().await;
+        for (date, pct) in [
+            ("2026-02-13", 40.0),
+            ("2026-02-14", 40.0),
+            ("2026-02-15", 40.0),
+            ("2026-02-16", 40.0),
+            ("2026-02-17", 40.0),
+        ] {
+            sqlx::query("INSERT INTO special_dates (date, uplift_pct) VALUES (?, ?)")
+                .bind(date)
+                .bind(pct)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let days = load_special_days(&pool, "2026-02-14", "2026-02-16")
+            .await
+            .unwrap();
+
+        // Cận trên bao gồm ngày trả phòng, nên 16 có mặt; 13 và 17 thì không.
+        let dates: Vec<&str> = days.iter().map(|day| day.date.as_str()).collect();
+        assert_eq!(dates, vec!["2026-02-14", "2026-02-15", "2026-02-16"]);
+    }
+
+    #[tokio::test]
+    async fn load_special_days_truncates_an_rfc3339_bound() {
+        let pool = test_pool().await;
+        sqlx::query("INSERT INTO special_dates (date, uplift_pct) VALUES (?, ?)")
+            .bind("2026-02-14")
+            .bind(40.0)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let days = load_special_days(&pool, "2026-02-14T08:00:00+07:00", "2026-02-14T20:00:00+07:00")
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(days[0].uplift_pct, 40.0);
+    }
+```
+
+Hai test này dùng lại hàm dựng pool **đã có sẵn** trong `mod tests` của `pricing_queries.rs` — nó tạo `special_dates` ở `:365`. Mở file, chép đúng tên hàm, đừng viết mới.
+
+Ngoài ra hai test cũ đang khẳng định `inputs.special_uplift_pct` ở `:551` và `:583`. Đổi chúng sang kiểu mới, ví dụ:
+
+```rust
+        assert_eq!(inputs.special_days.len(), 1);
+        assert_eq!(inputs.special_days[0].uplift_pct, 10.0);
+```
+và
+```rust
+        assert!(inputs.special_days.is_empty());
+```
+
+Trong `use super::{…}` của module test, thêm `load_special_days`.
+
+- [ ] **Bước 9: Chạy toàn bộ test Rust**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib 2>&1 | tail -20
+```
+
+Kỳ vọng: **PASS**, không có warning mới. Nếu có chỗ nào khác còn nhắc `special_uplift_pct`, trình biên dịch sẽ chỉ đúng dòng.
+
+- [ ] **Bước 10: Commit**
+
+```bash
+cd mhm/src-tauri && cargo fmt && cargo check --all-targets
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src-tauri/src/domain/booking/pricing.rs mhm/src-tauri/src/queries/booking/pricing_queries.rs
+git commit -m "fix(pricing): charge the holiday uplift per night, not per check-in day
+
+It looked special_dates up by the check-in date alone and then applied that one
+percentage to every night. A stay starting the day before Tet was quoted at 0%;
+a stay starting on the last day of Tet paid the full uplift for nights outside
+it.
+
+The rule now walks the stay day by day, exactly as the weekend uplift does, and
+hands calculate_price the average — which is algebraically the same as charging
+each night its own rate, so crate::pricing keeps its signature."
+```
+
+---
+
+### Task 3: Tầng ghi một dòng, và bỏ lệnh cũ
+
+**Files:**
+- Modify: `src-tauri/src/repositories/booking/pricing_repository.rs:74-98`
+- Modify: `src-tauri/src/commands/pricing.rs:168-190` (xoá `save_special_date`)
+- Modify: `src-tauri/src/lib.rs:396` (bỏ đăng ký)
+
+**Interfaces:**
+- Consumes: không có
+- Produces:
+  - `pub struct SpecialDateUpsert<'a> { pub id: &'a str, pub date: &'a str, pub label: &'a str, pub uplift_pct: f64, pub now: &'a str }`
+  - `pub async fn upsert_special_date_tx(tx: &mut Transaction<'_, Sqlite>, upsert: &SpecialDateUpsert<'_>) -> Result<(), sqlx::Error>`
+  - `pub async fn delete_special_dates_tx(tx: &mut Transaction<'_, Sqlite>, dates: &[String]) -> Result<(), sqlx::Error>`
+
+- [ ] **Bước 1: Viết test đỏ cho repository**
+
+Trong `mod tests` của `pricing_repository.rs` (nếu file chưa có `mod tests`, tạo mới ở cuối file theo lối `settings_store.rs`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::{delete_special_dates_tx, upsert_special_date_tx, SpecialDateUpsert};
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::{Executor, Pool, Sqlite};
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        pool.execute(
+            "CREATE TABLE special_dates (
+                id TEXT PRIMARY KEY,
+                date TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT '',
+                uplift_pct REAL NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                UNIQUE(date)
+            )",
+        )
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn upsert_keeps_the_original_created_at_when_the_date_already_exists() {
+        let pool = test_pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        upsert_special_date_tx(
+            &mut tx,
+            &SpecialDateUpsert {
+                id: "id-1",
+                date: "2026-02-14",
+                label: "Tết",
+                uplift_pct: 40.0,
+                now: "2026-01-01T00:00:00+07:00",
+            },
+        )
+        .await
+        .unwrap();
+        upsert_special_date_tx(
+            &mut tx,
+            &SpecialDateUpsert {
+                id: "id-2",
+                date: "2026-02-14",
+                label: "Tết Nguyên đán",
+                uplift_pct: 45.0,
+                now: "2026-06-01T00:00:00+07:00",
+            },
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let row: (String, String, f64, String) = sqlx::query_as(
+            "SELECT id, label, uplift_pct, created_at FROM special_dates WHERE date = ?",
+        )
+        .bind("2026-02-14")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row.0, "id-1", "id cũ phải được giữ");
+        assert_eq!(row.1, "Tết Nguyên đán");
+        assert_eq!(row.2, 45.0);
+        assert_eq!(row.3, "2026-01-01T00:00:00+07:00", "created_at phải được giữ");
+    }
+
+    #[tokio::test]
+    async fn delete_removes_exactly_the_listed_dates() {
+        let pool = test_pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        for (index, date) in ["2026-02-14", "2026-02-15", "2026-02-16"].iter().enumerate() {
+            upsert_special_date_tx(
+                &mut tx,
+                &SpecialDateUpsert {
+                    id: &format!("id-{index}"),
+                    date,
+                    label: "Tết",
+                    uplift_pct: 40.0,
+                    now: "2026-01-01T00:00:00+07:00",
+                },
+            )
+            .await
+            .unwrap();
+        }
+        delete_special_dates_tx(&mut tx, &["2026-02-15".to_string()])
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let remaining: Vec<(String,)> =
+            sqlx::query_as("SELECT date FROM special_dates ORDER BY date")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            remaining.iter().map(|row| row.0.as_str()).collect::<Vec<_>>(),
+            vec!["2026-02-14", "2026-02-16"]
+        );
+    }
+}
+```
+
+- [ ] **Bước 2: Chạy cho thấy đỏ**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib pricing_repository 2>&1 | head -20
+```
+
+Kỳ vọng: **FAIL biên dịch** — `cannot find function 'upsert_special_date_tx'`.
+
+- [ ] **Bước 3: Viết hai hàm repository**
+
+Trong `pricing_repository.rs`, đổi dòng import đầu file thành `use sqlx::{Pool, Sqlite, Transaction};`.
+
+Thay **toàn bộ** `upsert_special_date` (`:72-98`, kể cả khối doc phía trên) bằng:
+
+```rust
+/// Giá trị đã được service kiểm và đã đủ, writer không quyết định gì.
+pub struct SpecialDateUpsert<'a> {
+    pub id: &'a str,
+    pub date: &'a str,
+    pub label: &'a str,
+    pub uplift_pct: f64,
+    pub now: &'a str,
+}
+
+/// `created_at` chỉ được ghi lúc thêm mới; lần cập nhật giữ nguyên mốc cũ, nên
+/// nó không nằm trong danh sách `DO UPDATE SET`. `id` cũng vậy: ngày đã tồn tại
+/// thì giữ mã cũ, để mọi tham chiếu bên ngoài còn dùng được.
+///
+/// Nhận `tx` chứ không nhận `pool`: khai một khoảng là nhiều dòng, và mất nửa
+/// khoảng còn tệ hơn báo lỗi.
+pub async fn upsert_special_date_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    upsert: &SpecialDateUpsert<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(date) DO UPDATE SET
+            label = excluded.label,
+            uplift_pct = excluded.uplift_pct",
+    )
+    .bind(upsert.id)
+    .bind(upsert.date)
+    .bind(upsert.label)
+    .bind(upsert.uplift_pct)
+    .bind(upsert.now)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+/// Xoá từng ngày một thay vì dựng `IN (…)`: sqlx không bind được mảng cho
+/// SQLite, và ghép chuỗi SQL động là thứ không đáng đổi lấy một vòng lặp tối đa
+/// 366 bước.
+pub async fn delete_special_dates_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    dates: &[String],
+) -> Result<(), sqlx::Error> {
+    for date in dates {
+        sqlx::query("DELETE FROM special_dates WHERE date = ?")
+            .bind(date)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Bước 4: Bỏ lệnh `save_special_date`**
+
+Xoá toàn bộ khối `#[tauri::command]` + `pub async fn save_special_date(…)` ở `commands/pricing.rs:168-190` (mở file xác nhận biên trên và dưới trước khi xoá).
+
+Trong `lib.rs`, xoá dòng `commands::pricing::save_special_date,` (`:396`).
+
+Nếu sau khi xoá mà `uuid` hoặc `pricing_repository` không còn được `commands/pricing.rs` dùng nữa, xoá luôn dòng `use` tương ứng — `cargo check` sẽ báo warning nếu còn thừa.
+
+- [ ] **Bước 5: Chạy cho xanh**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib pricing_repository && cargo check --all-targets 2>&1 | tail -20
+```
+
+Kỳ vọng: hai test PASS, `cargo check` **không có warning nào**.
+
+- [ ] **Bước 6: Commit**
+
+```bash
+cd mhm/src-tauri && cargo fmt
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src-tauri/src/repositories/booking/pricing_repository.rs mhm/src-tauri/src/commands/pricing.rs mhm/src-tauri/src/lib.rs
+git commit -m "refactor(pricing): make the special-date write transactional, drop the dead command
+
+save_special_date had no caller on any live branch — only its definition and
+its invoke_handler line — and declaring a season is many rows, so the writer now
+takes a transaction. Keeping the old one-row pool version would have left two
+write paths into a money table for a command nobody invokes."
+```
+
+---
+
+### Task 4: Lệnh khai một khoảng
+
+**Files:**
+- Modify: `src-tauri/src/services/booking/pricing_service.rs`
+- Modify: `src-tauri/src/commands/pricing.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `SpecialDateUpsert`, `upsert_special_date_tx`, `delete_special_dates_tx` từ Task 3
+- Produces:
+  - `pub struct SaveSpecialDateRange { pub remove: Vec<String>, pub from: String, pub to: String, pub label: String, pub uplift_pct: f64 }`
+  - `pub async fn save_special_date_range(pool: &Pool<Sqlite>, request: SaveSpecialDateRange, id_base: String, now: String) -> CommandResult<()>`
+  - lệnh Tauri `save_special_date_range` với tham số `remove, from, to, label, uplift_pct`
+
+- [ ] **Bước 1: Viết test đỏ ở service**
+
+Trong `mod tests` của `pricing_service.rs`. Module ấy đã có hàm dựng pool riêng cho các test giá — **đừng sửa nó**, các test cũ đang dựa vào đúng những bảng nó tạo. Thêm một hàm riêng, chỉ dựng bảng cần cho phần này:
+
+```rust
+    async fn special_dates_pool() -> Pool<Sqlite> {
+        use sqlx::sqlite::SqlitePoolOptions;
+        use sqlx::Executor;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        pool.execute(
+            "CREATE TABLE special_dates (
+                id TEXT PRIMARY KEY,
+                date TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT '',
+                uplift_pct REAL NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                UNIQUE(date)
+            )",
+        )
+        .await
+        .unwrap();
+        pool
+    }
+```
+
+Lược đồ phải khớp `db/migrations.rs:209-216`, đặc biệt là `id TEXT PRIMARY KEY` — test `a_failed_write_leaves_every_removed_day_in_place` dựa vào đúng ràng buộc ấy để ép transaction hỏng.
+
+Trong `use super::{…}` của module test, thêm `delete_special_dates, save_special_date_range, SaveSpecialDateRange`.
+
+```rust
+    #[tokio::test]
+    async fn save_special_date_range_writes_one_row_per_day() {
+        let pool = special_dates_pool().await;
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-02-14".to_string(),
+                to: "2026-02-22".to_string(),
+                label: "Tết Nguyên đán".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 9);
+    }
+
+    #[tokio::test]
+    async fn save_special_date_range_accepts_a_single_day() {
+        let pool = special_dates_pool().await;
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-04-30".to_string(),
+                to: "2026-04-30".to_string(),
+                label: "Lễ 30/4".to_string(),
+                uplift_pct: 30.0,
+            },
+            "base".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1);
+    }
+
+    #[tokio::test]
+    async fn a_failed_write_leaves_every_removed_day_in_place() {
+        // Test quan trọng nhất của task này: `remove` tồn tại để việc xoá và
+        // việc ghi cùng chung một transaction.
+        //
+        // Ép hỏng giữa chừng bằng cách cho `id_base` sinh ra một mã đã tồn tại
+        // trên một ngày KHÁC, để bước upsert đụng khoá chính. `ON CONFLICT` chỉ
+        // đỡ cho `date`, không đỡ cho `id` — đây là chỗ hỏng-được-theo-ý duy
+        // nhất, và nó chỉ dùng được vì `id` do bên ngoài truyền vào.
+        let pool = special_dates_pool().await;
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES ('base-1', '2026-12-25', 'Noel', 10.0, '2026-01-01T00:00:00+07:00'),
+                    ('keep-1', '2026-02-25', 'Tết', 40.0, '2026-01-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let error = save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: vec!["2026-02-25".to_string()],
+                from: "2026-02-14".to_string(),
+                to: "2026-02-16".to_string(),
+                label: "Tết".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-06-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .expect_err("mã trùng phải làm cả transaction hỏng");
+        let _ = error;
+
+        let kept: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM special_dates WHERE date = '2026-02-25'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(kept.0, 1, "ngày trong `remove` phải còn nguyên khi ghi hỏng");
+
+        let written: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM special_dates WHERE date = '2026-02-14'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(written.0, 0, "không được để lại nửa khoảng");
+    }
+
+    #[tokio::test]
+    async fn remove_is_deleted_before_the_range_is_written() {
+        let pool = special_dates_pool().await;
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES ('old-1', '2026-02-20', 'Tết', 40.0, '2026-01-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: vec!["2026-02-20".to_string()],
+                from: "2026-02-14".to_string(),
+                to: "2026-02-16".to_string(),
+                label: "Tết".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-06-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let dates: Vec<(String,)> = sqlx::query_as("SELECT date FROM special_dates ORDER BY date")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            dates.iter().map(|row| row.0.as_str()).collect::<Vec<_>>(),
+            vec!["2026-02-14", "2026-02-15", "2026-02-16"]
+        );
+    }
+
+    #[tokio::test]
+    async fn save_special_date_range_rejects_bad_input() {
+        let pool = special_dates_pool().await;
+
+        let base = || SaveSpecialDateRange {
+            remove: Vec::new(),
+            from: "2026-02-14".to_string(),
+            to: "2026-02-16".to_string(),
+            label: "Tết".to_string(),
+            uplift_pct: 40.0,
+        };
+        let run = |request| {
+            let pool = pool.clone();
+            async move {
+                save_special_date_range(
+                    &pool,
+                    request,
+                    "base".to_string(),
+                    "2026-01-01T00:00:00+07:00".to_string(),
+                )
+                .await
+            }
+        };
+
+        // ngày sai định dạng
+        let mut request = base();
+        request.from = "14/02/2026".to_string();
+        run(request).await.expect_err("ngày sai định dạng");
+
+        // ngày kết thúc trước ngày bắt đầu
+        let mut request = base();
+        request.to = "2026-02-10".to_string();
+        run(request).await.expect_err("to < from");
+
+        // quá 366 ngày
+        let mut request = base();
+        request.to = "2027-02-16".to_string();
+        run(request).await.expect_err("367 ngày");
+
+        // phần trăm âm
+        let mut request = base();
+        request.uplift_pct = -10.0;
+        run(request).await.expect_err("phần trăm âm");
+
+        // phần trăm quá trần
+        let mut request = base();
+        request.uplift_pct = 600.0;
+        run(request).await.expect_err("phần trăm quá 500");
+
+        // nhãn toàn khoảng trắng
+        let mut request = base();
+        request.label = "   ".to_string();
+        run(request).await.expect_err("nhãn rỗng");
+
+        // phần tử của remove sai định dạng
+        let mut request = base();
+        request.remove = vec!["hôm-qua".to_string()];
+        run(request).await.expect_err("remove sai định dạng");
+
+        // remove chồng lên khoảng đang khai
+        let mut request = base();
+        request.remove = vec!["2026-02-15".to_string()];
+        run(request).await.expect_err("remove chồng lấn");
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0, "không lần nào được ghi gì");
+    }
+```
+
+- [ ] **Bước 2: Chạy cho thấy đỏ**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib pricing_service 2>&1 | head -20
+```
+
+Kỳ vọng: **FAIL biên dịch** — `cannot find function 'save_special_date_range'`.
+
+- [ ] **Bước 3: Viết service**
+
+Thêm vào `pricing_service.rs`. Bổ sung import: `use chrono::NaiveDate;`, `use crate::app_error::{codes, CommandError};`, và thêm `delete_special_dates_tx, upsert_special_date_tx, SpecialDateUpsert` vào khối `use crate::repositories::booking::pricing_repository::{…}`.
+
+```rust
+const MAX_SPECIAL_RANGE_DAYS: i64 = 366;
+const MAX_SPECIAL_UPLIFT_PCT: f64 = 500.0;
+
+pub struct SaveSpecialDateRange {
+    /// Những ngày phải xoá **cùng** transaction với lần ghi này. Rỗng là khai
+    /// mới; có giá trị là đang sửa một cụm cho ngắn lại. Đây là lý do lệnh xoá
+    /// và lệnh ghi không tách rời: xoá xong mà ghi hỏng là mất hẳn mấy ngày đã
+    /// khai, và không ai biết.
+    pub remove: Vec<String>,
+    pub from: String,
+    pub to: String,
+    pub label: String,
+    pub uplift_pct: f64,
+}
+
+fn parse_date_only(value: &str, field: &str) -> CommandResult<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| {
+        CommandError::user(
+            codes::VALIDATION_INVALID_INPUT,
+            format!("{field} phải có dạng YYYY-MM-DD"),
+        )
+    })
+}
+
+fn invalid_input(message: impl Into<String>) -> CommandError {
+    CommandError::user(codes::VALIDATION_INVALID_INPUT, message)
+}
+
+/// Khai một khoảng ngày là mùa cao điểm, một dòng cho một ngày.
+///
+/// `id_base` cấp mã cho từng ngày mới theo dạng `{id_base}-{chỉ số}`. Lệnh
+/// truyền vào một uuid nên trong thực tế không bao giờ đụng; test thì truyền
+/// một gốc đã có trong bảng để ép lỗi khoá chính giữa transaction — đó là chỗ
+/// hỏng-được-theo-ý duy nhất, vì `ON CONFLICT(date)` đã nuốt mất ràng buộc trên
+/// `date`.
+pub async fn save_special_date_range(
+    pool: &Pool<Sqlite>,
+    request: SaveSpecialDateRange,
+    id_base: String,
+    now: String,
+) -> CommandResult<()> {
+    let from = parse_date_only(&request.from, "Ngày bắt đầu")?;
+    let to = parse_date_only(&request.to, "Ngày kết thúc")?;
+    if to < from {
+        return Err(invalid_input("Ngày kết thúc không được trước ngày bắt đầu"));
+    }
+
+    let day_count = (to - from).num_days() + 1;
+    if day_count > MAX_SPECIAL_RANGE_DAYS {
+        return Err(invalid_input(format!(
+            "Khoảng ngày tối đa {MAX_SPECIAL_RANGE_DAYS} ngày"
+        )));
+    }
+
+    if !(0.0..=MAX_SPECIAL_UPLIFT_PCT).contains(&request.uplift_pct) {
+        return Err(invalid_input(format!(
+            "Mức phụ thu phải trong khoảng 0–{MAX_SPECIAL_UPLIFT_PCT:.0}%"
+        )));
+    }
+
+    let label = request.label.trim();
+    if label.is_empty() {
+        return Err(invalid_input("Tên đợt cao điểm không được để trống"));
+    }
+
+    if request.remove.len() as i64 > MAX_SPECIAL_RANGE_DAYS {
+        return Err(invalid_input(format!(
+            "Chỉ xoá được tối đa {MAX_SPECIAL_RANGE_DAYS} ngày một lần"
+        )));
+    }
+    for date in &request.remove {
+        let removed = parse_date_only(date, "Ngày cần xoá")?;
+        if removed >= from && removed <= to {
+            return Err(invalid_input(
+                "Ngày cần xoá không được nằm trong chính khoảng đang khai",
+            ));
+        }
+    }
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "save_special_date_range",
+            error.to_string(),
+            serde_json::json!({ "step": "begin" }),
+        )
+    })?;
+
+    // Xoá trước, ghi sau. Ngược lại thì một ngày vừa nằm trong `remove` vừa
+    // nằm trong khoảng sẽ bị xoá mất ngay bên trong transaction dựng lên để
+    // đừng mất nó. Đã chặn chồng lấn ở trên, nhưng thứ tự vẫn phải đúng.
+    delete_special_dates_tx(&mut tx, &request.remove)
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "save_special_date_range",
+                error.to_string(),
+                serde_json::json!({ "step": "delete_special_dates_tx" }),
+            )
+        })?;
+
+    let mut date = from;
+    for index in 0..day_count {
+        let id = format!("{id_base}-{index}");
+        let date_key = date.format("%Y-%m-%d").to_string();
+        upsert_special_date_tx(
+            &mut tx,
+            &SpecialDateUpsert {
+                id: &id,
+                date: &date_key,
+                label,
+                uplift_pct: request.uplift_pct,
+                now: &now,
+            },
+        )
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "save_special_date_range",
+                error.to_string(),
+                serde_json::json!({ "step": "upsert_special_date_tx", "date": &date_key }),
+            )
+        })?;
+        date = date.succ_opt().unwrap_or(date);
+    }
+
+    tx.commit().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "save_special_date_range",
+            error.to_string(),
+            serde_json::json!({ "step": "commit" }),
+        )
+    })
+}
+```
+
+- [ ] **Bước 4: Chạy cho xanh**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib pricing_service
+```
+
+Kỳ vọng: **PASS** toàn bộ, kể cả năm test mới.
+
+- [ ] **Bước 5: Thêm lệnh Tauri**
+
+Trong `commands/pricing.rs`, thêm (chỗ `save_special_date` vừa bị xoá ở Task 3):
+
+```rust
+#[tauri::command]
+pub async fn save_special_date_range(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    remove: Vec<String>,
+    from: String,
+    to: String,
+    label: String,
+    uplift_pct: f64,
+) -> Result<(), String> {
+    require_admin(&state)?;
+
+    pricing_service::save_special_date_range(
+        &state.db,
+        pricing_service::SaveSpecialDateRange {
+            remove,
+            from,
+            to,
+            label,
+            uplift_pct,
+        },
+        uuid::Uuid::new_v4().to_string(),
+        chrono::Local::now().to_rfc3339(),
+    )
+    .await?;
+
+    emit_db_update(&app, "pricing");
+    Ok(())
+}
+```
+
+Xác nhận `emit_db_update`, `require_admin`, `pricing_service` đều đã có trong `use` của file; `save_pricing_rule` ngay trên đó dùng cả ba.
+
+Trong `lib.rs`, thêm vào `invoke_handler`, ngay dưới `commands::pricing::get_special_dates,`:
+
+```rust
+            commands::pricing::save_special_date_range,
+```
+
+- [ ] **Bước 6: Kiểm tra biên dịch**
+
+```bash
+cd mhm/src-tauri && cargo check --all-targets 2>&1 | tail -20
+```
+
+Kỳ vọng: sạch, không warning.
+
+- [ ] **Bước 7: Commit**
+
+```bash
+cd mhm/src-tauri && cargo fmt
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src-tauri/src/services/booking/pricing_service.rs mhm/src-tauri/src/commands/pricing.rs mhm/src-tauri/src/lib.rs
+git commit -m "feat(pricing): declare a peak season as one date range
+
+The removals ride along with the write instead of taking a command of their
+own, so shortening a season cannot lose days to a failure between two
+transactions. The id comes from the command, matching save_pricing_rule — which
+is also what makes the mid-transaction failure testable at all."
+```
+
+---
+
+### Task 5: Lệnh xoá
+
+**Files:**
+- Modify: `src-tauri/src/services/booking/pricing_service.rs`
+- Modify: `src-tauri/src/commands/pricing.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `delete_special_dates_tx` từ Task 3, `parse_date_only`/`invalid_input` từ Task 4
+- Produces: `pub async fn delete_special_dates(pool: &Pool<Sqlite>, dates: Vec<String>) -> CommandResult<()>`; lệnh Tauri `delete_special_dates` với tham số `dates`
+
+- [ ] **Bước 1: Viết test đỏ**
+
+Trong `mod tests` của `pricing_service.rs`:
+
+```rust
+    #[tokio::test]
+    async fn delete_special_dates_removes_a_whole_cluster_at_once() {
+        let pool = special_dates_pool().await;
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-02-14".to_string(),
+                to: "2026-02-22".to_string(),
+                label: "Tết".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let dates: Vec<String> = (14..=22).map(|day| format!("2026-02-{day:02}")).collect();
+        delete_special_dates(&pool, dates).await.unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_special_dates_rejects_an_empty_list_and_a_bad_date() {
+        let pool = special_dates_pool().await;
+
+        delete_special_dates(&pool, Vec::new())
+            .await
+            .expect_err("danh sách rỗng là lệnh vô nghĩa");
+        delete_special_dates(&pool, vec!["14/02/2026".to_string()])
+            .await
+            .expect_err("ngày sai định dạng");
+    }
+```
+
+- [ ] **Bước 2: Chạy cho thấy đỏ**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib delete_special_dates 2>&1 | head -20
+```
+
+Kỳ vọng: **FAIL biên dịch** — `cannot find function 'delete_special_dates'`.
+
+- [ ] **Bước 3: Viết service**
+
+Thêm vào `pricing_service.rs`, ngay dưới `save_special_date_range`:
+
+```rust
+/// Xoá hẳn một số ngày khỏi bảng mùa cao điểm.
+///
+/// Danh sách rỗng bị từ chối — khác hẳn `SaveSpecialDateRange::remove`, nơi
+/// rỗng chính là ca khai mới. Ở đây rỗng nghĩa là gọi nhầm.
+pub async fn delete_special_dates(pool: &Pool<Sqlite>, dates: Vec<String>) -> CommandResult<()> {
+    if dates.is_empty() {
+        return Err(invalid_input("Chưa chọn ngày nào để xoá"));
+    }
+    if dates.len() as i64 > MAX_SPECIAL_RANGE_DAYS {
+        return Err(invalid_input(format!(
+            "Chỉ xoá được tối đa {MAX_SPECIAL_RANGE_DAYS} ngày một lần"
+        )));
+    }
+    for date in &dates {
+        parse_date_only(date, "Ngày cần xoá")?;
+    }
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "delete_special_dates",
+            error.to_string(),
+            serde_json::json!({ "step": "begin" }),
+        )
+    })?;
+
+    delete_special_dates_tx(&mut tx, &dates)
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "delete_special_dates",
+                error.to_string(),
+                serde_json::json!({ "step": "delete_special_dates_tx" }),
+            )
+        })?;
+
+    tx.commit().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "delete_special_dates",
+            error.to_string(),
+            serde_json::json!({ "step": "commit" }),
+        )
+    })
+}
+```
+
+- [ ] **Bước 4: Chạy cho xanh**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib pricing_service
+```
+
+Kỳ vọng: **PASS**.
+
+- [ ] **Bước 5: Thêm lệnh Tauri và đăng ký**
+
+Trong `commands/pricing.rs`, ngay dưới `save_special_date_range`:
+
+```rust
+#[tauri::command]
+pub async fn delete_special_dates(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    dates: Vec<String>,
+) -> Result<(), String> {
+    require_admin(&state)?;
+
+    pricing_service::delete_special_dates(&state.db, dates).await?;
+
+    emit_db_update(&app, "pricing");
+    Ok(())
+}
+```
+
+Trong `lib.rs`, thêm dưới dòng vừa thêm ở Task 4:
+
+```rust
+            commands::pricing::delete_special_dates,
+```
+
+- [ ] **Bước 6: Chạy toàn bộ Rust**
+
+```bash
+cd mhm/src-tauri && cargo test -p capyinn_lib 2>&1 | tail -10 && cargo check --all-targets 2>&1 | tail -10
+```
+
+Kỳ vọng: PASS toàn bộ, `cargo check` sạch.
+
+- [ ] **Bước 7: Commit**
+
+```bash
+cd mhm/src-tauri && cargo fmt
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src-tauri/src/services/booking/pricing_service.rs mhm/src-tauri/src/commands/pricing.rs mhm/src-tauri/src/lib.rs
+git commit -m "feat(pricing): let a declared peak season be deleted
+
+There was no delete command at all, so a mistyped season was permanent."
+```
+
+---
+
+### Task 6: Gom ngày liền nhau thành khoảng
+
+Hàm thuần, không React, để thử được mà không dựng component.
+
+**Files:**
+- Create: `src/lib/specialDateRanges.ts`
+- Test: `src/lib/specialDateRanges.test.ts`
+
+**Interfaces:**
+- Consumes: không có
+- Produces:
+  - `export type SpecialDateRow = { id: string; date: string; label: string; uplift_pct: number }`
+  - `export type SpecialDateRange = { from: string; to: string; days: number; label: string; uplift_pct: number; dates: string[] }`
+  - `export function groupSpecialDates(rows: SpecialDateRow[]): SpecialDateRange[]`
+  - `export function overlappingDates(rows: SpecialDateRow[], from: string, to: string, exclude?: string[]): SpecialDateRow[]`
+
+- [ ] **Bước 1: Viết test đỏ**
+
+Tạo `src/lib/specialDateRanges.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { groupSpecialDates, overlappingDates, type SpecialDateRow } from "./specialDateRanges";
+
+function row(date: string, label = "Tết", uplift_pct = 40): SpecialDateRow {
+    return { id: `id-${date}`, date, label, uplift_pct };
+}
+
+describe("groupSpecialDates", () => {
+    it("gom chín ngày liền nhau thành một khoảng", () => {
+        const rows = Array.from({ length: 9 }, (_, index) => row(`2026-02-${14 + index}`));
+
+        const ranges = groupSpecialDates(rows);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].from).toBe("2026-02-14");
+        expect(ranges[0].to).toBe("2026-02-22");
+        expect(ranges[0].days).toBe(9);
+        expect(ranges[0].dates).toHaveLength(9);
+    });
+
+    it("tách khi hở một ngày", () => {
+        const ranges = groupSpecialDates([row("2026-02-14"), row("2026-02-16")]);
+
+        expect(ranges).toHaveLength(2);
+        expect(ranges.map((range) => range.days)).toEqual([1, 1]);
+    });
+
+    it("tách khi liền ngày nhưng khác nhãn", () => {
+        const ranges = groupSpecialDates([
+            row("2026-02-14", "Tết"),
+            row("2026-02-15", "Hè"),
+        ]);
+
+        expect(ranges).toHaveLength(2);
+    });
+
+    it("tách khi liền ngày, cùng nhãn, nhưng khác mức", () => {
+        const ranges = groupSpecialDates([
+            row("2026-02-14", "Tết", 40),
+            row("2026-02-15", "Tết", 25),
+        ]);
+
+        expect(ranges).toHaveLength(2);
+    });
+
+    it("gom đúng dù đầu vào không theo thứ tự ngày", () => {
+        const ranges = groupSpecialDates([
+            row("2026-02-16"),
+            row("2026-02-14"),
+            row("2026-02-15"),
+        ]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].dates).toEqual(["2026-02-14", "2026-02-15", "2026-02-16"]);
+    });
+
+    it("vắt qua ranh giới tháng", () => {
+        const ranges = groupSpecialDates([row("2026-02-28"), row("2026-03-01")]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].days).toBe(2);
+    });
+
+    it("vắt qua ranh giới năm", () => {
+        const ranges = groupSpecialDates([row("2026-12-31"), row("2027-01-01")]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].days).toBe(2);
+    });
+
+    it("đầu vào rỗng trả mảng rỗng", () => {
+        expect(groupSpecialDates([])).toEqual([]);
+    });
+
+    it("bỏ qua ngày sai định dạng thay vì sập", () => {
+        // Cột `date` không có ràng buộc CHECK dưới DB, nên rác là có thật.
+        const ranges = groupSpecialDates([row("khong-phai-ngay"), row("2026-02-14")]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].from).toBe("2026-02-14");
+    });
+});
+
+describe("overlappingDates", () => {
+    it("chỉ trả những ngày đã khai nằm trong khoảng mới", () => {
+        const rows = [row("2026-02-19"), row("2026-02-20"), row("2026-02-21")];
+
+        const clashes = overlappingDates(rows, "2026-02-20", "2026-02-28");
+
+        expect(clashes.map((clash) => clash.date)).toEqual(["2026-02-20", "2026-02-21"]);
+    });
+
+    it("không tính ngày của chính cụm đang sửa là trùng", () => {
+        const rows = [row("2026-02-20"), row("2026-02-21")];
+
+        const clashes = overlappingDates(rows, "2026-02-20", "2026-02-28", [
+            "2026-02-20",
+            "2026-02-21",
+        ]);
+
+        expect(clashes).toEqual([]);
+    });
+});
+```
+
+- [ ] **Bước 2: Chạy cho thấy đỏ**
+
+```bash
+cd mhm && npx vitest run src/lib/specialDateRanges.test.ts
+```
+
+Kỳ vọng: **FAIL** — `Failed to resolve import "./specialDateRanges"`.
+
+- [ ] **Bước 3: Viết module**
+
+Tạo `src/lib/specialDateRanges.ts`:
+
+```ts
+/**
+ * Dưới DB, `special_dates` là một dòng cho một ngày. Chủ nhà thì nghĩ theo kỳ
+ * nghỉ. Module này bắc cầu giữa hai cách nhìn ấy, và chỉ làm việc đó.
+ */
+
+export type SpecialDateRow = {
+    id: string;
+    date: string;
+    label: string;
+    uplift_pct: number;
+};
+
+export type SpecialDateRange = {
+    from: string;
+    to: string;
+    days: number;
+    label: string;
+    uplift_pct: number;
+    /** Mọi ngày trong cụm — thứ phải gửi đi khi xoá. */
+    dates: string[];
+};
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Ngày kế tiếp của một `YYYY-MM-DD`.
+ *
+ * Tính trên UTC rồi cắt mười ký tự đầu. Tuyệt đối không dùng
+ * `new Date("2026-02-14T00:00:00")` — nó phân tích theo giờ địa phương rồi in
+ * ra UTC, và ở UTC+7 thì lệch mất một ngày.
+ *
+ * Hàm này cố ý để cục bộ chứ không tách sang `src/lib/`:
+ * `ReservationSheet.tsx` đã có một `addDays` nhận và trả `string`, còn nhánh
+ * `refactor/pricing-preview-honesty` đang thêm một `addDays` nhận và trả
+ * `Date`. Dựng thêm một module dùng chung lúc này là chuốc lấy đụng độ trùng
+ * tên với kiểu không tương thích.
+ */
+function nextDay(date: string): string {
+    const [year, month, day] = date.split("-").map(Number);
+    return new Date(Date.UTC(year, month - 1, day + 1)).toISOString().slice(0, 10);
+}
+
+/**
+ * Gom ngày liền nhau, cùng nhãn, cùng mức thành một khoảng.
+ *
+ * Đây là suy đoán chứ không phải dữ liệu: hai kỳ khác nhau tình cờ liền ngày,
+ * cùng nhãn, cùng mức sẽ hiện thành một dòng. Vô hại — xoá cụm ấy đúng là xoá
+ * chừng đó ngày — nhưng đừng coi đó là lỗi.
+ */
+export function groupSpecialDates(rows: SpecialDateRow[]): SpecialDateRange[] {
+    const sorted = rows
+        .filter((row) => DATE_ONLY.test(row.date))
+        .slice()
+        .sort((left, right) => left.date.localeCompare(right.date));
+
+    const ranges: SpecialDateRange[] = [];
+    for (const row of sorted) {
+        const open = ranges[ranges.length - 1];
+        const joinsOpenRange =
+            open !== undefined &&
+            open.label === row.label &&
+            open.uplift_pct === row.uplift_pct &&
+            nextDay(open.to) === row.date;
+
+        if (open !== undefined && joinsOpenRange) {
+            open.to = row.date;
+            open.days += 1;
+            open.dates.push(row.date);
+        } else {
+            ranges.push({
+                from: row.date,
+                to: row.date,
+                days: 1,
+                label: row.label,
+                uplift_pct: row.uplift_pct,
+                dates: [row.date],
+            });
+        }
+    }
+
+    return ranges;
+}
+
+/**
+ * Những ngày đã khai mà một khoảng mới sẽ ghi đè lên.
+ *
+ * `exclude` là các ngày của chính cụm đang sửa — chúng không phải là trùng.
+ * So sánh bằng chuỗi vì `YYYY-MM-DD` xếp theo từ điển đúng bằng xếp theo thời
+ * gian.
+ */
+export function overlappingDates(
+    rows: SpecialDateRow[],
+    from: string,
+    to: string,
+    exclude: string[] = [],
+): SpecialDateRow[] {
+    const excluded = new Set(exclude);
+
+    return rows
+        .filter(
+            (row) =>
+                DATE_ONLY.test(row.date) &&
+                !excluded.has(row.date) &&
+                row.date >= from &&
+                row.date <= to,
+        )
+        .sort((left, right) => left.date.localeCompare(right.date));
+}
+```
+
+- [ ] **Bước 4: Chạy cho xanh**
+
+```bash
+cd mhm && npx vitest run src/lib/specialDateRanges.test.ts
+```
+
+Kỳ vọng: **PASS**, 11 test, không warning.
+
+- [ ] **Bước 5: Commit**
+
+```bash
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src/lib/specialDateRanges.ts mhm/src/lib/specialDateRanges.test.ts
+git commit -m "feat(pricing): group contiguous declared days into a season
+
+The table stores one row per day; nobody thinks about Tet as nine separate
+facts. Contiguous plus same label plus same percentage is enough to recover the
+range, so the display can show one line without the schema changing."
+```
+
+---
+
+### Task 7: Màn hình khai báo
+
+**Files:**
+- Create: `src/pages/settings/SpecialDatesSection.tsx`
+- Test: `src/pages/settings/SpecialDatesSection.test.tsx`
+- Modify: `src/pages/settings/index.tsx:33` (kiểu), `:68` (mục thanh bên), `:132` (dòng render), và khối `import`
+- Modify: `src/__mocks__/tauri-core.ts` (thêm vào `defaults`)
+- Modify: `tests/frontend-invoke-wrapper-guardrails.test.ts` (cho phép `get_special_dates`)
+
+**Interfaces:**
+- Consumes: `groupSpecialDates`, `overlappingDates`, `SpecialDateRow`, `SpecialDateRange` từ Task 6; lệnh `save_special_date_range`, `delete_special_dates` từ Task 4 và 5
+- Produces: `export default function SpecialDatesSection()`
+
+- [ ] **Bước 1: Mở đường cho hạ tầng test trước, nếu không sẽ đỏ vì lý do sai**
+
+Trong `src/__mocks__/tauri-core.ts`, thêm vào object `defaults`:
+
+```ts
+        get_special_dates: [],
+        save_special_date_range: undefined,
+        delete_special_dates: undefined,
+```
+
+(`get_special_dates` đã có sẵn ở `:117` — chỉ thêm hai dòng mới.) File này **ném lỗi** với mọi lệnh chưa đăng ký, nên thiếu là mọi test của component sẽ chết.
+
+Trong `tests/frontend-invoke-wrapper-guardrails.test.ts`, thêm vào `RAW_INVOKE_ALLOWED_COMMANDS`, giữ đúng thứ tự chữ cái:
+
+```ts
+  get_special_dates: "read-only peak-season lookup",
+```
+
+Test ở `:260-290` đỏ với bất kỳ `invoke` trần nào không có trong danh sách này, và hôm nay `get_special_dates` chưa có vì chưa ai gọi.
+
+- [ ] **Bước 2: Viết test đỏ cho component**
+
+Tạo `src/pages/settings/SpecialDatesSection.test.tsx`. Mở một file test sẵn có trong cùng thư mục (ví dụ `PricingSection.test.tsx`) và chép đúng cách nó dựng mock và render — đừng tự nghĩ ra lối mới.
+
+```tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SpecialDatesSection from "./SpecialDatesSection";
+
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/invokeCommand", () => ({ invokeWriteCommand }));
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function tetRows() {
+    return Array.from({ length: 9 }, (_, index) => ({
+        id: `id-${index}`,
+        date: `2026-02-${14 + index}`,
+        label: "Tết Nguyên đán",
+        uplift_pct: 40,
+    }));
+}
+
+describe("SpecialDatesSection", () => {
+    beforeEach(() => {
+        invokeWriteCommand.mockReset().mockResolvedValue(undefined);
+        invoke.mockReset().mockResolvedValue(tetRows());
+    });
+
+    it("hiện chín ngày Tết thành một dòng", async () => {
+        render(<SpecialDatesSection />);
+
+        expect(await screen.findByText("Tết Nguyên đán")).toBeInTheDocument();
+        expect(screen.getByText(/9 ngày/)).toBeInTheDocument();
+        expect(screen.getAllByRole("button", { name: "Xoá" })).toHaveLength(1);
+    });
+
+    it("khai khoảng không trùng thì gọi thẳng lệnh ghi", async () => {
+        invoke.mockResolvedValue([]);
+        render(<SpecialDatesSection />);
+        await screen.findByText(/Chưa khai đợt cao điểm nào/);
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Lễ 30/4" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-04-30" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-05-03" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "30" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        expect(invokeWriteCommand).toHaveBeenCalledWith("save_special_date_range", {
+            remove: [],
+            from: "2026-04-30",
+            to: "2026-05-03",
+            label: "Lễ 30/4",
+            upliftPct: 30,
+        });
+    });
+
+    it("khai đè lên ngày đã có thì hỏi trước, và huỷ thì không ghi gì", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Hè" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        expect(await screen.findByText(/3 ngày đã khai sẽ bị ghi đè/)).toBeInTheDocument();
+        expect(screen.getByText(/2026-02-20/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Huỷ" }));
+
+        expect(invokeWriteCommand).not.toHaveBeenCalled();
+    });
+
+    it("bấm tiếp tục ở hộp trùng thì mới ghi", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Hè" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+        fireEvent.click(await screen.findByRole("button", { name: "Tiếp tục" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+    });
+
+    it("xoá một cụm gửi đúng chín ngày trong một lần gọi", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Xoá" }));
+        fireEvent.click(await screen.findByRole("button", { name: "Xoá đợt này" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        const [command, args] = invokeWriteCommand.mock.calls[0];
+        expect(command).toBe("delete_special_dates");
+        expect(args.dates).toHaveLength(9);
+    });
+
+    it("sửa cụm cho ngắn lại thì ngày rơi ra đi trong `remove`, không có lệnh xoá riêng", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Sửa" }));
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-19" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cập nhật" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        const [command, args] = invokeWriteCommand.mock.calls[0];
+        expect(command).toBe("save_special_date_range");
+        // 20, 21, 22 rơi ra khỏi khoảng mới 14–19.
+        expect(args.remove).toEqual(["2026-02-20", "2026-02-21", "2026-02-22"]);
+        expect(
+            invokeWriteCommand.mock.calls.some(([name]) => name === "delete_special_dates"),
+        ).toBe(false);
+    });
+
+    it("lệnh lỗi thì báo toast và không đổi danh sách ngầm", async () => {
+        const { toast } = await import("sonner");
+        invokeWriteCommand.mockRejectedValue(new Error("Không đủ quyền"));
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Xoá" }));
+        fireEvent.click(await screen.findByRole("button", { name: "Xoá đợt này" }));
+
+        await waitFor(() => expect(toast.error).toHaveBeenCalled());
+        expect(screen.getByText("Tết Nguyên đán")).toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Bước 3: Chạy cho thấy đỏ**
+
+```bash
+cd mhm && npx vitest run src/pages/settings/SpecialDatesSection.test.tsx
+```
+
+Kỳ vọng: **FAIL** — `Failed to resolve import "./SpecialDatesSection"`.
+
+- [ ] **Bước 4: Viết component**
+
+Tạo `src/pages/settings/SpecialDatesSection.tsx`:
+
+```tsx
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { CalendarDays } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
+import {
+    groupSpecialDates,
+    overlappingDates,
+    type SpecialDateRange,
+    type SpecialDateRow,
+} from "@/lib/specialDateRanges";
+
+/** Quá ngần này thì liệt kê hết chỉ tổ rối; phần còn lại đếm số. */
+const MAX_LISTED_CLASHES = 10;
+
+type PendingWrite = {
+    remove: string[];
+    from: string;
+    to: string;
+    label: string;
+    upliftPct: number;
+};
+
+export default function SpecialDatesSection() {
+    const [rows, setRows] = useState<SpecialDateRow[]>([]);
+    const [editing, setEditing] = useState<SpecialDateRange | null>(null);
+    const [label, setLabel] = useState("");
+    const [from, setFrom] = useState("");
+    const [to, setTo] = useState("");
+    const [upliftPct, setUpliftPct] = useState("30");
+    const [clashes, setClashes] = useState<SpecialDateRow[] | null>(null);
+    const [pending, setPending] = useState<PendingWrite | null>(null);
+    const [deleting, setDeleting] = useState<SpecialDateRange | null>(null);
+
+    const reload = useCallback(() => {
+        invoke<SpecialDateRow[]>("get_special_dates")
+            .then(setRows)
+            .catch(() => setRows([]));
+    }, []);
+
+    useEffect(reload, [reload]);
+
+    const ranges = groupSpecialDates(rows);
+
+    const resetForm = () => {
+        setEditing(null);
+        setLabel("");
+        setFrom("");
+        setTo("");
+        setUpliftPct("30");
+    };
+
+    const startEdit = (range: SpecialDateRange) => {
+        setEditing(range);
+        setLabel(range.label);
+        setFrom(range.from);
+        setTo(range.to);
+        setUpliftPct(String(range.uplift_pct));
+    };
+
+    const write = async (request: PendingWrite) => {
+        try {
+            await invokeWriteCommand("save_special_date_range", request);
+            toast.success("Đã lưu đợt cao điểm");
+            resetForm();
+            reload();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const handleSave = () => {
+        const trimmed = label.trim();
+        if (!trimmed || !from || !to || to < from) {
+            toast.error("Điền tên đợt và khoảng ngày hợp lệ");
+            return;
+        }
+
+        // Ngày rơi ra khỏi khoảng mới phải bị xoá thật, nếu không nó nằm lại
+        // thành một ngày lễ mồ côi. Chúng đi kèm lệnh ghi chứ không thành một
+        // lệnh xoá riêng, để cả hai nửa chung một transaction.
+        const remove = (editing?.dates ?? []).filter((date) => date < from || date > to);
+        const request: PendingWrite = {
+            remove,
+            from,
+            to,
+            label: trimmed,
+            upliftPct: Number(upliftPct),
+        };
+
+        const conflicts = overlappingDates(rows, from, to, editing?.dates ?? []);
+        if (conflicts.length > 0) {
+            setClashes(conflicts);
+            setPending(request);
+            return;
+        }
+
+        void write(request);
+    };
+
+    const handleDelete = async (range: SpecialDateRange) => {
+        try {
+            await invokeWriteCommand("delete_special_dates", { dates: range.dates });
+            toast.success("Đã xoá đợt cao điểm");
+            resetForm();
+            reload();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : String(error));
+        } finally {
+            setDeleting(null);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-bold mb-1 flex items-center gap-2">
+                    <CalendarDays size={20} className="text-emerald-500" />
+                    Mùa cao điểm
+                </h3>
+                <p className="text-sm text-brand-muted">
+                    Khai những đợt tăng giá theo ngày — Tết, lễ, mùa du lịch. Giá phòng tự cộng
+                    thêm cho đúng những đêm nằm trong đợt.
+                </p>
+            </div>
+
+            {ranges.length === 0 ? (
+                <p className="text-sm text-brand-muted">
+                    Chưa khai đợt cao điểm nào. Thêm một đợt ở dưới.
+                </p>
+            ) : (
+                <div className="space-y-2">
+                    {ranges.map((range) => (
+                        <div
+                            key={`${range.from}-${range.label}`}
+                            className="flex items-center justify-between p-4 bg-slate-50 rounded-xl"
+                        >
+                            <div>
+                                <p className="font-semibold text-sm">{range.label}</p>
+                                <p className="text-xs text-brand-muted">
+                                    {range.from} – {range.to} ({range.days} ngày) &nbsp;|&nbsp; +
+                                    {range.uplift_pct}%
+                                </p>
+                            </div>
+                            <div className="flex gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="rounded-lg"
+                                    onClick={() => startEdit(range)}
+                                >
+                                    Sửa
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="rounded-lg text-red-600"
+                                    onClick={() => setDeleting(range)}
+                                >
+                                    Xoá
+                                </Button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <div className="p-5 bg-slate-50 rounded-2xl space-y-4">
+                <h4 className="font-bold text-sm">
+                    {editing ? `Sửa: ${editing.label}` : "Thêm đợt cao điểm"}
+                </h4>
+                <div className="grid grid-cols-2 gap-3">
+                    <div>
+                        <Label htmlFor="special-label">Tên đợt</Label>
+                        <Input
+                            id="special-label"
+                            value={label}
+                            onChange={(event) => setLabel(event.target.value)}
+                            placeholder="Tết Nguyên đán"
+                            className="mt-1.5"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="special-uplift">% phụ thu</Label>
+                        <Input
+                            id="special-uplift"
+                            type="number"
+                            min={0}
+                            max={500}
+                            value={upliftPct}
+                            onChange={(event) => setUpliftPct(event.target.value)}
+                            className="mt-1.5 w-24"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="special-from">Từ ngày</Label>
+                        <Input
+                            id="special-from"
+                            type="date"
+                            value={from}
+                            onChange={(event) => setFrom(event.target.value)}
+                            className="mt-1.5"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="special-to">Đến ngày</Label>
+                        <Input
+                            id="special-to"
+                            type="date"
+                            min={from || undefined}
+                            value={to}
+                            onChange={(event) => setTo(event.target.value)}
+                            className="mt-1.5"
+                        />
+                    </div>
+                </div>
+                <div className="flex gap-2">
+                    <Button
+                        onClick={handleSave}
+                        className="bg-brand-primary text-white rounded-xl"
+                    >
+                        {editing ? "Cập nhật" : "Thêm"}
+                    </Button>
+                    {editing && (
+                        <Button variant="outline" className="rounded-xl" onClick={resetForm}>
+                            Huỷ sửa
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            {clashes && pending && (
+                <div className="p-5 border border-amber-300 bg-amber-50 rounded-2xl space-y-3">
+                    <p className="text-sm font-semibold">
+                        {clashes.length} ngày đã khai sẽ bị ghi đè
+                    </p>
+                    <ul className="text-xs text-brand-muted space-y-0.5">
+                        {clashes.slice(0, MAX_LISTED_CLASHES).map((clash) => (
+                            <li key={clash.date}>
+                                {clash.date} — {clash.label} +{clash.uplift_pct}% → {pending.label} +
+                                {pending.upliftPct}%
+                            </li>
+                        ))}
+                        {clashes.length > MAX_LISTED_CLASHES && (
+                            <li>…và {clashes.length - MAX_LISTED_CLASHES} ngày nữa</li>
+                        )}
+                    </ul>
+                    <div className="flex gap-2">
+                        <Button
+                            className="bg-brand-primary text-white rounded-xl"
+                            onClick={() => {
+                                const request = pending;
+                                setClashes(null);
+                                setPending(null);
+                                void write(request);
+                            }}
+                        >
+                            Tiếp tục
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className="rounded-xl"
+                            onClick={() => {
+                                setClashes(null);
+                                setPending(null);
+                            }}
+                        >
+                            Huỷ
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {deleting && (
+                <div className="p-5 border border-red-300 bg-red-50 rounded-2xl space-y-3">
+                    <p className="text-sm font-semibold">
+                        Xoá &quot;{deleting.label}&quot; ({deleting.days} ngày)?
+                    </p>
+                    <div className="flex gap-2">
+                        <Button
+                            className="bg-red-600 text-white rounded-xl"
+                            onClick={() => void handleDelete(deleting)}
+                        >
+                            Xoá đợt này
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className="rounded-xl"
+                            onClick={() => setDeleting(null)}
+                        >
+                            Giữ lại
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+```
+
+- [ ] **Bước 5: Chạy cho xanh**
+
+```bash
+cd mhm && npx vitest run src/pages/settings/SpecialDatesSection.test.tsx
+```
+
+Kỳ vọng: **PASS**, 7 test. Nếu một test đỏ vì tìm không ra nhãn hoặc nút, sửa **test hay component cho khớp nhau**, đừng nới lỏng khẳng định.
+
+- [ ] **Bước 6: Đấu vào thanh bên Cài đặt**
+
+Trong `src/pages/settings/index.tsx`:
+
+Thêm `CalendarDays` vào khối `import { … } from "lucide-react"` (giữ thứ tự chữ cái).
+
+Thêm import:
+```tsx
+import SpecialDatesSection from "./SpecialDatesSection";
+```
+
+Trong `type SettingsSectionKey`, thêm một nhánh:
+```tsx
+  | "peak-season"
+```
+
+Trong mảng `sections`, khối `isCurrentAdmin` (`:68-73`), thêm ngay dưới dòng `pricing`:
+```tsx
+        { key: "peak-season" as const, label: "Peak Season", icon: CalendarDays },
+```
+
+Trong phần render, ngay dưới dòng `{activeSection === "pricing" && …}` (`:132`):
+```tsx
+        {activeSection === "peak-season" && isCurrentAdmin && <SpecialDatesSection />}
+```
+
+- [ ] **Bước 7: Chạy toàn bộ cổng**
+
+```bash
+cd mhm && npm run verify:full 2>&1 | tail -30
+```
+
+Kỳ vọng: **PASS** toàn bộ, kể cả `frontend-invoke-wrapper-guardrails`. Nếu nó đỏ ở `get_special_dates`, xem lại Bước 1.
+
+- [ ] **Bước 8: Commit**
+
+```bash
+cd /Users/binhan/HotelManager/.worktrees/peak-season
+git add mhm/src/pages/settings/SpecialDatesSection.tsx mhm/src/pages/settings/SpecialDatesSection.test.tsx mhm/src/pages/settings/index.tsx mhm/src/__mocks__/tauri-core.ts mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+git commit -m "feat(settings): a screen for declaring peak seasons
+
+The special_dates table has existed since the first migration with a backend
+behind it and nothing in the UI that reached it — the only reference in src/ was
+a line in the test mock. Declaring a season by range now works, overwrites ask
+first instead of happening silently, and a mistyped season can be deleted."
+```
+
+---
+
+## Cổng cuối cùng
+
+Chạy sau khi cả bảy task xong, trước khi báo hoàn thành:
+
+```bash
+cd mhm/src-tauri && cargo fmt --check && cargo check --all-targets && cargo test -p capyinn_lib 2>&1 | tail -5
+```
+
+```bash
+cd mhm && npm run verify:full 2>&1 | tail -20
+```
+
+Cả ba lệnh phải xanh. `cargo fmt --check` là cái hay bị quên nhất: CI gác nó nhưng `verify:full` không chạy.

--- a/docs/superpowers/plans/2026-07-29-mua-cao-diem.md
+++ b/docs/superpowers/plans/2026-07-29-mua-cao-diem.md
@@ -22,7 +22,7 @@
 - **Cắt chuỗi ngày bằng `get(..10)`**, không bao giờ `&s[..10]` — cắt theo byte sẽ panic với ký tự nhiều byte.
 - **Chặn đầu vào nằm ở service**, trả `CommandError::user(codes::VALIDATION_INVALID_INPUT, …)` với thông điệp tiếng Việt.
 - **Trần:** khoảng ≤ 366 ngày; `0 <= uplift_pct <= 500`.
-- **Test Rust khẳng định trên `surcharge_amount`**, không phải `total`, và fixture phải đặt `weekend_uplift_pct = 0` — xem Task 2 Bước 1.
+- **Test Rust khẳng định trên `surcharge_amount`**, không phải `total`, và fixture phải đặt `weekend_uplift_pct = 0` — xem Task 2 Bước 1. **Một ngoại lệ duy nhất:** test `a_holiday_that_falls_on_a_weekend_still_charges_both` cố ý bật 20% và cố ý khẳng định `total`, vì thứ nó khoá chính là việc hai phụ thu cộng dồn.
 - **Chạy `cargo fmt` trước mỗi lần commit backend.** CI gác `cargo fmt --check` nhưng `verify:full` không chạy nó.
 
 ---
@@ -505,17 +505,14 @@ async fn load_special_days(
     check_in: &str,
     check_out: &str,
 ) -> BookingResult<Vec<SpecialDay>> {
-    let rows: Vec<(String, f64)> = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
+    let rows = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
         .bind(date_key(check_in))
         .bind(date_key(check_out))
         .fetch_all(pool)
         .await
         .map_err(database_error)?;
 
-    Ok(rows
-        .into_iter()
-        .map(|(date, uplift_pct)| SpecialDay { date, uplift_pct })
-        .collect())
+    Ok(special_days_from_rows(rows))
 }
 
 async fn load_special_days_tx(
@@ -523,17 +520,22 @@ async fn load_special_days_tx(
     check_in: &str,
     check_out: &str,
 ) -> BookingResult<Vec<SpecialDay>> {
-    let rows: Vec<(String, f64)> = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
+    let rows = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
         .bind(date_key(check_in))
         .bind(date_key(check_out))
         .fetch_all(&mut **tx)
         .await
         .map_err(database_error)?;
 
-    Ok(rows
-        .into_iter()
+    Ok(special_days_from_rows(rows))
+}
+
+/// Bản pool và bản transaction chỉ khác nhau ở chỗ chạy câu lệnh. Dùng chung
+/// một bộ ánh xạ để hai đường không thể hiểu khác nhau về cùng một hàng.
+fn special_days_from_rows(rows: Vec<(String, f64)>) -> Vec<SpecialDay> {
+    rows.into_iter()
         .map(|(date, uplift_pct)| SpecialDay { date, uplift_pct })
-        .collect())
+        .collect()
 }
 ```
 
@@ -1824,17 +1826,9 @@ range, so the display can show one line without the schema changing."
 
 - [ ] **Bước 1: Mở đường cho hạ tầng test trước, nếu không sẽ đỏ vì lý do sai**
 
-Trong `src/__mocks__/tauri-core.ts`, thêm vào object `defaults`:
+`src/__mocks__/tauri-core.ts` **không cần sửa**: `get_special_dates: []` đã có sẵn ở `:117`, và hai lệnh ghi mới không cần mặc định vì test dưới đây mock thẳng `@/lib/invokeCommand` — đúng lối `PricingSection.test.tsx` đang làm. Đừng thêm gì vào file ấy.
 
-```ts
-        get_special_dates: [],
-        save_special_date_range: undefined,
-        delete_special_dates: undefined,
-```
-
-(`get_special_dates` đã có sẵn ở `:117` — chỉ thêm hai dòng mới.) File này **ném lỗi** với mọi lệnh chưa đăng ký, nên thiếu là mọi test của component sẽ chết.
-
-Trong `tests/frontend-invoke-wrapper-guardrails.test.ts`, thêm vào `RAW_INVOKE_ALLOWED_COMMANDS`, giữ đúng thứ tự chữ cái:
+Chỉ sửa `tests/frontend-invoke-wrapper-guardrails.test.ts`: thêm vào `RAW_INVOKE_ALLOWED_COMMANDS`, giữ đúng thứ tự chữ cái:
 
 ```ts
   get_special_dates: "read-only peak-season lookup",
@@ -1844,7 +1838,9 @@ Test ở `:260-290` đỏ với bất kỳ `invoke` trần nào không có trong
 
 - [ ] **Bước 2: Viết test đỏ cho component**
 
-Tạo `src/pages/settings/SpecialDatesSection.test.tsx`. Mở một file test sẵn có trong cùng thư mục (ví dụ `PricingSection.test.tsx`) và chép đúng cách nó dựng mock và render — đừng tự nghĩ ra lối mới.
+Tạo `src/pages/settings/SpecialDatesSection.test.tsx`.
+
+Lối mock dưới đây là chép từ `PricingSection.test.tsx` — `vi.hoisted` rồi `vi.mock` cho ba module. File ấy còn thay các nguyên hàm shadcn (`Button`, `Input`, `Label`) bằng thẻ HTML trần. **Nếu** một khẳng định dưới đây tìm không ra nút hay ô nhập vì component thật cư xử lạ trong jsdom, chép luôn khối thay nguyên hàm ấy sang; đừng nới lỏng khẳng định.
 
 ```tsx
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";

--- a/docs/superpowers/plans/2026-07-29-mua-cao-diem.md
+++ b/docs/superpowers/plans/2026-07-29-mua-cao-diem.md
@@ -75,7 +75,7 @@ Thêm vào `mod tests` ở cuối `pricing_queries.rs`. Trong khối `use super:
 - [ ] **Bước 2: Chạy test cho thấy nó đỏ**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib date_key_does_not_panic -- --nocapture
+cd mhm/src-tauri && cargo test -p capyinn date_key_does_not_panic -- --nocapture
 ```
 
 Kỳ vọng: **FAIL**, panic với thông điệp kiểu `byte index 10 is not a char boundary`.
@@ -99,7 +99,7 @@ fn date_key(date_str: &str) -> &str {
 - [ ] **Bước 4: Chạy lại cho xanh**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib date_key_does_not_panic
+cd mhm/src-tauri && cargo test -p capyinn date_key_does_not_panic
 ```
 
 Kỳ vọng: **PASS**, `test result: ok. 1 passed`.
@@ -107,7 +107,7 @@ Kỳ vọng: **PASS**, `test result: ok. 1 passed`.
 - [ ] **Bước 5: Chạy cả module để chắc không vỡ gì**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib pricing_queries
+cd mhm/src-tauri && cargo test -p capyinn pricing_queries
 ```
 
 Kỳ vọng: PASS toàn bộ, không có warning mới.
@@ -375,7 +375,7 @@ Thêm vào `mod tests` của `domain/booking/pricing.rs`:
 - [ ] **Bước 3: Chạy cho thấy đỏ vì lý do đúng**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib domain::booking::pricing 2>&1 | head -40
+cd mhm/src-tauri && cargo test -p capyinn domain::booking::pricing 2>&1 | head -40
 ```
 
 Kỳ vọng: **FAIL biên dịch** — `no field 'special_days' on type 'StayPricingInputs'`, `cannot find function 'special'`, `cannot find type 'SpecialDay'`. Đây là đỏ đúng: kiểu chưa tồn tại.
@@ -558,7 +558,7 @@ Sửa ba chỗ dựng `StayPricingInputs`, **giữ nguyên** cách xử lỗi c�
 - [ ] **Bước 7: Chạy test domain cho xanh**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib domain::booking::pricing
+cd mhm/src-tauri && cargo test -p capyinn domain::booking::pricing
 ```
 
 Kỳ vọng: **PASS**, kể cả tám test mới. Nếu `special_uplift_spans_two_different_seasons` đỏ ở 199.999 thay vì 200.000, dừng lại và báo — con số ấy phụ thuộc vào chế độ làm tròn ở `money.rs:58`.
@@ -632,7 +632,7 @@ Trong `use super::{…}` của module test, thêm `load_special_days`.
 - [ ] **Bước 9: Chạy toàn bộ test Rust**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib 2>&1 | tail -20
+cd mhm/src-tauri && cargo test -p capyinn 2>&1 | tail -20
 ```
 
 Kỳ vọng: **PASS**, không có warning mới. Nếu có chỗ nào khác còn nhắc `special_uplift_pct`, trình biên dịch sẽ chỉ đúng dòng.
@@ -787,7 +787,7 @@ mod tests {
 - [ ] **Bước 2: Chạy cho thấy đỏ**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib pricing_repository 2>&1 | head -20
+cd mhm/src-tauri && cargo test -p capyinn pricing_repository 2>&1 | head -20
 ```
 
 Kỳ vọng: **FAIL biên dịch** — `cannot find function 'upsert_special_date_tx'`.
@@ -865,7 +865,7 @@ Nếu sau khi xoá mà `uuid` hoặc `pricing_repository` không còn được `
 - [ ] **Bước 5: Chạy cho xanh**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib pricing_repository && cargo check --all-targets 2>&1 | tail -20
+cd mhm/src-tauri && cargo test -p capyinn pricing_repository && cargo check --all-targets 2>&1 | tail -20
 ```
 
 Kỳ vọng: hai test PASS, `cargo check` **không có warning nào**.
@@ -1148,7 +1148,7 @@ Trong `use super::{…}` của module test, thêm `delete_special_dates, save_sp
 - [ ] **Bước 2: Chạy cho thấy đỏ**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib pricing_service 2>&1 | head -20
+cd mhm/src-tauri && cargo test -p capyinn pricing_service 2>&1 | head -20
 ```
 
 Kỳ vọng: **FAIL biên dịch** — `cannot find function 'save_special_date_range'`.
@@ -1296,7 +1296,7 @@ pub async fn save_special_date_range(
 - [ ] **Bước 4: Chạy cho xanh**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib pricing_service
+cd mhm/src-tauri && cargo test -p capyinn pricing_service
 ```
 
 Kỳ vọng: **PASS** toàn bộ, kể cả năm test mới.
@@ -1429,7 +1429,7 @@ Trong `mod tests` của `pricing_service.rs`:
 - [ ] **Bước 2: Chạy cho thấy đỏ**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib delete_special_dates 2>&1 | head -20
+cd mhm/src-tauri && cargo test -p capyinn delete_special_dates 2>&1 | head -20
 ```
 
 Kỳ vọng: **FAIL biên dịch** — `cannot find function 'delete_special_dates'`.
@@ -1487,7 +1487,7 @@ pub async fn delete_special_dates(pool: &Pool<Sqlite>, dates: Vec<String>) -> Co
 - [ ] **Bước 4: Chạy cho xanh**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib pricing_service
+cd mhm/src-tauri && cargo test -p capyinn pricing_service
 ```
 
 Kỳ vọng: **PASS**.
@@ -1521,7 +1521,7 @@ Trong `lib.rs`, thêm dưới dòng vừa thêm ở Task 4:
 - [ ] **Bước 6: Chạy toàn bộ Rust**
 
 ```bash
-cd mhm/src-tauri && cargo test -p capyinn_lib 2>&1 | tail -10 && cargo check --all-targets 2>&1 | tail -10
+cd mhm/src-tauri && cargo test -p capyinn 2>&1 | tail -10 && cargo check --all-targets 2>&1 | tail -10
 ```
 
 Kỳ vọng: PASS toàn bộ, `cargo check` sạch.
@@ -2357,7 +2357,7 @@ first instead of happening silently, and a mistyped season can be deleted."
 Chạy sau khi cả bảy task xong, trước khi báo hoàn thành:
 
 ```bash
-cd mhm/src-tauri && cargo fmt --check && cargo check --all-targets && cargo test -p capyinn_lib 2>&1 | tail -5
+cd mhm/src-tauri && cargo fmt --check && cargo check --all-targets && cargo test -p capyinn 2>&1 | tail -5
 ```
 
 ```bash

--- a/docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md
+++ b/docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md
@@ -65,10 +65,13 @@ trên phần của mình. Đó là định nghĩa của "chia đều theo ngày"
 đại số chứ không phải xấp xỉ.
 
 Điều **chỉ đúng với `nightly`, `overnight`, `daily`**: `base/N` đúng bằng giá một
-đêm đã cấu hình. Ba nhánh này tính `base = giá đêm × số ngày`, với **cùng một**
-biểu thức đếm ngày mà `calculate_weekend_uplift` đang dùng
-(`pricing.rs:115-116`, `:251-260`, `:345-346`, đối chiếu `:440`). Nên với ba
-nhánh này, "chia đều theo ngày" **chính là** "từng đêm chịu mức của nó":
+đêm đã cấu hình. Ba nhánh này tính `base = giá đêm × số ngày`, đếm ngày **tương
+đương** với `calculate_weekend_uplift` (`pricing.rs:115-116`, `:251-260`,
+`:345-346`, đối chiếu `:440`). Nói *tương đương* chứ không phải *cùng một biểu
+thức*: `calculate_overnight` viết `if days == 0 { 1 } else { days }` thay vì
+`.max(1)`. Hai cách cho cùng kết quả ở đây, vì `calculate_price` đã thoát sớm khi
+`co <= ci` (`pricing.rs:86-96`) nên `days` không bao giờ âm. Nên với ba nhánh
+này, "chia đều theo ngày" **chính là** "từng đêm chịu mức của nó":
 
 - 12/02→16/02, Tết 14–22 +40%. Bốn đêm 12,13,14,15 → Σ = 0+0+40+40 = 80, chia 4 =
   **20%**. Phụ thu = 20% × 4 đêm = 40% × 2 đêm. ✓
@@ -99,6 +102,12 @@ lên** thì đổi số. Ví dụ giá giờ 20k / qua đêm 300k / ngày 400k, 
 phụ thu, và chia đều theo ngày là cách phân bổ duy nhất có nghĩa khi `base` không
 tính theo đêm. Nó được chốt bằng một test riêng, không để trôi vào phần "không
 đổi".
+
+Và diện ảnh hưởng nhỏ hơn nghe tưởng. Muốn `N ≥ 2` thì kỳ ở phải **dài quá 24
+giờ**. Mà nhánh chặn trần về `overnight_rate` chỉ chạy khi `duration_hours <= 13`
+(`pricing.rs:161`), nên nó không bao giờ chạm tới `N ≥ 2`. Nói cách khác: đổi số
+**chỉ xảy ra với kỳ ở tính theo giờ mà dài hơn một ngày** — thứ vốn đã hiếm, và
+vốn đã là ca mà tính theo giờ cho ra giá kỳ quặc.
 
 ### Làm tròn
 
@@ -229,10 +238,28 @@ Ba chỗ dựng `StayPricingInputs` đổi theo, **giữ nguyên** cách xử l�
 ### Hai lệnh, không phải ba
 
 ```rust
-save_special_date_range(remove: Vec<String>, from: String, to: String,
-                        label: String, uplift_pct: f64)
-delete_special_dates(dates: Vec<String>)
+#[tauri::command]
+pub async fn save_special_date_range(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    remove: Vec<String>,
+    from: String,
+    to: String,
+    label: String,
+    uplift_pct: f64,
+) -> Result<(), String>
+
+#[tauri::command]
+pub async fn delete_special_dates(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    dates: Vec<String>,
+) -> Result<(), String>
 ```
+
+`state` và `app` là bắt buộc, không phải trang trí: `require_admin` cần `state`,
+và `emit_db_update` cần `AppHandle` (`commands/mod.rs:44`). `save_special_date`
+cũ không có `app` — đừng chép chữ ký của nó.
 
 `remove` là **chìa khoá của tính nguyên tử**. Khai mới thì nó rỗng. Sửa một cụm
 cho ngắn lại thì nó chứa những ngày rơi ra khỏi khoảng mới, và cả việc xoá lẫn
@@ -249,11 +276,18 @@ commit, như `save_pricing_rule` đang làm (`commands/pricing.rs:92`) — giá 
 
 ### Bỏ `save_special_date`
 
-Lệnh cũ (`commands/pricing.rs:141`, đăng ký ở `lib.rs:396`) **không có ai gọi** —
-không trong `src/`, không trong `gateway/`, đã dò trên mọi nhánh còn sống. Giữ nó
-lại nghĩa là có hai đường ghi vào cùng một bảng tiền, và phải nuôi một test chỉ
-để bảo vệ một lệnh không ai dùng. Bỏ. `save_special_date_range` với `from = to`
-làm được đúng việc ấy và làm được nhiều hơn.
+Lệnh cũ (`commands/pricing.rs:169`, đăng ký ở `lib.rs:396`) **không có ai gọi** —
+không trong `src/`, không trong `gateway/`, đã dò trên toàn bộ 73 nhánh còn sống:
+ở đâu cũng chỉ có đúng hai chỗ, định nghĩa và dòng đăng ký. `gateway/proxy.rs`
+không có đường chuyển tiếp lệnh theo tên, nên không ai với tới nó lúc chạy được.
+Giữ nó lại nghĩa là có hai đường ghi vào cùng một bảng tiền, và phải nuôi một
+test chỉ để bảo vệ một lệnh không ai dùng. Bỏ. `save_special_date_range` với
+`from = to` làm được đúng việc ấy và làm được nhiều hơn.
+
+Bỏ nó thì `pricing_repository::upsert_special_date(pool, …)`
+(`pricing_repository.rs:74-98`) mất người gọi cuối cùng. **Chuyển nó thành bản
+`_tx`**, đừng để lại bản nhận `pool`: nó `pub` trong lib crate nên `dead_code`
+không cảnh báo, và nó sẽ mục ở đó không ai biết.
 
 ### Tầng nào làm gì
 
@@ -263,9 +297,33 @@ have a clear service or lifecycle home") và theo đúng lối `save_pricing_rul
 
 | Tầng | Việc |
 |---|---|
-| `commands/pricing.rs` | `require_admin`, nhận tham số, gọi service, `emit_db_update` |
-| `services/booking/pricing_service.rs` | mở transaction, chặn đầu vào, trải `from..to` thành danh sách ngày, sinh `id`, gọi repository, commit |
+| `commands/pricing.rs` | `require_admin`, **sinh `id` và `now`**, gọi service, `emit_db_update` |
+| `services/booking/pricing_service.rs` | **chặn đầu vào**, mở transaction, trải `from..to` thành danh sách ngày, gọi repository, commit |
 | `repositories/booking/pricing_repository.rs` | `upsert_special_date_tx(tx, …)` một ngày một lần, và `delete_special_dates_tx(tx, dates)` |
+
+**Chặn đầu vào ở service, không phải ở lệnh.** `core-pms-boundaries.md:110` cho
+phép cả hai, nên đây là một lựa chọn thật chứ không phải chuyện hiển nhiên. Chọn
+service vì `save_pricing_rule` đã đi lối ấy, và vì như thế thì lỗi trả về là
+`CommandError::user` chứ không phải `String` trần. Bảy test chặn đầu vào cũng nằm
+ở service.
+
+**Sinh `id` và `now` ở tầng lệnh**, hệt `save_pricing_rule`
+(`commands/pricing.rs:87-88` truyền `uuid::Uuid::new_v4().to_string()` và
+`chrono::Local::now().to_rfc3339()` vào `pricing_service.rs:101-106`). Hai lý do,
+lý do thứ hai mới là lý do thật:
+
+1. Service thuần hơn — không tự đọc đồng hồ, không tự lấy số ngẫu nhiên.
+2. **Đó là đường duy nhất để viết được cái test quan trọng nhất của phần này.**
+   Mọi cột đều `NOT NULL` và do service tự điền, còn `ON CONFLICT(date)` đã nuốt
+   mất ràng buộc duy nhất trên `date`. Chỗ hỏng-được-theo-ý còn lại trong
+   transaction là **đụng khoá chính `id`** — mà muốn đụng thì `id` phải đến từ
+   bên ngoài. Service tự sinh `id` là tự bịt mất chỗ đó.
+
+**Thứ tự trong transaction: xoá `remove` trước, ghi khoảng sau.** Ghi trước xoá
+sau thì một ngày vừa nằm trong `remove` vừa nằm trong `[from..to]` sẽ bị xoá mất
+ngay bên trong chính cái transaction dựng lên để đừng mất nó. Giao diện như đặc
+tả không bao giờ sinh ra chồng lấn ấy, nhưng đây là hợp đồng của lệnh chứ không
+phải của một màn hình, nên **chặn luôn**: `remove` giao `[from..to]` phải rỗng.
 
 Trải khoảng thành từng ngày là quy tắc nghiệp vụ, nên nó ở service; repository
 giữ nguyên độ ngu ngốc của nó, mỗi lần một dòng, dùng lại `ON CONFLICT(date) DO
@@ -278,7 +336,9 @@ UPDATE` sẵn có. Ngày đã tồn tại thì `ON CONFLICT` giữ `id` và `cre
 > có lệnh nào cầm `Transaction<'_, Sqlite>`; mọi `pool.begin()` đều nằm ở service
 > (hoặc `folio_repository.rs:20`). Đi theo lối đó.
 
-### Chặn đầu vào (ở tầng lệnh, trước khi mở transaction)
+### Chặn đầu vào (ở service, trước khi mở transaction)
+
+`save_special_date_range`:
 
 | Điều kiện | Vì sao |
 |---|---|
@@ -287,9 +347,21 @@ UPDATE` sẵn có. Ngày đã tồn tại thì `ON CONFLICT` giữ `id` và `cre
 | khoảng ≤ 366 ngày | gõ nhầm năm sẽ sinh hàng nghìn dòng |
 | `0 <= uplift_pct <= 500` | `uplift_pct` là `REAL` không chặn gì; âm là giảm giá ngầm |
 | `label` bỏ khoảng trắng còn khác rỗng | gom cụm dựa vào nhãn; nhãn rỗng gom nhầm hai kỳ khác nhau |
-| `dates` không rỗng, mỗi phần tử đúng dạng | xoá rỗng là lệnh vô nghĩa |
+| `remove` **được phép rỗng** — đó là ca khai mới | đừng bắt buộc như `dates` |
+| mỗi phần tử của `remove` đúng dạng `YYYY-MM-DD` | nó đi thẳng vào `DELETE … WHERE date IN (…)` |
+| `remove` ≤ 366 phần tử | cùng lý do với trần của khoảng |
+| `remove` giao `[from..to]` phải rỗng | xem phần thứ tự ở trên: chồng lấn là mất ngày |
 
-Lỗi trả về tiếng Việt, theo lối các lệnh khác trong `commands/pricing.rs`.
+`delete_special_dates`:
+
+| Điều kiện | Vì sao |
+|---|---|
+| `dates` **không rỗng**, mỗi phần tử đúng dạng | xoá rỗng là lệnh vô nghĩa |
+
+Hai bảng tách riêng vì luật của `remove` và của `dates` **ngược nhau** ở chỗ
+rỗng: `remove` rỗng là hợp lệ, `dates` rỗng là lỗi.
+
+Lỗi trả về tiếng Việt qua `CommandError::user`, theo lối `pricing_service.rs`.
 
 ### Không thêm
 
@@ -408,9 +480,33 @@ số học, không phải vì thiếu hàm.
 
 ### Rust — `domain/booking/pricing.rs`
 
-Mọi test ghi **số tuyệt đối**. Cấm viết kiểu "tính từng đêm rồi cộng lại rồi so
-bằng" — xem phần Làm tròn, cách ấy lệch vài đồng với giá lẻ và sẽ đỏ vì lý do
-không liên quan tới luật.
+Ba luật bắt buộc cho mọi test ở phần này. Vi phạm luật nào cũng ra một test đỏ vì
+lý do chẳng liên quan gì tới thứ đang kiểm.
+
+**Một — ghi số tuyệt đối.** Cấm viết kiểu "tính từng đêm rồi cộng lại rồi so
+bằng": xem phần Làm tròn, cách ấy lệch vài đồng với giá lẻ.
+
+**Hai — khẳng định trên `surcharge_amount`, không phải `total`.** Mọi con số dưới
+đây là **riêng phần phụ thu ngày lễ**, đúng bằng `surcharge_amount` trong
+`calculate_nightly` (`pricing.rs:141`) và `calculate_hourly` (`:227`).
+
+**Ba — đặt `weekend_uplift_pct = 0` trong fixture.** Cái bẫy: `sample_inputs()`
+để `stored_rule: None`, nên `build_effective_pricing_rule`
+(`domain/booking/pricing.rs:75-83`) rơi xuống `..Default::default()`, tức
+`weekend_uplift_pct: 20.0` (`pricing.rs:46`). Mà **mọi** ngày trong các ví dụ
+dưới đây đều đụng cuối tuần:
+
+| Ngày | Thứ | | Ngày | Thứ |
+|---|---|---|---|---|
+| 12/02/2026 | Năm | | 20/02/2026 | Sáu |
+| 13/02/2026 | Sáu | | **21/02/2026** | **Bảy** |
+| **14/02/2026** | **Bảy** | | **22/02/2026** | **CN** |
+| **15/02/2026** | **CN** | | 23/02/2026 | Hai |
+| 16/02/2026 | Hai | | 24/02/2026 | Ba |
+
+Để mặc 20% thì `total` gánh thêm phụ thu cuối tuần và mọi con số dưới đây sai
+hết. Test cũ `calculate_from_loaded_inputs_applies_special_uplift` né bằng cách
+chọn 20–22/04 (Hai–Ba) — đó là chủ ý, không phải ngẫu nhiên.
 
 | Test | Con số |
 |---|---|
@@ -437,9 +533,14 @@ không liên quan tới luật.
 - `from = to` ghi đúng **một** dòng.
 - Ghi đè khoảng có ngày trùng: `label` và `uplift_pct` đổi, `created_at` **giữ
   nguyên**.
-- **`remove` và ghi trong cùng một transaction**: cho bước ghi hỏng giữa chừng,
-  khẳng định những ngày trong `remove` **vẫn còn nguyên** trong DB. Đây là test
-  quan trọng nhất của phần này — nó là lý do tồn tại của tham số `remove`.
+- **`remove` và ghi trong cùng một transaction** — test quan trọng nhất của phần
+  này, là lý do tồn tại của tham số `remove`. Cách làm cho nó hỏng có kiểm soát:
+  truyền vào một `id` đã tồn tại trên **một ngày khác**, để bước upsert đụng khoá
+  chính `id` giữa chừng. (`ON CONFLICT` chỉ đỡ cho `date`, không đỡ cho `id`.)
+  Rồi khẳng định những ngày trong `remove` **vẫn còn nguyên** trong DB. Test này
+  chỉ viết được vì `id` do tầng lệnh truyền vào — xem phần Tầng nào làm gì.
+- `remove` giao `[from..to]` khác rỗng → bị từ chối, không ghi gì.
+- Thứ tự đúng: `remove` được xoá **trước** khi ghi khoảng.
 - `delete_special_dates` xoá đúng danh sách, không đụng ngày khác.
 - Mỗi luật chặn đầu vào một test: ngày sai dạng, `to < from`, 367 ngày, `-10`,
   `600`, nhãn toàn khoảng trắng, `dates` rỗng.
@@ -458,6 +559,11 @@ không liên quan tới luật.
   buộc `CHECK` (`db/migrations.rs:209-216`) và lệnh ghi cũ chưa hề kiểm tra, nên
   dữ liệu rác là có thật.
 
+Ở phía Rust, tính chất "ngày rác thì coi như không khai" **tự có** từ cách so
+sánh: `effective_special_uplift` dựng khoá `YYYY-MM-DD` rồi dò trong danh sách,
+nên chuỗi rác đơn giản là không bao giờ khớp. Đừng thêm đường phân tích-rồi-báo-
+lỗi; làm thế là đổi đúng cái hành vi mà test này sinh ra để khoá.
+
 ### Frontend — `SpecialDatesSection.test.tsx`
 
 - Danh sách hiện **một** dòng cho chín ngày Tết.
@@ -467,7 +573,9 @@ không liên quan tới luật.
   `invokeWriteCommand` **không** được gọi.
 - Bấm tiếp tục → mới gọi lệnh ghi.
 - Xoá cụm → `delete_special_dates` nhận đúng 9 ngày trong một lần gọi.
-- Sửa cụm cho ngắn lại → những ngày rơi ra có mặt trong lệnh xoá.
+- Sửa cụm cho ngắn lại → những ngày rơi ra có mặt trong tham số **`remove` của
+  lệnh ghi**, và **không** có lệnh `delete_special_dates` nào được gọi. Test này
+  chính là chỗ khoá lại việc bỏ luồng hai lệnh.
 - Lệnh lỗi → hiện toast lỗi, danh sách không bị đổi ngầm.
 
 ### Cổng chung
@@ -517,9 +625,12 @@ nhánh, tách sẵn thế này là đỡ nhất.
   **chưa tồn tại** và các loader chưa có tham số `guests` — cả hai thứ ấy lên
   `main` sau. Nghĩa là nhánh kia phải rebase lên `main` trước đã; việc gỡ tay là
   của bước rebase đó, không phải của nhánh này.
-  - File production tranh chấp thật sự: **`queries/booking/pricing_queries.rs`**,
-    một file. Phần nhánh kia sửa trong `pricing_service.rs` **chỉ nằm trong
-    `mod tests`**.
+  - Ở tầng engine, file production tranh chấp thật sự là
+    **`queries/booking/pricing_queries.rs`**, một file.
+  - `services/booking/pricing_service.rs` bị **cả hai** nhánh chạm, nhưng lệch
+    vùng: nhánh này thêm code production (hai hàm ghi mới, theo phần 2), nhánh
+    kia chỉ thêm trong `mod tests`. Nhiều khả năng tự gộp được, nhưng đừng đọc
+    câu trên thành "chỉ một file bị đụng".
   - Trong file ấy, nhánh kia còn đổi `FALLBACK_BASE_PRICE_SQL` (thêm `ORDER BY
     id`, `pricing_queries.rs:25`) — khác vùng, nhiều khả năng tự gộp được, nhưng
     ghi ra đây để không ai bất ngờ.
@@ -535,6 +646,6 @@ nhánh, tách sẵn thế này là đỡ nhất.
 - **Gom cụm là suy đoán, không phải dữ liệu.** Hai kỳ khác nhau tình cờ liền
   ngày, cùng nhãn, cùng mức sẽ hiện thành một dòng. Vô hại — xoá cụm ấy đúng là
   xoá chừng đó ngày — nhưng phải nói rõ để sau này không ai coi đó là lỗi.
-- **Không có ràng buộc `CHECK` dưới DB.** Mọi chặn đầu vào nằm ở tầng lệnh. Ghi
+- **Không có ràng buộc `CHECK` dưới DB.** Mọi chặn đầu vào nằm ở tầng service. Ghi
   thẳng vào SQLite bằng tay vẫn lọt. Chấp nhận: mọi bảng khác trong dự án cũng
   thế.

--- a/docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md
+++ b/docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md
@@ -1,0 +1,393 @@
+# Mùa cao điểm — khai theo khoảng ngày, và tính đúng từng đêm
+
+- **Ngày**: 2026-07-29
+- **Nhánh**: `feature/peak-season`, cắt từ `main` tại `a233ac9`
+- **Tiếp nối**: `2026-07-28-dat-phong-truoc-gia-theo-so-khach-design.md`
+
+## Bối cảnh
+
+Lời than gốc của chủ khách sạn là *"ngày đặt là mùa cao điểm với 4 người, nên anh
+lấy giá 600k"*. Phiên trước xử nửa **"4 người"**: số khách giờ đẩy giá lên qua
+`rooms.extra_person_fee`. Nửa **"mùa cao điểm"** vẫn treo, vì hai lý do độc lập
+nhau:
+
+1. **Không có chỗ nào để khai.** Bảng `special_dates` tồn tại từ đầu, backend đã
+   có `get_special_dates` và `save_special_date`, nhưng giao diện chưa hề có màn
+   hình nào gọi tới. Cả `src/` chỉ có đúng một tham chiếu, và nó nằm trong file
+   mock (`src/__mocks__/tauri-core.ts:117`). Cũng **chưa có lệnh xoá**, nên kể cả
+   khai được thì khai sai là kẹt luôn.
+
+2. **Khai được cũng ra giá sai.** Engine tra `special_dates` bằng **đúng ngày
+   nhận phòng**, rồi nhân mức % ấy cho **toàn bộ** số đêm
+   (`pricing_queries.rs:311` → `domain/booking/pricing.rs:137` →
+   `pricing.rs:118`). Nó không đi từng đêm như phụ thu cuối tuần vẫn làm
+   (`pricing.rs:419`).
+
+Hậu quả của (2), lấy Tết khai 14/02–22/02 +40%:
+
+| Khách ở | Đêm nằm trong Tết | Engine tính | Đúng ra |
+|---|---|---|---|
+| 12/02 → 16/02 | 2 / 4 đêm | **+0%** — ngày đến 12/02 không phải lễ | +40% cho 2 đêm |
+| 22/02 → 25/02 | 1 / 3 đêm | **+40% cả 3 đêm** | +40% cho 1 đêm |
+
+Chiều thứ nhất là mất tiền của nhà, chiều thứ hai là thu lố của khách. Làm màn
+hình khai báo mà bỏ qua (2) thì đưa cho chủ nhà một nút bấm ra giá sai.
+
+## Quyết định thiết kế
+
+- **Khai theo khoảng ngày, một mức % cho cả khoảng.** Dưới DB vẫn một dòng một
+  ngày, không đổi bảng, không migration.
+- **Màn hình gom ngày liền nhau + cùng nhãn + cùng % thành một dòng.** Chủ nhà
+  nghĩ theo kỳ nghỉ chứ không theo ngày lẻ. Gom được là suy ra chắc chắn từ ba
+  thuộc tính đó, không cần lưu thêm gì.
+- **Trùng ngày thì báo rõ rồi hỏi**, chứ không ghi đè im lặng như backend hiện
+  giờ đang làm (`pricing_repository.rs:85`, `ON CONFLICT(date) DO UPDATE`).
+- **Sửa luật đếm đêm luôn trong đợt này**, vì màn hình khai báo không có giá trị
+  nếu luật sai.
+
+### Vì sao tính bằng **mức bình quân** chứ không sửa `pricing.rs`
+
+Cách hiển nhiên là cho `crate::pricing::calculate_price` nhận một danh sách % theo
+từng đêm. Nhưng có một cách cho ra **kết quả đúng y hệt** mà không phải chạm vào
+`pricing.rs`:
+
+```
+% hiệu dụng = (tổng % của từng đêm trong kỳ ở) ÷ số đêm
+```
+
+Đây **không phải xấp xỉ**. Vì `special = base × pct`, và `base = giá đêm × số đêm`:
+
+```
+base × (Σ pct_d / N) = (base/N) × Σ pct_d = giá đêm × Σ pct_d
+```
+
+đúng bằng tổng phụ thu tính riêng từng đêm. Kiểm hai ví dụ:
+
+- 12/02→16/02, Tết 14–22 +40%. Bốn đêm 12,13,14,15 → Σ = 0+0+40+40 = 80, chia 4 =
+  **20%**. Phụ thu = 20% × 4 đêm = 40% × 2 đêm. ✓
+- 20/02→25/02, Tết +40% các đêm 20,21,22 rồi Hè +25% các đêm 23,24 → Σ = 170,
+  chia 5 = **34%**. 5 đêm × 34% = 3 đêm × 40% + 2 đêm × 25%. ✓ Kỳ ở vắt qua hai
+  mùa khác giá cũng ra đúng, mà chữ ký hàm không đổi.
+
+Lợi thêm: chỉ **một** lần làm tròn ở bước nhân %, thay vì làm tròn từng đêm rồi
+cộng lại.
+
+Lợi về va chạm: nhánh `refactor/pricing-preview-honesty` đang chạy song song ở
+phiên khác **không chạm `pricing.rs`** (đã đối chiếu `git diff main...`). Giữ
+`pricing.rs` nguyên vẹn thu vùng va chạm còn đúng hai file, và một trong hai
+(`domain/booking/pricing.rs`) là của phiên này.
+
+### Vì sao không thêm bảng "khoảng" thật
+
+Sạch hơn về mô hình, nhưng phải thêm migration, thêm đường sinh ngày, thêm chỗ
+đồng bộ giữa bảng khoảng và bảng ngày. Gom hiển thị đạt đúng mục tiêu người dùng
+với chi phí bằng không dưới tầng dữ liệu. Nếu sau này cần khoảng chồng nhau có
+thứ tự ưu tiên thì mới đáng đổi.
+
+## 1. Luật tính giá — đếm từng đêm
+
+### `domain/booking/pricing.rs`
+
+`StayPricingInputs.special_uplift_pct: f64` **bị thay** bằng dữ liệu thô của cả
+kỳ ở:
+
+```rust
+/// Các ngày đã khai là mùa cao điểm, đọc cho đúng khoảng của kỳ ở này.
+/// Ngày nào không khai thì không có mặt trong danh sách.
+pub(crate) special_days: Vec<SpecialDay>,
+
+#[derive(Debug, Clone)]
+pub(crate) struct SpecialDay {
+    pub(crate) date: String, // `YYYY-MM-DD`
+    pub(crate) uplift_pct: f64,
+}
+```
+
+Kiểu này định nghĩa **trong `domain`**, không mượn `SpecialDate` của
+`queries::booking::pricing_queries`. Chiều phụ thuộc là queries → domain;
+`architecture_guard` giữ chiều ấy.
+
+Hàm thuần mới, đi từng ngày y hệt `calculate_weekend_uplift` (`pricing.rs:419`)
+để hai phụ thu không bao giờ bất đồng về "một kỳ ở gồm những ngày nào":
+
+```rust
+/// Mức uplift bình quân trên số đêm. Xem phần "Vì sao tính bằng mức bình quân"
+/// trong spec: nhân mức này với `base` ra đúng bằng cộng phụ thu từng đêm.
+fn effective_special_uplift(inputs: &StayPricingInputs) -> BookingResult<f64>
+```
+
+- Lấy ngày của `check_in`, `check_out` bằng chính bộ phân tích mà
+  `nights_between` đang dùng (`value.get(..10)`, an toàn với chuỗi nhiều byte).
+- `total_days = (co - ci).num_days().max(1)` — **y hệt** `calculate_weekend_uplift`,
+  nên kỳ ở trong ngày (theo giờ) đếm đúng ngày nhận phòng.
+- Đi `total_days` bước từ `ci`, mỗi bước cộng `uplift_pct` của ngày đó, không có
+  thì cộng 0.
+- Trả `tổng / total_days`.
+- `special_days` rỗng → trả `0.0`, không rẽ nhánh riêng.
+
+`calculate_from_loaded_inputs` (`pricing.rs` dòng 132–138 hiện tại) đổi đối số
+cuối từ `inputs.special_uplift_pct` thành `effective_special_uplift(inputs)?`.
+Không còn thay đổi nào khác trong hàm.
+
+### `queries/booking/pricing_queries.rs`
+
+`SPECIAL_UPLIFT_SQL` (tra một ngày) **bị thay** bằng:
+
+```rust
+const SPECIAL_DAYS_IN_RANGE_SQL: &str =
+    "SELECT date, CAST(uplift_pct AS REAL) AS uplift_pct
+     FROM special_dates WHERE date >= ? AND date <= ? ORDER BY date";
+```
+
+Cận trên lấy **bao gồm** ngày trả phòng. Đọc dư một ngày là cố ý: quyết định
+"ngày nào là một đêm" thuộc về `domain`, tầng đọc không được tự cắt.
+
+`load_special_uplift` / `load_special_uplift_tx` thành
+`load_special_days(pool, check_in, check_out)` / `load_special_days_tx(...)`,
+bind `date_key(check_in)` và `date_key(check_out)`.
+
+Ba chỗ dựng `StayPricingInputs` đổi theo, **giữ nguyên** cách xử lỗi đang có:
+
+| Chỗ dựng | Dòng hiện tại | Lỗi đọc `special_dates` |
+|---|---|---|
+| `load_stay_pricing_inputs_tx` | 166 | ném lỗi — đường này thu tiền thật |
+| `load_stay_pricing_inputs_for_room_type` | 205 | `unwrap_or_default()` — chỉ xem trước |
+| `load_stay_pricing_inputs_for_room` | 243 | `unwrap_or_default()` — chỉ xem trước |
+
+> **Ghi chú va chạm.** Nhánh `refactor/pricing-preview-honesty` đang đổi chính
+> quy ước này theo chiều ngược lại: bên đó bản xem trước cũng ném lỗi (test
+> `a_failed_special_date_read_fails_the_preview_instead_of_quoting_no_uplift`).
+> Spec này **cố ý giữ hành vi của `main`** để phần diff còn lại là đổi kiểu dữ
+> liệu thuần. Lúc gộp hai nhánh, lấy bản nghiêm của nhánh kia.
+
+### Không đổi
+
+- Đêm vừa là thứ 7 vừa là ngày lễ **ăn cả hai** phụ thu. Đó là hành vi hiện tại,
+  đổi nó là quyết định về giá chứ không phải sửa lỗi.
+- Nhãn dòng phân tích vẫn là `"Phụ thu ngày lễ"` (`pricing.rs:133`), không kèm
+  số ngày. Muốn hiện "2 đêm lễ" thì phải sửa `pricing.rs` — đúng thứ đang tránh.
+- Phụ thu thêm khách vẫn nằm **ngoài** `base_amount` (`domain/booking/pricing.rs:99`),
+  nên khai Tết không thổi phồng tiền phụ thu khách.
+- Kỳ ở theo giờ trong ngày ra kết quả y như trước khi sửa.
+
+## 2. Lệnh backend
+
+### Thêm mới
+
+```rust
+save_special_date_range(from: String, to: String, label: String, uplift_pct: f64)
+delete_special_dates(dates: Vec<String>)
+```
+
+Cả hai `require_admin`, cả hai chạy trong **một** transaction — nửa khoảng nằm
+lại trong DB là giá sai âm thầm, tệ hơn là báo lỗi.
+
+`save_special_date` cũ **giữ nguyên chữ ký** (đã đăng ký ở `lib.rs:395`), nhưng
+gọi lại đường khoảng với `from = to = date`, để chỉ còn một đường ghi.
+
+Repository nhận cả khoảng, giữ nguyên `ON CONFLICT(date) DO UPDATE` hiện có:
+
+```rust
+upsert_special_date_range_tx(tx, ids, from, to, label, uplift_pct, now)
+delete_special_dates_tx(tx, dates)
+```
+
+`id` sinh mới cho từng ngày; ngày đã tồn tại thì `ON CONFLICT` giữ `id` và
+`created_at` cũ, đúng như ghi chú ở `pricing_repository.rs:72`.
+
+### Chặn đầu vào (ở tầng lệnh, trước khi mở transaction)
+
+| Điều kiện | Vì sao |
+|---|---|
+| `from` và `to` đúng dạng `YYYY-MM-DD` | tránh ghi rác vào cột `date` |
+| `to >= from` | gõ ngược thì khoảng rỗng, ghi xong không hiện ra |
+| khoảng ≤ 366 ngày | gõ nhầm năm sẽ sinh hàng nghìn dòng |
+| `0 <= uplift_pct <= 500` | `uplift_pct` là `REAL` không chặn gì; âm là giảm giá ngầm |
+| `label` bỏ khoảng trắng còn khác rỗng | gom cụm dựa vào nhãn; nhãn rỗng gom nhầm hai kỳ khác nhau |
+| `dates` không rỗng, mỗi phần tử đúng dạng | xoá rỗng là lệnh vô nghĩa |
+
+Lỗi trả về tiếng Việt, theo lối các lệnh khác trong `commands/pricing.rs`.
+
+### Không thêm
+
+Không cần lệnh đọc mới. Màn hình đã tải toàn bộ qua `get_special_dates`, nên
+việc dò trùng ngày làm ngay phía giao diện. Đây là ứng dụng một máy một người
+dùng; khoảng hở giữa lúc dò và lúc ghi không có ý nghĩa thực tế.
+
+## 3. Màn hình khai báo
+
+Cài đặt → mục mới **Peak Season** (`CalendarDays`), chỉ hiện với admin, xếp cạnh
+**Pricing** trong khối `isCurrentAdmin` ở `src/pages/settings/index.tsx:68`.
+Nhãn thanh bên bằng tiếng Anh cho khớp các mục cũ; nội dung bên trong tiếng Việt,
+đúng như `PricingSection.tsx` đang làm.
+
+File mới `src/pages/settings/SpecialDatesSection.tsx`. Không nhét vào
+`PricingSection.tsx` — file đó đang lo bảng giá theo loại phòng, thêm một CRUD
+nữa là nó ôm hai việc.
+
+### Danh sách
+
+```
+Tết Nguyên đán    14/02 – 22/02  (9 ngày)   +40%   [Sửa] [Xoá]
+Lễ 30/4           30/04 – 03/05  (4 ngày)   +30%   [Sửa] [Xoá]
+```
+
+Gom cụm là hàm thuần, tách riêng ra `src/lib/specialDateRanges.ts` để thử được
+mà không cần dựng component:
+
+```ts
+export type SpecialDateRow = { id: string; date: string; label: string; uplift_pct: number };
+export type SpecialDateRange = {
+  from: string; to: string; days: number;
+  label: string; uplift_pct: number;
+  dates: string[]; // mọi ngày trong cụm, dùng khi xoá
+};
+export function groupSpecialDates(rows: SpecialDateRow[]): SpecialDateRange[];
+```
+
+Luật gom: sắp theo `date`, nối ngày kế tiếp vào cụm đang mở khi **cả ba** đều
+khớp — liền ngay hôm sau, cùng `label`, cùng `uplift_pct`. Hở một ngày, hoặc
+khác nhãn, hoặc khác mức, thì mở cụm mới.
+
+So sánh ngày bằng chuỗi `YYYY-MM-DD` thuần. "Ngày kế tiếp" cần một bước lịch, làm
+bằng `Date.UTC(...)` rồi cắt mười ký tự đầu — **tuyệt đối không**
+`new Date("2026-02-14T00:00:00")`, kiểu ấy phân tích theo giờ địa phương rồi in
+ra UTC, lệch một ngày ở UTC+7. Đó đúng là lỗi phiên trước đã dính.
+
+Hàm bước ngày này để **cục bộ trong `specialDateRanges.ts`**, không tách ra
+`src/lib/`. Lý do là va chạm: `ReservationSheet.tsx:35` có `addDays` riêng nhận
+và trả `string`, còn nhánh `refactor/pricing-preview-honesty` đang thêm
+`src/lib/datetime.ts` với một `addDays` **khác chữ ký** (nhận và trả `Date`).
+Dựng thêm một module dùng chung lúc này là chuốc lấy đụng độ trùng tên với kiểu
+không tương thích. Gộp ba chỗ này về một chỗ là việc **sau khi hai nhánh đã
+gộp**, đã ghi ở phần Ngoài phạm vi.
+
+Trống thì hiện một dòng chỉ đường, không phải bảng rỗng.
+
+### Form
+
+Nhãn / Từ ngày / Đến ngày / % phụ thu. Hai ô ngày đều bấm ra lịch, giống ô ngày
+trong `ReservationSheet.tsx`. Nút lưu tắt khi nhãn rỗng hoặc `to < from`.
+
+### Trùng ngày
+
+Trước khi gọi lệnh ghi, dò khoảng đang khai với danh sách đã tải. Có trùng thì
+hiện hộp xác nhận liệt kê thẳng, kèm mức cũ và mức mới:
+
+> 3 ngày đã khai sẽ bị ghi đè: 20/02, 21/02, 22/02 — Tết Nguyên đán +40% → Hè
+> đầu năm +25%. Tiếp tục?
+
+Quá 10 ngày trùng thì liệt kê 10 ngày đầu rồi "…và N ngày nữa". Bấm huỷ thì
+**không gọi lệnh ghi nào**. Khi sửa chính cụm đang mở thì ngày của chính cụm ấy
+không tính là trùng.
+
+### Sửa và xoá
+
+- **Sửa**: đổ cụm vào form. Lưu = `delete_special_dates(ngày cũ không còn nằm
+  trong khoảng mới)` rồi `save_special_date_range(khoảng mới)`. Rút ngắn khoảng
+  thì mấy ngày rơi ra bị xoá thật, không sót lại thành ngày lễ mồ côi.
+- **Xoá**: hỏi lại một lần, rồi `delete_special_dates(cụm.dates)` — một lệnh cho
+  cả cụm.
+- Xong việc thì tải lại bằng `get_special_dates`, không tự sửa state cục bộ, để
+  màn hình luôn phản ánh cái đang thật sự nằm trong DB.
+
+Ghi qua `invokeWriteCommand` như `PricingSection.tsx:47`. Báo kết quả bằng
+`toast`, theo đúng lối file đó.
+
+## 4. Kiểm chứng
+
+Theo TDD: test đỏ trước, và với hai ca dưới đây phải **thấy** nó đỏ đúng vì lý do
+số học, không phải vì thiếu hàm.
+
+### Rust — `domain/booking/pricing.rs`
+
+| Test | Con số |
+|---|---|
+| kỳ ở bắt đầu **trước** mùa | 12/02→16/02, Tết 14–22 +40%, giá 500k/đêm → phụ thu 400.000₫ (2 đêm × 40%), **không phải 0** |
+| kỳ ở kéo **quá** mùa | 22/02→25/02, cùng khai → phụ thu 200.000₫ (1 đêm), **không phải 600.000₫** |
+| vắt qua hai mức | 20/02→25/02, +40% ba đêm rồi +25% hai đêm → đúng bằng tổng tính riêng từng đêm |
+| nằm trọn trong mùa | kết quả **y hệt** trước khi sửa — chống hồi quy |
+| không khai ngày nào | `special_days` rỗng → phụ thu 0 |
+| kỳ ở theo giờ | cùng ngày, ngày đó có khai → ra như cũ |
+| lễ trùng thứ 7 | vẫn ăn **cả hai** phụ thu — khoá hành vi hiện có |
+
+### Rust — `queries/booking/pricing_queries.rs`
+
+- `load_special_days` chỉ trả ngày trong khoảng, bỏ ngày ngoài hai đầu.
+- Ngày trả phòng nằm trong kết quả (cận trên bao gồm).
+- Bản theo mã phòng và bản theo loại phòng đọc cùng một khoảng.
+- `special_dates` hỏng: đường `_tx` ném lỗi, hai đường xem trước trả rỗng.
+
+### Rust — lệnh và repository
+
+- `save_special_date_range` 14/02→22/02 ghi đúng **9** dòng.
+- Ghi đè khoảng có ngày trùng: `label` và `uplift_pct` đổi, `created_at` **giữ
+  nguyên**.
+- `save_special_date` một ngày vẫn ghi đúng một dòng (chữ ký cũ còn dùng được).
+- `delete_special_dates` xoá đúng danh sách, không đụng ngày khác.
+- Mỗi luật chặn đầu vào một test: ngày sai dạng, `to < from`, 367 ngày, `-10`,
+  `600`, nhãn toàn khoảng trắng, `dates` rỗng.
+- Không phải admin thì cả hai lệnh ghi bị từ chối.
+- Lỗi giữa chừng khi ghi khoảng → DB không còn dòng nào của khoảng đó.
+
+### Frontend — `src/lib/specialDateRanges.test.ts`
+
+- 9 dòng liền nhau cùng nhãn cùng mức → **1** cụm, `days = 9`, `dates` đủ 9.
+- Hở một ngày → **2** cụm.
+- Liền ngày nhưng khác nhãn → **2** cụm.
+- Liền ngày, cùng nhãn, khác mức → **2** cụm.
+- Đầu vào rỗng → mảng rỗng.
+- Đầu vào không theo thứ tự ngày → vẫn gom đúng.
+- Vắt qua ranh giới tháng và ranh giới năm (28/02→01/03, 31/12→01/01).
+
+### Frontend — `SpecialDatesSection.test.tsx`
+
+- Danh sách hiện **một** dòng cho chín ngày Tết.
+- Khai khoảng không trùng → gọi `save_special_date_range` đúng một lần với đúng
+  đối số.
+- Khai khoảng có trùng → hiện đúng danh sách ngày trùng; bấm **huỷ** thì
+  `invokeWriteCommand` **không** được gọi.
+- Bấm tiếp tục → mới gọi lệnh ghi.
+- Xoá cụm → `delete_special_dates` nhận đúng 9 ngày trong một lần gọi.
+- Sửa cụm cho ngắn lại → những ngày rơi ra có mặt trong lệnh xoá.
+- Lệnh lỗi → hiện toast lỗi, danh sách không bị đổi ngầm.
+
+### Cổng chung
+
+`npm run verify:full`, `cargo check --all-targets`, và **`cargo fmt --check`** —
+cái cuối CI có gác mà `verify:full` không chạy, phiên trước đã dính đỏ vì nó.
+
+## Ngoài phạm vi
+
+- **Hiện số đêm lễ trong dòng phân tích.** Muốn "Phụ thu 2 đêm lễ (Tết)" thì
+  phải sửa `pricing.rs` — đúng file đang cố giữ nguyên để khỏi đụng nhánh kia.
+  Làm sau khi hai nhánh đã gộp.
+- **Khoảng chồng nhau có thứ tự ưu tiên.** `UNIQUE(date)` chỉ cho một mức mỗi
+  ngày. Hộp xác nhận ghi đè là câu trả lời cho vòng này.
+- **Mức phụ thu khác nhau theo loại phòng.** `special_dates` không có cột loại
+  phòng. Đổi được nhưng là quyết định về giá, không phải sửa lỗi.
+- **Nhãn hoá đơn còn tiếng Anh** (`invoice_generation.rs:120`). Tiền đúng, chỉ
+  chữ sai. Đã ghi ở spec trước, vẫn treo.
+- **Gộp ba bộ trợ giúp ngày về một chỗ.** `ReservationSheet.tsx:35`, module gom
+  cụm của spec này, và `src/lib/datetime.ts` của nhánh kia — mỗi nơi một hàm
+  bước ngày, chữ ký khác nhau. Gộp trước khi hai nhánh gộp là tự tạo đụng độ.
+- **Số khách cho nhận phòng vãng lai và nhận phòng đoàn.** Là việc của phiên
+  kia, cố ý không đụng.
+- **Ngày "hôm nay" tính theo UTC**, sai trong khoảng 00:00–07:00 giờ Việt Nam.
+  Không thuộc màn hình này.
+
+## Rủi ro
+
+- **Va chạm với `refactor/pricing-preview-honesty`.** Hai nhánh cùng sửa
+  `pricing_queries.rs` và `pricing_service.rs`. Đã thu hẹp bằng cách không đụng
+  `pricing.rs`, nhưng lúc gộp vẫn phải gỡ tay ba chỗ dựng `StayPricingInputs`.
+  Chốt sẵn: giữ **kiểu dữ liệu của nhánh này**, giữ **cách xử lỗi của nhánh kia**.
+- **Đổi luật là đổi giá cho đơn đã đặt.** Đơn đã lưu giữ `total_price` cũ, không
+  bị tính lại. Nhưng đặt trước rồi **sửa ngày** hay **gia hạn** thì đi lại engine
+  và ra số mới — đúng hơn số cũ, mà vẫn là một thay đổi chủ nhà cần biết.
+- **Gom cụm là suy đoán, không phải dữ liệu.** Hai kỳ khác nhau tình cờ liền
+  ngày, cùng nhãn, cùng mức sẽ hiện thành một dòng. Vô hại — xoá cụm ấy đúng là
+  xoá chừng đó ngày — nhưng phải nói rõ để sau này không ai coi đó là lỗi.
+- **Không có ràng buộc `CHECK` dưới DB.** Mọi chặn đầu vào nằm ở tầng lệnh. Ghi
+  thẳng vào SQLite bằng tay vẫn lọt. Chấp nhận: mọi bảng khác trong dự án cũng
+  thế.

--- a/docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md
+++ b/docs/superpowers/specs/2026-07-29-mua-cao-diem-design.md
@@ -21,7 +21,7 @@ nhau:
    nhận phòng**, rồi nhân mức % ấy cho **toàn bộ** số đêm
    (`pricing_queries.rs:311` → `domain/booking/pricing.rs:137` →
    `pricing.rs:118`). Nó không đi từng đêm như phụ thu cuối tuần vẫn làm
-   (`pricing.rs:419`).
+   (`pricing.rs:427`).
 
 Hậu quả của (2), lấy Tết khai 14/02–22/02 +40%:
 
@@ -41,27 +41,34 @@ hình khai báo mà bỏ qua (2) thì đưa cho chủ nhà một nút bấm ra g
   nghĩ theo kỳ nghỉ chứ không theo ngày lẻ. Gom được là suy ra chắc chắn từ ba
   thuộc tính đó, không cần lưu thêm gì.
 - **Trùng ngày thì báo rõ rồi hỏi**, chứ không ghi đè im lặng như backend hiện
-  giờ đang làm (`pricing_repository.rs:85`, `ON CONFLICT(date) DO UPDATE`).
+  giờ đang làm (`repositories/booking/pricing_repository.rs:85`, `ON CONFLICT(date) DO UPDATE`).
 - **Sửa luật đếm đêm luôn trong đợt này**, vì màn hình khai báo không có giá trị
   nếu luật sai.
 
 ### Vì sao tính bằng **mức bình quân** chứ không sửa `pricing.rs`
 
 Cách hiển nhiên là cho `crate::pricing::calculate_price` nhận một danh sách % theo
-từng đêm. Nhưng có một cách cho ra **kết quả đúng y hệt** mà không phải chạm vào
-`pricing.rs`:
+từng đêm. Nhưng có một cách rẻ hơn nhiều mà không phải chạm vào `pricing.rs`:
 
 ```
-% hiệu dụng = (tổng % của từng đêm trong kỳ ở) ÷ số đêm
+% hiệu dụng = (tổng % của từng ngày trong kỳ ở) ÷ N        (N = số ngày kỳ ở)
 ```
 
-Đây **không phải xấp xỉ**. Vì `special = base × pct`, và `base = giá đêm × số đêm`:
+Điều luôn đúng, với **mọi** kiểu tính giá:
 
 ```
-base × (Σ pct_d / N) = (base/N) × Σ pct_d = giá đêm × Σ pct_d
+base × (Σ pct_d / N) = Σ ( (base/N) × pct_d )
 ```
 
-đúng bằng tổng phụ thu tính riêng từng đêm. Kiểm hai ví dụ:
+Nghĩa là: chia `base` thành N phần bằng nhau, mỗi ngày chịu mức % của riêng nó
+trên phần của mình. Đó là định nghĩa của "chia đều theo ngày", và nó là hệ quả
+đại số chứ không phải xấp xỉ.
+
+Điều **chỉ đúng với `nightly`, `overnight`, `daily`**: `base/N` đúng bằng giá một
+đêm đã cấu hình. Ba nhánh này tính `base = giá đêm × số ngày`, với **cùng một**
+biểu thức đếm ngày mà `calculate_weekend_uplift` đang dùng
+(`pricing.rs:115-116`, `:251-260`, `:345-346`, đối chiếu `:440`). Nên với ba
+nhánh này, "chia đều theo ngày" **chính là** "từng đêm chịu mức của nó":
 
 - 12/02→16/02, Tết 14–22 +40%. Bốn đêm 12,13,14,15 → Σ = 0+0+40+40 = 80, chia 4 =
   **20%**. Phụ thu = 20% × 4 đêm = 40% × 2 đêm. ✓
@@ -69,13 +76,45 @@ base × (Σ pct_d / N) = (base/N) × Σ pct_d = giá đêm × Σ pct_d
   chia 5 = **34%**. 5 đêm × 34% = 3 đêm × 40% + 2 đêm × 25%. ✓ Kỳ ở vắt qua hai
   mùa khác giá cũng ra đúng, mà chữ ký hàm không đổi.
 
-Lợi thêm: chỉ **một** lần làm tròn ở bước nhân %, thay vì làm tròn từng đêm rồi
-cộng lại.
+### `hourly` là ngoại lệ, và nó đổi hành vi
 
-Lợi về va chạm: nhánh `refactor/pricing-preview-honesty` đang chạy song song ở
-phiên khác **không chạm `pricing.rs`** (đã đối chiếu `git diff main...`). Giữ
-`pricing.rs` nguyên vẹn thu vùng va chạm còn đúng hai file, và một trong hai
-(`domain/booking/pricing.rs`) là của phiên này.
+`calculate_hourly` (`pricing.rs:155-174`) tính `base = giá giờ × số giờ`, hoặc
+một mức trần `overnight_rate`, hoặc `daily_rate × ceil(số giờ / 24)`. **Không**
+cái nào tỉ lệ với `total_days` của `calculate_weekend_uplift`. Nên với kiểu giờ,
+`base/N` không phải giá một đêm, và "chia đều theo ngày" **không** trùng với
+"từng đêm chịu mức của nó".
+
+Kỳ ở theo giờ **trong cùng một ngày** thì `N = 1`, mức hiệu dụng bằng đúng mức
+của ngày đó, kết quả **y hệt** hôm nay. Kỳ ở theo giờ **vắt qua từ hai ngày trở
+lên** thì đổi số. Ví dụ giá giờ 20k / qua đêm 300k / ngày 400k, ở
+`2026-02-13T20:00 → 2026-02-15T02:00` (30 giờ), Tết 14–22 +40%:
+
+| | Kết quả |
+|---|---|
+| `base` | 600.000₫ (`raw_hourly`, không chạm trần) |
+| Hôm nay | phụ thu **0₫** — ngày đến 13/02 chưa khai |
+| Sau khi sửa | `(0+40)/2 = 20%` → phụ thu **120.000₫** |
+
+Đây là **chủ ý**, không phải tác dụng phụ: một kỳ ở đè lên ngày lễ thì phải chịu
+phụ thu, và chia đều theo ngày là cách phân bổ duy nhất có nghĩa khi `base` không
+tính theo đêm. Nó được chốt bằng một test riêng, không để trôi vào phần "không
+đổi".
+
+### Làm tròn
+
+Chỉ **một** lần làm tròn, ở bước nhân %, thay vì làm tròn từng đêm rồi cộng lại.
+Với giá đêm chẵn thì hai cách ra cùng số. Với giá lẻ thì lệch vài đồng — 333.333₫
+một đêm, ba đêm +40%: gộp ra 400.000₫, cộng từng đêm ra 399.999₫. Bản gộp là bản
+đúng theo hợp đồng; test phải ghi **số tuyệt đối**, không được viết kiểu "tính
+từng đêm rồi cộng lại rồi so bằng".
+
+### Lợi thêm: vùng tranh chấp co lại
+
+Nhánh `refactor/pricing-preview-honesty` đang chạy song song ở
+phiên khác **không chạm `pricing.rs`** (đã đối chiếu `git diff --stat main...`,
+21 file, không có file này). Giữ `pricing.rs` nguyên vẹn thu vùng tranh chấp ở
+tầng engine còn đúng **một** file production: `queries/booking/pricing_queries.rs`.
+Chi tiết ở phần Rủi ro.
 
 ### Vì sao không thêm bảng "khoảng" thật
 
@@ -107,21 +146,29 @@ Kiểu này định nghĩa **trong `domain`**, không mượn `SpecialDate` củ
 `queries::booking::pricing_queries`. Chiều phụ thuộc là queries → domain;
 `architecture_guard` giữ chiều ấy.
 
-Hàm thuần mới, đi từng ngày y hệt `calculate_weekend_uplift` (`pricing.rs:419`)
+Hàm thuần mới, đi từng ngày y hệt `calculate_weekend_uplift` (`pricing.rs:427`)
 để hai phụ thu không bao giờ bất đồng về "một kỳ ở gồm những ngày nào":
 
 ```rust
-/// Mức uplift bình quân trên số đêm. Xem phần "Vì sao tính bằng mức bình quân"
-/// trong spec: nhân mức này với `base` ra đúng bằng cộng phụ thu từng đêm.
+/// Mức uplift bình quân trên số ngày của kỳ ở.
+///
+/// Nhân mức này với `base` là chia đều `base` cho từng ngày rồi cho mỗi ngày
+/// chịu mức của riêng nó. Với `nightly`/`overnight`/`daily`, phần chia đều ấy
+/// đúng bằng giá một đêm, nên kết quả là "từng đêm chịu mức của nó". Với
+/// `hourly` thì `base` không tính theo đêm, và đây là phép phân bổ theo ngày —
+/// cố ý, xem spec 2026-07-29-mua-cao-diem-design.md.
 fn effective_special_uplift(inputs: &StayPricingInputs) -> BookingResult<f64>
 ```
 
 - Lấy ngày của `check_in`, `check_out` bằng chính bộ phân tích mà
   `nights_between` đang dùng (`value.get(..10)`, an toàn với chuỗi nhiều byte).
-- `total_days = (co - ci).num_days().max(1)` — **y hệt** `calculate_weekend_uplift`,
-  nên kỳ ở trong ngày (theo giờ) đếm đúng ngày nhận phòng.
-- Đi `total_days` bước từ `ci`, mỗi bước cộng `uplift_pct` của ngày đó, không có
-  thì cộng 0.
+- `total_days = (co_date - ci_date).num_days().max(1)` — trừ trên **`NaiveDate`**
+  đã cắt, không phải trên datetime. Trừ datetime cho ra 3 với
+  `12/02T14:00 → 16/02T12:00` trong khi đáp án là 4. Con số này phải **y hệt**
+  `calculate_weekend_uplift` (`pricing.rs:440`), nếu không hai phụ thu sẽ bất
+  đồng về "kỳ ở này gồm những ngày nào".
+- Đi `total_days` bước từ `ci_date`, mỗi bước cộng `uplift_pct` của ngày đó,
+  không có thì cộng 0.
 - Trả `tổng / total_days`.
 - `special_days` rỗng → trả `0.0`, không rẽ nhánh riêng.
 
@@ -145,6 +192,13 @@ Cận trên lấy **bao gồm** ngày trả phòng. Đọc dư một ngày là c
 `load_special_uplift` / `load_special_uplift_tx` thành
 `load_special_days(pool, check_in, check_out)` / `load_special_days_tx(...)`,
 bind `date_key(check_in)` và `date_key(check_out)`.
+
+**Sửa `date_key` luôn** (`pricing_queries.rs:72-78`). Nó đang là `&date_str[..10]`
+— cắt theo **byte**, nên **panic** nếu byte thứ 10 rơi vào giữa một ký tự nhiều
+byte. Tầng domain đã được vá đúng lỗi này ở phiên trước (`get(..10)`, kèm test
+`nights_between_rejects_check_in_with_non_char_boundary_byte_ten_without_panicking`,
+`domain/booking/pricing.rs:288`). Thay đổi này cho `date_key` ăn **hai** chuỗi
+thay vì một, nên phải vá trước khi tăng phơi nhiễm: `get(..10).unwrap_or(date_str)`.
 
 Ba chỗ dựng `StayPricingInputs` đổi theo, **giữ nguyên** cách xử lỗi đang có:
 
@@ -172,28 +226,57 @@ Ba chỗ dựng `StayPricingInputs` đổi theo, **giữ nguyên** cách xử l�
 
 ## 2. Lệnh backend
 
-### Thêm mới
+### Hai lệnh, không phải ba
 
 ```rust
-save_special_date_range(from: String, to: String, label: String, uplift_pct: f64)
+save_special_date_range(remove: Vec<String>, from: String, to: String,
+                        label: String, uplift_pct: f64)
 delete_special_dates(dates: Vec<String>)
 ```
 
-Cả hai `require_admin`, cả hai chạy trong **một** transaction — nửa khoảng nằm
-lại trong DB là giá sai âm thầm, tệ hơn là báo lỗi.
+`remove` là **chìa khoá của tính nguyên tử**. Khai mới thì nó rỗng. Sửa một cụm
+cho ngắn lại thì nó chứa những ngày rơi ra khỏi khoảng mới, và cả việc xoá lẫn
+việc ghi nằm trong **cùng một** transaction.
 
-`save_special_date` cũ **giữ nguyên chữ ký** (đã đăng ký ở `lib.rs:395`), nhưng
-gọi lại đường khoảng với `from = to = date`, để chỉ còn một đường ghi.
+Nếu tách thành "gọi xoá rồi gọi ghi" thì đó là hai transaction: xoá xong mà ghi
+hỏng là mất hẳn mấy ngày đã khai, màn hình tải lại hiện một mùa bị cụt, không ai
+biết. Đúng cái "nửa khoảng nằm lại trong DB" mà spec này nói là không chấp nhận
+được — và nó rơi vào luồng dễ gặp nhất.
 
-Repository nhận cả khoảng, giữ nguyên `ON CONFLICT(date) DO UPDATE` hiện có:
+Cả hai lệnh `require_admin`. Cả hai gọi `emit_db_update(&app, "pricing")` sau khi
+commit, như `save_pricing_rule` đang làm (`commands/pricing.rs:92`) — giá vừa
+đổi thì màn hình khác đang hiện giá phải biết.
 
-```rust
-upsert_special_date_range_tx(tx, ids, from, to, label, uplift_pct, now)
-delete_special_dates_tx(tx, dates)
-```
+### Bỏ `save_special_date`
 
-`id` sinh mới cho từng ngày; ngày đã tồn tại thì `ON CONFLICT` giữ `id` và
-`created_at` cũ, đúng như ghi chú ở `pricing_repository.rs:72`.
+Lệnh cũ (`commands/pricing.rs:141`, đăng ký ở `lib.rs:396`) **không có ai gọi** —
+không trong `src/`, không trong `gateway/`, đã dò trên mọi nhánh còn sống. Giữ nó
+lại nghĩa là có hai đường ghi vào cùng một bảng tiền, và phải nuôi một test chỉ
+để bảo vệ một lệnh không ai dùng. Bỏ. `save_special_date_range` với `from = to`
+làm được đúng việc ấy và làm được nhiều hơn.
+
+### Tầng nào làm gì
+
+Theo `docs/architecture/core-pms-boundaries.md:100` ("new write behavior should
+have a clear service or lifecycle home") và theo đúng lối `save_pricing_rule`
+đang đi (`commands/pricing.rs:70-93` → `pricing_service.rs:101-140`):
+
+| Tầng | Việc |
+|---|---|
+| `commands/pricing.rs` | `require_admin`, nhận tham số, gọi service, `emit_db_update` |
+| `services/booking/pricing_service.rs` | mở transaction, chặn đầu vào, trải `from..to` thành danh sách ngày, sinh `id`, gọi repository, commit |
+| `repositories/booking/pricing_repository.rs` | `upsert_special_date_tx(tx, …)` một ngày một lần, và `delete_special_dates_tx(tx, dates)` |
+
+Trải khoảng thành từng ngày là quy tắc nghiệp vụ, nên nó ở service; repository
+giữ nguyên độ ngu ngốc của nó, mỗi lần một dòng, dùng lại `ON CONFLICT(date) DO
+UPDATE` sẵn có. Ngày đã tồn tại thì `ON CONFLICT` giữ `id` và `created_at` cũ,
+đúng như ghi chú ở `pricing_repository.rs:72`.
+
+> **Lưu ý cho người làm.** `architecture_guard.rs:244` chỉ dò chuỗi `sqlx::query`
+> trong `commands/`, nên một lệnh tự mở transaction vẫn **qua được** guard. Đừng
+> lấy "test xanh" làm bằng chứng là đã đặt đúng tầng. Trong toàn bộ cây, không
+> có lệnh nào cầm `Transaction<'_, Sqlite>`; mọi `pool.begin()` đều nằm ở service
+> (hoặc `folio_repository.rs:20`). Đi theo lối đó.
 
 ### Chặn đầu vào (ở tầng lệnh, trước khi mở transaction)
 
@@ -214,12 +297,21 @@ Không cần lệnh đọc mới. Màn hình đã tải toàn bộ qua `get_spec
 việc dò trùng ngày làm ngay phía giao diện. Đây là ứng dụng một máy một người
 dùng; khoảng hở giữa lúc dò và lúc ghi không có ý nghĩa thực tế.
 
+Gateway MCP cũng không cần đổi gì. Không có công cụ MCP nào đọc hay ghi
+`special_dates`. Nhưng công cụ `calculate_price` (`gateway/tools.rs:1233-1249`)
+đi qua `load_stay_pricing_inputs_for_room_type` — một trong ba chỗ spec này sửa —
+nên nó **được hưởng bản sửa miễn phí**, không phải đụng dòng nào.
+
 ## 3. Màn hình khai báo
 
 Cài đặt → mục mới **Peak Season** (`CalendarDays`), chỉ hiện với admin, xếp cạnh
 **Pricing** trong khối `isCurrentAdmin` ở `src/pages/settings/index.tsx:68`.
 Nhãn thanh bên bằng tiếng Anh cho khớp các mục cũ; nội dung bên trong tiếng Việt,
 đúng như `PricingSection.tsx` đang làm.
+
+Đấu dây đủ ba chỗ, đừng sót: thêm `"peak-season"` vào `SettingsSectionKey`
+(`index.tsx:33`), thêm một dòng render cạnh `{activeSection === "pricing" && …}`
+(`index.tsx:132`), và đăng ký hai lệnh mới trong `invoke_handler` ở `lib.rs`.
 
 File mới `src/pages/settings/SpecialDatesSection.tsx`. Không nhét vào
 `PricingSection.tsx` — file đó đang lo bảng giá theo loại phòng, thêm một CRUD
@@ -283,9 +375,11 @@ không tính là trùng.
 
 ### Sửa và xoá
 
-- **Sửa**: đổ cụm vào form. Lưu = `delete_special_dates(ngày cũ không còn nằm
-  trong khoảng mới)` rồi `save_special_date_range(khoảng mới)`. Rút ngắn khoảng
-  thì mấy ngày rơi ra bị xoá thật, không sót lại thành ngày lễ mồ côi.
+- **Sửa**: đổ cụm vào form. Lưu = **một** lệnh
+  `save_special_date_range(remove: ngày cũ không còn trong khoảng mới, …)`. Rút
+  ngắn khoảng thì mấy ngày rơi ra bị xoá thật, không sót lại thành ngày lễ mồ
+  côi — và xoá với ghi cùng chung một transaction, hỏng thì hỏng cả, không mất
+  ngày nào.
 - **Xoá**: hỏi lại một lần, rồi `delete_special_dates(cụm.dates)` — một lệnh cho
   cả cụm.
 - Xong việc thì tải lại bằng `get_special_dates`, không tự sửa state cục bộ, để
@@ -294,6 +388,19 @@ không tính là trùng.
 Ghi qua `invokeWriteCommand` như `PricingSection.tsx:47`. Báo kết quả bằng
 `toast`, theo đúng lối file đó.
 
+### Hai file hạ tầng phải sửa kèm, không sửa là đỏ
+
+- **`mhm/tests/frontend-invoke-wrapper-guardrails.test.ts`** là bánh cóc hai
+  chiều: `RAW_INVOKE_ALLOWED_COMMANDS` (`:20-62`) liệt kê mọi `invoke` trần trong
+  `src/` kèm lý do, và test ở `:260-290` đỏ với bất kỳ `invoke` trần nào không có
+  trong danh sách. `get_special_dates` **chưa có** trong đó (hôm nay không ai
+  gọi). Bắt chước y `PricingSection.tsx` — nơi `invoke("get_pricing_rules")` trần
+  *đã* được cho phép ở `:45` — sẽ ra một test đỏ mà nguyên nhân rất khó lần. Phải
+  thêm `get_special_dates` kèm lý do, và cân nhắc thêm hai lệnh ghi mới vào
+  `PMS_WRITE_COMMANDS_REQUIRING_WRAPPER`.
+- **`src/__mocks__/tauri-core.ts`** **ném lỗi** với mọi lệnh chưa đăng ký. Hai
+  lệnh mới phải có trong `defaults`, hoặc mỗi test phải `setMockResponse`.
+
 ## 4. Kiểm chứng
 
 Theo TDD: test đỏ trước, và với hai ca dưới đây phải **thấy** nó đỏ đúng vì lý do
@@ -301,15 +408,21 @@ số học, không phải vì thiếu hàm.
 
 ### Rust — `domain/booking/pricing.rs`
 
+Mọi test ghi **số tuyệt đối**. Cấm viết kiểu "tính từng đêm rồi cộng lại rồi so
+bằng" — xem phần Làm tròn, cách ấy lệch vài đồng với giá lẻ và sẽ đỏ vì lý do
+không liên quan tới luật.
+
 | Test | Con số |
 |---|---|
-| kỳ ở bắt đầu **trước** mùa | 12/02→16/02, Tết 14–22 +40%, giá 500k/đêm → phụ thu 400.000₫ (2 đêm × 40%), **không phải 0** |
-| kỳ ở kéo **quá** mùa | 22/02→25/02, cùng khai → phụ thu 200.000₫ (1 đêm), **không phải 600.000₫** |
-| vắt qua hai mức | 20/02→25/02, +40% ba đêm rồi +25% hai đêm → đúng bằng tổng tính riêng từng đêm |
+| kỳ ở bắt đầu **trước** mùa | 12/02→16/02, Tết 14–22 +40%, giá 500k/đêm → phụ thu **400.000₫**, **không phải 0** |
+| kỳ ở kéo **quá** mùa | 22/02→25/02, cùng khai → phụ thu **200.000₫**, **không phải 600.000₫** |
+| vắt qua hai mức | 20/02→25/02, giá 500k/đêm, +40% ba đêm rồi +25% hai đêm → mức hiệu dụng 34%, phụ thu **850.000₫** trên `base` 2.500.000₫ |
 | nằm trọn trong mùa | kết quả **y hệt** trước khi sửa — chống hồi quy |
 | không khai ngày nào | `special_days` rỗng → phụ thu 0 |
-| kỳ ở theo giờ | cùng ngày, ngày đó có khai → ra như cũ |
+| theo giờ, **cùng ngày** | ngày đó có khai → ra **như cũ** |
+| theo giờ, **vắt hai ngày** | ví dụ 30 giờ ở phần `hourly` là ngoại lệ: `base` 600.000₫, phụ thu **120.000₫** — khoá lại đúng cái hành vi đã đổi, kèm chú thích là chủ ý |
 | lễ trùng thứ 7 | vẫn ăn **cả hai** phụ thu — khoá hành vi hiện có |
+| ngày sai định dạng trong DB | không panic, coi như không khai |
 
 ### Rust — `queries/booking/pricing_queries.rs`
 
@@ -318,17 +431,19 @@ số học, không phải vì thiếu hàm.
 - Bản theo mã phòng và bản theo loại phòng đọc cùng một khoảng.
 - `special_dates` hỏng: đường `_tx` ném lỗi, hai đường xem trước trả rỗng.
 
-### Rust — lệnh và repository
+### Rust — service, lệnh và repository
 
 - `save_special_date_range` 14/02→22/02 ghi đúng **9** dòng.
+- `from = to` ghi đúng **một** dòng.
 - Ghi đè khoảng có ngày trùng: `label` và `uplift_pct` đổi, `created_at` **giữ
   nguyên**.
-- `save_special_date` một ngày vẫn ghi đúng một dòng (chữ ký cũ còn dùng được).
+- **`remove` và ghi trong cùng một transaction**: cho bước ghi hỏng giữa chừng,
+  khẳng định những ngày trong `remove` **vẫn còn nguyên** trong DB. Đây là test
+  quan trọng nhất của phần này — nó là lý do tồn tại của tham số `remove`.
 - `delete_special_dates` xoá đúng danh sách, không đụng ngày khác.
 - Mỗi luật chặn đầu vào một test: ngày sai dạng, `to < from`, 367 ngày, `-10`,
   `600`, nhãn toàn khoảng trắng, `dates` rỗng.
 - Không phải admin thì cả hai lệnh ghi bị từ chối.
-- Lỗi giữa chừng khi ghi khoảng → DB không còn dòng nào của khoảng đó.
 
 ### Frontend — `src/lib/specialDateRanges.test.ts`
 
@@ -339,6 +454,9 @@ số học, không phải vì thiếu hàm.
 - Đầu vào rỗng → mảng rỗng.
 - Đầu vào không theo thứ tự ngày → vẫn gom đúng.
 - Vắt qua ranh giới tháng và ranh giới năm (28/02→01/03, 31/12→01/01).
+- Ngày sai định dạng trong DB → danh sách **không sập**. Cột `date` không có ràng
+  buộc `CHECK` (`db/migrations.rs:209-216`) và lệnh ghi cũ chưa hề kiểm tra, nên
+  dữ liệu rác là có thật.
 
 ### Frontend — `SpecialDatesSection.test.tsx`
 
@@ -357,6 +475,20 @@ số học, không phải vì thiếu hàm.
 `npm run verify:full`, `cargo check --all-targets`, và **`cargo fmt --check`** —
 cái cuối CI có gác mà `verify:full` không chạy, phiên trước đã dính đỏ vì nó.
 
+## Thứ tự thi công
+
+Ba khối tách rời được, và **luật tính giá phải đi trước, thành commit riêng**:
+
+1. **Luật đếm đêm** — `domain/booking/pricing.rs` + `queries/booking/pricing_queries.rs`
+   (kèm bản vá `date_key`). Khối này ôm toàn bộ rủi ro về tiền và toàn bộ rủi ro
+   va chạm. Nó đứng một mình cũng có giá trị: ai đã lỡ khai `special_dates` bằng
+   tay thì được tính đúng ngay.
+2. **Lệnh ghi** — command + service + repository, kèm test.
+3. **Màn hình** — module gom cụm, section, và hai file hạ tầng nói ở trên.
+
+Đừng trộn (1) vào giữa phần CRUD. Nếu phải quay lại hoặc phải gỡ tay lúc gộp
+nhánh, tách sẵn thế này là đỡ nhất.
+
 ## Ngoài phạm vi
 
 - **Hiện số đêm lễ trong dòng phân tích.** Muốn "Phụ thu 2 đêm lễ (Tết)" thì
@@ -374,17 +506,32 @@ cái cuối CI có gác mà `verify:full` không chạy, phiên trước đã d�
 - **Số khách cho nhận phòng vãng lai và nhận phòng đoàn.** Là việc của phiên
   kia, cố ý không đụng.
 - **Ngày "hôm nay" tính theo UTC**, sai trong khoảng 00:00–07:00 giờ Việt Nam.
-  Không thuộc màn hình này.
+  Đây đúng là thứ `src/lib/datetime.ts` của nhánh
+  `refactor/pricing-preview-honesty` (`localRfc3339` / `localDayKey`) sinh ra để
+  vá. Để nhánh ấy lo, đừng vá song song.
 
 ## Rủi ro
 
-- **Va chạm với `refactor/pricing-preview-honesty`.** Hai nhánh cùng sửa
-  `pricing_queries.rs` và `pricing_service.rs`. Đã thu hẹp bằng cách không đụng
-  `pricing.rs`, nhưng lúc gộp vẫn phải gỡ tay ba chỗ dựng `StayPricingInputs`.
-  Chốt sẵn: giữ **kiểu dữ liệu của nhánh này**, giữ **cách xử lỗi của nhánh kia**.
-- **Đổi luật là đổi giá cho đơn đã đặt.** Đơn đã lưu giữ `total_price` cũ, không
-  bị tính lại. Nhưng đặt trước rồi **sửa ngày** hay **gia hạn** thì đi lại engine
-  và ra số mới — đúng hơn số cũ, mà vẫn là một thay đổi chủ nhà cần biết.
+- **Va chạm với `refactor/pricing-preview-honesty`.** Nhánh kia cắt từ `36878af`
+  chứ không phải từ `main` (`a233ac9`), nên bên đó `load_stay_pricing_inputs_for_room`
+  **chưa tồn tại** và các loader chưa có tham số `guests` — cả hai thứ ấy lên
+  `main` sau. Nghĩa là nhánh kia phải rebase lên `main` trước đã; việc gỡ tay là
+  của bước rebase đó, không phải của nhánh này.
+  - File production tranh chấp thật sự: **`queries/booking/pricing_queries.rs`**,
+    một file. Phần nhánh kia sửa trong `pricing_service.rs` **chỉ nằm trong
+    `mod tests`**.
+  - Trong file ấy, nhánh kia còn đổi `FALLBACK_BASE_PRICE_SQL` (thêm `ORDER BY
+    id`, `pricing_queries.rs:25`) — khác vùng, nhiều khả năng tự gộp được, nhưng
+    ghi ra đây để không ai bất ngờ.
+  - Chốt sẵn cách gỡ: giữ **kiểu dữ liệu của nhánh này**, giữ **cách xử lỗi
+    nghiêm của nhánh kia** (xem trước cũng ném lỗi).
+- **Đổi luật là đổi giá cho khách đang ở, không chỉ đơn bị sửa.** Đơn đã lưu giữ
+  `total_price` cũ. Nhưng `CheckoutSettlementMode::ActualNights`
+  (`stay_lifecycle.rs:668-690`) **tính lại cả kỳ ở** lúc trả phòng. Khai Tết khi
+  khách đang ở trong phòng sẽ đổi số tiền họ trả lúc đi, dù không ai sửa ngày,
+  không ai gia hạn. Đây là **chủ ý** — luật cũ sai thì số cũ cũng sai — nhưng
+  phải ghi ra để sau này không ai coi là lỗi. (`extend_stay` `:1078` thì không
+  ảnh hưởng: nó chỉ tính một đêm tăng thêm, `N = 1`, luật cũ và mới ra cùng số.)
 - **Gom cụm là suy đoán, không phải dữ liệu.** Hai kỳ khác nhau tình cờ liền
   ngày, cùng nhãn, cùng mức sẽ hiện thành một dòng. Vô hại — xoá cụm ấy đúng là
   xoá chừng đó ngày — nhưng phải nói rõ để sau này không ai coi đó là lỗi.

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -221,6 +221,20 @@ pub async fn save_special_date_range(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn delete_special_dates(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    dates: Vec<String>,
+) -> Result<(), String> {
+    require_admin(&state)?;
+
+    pricing_service::delete_special_dates(&state.db, dates).await?;
+
+    emit_db_update(&app, "pricing");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::do_get_room_type_rates;

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -191,6 +191,36 @@ pub async fn get_special_dates(
         .collect())
 }
 
+#[tauri::command]
+pub async fn save_special_date_range(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    remove: Vec<String>,
+    from: String,
+    to: String,
+    label: String,
+    uplift_pct: f64,
+) -> Result<(), String> {
+    require_admin(&state)?;
+
+    pricing_service::save_special_date_range(
+        &state.db,
+        pricing_service::SaveSpecialDateRange {
+            remove,
+            from,
+            to,
+            label,
+            uplift_pct,
+        },
+        uuid::Uuid::new_v4().to_string(),
+        chrono::Local::now().to_rfc3339(),
+    )
+    .await?;
+
+    emit_db_update(&app, "pricing");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::do_get_room_type_rates;

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -8,7 +8,6 @@
 use super::{emit_db_update, require_admin, AppState};
 use crate::money::MoneyVnd;
 use crate::queries::booking::pricing_queries;
-use crate::repositories::booking::pricing_repository;
 use crate::services::booking::pricing_service::{self, SavePricingRule};
 use sqlx::{Pool, Sqlite};
 use tauri::State;
@@ -190,27 +189,6 @@ pub async fn get_special_dates(
             })
         })
         .collect())
-}
-
-#[tauri::command]
-pub async fn save_special_date(
-    state: State<'_, AppState>,
-    date: String,
-    label: String,
-    uplift_pct: f64,
-) -> Result<(), String> {
-    require_admin(&state)?;
-
-    pricing_repository::upsert_special_date(
-        &state.db,
-        &uuid::Uuid::new_v4().to_string(),
-        &date,
-        &label,
-        uplift_pct,
-        &chrono::Local::now().to_rfc3339(),
-    )
-    .await
-    .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -16,7 +16,9 @@ pub(crate) struct StayPricingInputs {
     pub(crate) room_type: String,
     pub(crate) stored_rule: Option<StoredPricingRule>,
     pub(crate) fallback_base_price: Option<MoneyVnd>,
-    pub(crate) special_uplift_pct: f64,
+    /// Những ngày trong khoảng kỳ ở đã được khai là mùa cao điểm. Ngày không
+    /// khai thì không có mặt. Rỗng nghĩa là không phụ thu.
+    pub(crate) special_days: Vec<SpecialDay>,
     pub(crate) check_in: String,
     pub(crate) check_out: String,
     pub(crate) pricing_type: String,
@@ -27,6 +29,17 @@ pub(crate) struct StayPricingInputs {
     pub(crate) base_guests: i32,
     /// `rooms.extra_person_fee`: phụ thu mỗi khách vượt mốc, mỗi đêm.
     pub(crate) extra_person_fee: MoneyVnd,
+}
+
+/// Một ngày đã khai là mùa cao điểm.
+///
+/// Định nghĩa ở đây chứ không mượn `queries::booking::pricing_queries::SpecialDate`:
+/// chiều phụ thuộc là queries → domain, và `architecture_guard` giữ chiều ấy.
+#[derive(Debug, Clone)]
+pub(crate) struct SpecialDay {
+    /// `YYYY-MM-DD` đúng như nằm trong cột `special_dates.date`.
+    pub(crate) date: String,
+    pub(crate) uplift_pct: f64,
 }
 
 /// A row of `pricing_rules`, decoded but not yet interpreted.
@@ -119,15 +132,55 @@ pub(crate) fn build_effective_pricing_rule(
     }
 }
 
-/// Số đêm giữa hai mốc, chấp nhận cả `YYYY-MM-DD` lẫn RFC3339 (cắt 10 ký tự đầu).
-/// Trả 0 khi ngày đi không sau ngày đến — đúng lúc `calculate_price` cũng trả 0.
-fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
-    let parse = |value: &str| {
-        let head = value.get(..10).unwrap_or(value);
-        NaiveDate::parse_from_str(head, "%Y-%m-%d")
-            .map_err(|error| BookingError::datetime_parse(error.to_string()))
-    };
-    Ok((parse(check_out)? - parse(check_in)?).num_days().max(0))
+/// Ngày lịch của một mốc thời gian.
+///
+/// Cắt bằng `get` chứ không phải `&value[..10]`: một chuỗi nhiều byte sẽ làm
+/// bản cắt theo byte panic.
+fn date_only(value: &str) -> BookingResult<NaiveDate> {
+    let head = value.get(..10).unwrap_or(value);
+    NaiveDate::parse_from_str(head, "%Y-%m-%d")
+        .map_err(|error| BookingError::datetime_parse(error.to_string()))
+}
+
+pub(crate) fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
+    Ok((date_only(check_out)? - date_only(check_in)?)
+        .num_days()
+        .max(0))
+}
+
+/// Mức uplift bình quân trên số ngày của kỳ ở.
+///
+/// Nhân mức này với `base` là chia đều `base` cho từng ngày rồi cho mỗi ngày
+/// chịu mức của riêng nó: `base × (Σ pct_d / N) = Σ ((base/N) × pct_d)`.
+///
+/// Với `nightly`/`overnight`/`daily`, `base/N` đúng bằng giá một đêm đã cấu
+/// hình, nên kết quả **là** "từng đêm chịu mức của nó". Với `hourly` thì `base`
+/// không tính theo đêm và đây là phép phân bổ theo ngày — cố ý, xem spec
+/// `2026-07-29-mua-cao-diem-design.md`.
+///
+/// Đi từng ngày y hệt `crate::pricing::calculate_weekend_uplift`, nên phụ thu
+/// cuối tuần và phụ thu ngày lễ không bao giờ bất đồng về việc một kỳ ở gồm
+/// những ngày nào.
+fn effective_special_uplift(inputs: &StayPricingInputs) -> BookingResult<f64> {
+    if inputs.special_days.is_empty() {
+        return Ok(0.0);
+    }
+
+    let check_in = date_only(&inputs.check_in)?;
+    let check_out = date_only(&inputs.check_out)?;
+    let total_days = (check_out - check_in).num_days().max(1);
+
+    let mut total_pct = 0.0;
+    let mut date = check_in;
+    for _ in 0..total_days {
+        let key = date.format("%Y-%m-%d").to_string();
+        if let Some(day) = inputs.special_days.iter().find(|day| day.date == key) {
+            total_pct += day.uplift_pct;
+        }
+        date = date.succ_opt().unwrap_or(date);
+    }
+
+    Ok(total_pct / total_days as f64)
 }
 
 /// Phụ thu thêm người: khoản phẳng theo đêm.
@@ -174,7 +227,7 @@ pub(crate) fn calculate_from_loaded_inputs(
         &inputs.check_in,
         &inputs.check_out,
         &inputs.pricing_type,
-        inputs.special_uplift_pct,
+        effective_special_uplift(inputs)?,
     )
     .map_err(BookingError::datetime_parse)?;
 
@@ -195,7 +248,7 @@ pub(crate) fn calculate_from_loaded_inputs(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_effective_pricing_rule, calculate_from_loaded_inputs, nights_between,
+        build_effective_pricing_rule, calculate_from_loaded_inputs, nights_between, SpecialDay,
         StayPricingInputs, StoredPricingRule,
     };
     use crate::domain::booking::BookingError;
@@ -206,7 +259,7 @@ mod tests {
             room_type: "standard".to_string(),
             stored_rule: None,
             fallback_base_price: None,
-            special_uplift_pct: 0.0,
+            special_days: Vec::new(),
             check_in: "2026-04-20".to_string(),
             check_out: "2026-04-22".to_string(),
             pricing_type: "nightly".to_string(),
@@ -214,6 +267,39 @@ mod tests {
             base_guests: 2,
             extra_person_fee: 0,
         }
+    }
+
+    /// Giá 500k một đêm, **không** phụ thu cuối tuần. Bỏ `weekend_uplift_pct`
+    /// đi là mọi con số trong các test ngày lễ dưới đây sai, vì `sample_inputs`
+    /// không có `stored_rule` sẽ rơi xuống mặc định 20% của `PricingRule`.
+    fn holiday_rule() -> StoredPricingRule {
+        StoredPricingRule {
+            room_type: "standard".to_string(),
+            hourly_rate: 20_000,
+            overnight_rate: 300_000,
+            daily_rate: 500_000,
+            overnight_start: "22:00".to_string(),
+            overnight_end: "11:00".to_string(),
+            daily_checkin: "14:00".to_string(),
+            daily_checkout: "12:00".to_string(),
+            early_checkin_surcharge_pct: 0.0,
+            late_checkout_surcharge_pct: 0.0,
+            weekend_uplift_pct: 0.0,
+        }
+    }
+
+    fn special(date: &str, uplift_pct: f64) -> SpecialDay {
+        SpecialDay {
+            date: date.to_string(),
+            uplift_pct,
+        }
+    }
+
+    /// Tết 14/02–22/02 +40%, đúng khai báo dùng chung cho các test dưới.
+    fn tet_2026() -> Vec<SpecialDay> {
+        (14..=22)
+            .map(|day| special(&format!("2026-02-{day:02}"), 40.0))
+            .collect()
     }
 
     #[test]
@@ -306,7 +392,7 @@ mod tests {
         inputs.fallback_base_price = Some(500_000);
         inputs.check_in = "2026-04-20T10:00:00+07:00".to_string();
         inputs.check_out = "2026-04-22T10:00:00+07:00".to_string();
-        inputs.special_uplift_pct = 10.0;
+        inputs.special_days = vec![special("2026-04-20", 10.0), special("2026-04-21", 10.0)];
 
         let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
 
@@ -412,7 +498,7 @@ mod tests {
     fn extra_guest_line_is_not_multiplied_by_uplift() {
         let mut inputs = sample_inputs();
         inputs.fallback_base_price = Some(500_000);
-        inputs.special_uplift_pct = 10.0;
+        inputs.special_days = vec![special("2026-04-20", 10.0), special("2026-04-21", 10.0)];
         inputs.guests = Some(3);
         inputs.base_guests = 2;
         inputs.extra_person_fee = 50_000;
@@ -462,5 +548,161 @@ mod tests {
         let error = calculate_from_loaded_inputs(&inputs).unwrap_err();
 
         assert!(matches!(error, BookingError::Validation(_)));
+    }
+
+    #[test]
+    fn special_uplift_covers_only_the_nights_inside_the_season() {
+        // 12/02→16/02 là bốn đêm 12,13,14,15. Tết phủ 14 và 15.
+        // Hôm nay engine nhìn mỗi ngày đến 12/02 rồi báo 0₫.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.check_in = "2026-02-12".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 2 đêm × 500.000 × 40% = 400.000
+        assert_eq!(pricing.surcharge_amount, 400_000);
+    }
+
+    #[test]
+    fn special_uplift_stops_at_the_end_of_the_season() {
+        // 22/02→25/02 là ba đêm 22,23,24. Chỉ đêm 22 còn trong Tết.
+        // Hôm nay engine thấy ngày đến 22/02 là lễ rồi tính 40% cho cả ba đêm.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.check_in = "2026-02-22".to_string();
+        inputs.check_out = "2026-02-25".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 1 đêm × 500.000 × 40% = 200.000, không phải 600.000
+        assert_eq!(pricing.surcharge_amount, 200_000);
+    }
+
+    #[test]
+    fn special_uplift_spans_two_different_seasons() {
+        // 20/02→25/02 là năm đêm. Tết +40% ba đêm 20,21,22; Hè +25% hai đêm 23,24.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026()
+            .into_iter()
+            .chain([special("2026-02-23", 25.0), special("2026-02-24", 25.0)])
+            .collect();
+        inputs.check_in = "2026-02-20".to_string();
+        inputs.check_out = "2026-02-25".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // Mức bình quân (40×3 + 25×2)/5 = 34%. base = 5 × 500.000 = 2.500.000.
+        // 2.500.000 × 34% = 850.000 = 3×200.000 + 2×125.000.
+        assert_eq!(pricing.base_amount, 2_500_000);
+        assert_eq!(pricing.surcharge_amount, 850_000);
+    }
+
+    #[test]
+    fn special_uplift_is_unchanged_for_a_stay_entirely_inside_the_season() {
+        // Chống hồi quy: kỳ ở nằm trọn trong mùa phải ra y như luật cũ.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.check_in = "2026-02-15".to_string();
+        inputs.check_out = "2026-02-18".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // Cả ba đêm 15,16,17 đều là Tết → vẫn đúng 40% trên toàn bộ base.
+        assert_eq!(pricing.base_amount, 1_500_000);
+        assert_eq!(pricing.surcharge_amount, 600_000);
+    }
+
+    #[test]
+    fn no_special_days_means_no_surcharge() {
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.check_in = "2026-02-12".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.surcharge_amount, 0);
+    }
+
+    #[test]
+    fn hourly_stay_within_one_day_is_unchanged() {
+        // N = 1, mức bình quân bằng đúng mức của ngày ấy. Kết quả như luật cũ.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.pricing_type = "hourly".to_string();
+        inputs.check_in = "2026-02-14T08:00:00".to_string();
+        inputs.check_out = "2026-02-14T13:00:00".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 5 giờ × 20.000 = 100.000; 100.000 × 40% = 40.000.
+        assert_eq!(pricing.base_amount, 100_000);
+        assert_eq!(pricing.surcharge_amount, 40_000);
+    }
+
+    #[test]
+    fn hourly_stay_across_two_days_is_prorated_and_this_is_a_deliberate_change() {
+        // Ngoại lệ đã ghi trong spec: `base` của kiểu giờ không tính theo đêm,
+        // nên chia đều theo ngày là cách phân bổ duy nhất có nghĩa. Trước khi
+        // sửa, kỳ ở này ra 0₫ vì ngày đến 13/02 chưa khai.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = tet_2026();
+        inputs.pricing_type = "hourly".to_string();
+        inputs.check_in = "2026-02-13T20:00:00".to_string();
+        inputs.check_out = "2026-02-15T02:00:00".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        // 30 giờ × 20.000 = 600.000, không chạm trần nào.
+        // Hai ngày lịch 13 và 14; (0 + 40)/2 = 20% → 120.000.
+        assert_eq!(pricing.base_amount, 600_000);
+        assert_eq!(pricing.surcharge_amount, 120_000);
+    }
+
+    #[test]
+    fn a_holiday_that_falls_on_a_weekend_still_charges_both() {
+        // Khoá hành vi hiện có: hai phụ thu cộng dồn, không cái nào nuốt cái
+        // nào. Đây là quyết định về giá, đổi nó không thuộc phạm vi đợt này.
+        // Chú ý fixture: test này là chỗ DUY NHẤT cố ý bật phụ thu cuối tuần.
+        let mut rule = holiday_rule();
+        rule.weekend_uplift_pct = 20.0;
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(rule);
+        inputs.special_days = tet_2026();
+        // 14/02/2026 là thứ Bảy, 15/02 là Chủ nhật — hai đêm, cả hai đều cuối
+        // tuần và cả hai đều trong Tết.
+        inputs.check_in = "2026-02-14".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.base_amount, 1_000_000);
+        assert_eq!(pricing.weekend_amount, 200_000, "2 đêm × 500.000 × 20%");
+        assert_eq!(pricing.surcharge_amount, 400_000, "2 đêm × 500.000 × 40%");
+        assert_eq!(pricing.total, 1_600_000, "cả hai phụ thu đều được cộng");
+    }
+
+    #[test]
+    fn a_malformed_stored_date_simply_never_matches() {
+        // Cột `date` không có ràng buộc CHECK, nên rác là có thật. Tính chất
+        // "coi như không khai" tự có từ việc so sánh chuỗi — đừng thêm đường
+        // phân tích-rồi-báo-lỗi, làm thế là đổi đúng hành vi test này khoá.
+        let mut inputs = sample_inputs();
+        inputs.stored_rule = Some(holiday_rule());
+        inputs.special_days = vec![special("khong-phai-ngay", 40.0)];
+        inputs.check_in = "2026-02-12".to_string();
+        inputs.check_out = "2026-02-16".to_string();
+
+        let pricing = calculate_from_loaded_inputs(&inputs).unwrap();
+
+        assert_eq!(pricing.surcharge_amount, 0);
     }
 }

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -142,7 +142,9 @@ fn date_only(value: &str) -> BookingResult<NaiveDate> {
         .map_err(|error| BookingError::datetime_parse(error.to_string()))
 }
 
-pub(crate) fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
+/// Số đêm giữa hai mốc, chấp nhận cả `YYYY-MM-DD` lẫn RFC3339 (cắt 10 ký tự đầu).
+/// Trả 0 khi ngày đi không sau ngày đến — đúng lúc `calculate_price` cũng trả 0.
+fn nights_between(check_in: &str, check_out: &str) -> BookingResult<i64> {
     Ok((date_only(check_out)? - date_only(check_in)?)
         .num_days()
         .max(0))

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -396,6 +396,7 @@ pub fn run() {
             commands::pricing::calculate_room_price_preview,
             commands::pricing::get_special_dates,
             commands::pricing::save_special_date_range,
+            commands::pricing::delete_special_dates,
             // Folio/Billing
             commands::billing::add_folio_line,
             commands::billing::record_payment,

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -395,7 +395,6 @@ pub fn run() {
             commands::pricing::calculate_price_preview,
             commands::pricing::calculate_room_price_preview,
             commands::pricing::get_special_dates,
-            commands::pricing::save_special_date,
             // Folio/Billing
             commands::billing::add_folio_line,
             commands::billing::record_payment,

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -395,6 +395,7 @@ pub fn run() {
             commands::pricing::calculate_price_preview,
             commands::pricing::calculate_room_price_preview,
             commands::pricing::get_special_dates,
+            commands::pricing::save_special_date_range,
             // Folio/Billing
             commands::billing::add_folio_line,
             commands::billing::record_payment,

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -129,12 +129,12 @@ fn room_not_found(room_id: &str) -> BookingError {
 
 /// `special_dates.date` is a bare `YYYY-MM-DD`, so an RFC3339 check-in has to
 /// be truncated before it will match.
+///
+/// Cắt bằng `get` chứ không phải `&value[..10]`: chuỗi đến từ dữ liệu người
+/// dùng, và cắt theo byte sẽ panic nếu byte thứ mười rơi vào giữa một ký tự
+/// nhiều byte. Tầng domain đã vá đúng lỗi này ở `nights_between`.
 fn date_key(date_str: &str) -> &str {
-    if date_str.len() >= 10 {
-        &date_str[..10]
-    } else {
-        date_str
-    }
+    date_str.get(..10).unwrap_or(date_str)
 }
 
 /// Mốc tính giá của một phòng. Phòng không tìm thấy thì dùng mặc định của schema
@@ -486,7 +486,7 @@ async fn load_special_uplift_tx(
 
 #[cfg(test)]
 mod tests {
-    use super::{load_stay_pricing_inputs_tx, stored_rule_from_row};
+    use super::{date_key, load_stay_pricing_inputs_tx, stored_rule_from_row};
     use sqlx::{sqlite::SqlitePoolOptions, Connection, Executor, SqliteConnection};
 
     #[tokio::test]
@@ -523,6 +523,15 @@ mod tests {
         assert_eq!(rule.early_checkin_surcharge_pct, 15.0);
         assert_eq!(rule.late_checkout_surcharge_pct, 20.0);
         assert_eq!(rule.weekend_uplift_pct, 12.5);
+    }
+
+    #[test]
+    fn date_key_does_not_panic_when_byte_ten_splits_a_character() {
+        // Chín ký tự ASCII rồi một ký tự hai byte: byte thứ 10 rơi vào giữa
+        // ký tự ấy. `&value[..10]` sẽ panic ở đây.
+        let value = "123456789é";
+
+        assert_eq!(date_key(value), value);
     }
 
     async fn setup_loader_pool() -> sqlx::SqlitePool {

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -10,7 +10,7 @@
 use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::db::row::{get_f64, get_money_vnd};
-use crate::domain::booking::pricing::{StayPricingInputs, StoredPricingRule};
+use crate::domain::booking::pricing::{SpecialDay, StayPricingInputs, StoredPricingRule};
 use crate::domain::booking::{BookingError, BookingResult};
 use crate::money::MoneyVnd;
 
@@ -78,8 +78,8 @@ const ROOM_GUEST_PRICING_BY_TYPE_SQL: &str = "SELECT COALESCE(max_guests, 2) AS 
             COALESCE(extra_person_fee, 0) AS extra_person_fee
      FROM rooms WHERE LOWER(type) = LOWER(?) ORDER BY id LIMIT 1";
 
-const SPECIAL_UPLIFT_SQL: &str =
-    "SELECT CAST(uplift_pct AS REAL) FROM special_dates WHERE date = ?";
+const SPECIAL_DAYS_IN_RANGE_SQL: &str = "SELECT date, CAST(uplift_pct AS REAL) AS uplift_pct
+     FROM special_dates WHERE date >= ? AND date <= ? ORDER BY date";
 
 /// Every room type the house actually has rooms in. A type with a
 /// `pricing_rules` row but no rooms prices nothing, so it is not listed.
@@ -223,14 +223,14 @@ pub(crate) async fn load_stay_pricing_inputs_tx(
     } else {
         None
     };
-    let special_uplift_pct = load_special_uplift_tx(tx, check_in).await?;
+    let special_days = load_special_days_tx(tx, check_in, check_out).await?;
     let guest_pricing = load_room_guest_pricing_tx(tx, room_id).await?;
 
     Ok(StayPricingInputs {
         room_type,
         stored_rule,
         fallback_base_price,
-        special_uplift_pct,
+        special_days,
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
         pricing_type: pricing_type.to_string(),
@@ -264,14 +264,14 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
     guests: Option<i32>,
 ) -> BookingResult<StayPricingInputs> {
     let rule_inputs = load_type_rule_inputs(pool, room_type).await?;
-    let special_uplift_pct = load_special_uplift(pool, check_in).await?;
+    let special_days = load_special_days(pool, check_in, check_out).await?;
     let guest_pricing = load_room_guest_pricing_for_type(pool, room_type).await?;
 
     Ok(StayPricingInputs {
         room_type: room_type.to_string(),
         stored_rule: rule_inputs.stored_rule,
         fallback_base_price: rule_inputs.fallback_base_price,
-        special_uplift_pct,
+        special_days,
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
         pricing_type: pricing_type.to_string(),
@@ -299,14 +299,14 @@ pub(crate) async fn load_stay_pricing_inputs_for_room(
 ) -> BookingResult<StayPricingInputs> {
     let room_type = load_room_type(pool, room_id).await?;
     let rule_inputs = load_type_rule_inputs(pool, &room_type).await?;
-    let special_uplift_pct = load_special_uplift(pool, check_in).await?;
+    let special_days = load_special_days(pool, check_in, check_out).await?;
     let guest_pricing = load_room_guest_pricing(pool, room_id).await?;
 
     Ok(StayPricingInputs {
         room_type,
         stored_rule: rule_inputs.stored_rule,
         fallback_base_price: rule_inputs.fallback_base_price,
-        special_uplift_pct,
+        special_days,
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
         pricing_type: pricing_type.to_string(),
@@ -391,14 +391,46 @@ async fn load_fallback_base_price(
     Ok(row.as_ref().map(|row| get_money_vnd(row, "base_price")))
 }
 
-async fn load_special_uplift(pool: &Pool<Sqlite>, date_str: &str) -> BookingResult<f64> {
-    let row: Option<(f64,)> = sqlx::query_as(SPECIAL_UPLIFT_SQL)
-        .bind(date_key(date_str))
-        .fetch_optional(pool)
+/// Ngày lễ trong khoảng kỳ ở.
+///
+/// Cận trên **bao gồm** ngày trả phòng. Đọc dư một ngày là cố ý: quyết định
+/// "ngày nào là một đêm" thuộc về `domain`, tầng đọc không được tự cắt.
+async fn load_special_days(
+    pool: &Pool<Sqlite>,
+    check_in: &str,
+    check_out: &str,
+) -> BookingResult<Vec<SpecialDay>> {
+    let rows = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
+        .bind(date_key(check_in))
+        .bind(date_key(check_out))
+        .fetch_all(pool)
         .await
         .map_err(database_error)?;
 
-    Ok(row.map(|value| value.0).unwrap_or(0.0))
+    Ok(special_days_from_rows(rows))
+}
+
+async fn load_special_days_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    check_in: &str,
+    check_out: &str,
+) -> BookingResult<Vec<SpecialDay>> {
+    let rows = sqlx::query_as(SPECIAL_DAYS_IN_RANGE_SQL)
+        .bind(date_key(check_in))
+        .bind(date_key(check_out))
+        .fetch_all(&mut **tx)
+        .await
+        .map_err(database_error)?;
+
+    Ok(special_days_from_rows(rows))
+}
+
+/// Bản pool và bản transaction chỉ khác nhau ở chỗ chạy câu lệnh. Dùng chung
+/// một bộ ánh xạ để hai đường không thể hiểu khác nhau về cùng một hàng.
+fn special_days_from_rows(rows: Vec<(String, f64)>) -> Vec<SpecialDay> {
+    rows.into_iter()
+        .map(|(date, uplift_pct)| SpecialDay { date, uplift_pct })
+        .collect()
 }
 
 pub(crate) async fn load_pricing_rule_listings(
@@ -471,22 +503,9 @@ async fn load_fallback_base_price_tx(
         .map(|row| get_money_vnd(row, "base_price")))
 }
 
-async fn load_special_uplift_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    date_str: &str,
-) -> BookingResult<f64> {
-    let row: Option<(f64,)> = sqlx::query_as(SPECIAL_UPLIFT_SQL)
-        .bind(date_key(date_str))
-        .fetch_optional(&mut **tx)
-        .await
-        .map_err(database_error)?;
-
-    Ok(row.map(|value| value.0).unwrap_or(0.0))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{date_key, load_stay_pricing_inputs_tx, stored_rule_from_row};
+    use super::{date_key, load_special_days, load_stay_pricing_inputs_tx, stored_rule_from_row};
     use sqlx::{sqlite::SqlitePoolOptions, Connection, Executor, SqliteConnection};
 
     #[tokio::test]
@@ -640,7 +659,8 @@ mod tests {
         assert_eq!(inputs.room_type, "deluxe");
         assert!(inputs.stored_rule.is_some());
         assert_eq!(inputs.fallback_base_price, None);
-        assert_eq!(inputs.special_uplift_pct, 10.0);
+        assert_eq!(inputs.special_days.len(), 1);
+        assert_eq!(inputs.special_days[0].uplift_pct, 10.0);
 
         tx.rollback().await.unwrap();
     }
@@ -672,8 +692,57 @@ mod tests {
         assert_eq!(inputs.room_type, "standard");
         assert!(inputs.stored_rule.is_none());
         assert_eq!(inputs.fallback_base_price, Some(480000));
-        assert_eq!(inputs.special_uplift_pct, 0.0);
+        assert!(inputs.special_days.is_empty());
 
         tx.rollback().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_special_days_returns_only_the_days_inside_the_stay() {
+        let pool = setup_loader_pool().await;
+        for (date, pct) in [
+            ("2026-02-13", 40.0),
+            ("2026-02-14", 40.0),
+            ("2026-02-15", 40.0),
+            ("2026-02-16", 40.0),
+            ("2026-02-17", 40.0),
+        ] {
+            sqlx::query("INSERT INTO special_dates (date, uplift_pct) VALUES (?, ?)")
+                .bind(date)
+                .bind(pct)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let days = load_special_days(&pool, "2026-02-14", "2026-02-16")
+            .await
+            .unwrap();
+
+        // Cận trên bao gồm ngày trả phòng, nên 16 có mặt; 13 và 17 thì không.
+        let dates: Vec<&str> = days.iter().map(|day| day.date.as_str()).collect();
+        assert_eq!(dates, vec!["2026-02-14", "2026-02-15", "2026-02-16"]);
+    }
+
+    #[tokio::test]
+    async fn load_special_days_truncates_an_rfc3339_bound() {
+        let pool = setup_loader_pool().await;
+        sqlx::query("INSERT INTO special_dates (date, uplift_pct) VALUES (?, ?)")
+            .bind("2026-02-14")
+            .bind(40.0)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let days = load_special_days(
+            &pool,
+            "2026-02-14T08:00:00+07:00",
+            "2026-02-14T20:00:00+07:00",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(days[0].uplift_pct, 40.0);
     }
 }

--- a/mhm/src-tauri/src/repositories/booking/pricing_repository.rs
+++ b/mhm/src-tauri/src/repositories/booking/pricing_repository.rs
@@ -70,9 +70,6 @@ pub async fn upsert_pricing_rule(
 }
 
 /// Giá trị đã được service kiểm và đã đủ, writer không quyết định gì.
-// `repositories` is a private module, so `pub` here doesn't reach the crate's
-// external API — rustc still flags it as dead code until Task 4 wires in the caller.
-#[allow(dead_code)]
 pub struct SpecialDateUpsert<'a> {
     pub id: &'a str,
     pub date: &'a str,
@@ -87,8 +84,6 @@ pub struct SpecialDateUpsert<'a> {
 ///
 /// Nhận `tx` chứ không nhận `pool`: khai một khoảng là nhiều dòng, và mất nửa
 /// khoảng còn tệ hơn báo lỗi.
-// No caller yet outside these tests; Task 4 wires this into the service.
-#[allow(dead_code)]
 pub async fn upsert_special_date_tx(
     tx: &mut Transaction<'_, Sqlite>,
     upsert: &SpecialDateUpsert<'_>,
@@ -114,8 +109,6 @@ pub async fn upsert_special_date_tx(
 /// Xoá từng ngày một thay vì dựng `IN (…)`: sqlx không bind được mảng cho
 /// SQLite, và ghép chuỗi SQL động là thứ không đáng đổi lấy một vòng lặp tối đa
 /// 366 bước.
-// No caller yet outside these tests; Task 4 wires this into the service.
-#[allow(dead_code)]
 pub async fn delete_special_dates_tx(
     tx: &mut Transaction<'_, Sqlite>,
     dates: &[String],

--- a/mhm/src-tauri/src/repositories/booking/pricing_repository.rs
+++ b/mhm/src-tauri/src/repositories/booking/pricing_repository.rs
@@ -3,7 +3,7 @@
 //! Both are upserts keyed on the natural business key — one rule per room type,
 //! one uplift per date — so saving twice replaces rather than duplicating.
 
-use sqlx::{Pool, Sqlite};
+use sqlx::{Pool, Sqlite, Transaction};
 
 use crate::money::MoneyVnd;
 
@@ -69,15 +69,29 @@ pub async fn upsert_pricing_rule(
     Ok(())
 }
 
-/// `created_at` is only written on insert; an update leaves the original date in
-/// place, which is why it is not in the `DO UPDATE SET` list.
-pub async fn upsert_special_date(
-    pool: &Pool<Sqlite>,
-    id: &str,
-    date: &str,
-    label: &str,
-    uplift_pct: f64,
-    now: &str,
+/// Giá trị đã được service kiểm và đã đủ, writer không quyết định gì.
+// `repositories` is a private module, so `pub` here doesn't reach the crate's
+// external API — rustc still flags it as dead code until Task 4 wires in the caller.
+#[allow(dead_code)]
+pub struct SpecialDateUpsert<'a> {
+    pub id: &'a str,
+    pub date: &'a str,
+    pub label: &'a str,
+    pub uplift_pct: f64,
+    pub now: &'a str,
+}
+
+/// `created_at` chỉ được ghi lúc thêm mới; lần cập nhật giữ nguyên mốc cũ, nên
+/// nó không nằm trong danh sách `DO UPDATE SET`. `id` cũng vậy: ngày đã tồn tại
+/// thì giữ mã cũ, để mọi tham chiếu bên ngoài còn dùng được.
+///
+/// Nhận `tx` chứ không nhận `pool`: khai một khoảng là nhiều dòng, và mất nửa
+/// khoảng còn tệ hơn báo lỗi.
+// No caller yet outside these tests; Task 4 wires this into the service.
+#[allow(dead_code)]
+pub async fn upsert_special_date_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    upsert: &SpecialDateUpsert<'_>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
@@ -86,13 +100,148 @@ pub async fn upsert_special_date(
             label = excluded.label,
             uplift_pct = excluded.uplift_pct",
     )
-    .bind(id)
-    .bind(date)
-    .bind(label)
-    .bind(uplift_pct)
-    .bind(now)
-    .execute(pool)
+    .bind(upsert.id)
+    .bind(upsert.date)
+    .bind(upsert.label)
+    .bind(upsert.uplift_pct)
+    .bind(upsert.now)
+    .execute(&mut **tx)
     .await?;
 
     Ok(())
+}
+
+/// Xoá từng ngày một thay vì dựng `IN (…)`: sqlx không bind được mảng cho
+/// SQLite, và ghép chuỗi SQL động là thứ không đáng đổi lấy một vòng lặp tối đa
+/// 366 bước.
+// No caller yet outside these tests; Task 4 wires this into the service.
+#[allow(dead_code)]
+pub async fn delete_special_dates_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    dates: &[String],
+) -> Result<(), sqlx::Error> {
+    for date in dates {
+        sqlx::query("DELETE FROM special_dates WHERE date = ?")
+            .bind(date)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{delete_special_dates_tx, upsert_special_date_tx, SpecialDateUpsert};
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::{Executor, Pool, Sqlite};
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        pool.execute(
+            "CREATE TABLE special_dates (
+                id TEXT PRIMARY KEY,
+                date TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT '',
+                uplift_pct REAL NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                UNIQUE(date)
+            )",
+        )
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn upsert_keeps_the_original_created_at_when_the_date_already_exists() {
+        let pool = test_pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        upsert_special_date_tx(
+            &mut tx,
+            &SpecialDateUpsert {
+                id: "id-1",
+                date: "2026-02-14",
+                label: "Tết",
+                uplift_pct: 40.0,
+                now: "2026-01-01T00:00:00+07:00",
+            },
+        )
+        .await
+        .unwrap();
+        upsert_special_date_tx(
+            &mut tx,
+            &SpecialDateUpsert {
+                id: "id-2",
+                date: "2026-02-14",
+                label: "Tết Nguyên đán",
+                uplift_pct: 45.0,
+                now: "2026-06-01T00:00:00+07:00",
+            },
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let row: (String, String, f64, String) = sqlx::query_as(
+            "SELECT id, label, uplift_pct, created_at FROM special_dates WHERE date = ?",
+        )
+        .bind("2026-02-14")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row.0, "id-1", "id cũ phải được giữ");
+        assert_eq!(row.1, "Tết Nguyên đán");
+        assert_eq!(row.2, 45.0);
+        assert_eq!(
+            row.3, "2026-01-01T00:00:00+07:00",
+            "created_at phải được giữ"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_removes_exactly_the_listed_dates() {
+        let pool = test_pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        for (index, date) in ["2026-02-14", "2026-02-15", "2026-02-16"]
+            .iter()
+            .enumerate()
+        {
+            upsert_special_date_tx(
+                &mut tx,
+                &SpecialDateUpsert {
+                    id: &format!("id-{index}"),
+                    date,
+                    label: "Tết",
+                    uplift_pct: 40.0,
+                    now: "2026-01-01T00:00:00+07:00",
+                },
+            )
+            .await
+            .unwrap();
+        }
+        delete_special_dates_tx(&mut tx, &["2026-02-15".to_string()])
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let remaining: Vec<(String,)> =
+            sqlx::query_as("SELECT date FROM special_dates ORDER BY date")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|row| row.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["2026-02-14", "2026-02-16"]
+        );
+    }
 }

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -316,11 +316,56 @@ pub async fn save_special_date_range(
     })
 }
 
+/// Xoá hẳn một số ngày khỏi bảng mùa cao điểm.
+///
+/// Danh sách rỗng bị từ chối — khác hẳn `SaveSpecialDateRange::remove`, nơi
+/// rỗng chính là ca khai mới. Ở đây rỗng nghĩa là gọi nhầm.
+pub async fn delete_special_dates(pool: &Pool<Sqlite>, dates: Vec<String>) -> CommandResult<()> {
+    if dates.is_empty() {
+        return Err(invalid_input("Chưa chọn ngày nào để xoá"));
+    }
+    if dates.len() as i64 > MAX_SPECIAL_RANGE_DAYS {
+        return Err(invalid_input(format!(
+            "Chỉ xoá được tối đa {MAX_SPECIAL_RANGE_DAYS} ngày một lần"
+        )));
+    }
+    for date in &dates {
+        parse_date_only(date, "Ngày cần xoá")?;
+    }
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "delete_special_dates",
+            error.to_string(),
+            serde_json::json!({ "step": "begin" }),
+        )
+    })?;
+
+    delete_special_dates_tx(&mut tx, &dates)
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "delete_special_dates",
+                error.to_string(),
+                serde_json::json!({ "step": "delete_special_dates_tx" }),
+            )
+        })?;
+
+    tx.commit().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "delete_special_dates",
+            error.to_string(),
+            serde_json::json!({ "step": "commit" }),
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         calculate_price_preview, calculate_room_price_preview, calculate_stay_price_tx,
-        save_pricing_rule, save_special_date_range, SavePricingRule, SaveSpecialDateRange,
+        delete_special_dates, save_pricing_rule, save_special_date_range, SavePricingRule,
+        SaveSpecialDateRange,
     };
     use crate::app_error::{codes, AppErrorKind};
     use crate::domain::booking::BookingError;
@@ -1223,5 +1268,45 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 0, "không lần nào được ghi gì");
+    }
+
+    #[tokio::test]
+    async fn delete_special_dates_removes_a_whole_cluster_at_once() {
+        let pool = special_dates_pool().await;
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-02-14".to_string(),
+                to: "2026-02-22".to_string(),
+                label: "Tết".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let dates: Vec<String> = (14..=22).map(|day| format!("2026-02-{day:02}")).collect();
+        delete_special_dates(&pool, dates).await.unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_special_dates_rejects_an_empty_list_and_a_bad_date() {
+        let pool = special_dates_pool().await;
+
+        delete_special_dates(&pool, Vec::new())
+            .await
+            .expect_err("danh sách rỗng là lệnh vô nghĩa");
+        delete_special_dates(&pool, vec!["14/02/2026".to_string()])
+            .await
+            .expect_err("ngày sai định dạng");
     }
 }

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -10,9 +10,10 @@
 //! else a 350k house default — which meant a preview could in principle
 //! disagree with what the guest was actually charged.
 
+use chrono::NaiveDate;
 use sqlx::{Pool, Sqlite, Transaction};
 
-use crate::app_error::CommandResult;
+use crate::app_error::{codes, CommandError, CommandResult};
 use crate::domain::booking::pricing::{build_effective_pricing_rule, calculate_from_loaded_inputs};
 use crate::domain::booking::BookingResult;
 use crate::money::{validate_non_negative_money_vnd, MoneyVnd};
@@ -20,7 +21,9 @@ use crate::queries::booking::pricing_queries::{
     load_room_type_names, load_stay_pricing_inputs_for_room,
     load_stay_pricing_inputs_for_room_type, load_stay_pricing_inputs_tx, load_type_rule_inputs,
 };
-use crate::repositories::booking::pricing_repository::{self, PricingRuleUpsert};
+use crate::repositories::booking::pricing_repository::{
+    self, delete_special_dates_tx, upsert_special_date_tx, PricingRuleUpsert, SpecialDateUpsert,
+};
 
 /// Prices inside the caller's transaction so a lifecycle write can read the
 /// rows it just inserted but has not committed.
@@ -183,11 +186,145 @@ pub async fn save_pricing_rule(
         })
 }
 
+const MAX_SPECIAL_RANGE_DAYS: i64 = 366;
+const MAX_SPECIAL_UPLIFT_PCT: f64 = 500.0;
+
+pub struct SaveSpecialDateRange {
+    /// Những ngày phải xoá **cùng** transaction với lần ghi này. Rỗng là khai
+    /// mới; có giá trị là đang sửa một cụm cho ngắn lại. Đây là lý do lệnh xoá
+    /// và lệnh ghi không tách rời: xoá xong mà ghi hỏng là mất hẳn mấy ngày đã
+    /// khai, và không ai biết.
+    pub remove: Vec<String>,
+    pub from: String,
+    pub to: String,
+    pub label: String,
+    pub uplift_pct: f64,
+}
+
+fn parse_date_only(value: &str, field: &str) -> CommandResult<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| {
+        CommandError::user(
+            codes::VALIDATION_INVALID_INPUT,
+            format!("{field} phải có dạng YYYY-MM-DD"),
+        )
+    })
+}
+
+fn invalid_input(message: impl Into<String>) -> CommandError {
+    CommandError::user(codes::VALIDATION_INVALID_INPUT, message)
+}
+
+/// Khai một khoảng ngày là mùa cao điểm, một dòng cho một ngày.
+///
+/// `id_base` cấp mã cho từng ngày mới theo dạng `{id_base}-{chỉ số}`. Lệnh
+/// truyền vào một uuid nên trong thực tế không bao giờ đụng; test thì truyền
+/// một gốc đã có trong bảng để ép lỗi khoá chính giữa transaction — đó là chỗ
+/// hỏng-được-theo-ý duy nhất, vì `ON CONFLICT(date)` đã nuốt mất ràng buộc trên
+/// `date`.
+pub async fn save_special_date_range(
+    pool: &Pool<Sqlite>,
+    request: SaveSpecialDateRange,
+    id_base: String,
+    now: String,
+) -> CommandResult<()> {
+    let from = parse_date_only(&request.from, "Ngày bắt đầu")?;
+    let to = parse_date_only(&request.to, "Ngày kết thúc")?;
+    if to < from {
+        return Err(invalid_input("Ngày kết thúc không được trước ngày bắt đầu"));
+    }
+
+    let day_count = (to - from).num_days() + 1;
+    if day_count > MAX_SPECIAL_RANGE_DAYS {
+        return Err(invalid_input(format!(
+            "Khoảng ngày tối đa {MAX_SPECIAL_RANGE_DAYS} ngày"
+        )));
+    }
+
+    if !(0.0..=MAX_SPECIAL_UPLIFT_PCT).contains(&request.uplift_pct) {
+        return Err(invalid_input(format!(
+            "Mức phụ thu phải trong khoảng 0–{MAX_SPECIAL_UPLIFT_PCT:.0}%"
+        )));
+    }
+
+    let label = request.label.trim();
+    if label.is_empty() {
+        return Err(invalid_input("Tên đợt cao điểm không được để trống"));
+    }
+
+    if request.remove.len() as i64 > MAX_SPECIAL_RANGE_DAYS {
+        return Err(invalid_input(format!(
+            "Chỉ xoá được tối đa {MAX_SPECIAL_RANGE_DAYS} ngày một lần"
+        )));
+    }
+    for date in &request.remove {
+        let removed = parse_date_only(date, "Ngày cần xoá")?;
+        if removed >= from && removed <= to {
+            return Err(invalid_input(
+                "Ngày cần xoá không được nằm trong chính khoảng đang khai",
+            ));
+        }
+    }
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "save_special_date_range",
+            error.to_string(),
+            serde_json::json!({ "step": "begin" }),
+        )
+    })?;
+
+    // Xoá trước, ghi sau. Ngược lại thì một ngày vừa nằm trong `remove` vừa
+    // nằm trong khoảng sẽ bị xoá mất ngay bên trong transaction dựng lên để
+    // đừng mất nó. Đã chặn chồng lấn ở trên, nhưng thứ tự vẫn phải đúng.
+    delete_special_dates_tx(&mut tx, &request.remove)
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "save_special_date_range",
+                error.to_string(),
+                serde_json::json!({ "step": "delete_special_dates_tx" }),
+            )
+        })?;
+
+    let mut date = from;
+    for index in 0..day_count {
+        let id = format!("{id_base}-{index}");
+        let date_key = date.format("%Y-%m-%d").to_string();
+        upsert_special_date_tx(
+            &mut tx,
+            &SpecialDateUpsert {
+                id: &id,
+                date: &date_key,
+                label,
+                uplift_pct: request.uplift_pct,
+                now: &now,
+            },
+        )
+        .await
+        .map_err(|error| {
+            crate::app_error::log_system_error(
+                "save_special_date_range",
+                error.to_string(),
+                serde_json::json!({ "step": "upsert_special_date_tx", "date": &date_key }),
+            )
+        })?;
+        date = date.succ_opt().unwrap_or(date);
+    }
+
+    tx.commit().await.map_err(|error| {
+        crate::app_error::log_system_error(
+            "save_special_date_range",
+            error.to_string(),
+            serde_json::json!({ "step": "commit" }),
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         calculate_price_preview, calculate_room_price_preview, calculate_stay_price_tx,
-        save_pricing_rule, SavePricingRule,
+        save_pricing_rule, save_special_date_range, SavePricingRule, SaveSpecialDateRange,
     };
     use crate::app_error::codes;
     use crate::domain::booking::BookingError;
@@ -221,6 +358,33 @@ mod tests {
         crate::db::run_migrations(&pool)
             .await
             .expect("run migrations");
+        pool
+    }
+
+    /// Dựng riêng cho phần khai mùa cao điểm — chỉ bảng `special_dates`, không
+    /// chạy migrations đầy đủ như `migrated_pool`, để không đụng vào các test
+    /// giá đang dựa vào đúng bộ bảng của hàm đó.
+    async fn special_dates_pool() -> Pool<Sqlite> {
+        use sqlx::sqlite::SqlitePoolOptions;
+        use sqlx::Executor;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        pool.execute(
+            "CREATE TABLE special_dates (
+                id TEXT PRIMARY KEY,
+                date TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT '',
+                uplift_pct REAL NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                UNIQUE(date)
+            )",
+        )
+        .await
+        .unwrap();
         pool
     }
 
@@ -771,5 +935,217 @@ mod tests {
         assert_eq!(rows.len(), 1, "one rule per room type");
         assert_eq!(rows[0].1, 550_000, "the later save wins");
         assert_eq!(rows[0].0, "rule-a", "the original row id is kept");
+    }
+
+    #[tokio::test]
+    async fn save_special_date_range_writes_one_row_per_day() {
+        let pool = special_dates_pool().await;
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-02-14".to_string(),
+                to: "2026-02-22".to_string(),
+                label: "Tết Nguyên đán".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 9);
+    }
+
+    #[tokio::test]
+    async fn save_special_date_range_accepts_a_single_day() {
+        let pool = special_dates_pool().await;
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-04-30".to_string(),
+                to: "2026-04-30".to_string(),
+                label: "Lễ 30/4".to_string(),
+                uplift_pct: 30.0,
+            },
+            "base".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1);
+    }
+
+    #[tokio::test]
+    async fn a_failed_write_leaves_every_removed_day_in_place() {
+        // Test quan trọng nhất của task này: `remove` tồn tại để việc xoá và
+        // việc ghi cùng chung một transaction.
+        //
+        // Ép hỏng giữa chừng bằng cách cho `id_base` sinh ra một mã đã tồn tại
+        // trên một ngày KHÁC, để bước upsert đụng khoá chính. `ON CONFLICT` chỉ
+        // đỡ cho `date`, không đỡ cho `id` — đây là chỗ hỏng-được-theo-ý duy
+        // nhất, và nó chỉ dùng được vì `id` do bên ngoài truyền vào.
+        let pool = special_dates_pool().await;
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES ('base-1', '2026-12-25', 'Noel', 10.0, '2026-01-01T00:00:00+07:00'),
+                    ('keep-1', '2026-02-25', 'Tết', 40.0, '2026-01-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let error = save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: vec!["2026-02-25".to_string()],
+                from: "2026-02-14".to_string(),
+                to: "2026-02-16".to_string(),
+                label: "Tết".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-06-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .expect_err("mã trùng phải làm cả transaction hỏng");
+        let _ = error;
+
+        let kept: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM special_dates WHERE date = '2026-02-25'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            kept.0, 1,
+            "ngày trong `remove` phải còn nguyên khi ghi hỏng"
+        );
+
+        let written: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM special_dates WHERE date = '2026-02-14'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(written.0, 0, "không được để lại nửa khoảng");
+    }
+
+    #[tokio::test]
+    async fn remove_is_deleted_before_the_range_is_written() {
+        let pool = special_dates_pool().await;
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES ('old-1', '2026-02-20', 'Tết', 40.0, '2026-01-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: vec!["2026-02-20".to_string()],
+                from: "2026-02-14".to_string(),
+                to: "2026-02-16".to_string(),
+                label: "Tết".to_string(),
+                uplift_pct: 40.0,
+            },
+            "base".to_string(),
+            "2026-06-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let dates: Vec<(String,)> = sqlx::query_as("SELECT date FROM special_dates ORDER BY date")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            dates.iter().map(|row| row.0.as_str()).collect::<Vec<_>>(),
+            vec!["2026-02-14", "2026-02-15", "2026-02-16"]
+        );
+    }
+
+    #[tokio::test]
+    async fn save_special_date_range_rejects_bad_input() {
+        let pool = special_dates_pool().await;
+
+        let base = || SaveSpecialDateRange {
+            remove: Vec::new(),
+            from: "2026-02-14".to_string(),
+            to: "2026-02-16".to_string(),
+            label: "Tết".to_string(),
+            uplift_pct: 40.0,
+        };
+        let run = |request| {
+            let pool = pool.clone();
+            async move {
+                save_special_date_range(
+                    &pool,
+                    request,
+                    "base".to_string(),
+                    "2026-01-01T00:00:00+07:00".to_string(),
+                )
+                .await
+            }
+        };
+
+        // ngày sai định dạng
+        let mut request = base();
+        request.from = "14/02/2026".to_string();
+        run(request).await.expect_err("ngày sai định dạng");
+
+        // ngày kết thúc trước ngày bắt đầu
+        let mut request = base();
+        request.to = "2026-02-10".to_string();
+        run(request).await.expect_err("to < from");
+
+        // quá 366 ngày
+        let mut request = base();
+        request.to = "2027-02-16".to_string();
+        run(request).await.expect_err("367 ngày");
+
+        // phần trăm âm
+        let mut request = base();
+        request.uplift_pct = -10.0;
+        run(request).await.expect_err("phần trăm âm");
+
+        // phần trăm quá trần
+        let mut request = base();
+        request.uplift_pct = 600.0;
+        run(request).await.expect_err("phần trăm quá 500");
+
+        // nhãn toàn khoảng trắng
+        let mut request = base();
+        request.label = "   ".to_string();
+        run(request).await.expect_err("nhãn rỗng");
+
+        // phần tử của remove sai định dạng
+        let mut request = base();
+        request.remove = vec!["hôm-qua".to_string()];
+        run(request).await.expect_err("remove sai định dạng");
+
+        // remove chồng lên khoảng đang khai
+        let mut request = base();
+        request.remove = vec!["2026-02-15".to_string()];
+        run(request).await.expect_err("remove chồng lấn");
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0, "không lần nào được ghi gì");
     }
 }

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -365,10 +365,11 @@ mod tests {
     use super::{
         calculate_price_preview, calculate_room_price_preview, calculate_stay_price_tx,
         delete_special_dates, save_pricing_rule, save_special_date_range, SavePricingRule,
-        SaveSpecialDateRange,
+        SaveSpecialDateRange, MAX_SPECIAL_RANGE_DAYS,
     };
     use crate::app_error::{codes, AppErrorKind};
     use crate::domain::booking::BookingError;
+    use chrono::NaiveDate;
     use sqlx::{sqlite::SqlitePoolOptions, Executor, Pool, Row, Sqlite};
 
     const CHECK_IN: &str = "2026-04-20T14:00:00+07:00";
@@ -1270,6 +1271,14 @@ mod tests {
         assert_eq!(count.0, 0, "không lần nào được ghi gì");
     }
 
+    /// Seeds two independent, non-adjacent seasons and deletes only one of
+    /// them. A bare `COUNT(*) == 0` on a pool that only ever held the deleted
+    /// season would pass just as well for an unconditional `DELETE FROM
+    /// special_dates` (or one matching on the wrong column) as for a correct,
+    /// targeted delete — it proves the table got emptied, not that the right
+    /// rows were the ones targeted. Comparing the full remaining date list
+    /// against the untouched season closes that gap: an unconditional delete
+    /// wipes it out too, and the second assertion below catches that.
     #[tokio::test]
     async fn delete_special_dates_removes_a_whole_cluster_at_once() {
         let pool = special_dates_pool().await;
@@ -1282,20 +1291,52 @@ mod tests {
                 label: "Tết".to_string(),
                 uplift_pct: 40.0,
             },
-            "base".to_string(),
+            "tet".to_string(),
             "2026-01-01T00:00:00+07:00".to_string(),
         )
         .await
         .unwrap();
 
-        let dates: Vec<String> = (14..=22).map(|day| format!("2026-02-{day:02}")).collect();
-        delete_special_dates(&pool, dates).await.unwrap();
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-04-01".to_string(),
+                to: "2026-04-04".to_string(),
+                label: "Nghỉ lễ".to_string(),
+                uplift_pct: 20.0,
+            },
+            "le".to_string(),
+            "2026-01-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
 
-        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-        assert_eq!(count.0, 0);
+        let deleted: Vec<String> = (14..=22).map(|day| format!("2026-02-{day:02}")).collect();
+        delete_special_dates(&pool, deleted.clone()).await.unwrap();
+
+        let remaining: Vec<String> =
+            sqlx::query_as::<_, (String,)>("SELECT date FROM special_dates ORDER BY date")
+                .fetch_all(&pool)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|row| row.0)
+                .collect();
+
+        for date in &deleted {
+            assert!(
+                !remaining.contains(date),
+                "{date} from the deleted season must be gone"
+            );
+        }
+
+        let expected_untouched: Vec<String> =
+            (1..=4).map(|day| format!("2026-04-{day:02}")).collect();
+        assert_eq!(
+            remaining, expected_untouched,
+            "the untouched season must survive, date for date"
+        );
     }
 
     #[tokio::test]
@@ -1308,5 +1349,42 @@ mod tests {
         delete_special_dates(&pool, vec!["14/02/2026".to_string()])
             .await
             .expect_err("ngày sai định dạng");
+    }
+
+    /// `MAX_SPECIAL_RANGE_DAYS` caps how many dates a single delete call may
+    /// carry. Only the empty-list and malformed-date rejections were covered
+    /// before; this exercises the length cap itself, and checks the table is
+    /// untouched afterwards so a rejection that half-executed would be
+    /// caught.
+    #[tokio::test]
+    async fn delete_special_dates_rejects_a_list_longer_than_the_max_range() {
+        let pool = special_dates_pool().await;
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES ('kept-1', '2026-02-14', 'Tết', 40.0, '2026-01-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let from = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let too_many: Vec<String> = (0..(MAX_SPECIAL_RANGE_DAYS + 1))
+            .map(|offset| {
+                (from + chrono::Duration::days(offset))
+                    .format("%Y-%m-%d")
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(too_many.len() as i64, MAX_SPECIAL_RANGE_DAYS + 1);
+
+        delete_special_dates(&pool, too_many)
+            .await
+            .expect_err("367 ngày vượt trần xoá");
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM special_dates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1, "một lệnh bị từ chối không được đụng vào bảng");
     }
 }

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -201,17 +201,13 @@ pub struct SaveSpecialDateRange {
     pub uplift_pct: f64,
 }
 
-fn parse_date_only(value: &str, field: &str) -> CommandResult<NaiveDate> {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| {
-        CommandError::user(
-            codes::VALIDATION_INVALID_INPUT,
-            format!("{field} phải có dạng YYYY-MM-DD"),
-        )
-    })
-}
-
 fn invalid_input(message: impl Into<String>) -> CommandError {
     CommandError::user(codes::VALIDATION_INVALID_INPUT, message)
+}
+
+fn parse_date_only(value: &str, field: &str) -> CommandResult<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| invalid_input(format!("{field} phải có dạng YYYY-MM-DD")))
 }
 
 /// Khai một khoảng ngày là mùa cao điểm, một dòng cho một ngày.
@@ -326,7 +322,7 @@ mod tests {
         calculate_price_preview, calculate_room_price_preview, calculate_stay_price_tx,
         save_pricing_rule, save_special_date_range, SavePricingRule, SaveSpecialDateRange,
     };
-    use crate::app_error::codes;
+    use crate::app_error::{codes, AppErrorKind};
     use crate::domain::booking::BookingError;
     use sqlx::{sqlite::SqlitePoolOptions, Executor, Pool, Row, Sqlite};
 
@@ -961,6 +957,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 9);
+
+        let row: (String, f64, String) = sqlx::query_as(
+            "SELECT label, uplift_pct, created_at FROM special_dates WHERE date = ?",
+        )
+        .bind("2026-02-15")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, "Tết Nguyên đán", "label must be written");
+        assert_eq!(row.1, 40.0, "uplift_pct must be written");
+        assert_eq!(
+            row.2, "2026-01-01T00:00:00+07:00",
+            "created_at must be written"
+        );
     }
 
     #[tokio::test]
@@ -1022,7 +1032,25 @@ mod tests {
         )
         .await
         .expect_err("mã trùng phải làm cả transaction hỏng");
-        let _ = error;
+
+        // The failure must come from *inside* the transaction (the upsert's
+        // primary-key clash), not from validation — validation runs before
+        // `pool.begin()` and would also leave every row untouched, which
+        // would make the assertions below pass for the wrong reason. Pinning
+        // the error to `log_system_error`'s contract (`SYSTEM_INTERNAL_ERROR`,
+        // `AppErrorKind::System`, a support id) is what keeps this test
+        // honest if a future validation rule started rejecting this input
+        // earlier.
+        assert_eq!(
+            error.code,
+            codes::SYSTEM_INTERNAL_ERROR,
+            "failure must be the in-transaction upsert error, not a validation rejection"
+        );
+        assert_eq!(error.kind, AppErrorKind::System);
+        assert!(
+            error.support_id.is_some(),
+            "system errors carry a support id"
+        );
 
         let kept: (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM special_dates WHERE date = '2026-02-25'")
@@ -1040,6 +1068,54 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(written.0, 0, "không được để lại nửa khoảng");
+    }
+
+    /// The main production flow: re-saving a range that overlaps rows already
+    /// in the table (editing a peak season), not just declaring a brand new
+    /// one. This exercises `upsert_special_date_tx`'s `ON CONFLICT(date) DO
+    /// UPDATE` through the service, which must keep the existing row's `id`
+    /// and `created_at` while updating `label` and `uplift_pct`.
+    #[tokio::test]
+    async fn save_special_date_range_edits_an_existing_day_in_place() {
+        let pool = special_dates_pool().await;
+        sqlx::query(
+            "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+             VALUES ('old-9', '2026-02-15', 'Tết', 40.0, '2026-01-01T00:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        save_special_date_range(
+            &pool,
+            SaveSpecialDateRange {
+                remove: Vec::new(),
+                from: "2026-02-14".to_string(),
+                to: "2026-02-16".to_string(),
+                label: "Tết Nguyên đán".to_string(),
+                uplift_pct: 55.0,
+            },
+            "base".to_string(),
+            "2026-06-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let row: (String, String, f64, String) = sqlx::query_as(
+            "SELECT id, label, uplift_pct, created_at FROM special_dates WHERE date = ?",
+        )
+        .bind("2026-02-15")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row.0, "old-9", "editing must keep the existing row id");
+        assert_eq!(row.1, "Tết Nguyên đán", "label must be updated");
+        assert_eq!(row.2, 55.0, "uplift_pct must be updated");
+        assert_eq!(
+            row.3, "2026-01-01T00:00:00+07:00",
+            "created_at must not move on an edit"
+        );
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -52,6 +52,7 @@ mod groups;
 mod guests;
 mod money_guards;
 mod payments;
+mod peak_season_e2e;
 mod pricing;
 mod reporting;
 mod reservation_idempotency;

--- a/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
+++ b/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
@@ -1,0 +1,706 @@
+//! End-to-end QA cho mùa cao điểm, chạy trên **database thật đã migrate**.
+//!
+//! Khác `support::db::test_pool`: chỗ đó dựng bảng bằng `CREATE TABLE` viết tay,
+//! nên một test xanh ở đó vẫn có thể xanh khi migration thật tạo ra schema khác.
+//! Mọi test trong file này mở một file SQLite thật qua đúng đường kết nối của
+//! production (`db::connect_configured_sqlite_pool`) rồi chạy `db::run_migrations`,
+//! và đi qua đúng các hàm service mà lệnh Tauri gọi.
+//!
+//! Mọi con số kỳ vọng đều được tính tay trước và ghi phép tính vào comment.
+
+use super::prelude::*;
+use crate::queries::booking::pricing_queries;
+use sqlx::{Pool, Sqlite};
+use std::path::PathBuf;
+
+// ─── Fixtures ───
+
+/// Một database thật, đã chạy đúng bộ migration của app.
+struct MigratedDb {
+    pool: Pool<Sqlite>,
+    path: PathBuf,
+}
+
+impl MigratedDb {
+    async fn close(self) {
+        self.pool.close().await;
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(PathBuf::from(format!("{}{suffix}", self.path.display())));
+        }
+    }
+}
+
+async fn migrated_db(label: &str) -> MigratedDb {
+    let path = std::env::temp_dir().join(format!(
+        "capyinn-qa-{label}-{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let url = format!("sqlite:{}?mode=rwc", path.display());
+
+    let pool = crate::db::connect_configured_sqlite_pool(&url)
+        .await
+        .expect("mở pool sqlite như production");
+    crate::db::run_migrations(&pool)
+        .await
+        .expect("chạy migration thật");
+
+    MigratedDb { pool, path }
+}
+
+/// Phòng đôi 500.000₫/đêm, giá base đã gồm `max_guests` khách, mỗi khách vượt
+/// mốc chịu `extra_person_fee` một đêm. Không khai `pricing_rules`, nên engine
+/// suy rule từ `rooms.base_price` — đúng cảnh nhà nghỉ nhỏ trong lời phàn nàn.
+async fn seed_room(
+    pool: &Pool<Sqlite>,
+    room_id: &str,
+    room_type: &str,
+    base_price: i64,
+    max_guests: i64,
+    extra_person_fee: i64,
+) {
+    sqlx::query(
+        "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price,
+                            max_guests, extra_person_fee, status)
+         VALUES (?, ?, ?, 1, 0, ?, ?, ?, 'vacant')",
+    )
+    .bind(room_id)
+    .bind(format!("Phòng {room_id}"))
+    .bind(room_type)
+    .bind(base_price)
+    .bind(max_guests)
+    .bind(extra_person_fee)
+    .execute(pool)
+    .await
+    .expect("seed room");
+}
+
+async fn declare_season(pool: &Pool<Sqlite>, from: &str, to: &str, label: &str, pct: f64) {
+    pricing_service::save_special_date_range(
+        pool,
+        pricing_service::SaveSpecialDateRange {
+            remove: Vec::new(),
+            from: from.to_string(),
+            to: to.to_string(),
+            label: label.to_string(),
+            uplift_pct: pct,
+        },
+        uuid::Uuid::new_v4().to_string(),
+        "2026-01-15T09:00:00+07:00".to_string(),
+    )
+    .await
+    .expect("khai mùa cao điểm");
+}
+
+async fn stored_dates(pool: &Pool<Sqlite>) -> Vec<(String, String, f64)> {
+    sqlx::query_as::<_, (String, String, f64)>(
+        "SELECT date, label, CAST(uplift_pct AS REAL) FROM special_dates ORDER BY date",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("đọc special_dates")
+}
+
+// ─── 1. Ca của chủ nhà ───
+
+/// *"Phòng ghi 500k, mà ngày đặt là mùa cao điểm lại 4 người, nên tôi thu 600k,
+/// và không có chỗ nào sửa giá phòng."*
+///
+/// Cả hai nửa phải cộng vào nhau đúng cách: phần trăm cao điểm chỉ ăn vào tiền
+/// phòng, **không** nhân lên phụ thu thêm người.
+///
+/// Phòng đôi 500.000₫/đêm, `max_guests` = 2, phụ thu 50.000₫/khách/đêm.
+/// Mùa cao điểm 01/03→05/03/2026, +20%.
+/// Kỳ ở 02/03→04/03/2026 = 2 đêm (02/03 thứ Hai, 03/03 thứ Ba — không đêm nào
+/// rơi vào cuối tuần, nên uplift cuối tuần 20% mặc định không tham gia).
+/// 4 khách.
+///
+///   base               = 500.000 × 2 đêm                  = 1.000.000
+///   phụ thu cao điểm   = 1.000.000 × (20 + 20) / 2 %      =   200.000
+///   phụ thu cuối tuần  = 0 đêm cuối tuần                  =         0
+///   phụ thu thêm người = 50.000 × (4 − 2) khách × 2 đêm   =   200.000
+///   ─────────────────────────────────────────────────────────────────
+///   tổng                                                  = 1.400.000
+///
+/// Nếu uplift nhân cả phần thêm người, tổng sẽ là
+/// (1.000.000 + 200.000) × 1,20 = 1.440.000 — con số đó phải không xuất hiện.
+#[tokio::test]
+async fn the_owners_case_peak_season_and_four_guests_compose_without_multiplying_each_other() {
+    let db = migrated_db("owner-case").await;
+    seed_room(&db.pool, "P101", "Phòng đôi", 500_000, 2, 50_000).await;
+    declare_season(&db.pool, "2026-03-01", "2026-03-05", "Cao điểm hè", 20.0).await;
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let charged = calculate_stay_price_tx(
+        &mut tx,
+        "P101",
+        "2026-03-02",
+        "2026-03-04",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .expect("tính giá kỳ ở");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(charged.base_amount, 1_000_000, "tiền phòng 2 đêm");
+    assert_eq!(charged.surcharge_amount, 200_000, "cao điểm 20% trên base");
+    assert_eq!(charged.weekend_amount, 0, "hai đêm đều là ngày thường");
+    assert_eq!(charged.total, 1_400_000, "tổng chủ nhà mong đợi");
+    assert_ne!(
+        charged.total, 1_440_000,
+        "cao điểm không được nhân lên phụ thu thêm người"
+    );
+
+    let extra_line = charged
+        .breakdown
+        .iter()
+        .find(|line| line.label.contains("khách"))
+        .expect("phải có dòng phụ thu thêm người");
+    assert_eq!(extra_line.label, "Phụ thu 2 khách");
+    assert_eq!(
+        extra_line.amount, 200_000,
+        "phụ thu thêm người là khoản phẳng, không bị uplift chạm vào"
+    );
+
+    db.close().await;
+}
+
+/// Cùng ca trên nhưng đi qua vòng đời đặt phòng thật: số ghi vào
+/// `bookings.total_price` phải đúng bằng 1.400.000 đã tính tay ở trên.
+#[tokio::test]
+async fn the_owners_case_is_what_gets_written_to_the_booking() {
+    let db = migrated_db("owner-case-booking").await;
+    seed_room(&db.pool, "P101", "Phòng đôi", 500_000, 2, 50_000).await;
+    declare_season(&db.pool, "2026-03-01", "2026-03-05", "Cao điểm hè", 20.0).await;
+
+    let booking = reservation_lifecycle::create_reservation(
+        &db.pool,
+        CreateReservationRequest {
+            room_id: "P101".to_string(),
+            guest_name: "Nguyễn Văn A".to_string(),
+            guest_phone: Some("0900000000".to_string()),
+            guest_doc_number: Some("001234567890".to_string()),
+            check_in_date: "2026-03-02".to_string(),
+            check_out_date: "2026-03-04".to_string(),
+            nights: 2,
+            deposit_amount: None,
+            source: Some("phone".to_string()),
+            notes: None,
+            guests: Some(4),
+        },
+    )
+    .await
+    .expect("tạo đặt phòng");
+
+    assert_eq!(booking.total_price, 1_400_000);
+
+    let stored: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind(&booking.id)
+        .fetch_one(&db.pool)
+        .await
+        .expect("đọc lại booking");
+    assert_eq!(stored, 1_400_000, "số ghi xuống bảng phải khớp");
+
+    db.close().await;
+}
+
+// ─── 2. Kỳ ở bắt đầu trước mùa ───
+
+/// Mùa cao điểm 04/03→08/03/2026, +30%.
+/// Kỳ ở 02/03→06/03 = 4 đêm: 02(T2), 03(T3), 04(T4), 05(T5). Không đêm cuối tuần.
+/// Chỉ hai đêm 04 và 05 nằm trong mùa.
+///
+///   base            = 500.000 × 4 đêm              = 2.000.000
+///   mức bình quân   = (0 + 0 + 30 + 30) / 4        =        15%
+///   phụ thu cao điểm= 2.000.000 × 15%              =   300.000
+///                   ( = 2 đêm × 500.000 × 30%  ✓)
+///   ───────────────────────────────────────────────────────────
+///   tổng                                           = 2.300.000
+///
+/// Luật cũ (đọc phần trăm ở ngày đến) sẽ ra 0₫ vì 02/03 chưa khai.
+#[tokio::test]
+async fn a_stay_starting_before_the_season_is_surcharged_only_for_the_nights_inside() {
+    let db = migrated_db("before-season").await;
+    seed_room(&db.pool, "P201", "Phòng đôi", 500_000, 2, 0).await;
+    declare_season(&db.pool, "2026-03-04", "2026-03-08", "Giỗ Tổ", 30.0).await;
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let charged =
+        calculate_stay_price_tx(&mut tx, "P201", "2026-03-02", "2026-03-06", "nightly", None)
+            .await
+            .expect("tính giá");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(charged.base_amount, 2_000_000);
+    assert_eq!(charged.weekend_amount, 0);
+    assert_eq!(charged.surcharge_amount, 300_000);
+    assert_eq!(charged.total, 2_300_000);
+    assert_ne!(
+        charged.surcharge_amount, 0,
+        "luật cũ đọc ngày đến sẽ ra 0₫ — đây chính là lỗi được sửa"
+    );
+
+    db.close().await;
+}
+
+// ─── 3. Kỳ ở kéo qua khỏi mùa ───
+
+/// Mùa cao điểm 02/03→04/03/2026, +40%.
+/// Kỳ ở 03/03→07/03 = 4 đêm: 03(T3), 04(T4), 05(T5), 06(T6). Không đêm cuối tuần.
+/// Chỉ hai đêm 03 và 04 nằm trong mùa.
+///
+///   base            = 500.000 × 4 đêm              = 2.000.000
+///   mức bình quân   = (40 + 40 + 0 + 0) / 4        =        20%
+///   phụ thu cao điểm= 2.000.000 × 20%              =   400.000
+///                   ( = 2 đêm × 500.000 × 40%  ✓)
+///   ───────────────────────────────────────────────────────────
+///   tổng                                           = 2.400.000
+///
+/// Luật cũ sẽ thu 40% cho cả bốn đêm: 2.000.000 × 40% = 800.000 — thu lố.
+#[tokio::test]
+async fn a_stay_running_past_the_end_of_the_season_stops_being_surcharged() {
+    let db = migrated_db("after-season").await;
+    seed_room(&db.pool, "P301", "Phòng đôi", 500_000, 2, 0).await;
+    declare_season(&db.pool, "2026-03-02", "2026-03-04", "Cao điểm", 40.0).await;
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let charged =
+        calculate_stay_price_tx(&mut tx, "P301", "2026-03-03", "2026-03-07", "nightly", None)
+            .await
+            .expect("tính giá");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(charged.base_amount, 2_000_000);
+    assert_eq!(charged.weekend_amount, 0);
+    assert_eq!(charged.surcharge_amount, 400_000);
+    assert_eq!(charged.total, 2_400_000);
+    assert_ne!(
+        charged.surcharge_amount, 800_000,
+        "luật cũ thu 40% cho cả bốn đêm"
+    );
+
+    db.close().await;
+}
+
+// ─── 4. Khai rồi rút ngắn ───
+
+/// Khai 01/03→10/03 (+25%), rồi lưu lại thành 01/03→05/03 (+30%) với năm ngày
+/// 06/03–10/03 nằm trong `remove`.
+///
+/// Sau lần lưu thứ hai bảng phải còn đúng năm dòng 01–05, uplift 30, và các
+/// dòng ấy phải là dòng cũ được sửa tại chỗ (`created_at` giữ nguyên mốc lần
+/// khai đầu), chứ không phải dòng mới chèn đè.
+#[tokio::test]
+async fn shortening_a_declared_season_drops_exactly_the_removed_days() {
+    let db = migrated_db("shorten").await;
+
+    pricing_service::save_special_date_range(
+        &db.pool,
+        pricing_service::SaveSpecialDateRange {
+            remove: Vec::new(),
+            from: "2026-03-01".to_string(),
+            to: "2026-03-10".to_string(),
+            label: "Cao điểm hè".to_string(),
+            uplift_pct: 25.0,
+        },
+        "seed-base".to_string(),
+        "2026-01-15T09:00:00+07:00".to_string(),
+    )
+    .await
+    .expect("khai lần đầu");
+
+    assert_eq!(
+        stored_dates(&db.pool).await.len(),
+        10,
+        "10 ngày 01/03–10/03"
+    );
+
+    let dropped: Vec<String> = (6..=10).map(|day| format!("2026-03-{day:02}")).collect();
+    pricing_service::save_special_date_range(
+        &db.pool,
+        pricing_service::SaveSpecialDateRange {
+            remove: dropped.clone(),
+            from: "2026-03-01".to_string(),
+            to: "2026-03-05".to_string(),
+            label: "Cao điểm hè".to_string(),
+            uplift_pct: 30.0,
+        },
+        "edit-base".to_string(),
+        "2026-02-20T09:00:00+07:00".to_string(),
+    )
+    .await
+    .expect("lưu lại ngắn hơn");
+
+    let rows = stored_dates(&db.pool).await;
+    let kept: Vec<String> = (1..=5).map(|day| format!("2026-03-{day:02}")).collect();
+    assert_eq!(
+        rows.iter().map(|row| row.0.clone()).collect::<Vec<_>>(),
+        kept,
+        "chỉ còn 01/03–05/03"
+    );
+    for row in &rows {
+        assert_eq!(row.1, "Cao điểm hè", "nhãn phải được cập nhật");
+        assert_eq!(row.2, 30.0, "uplift phải được cập nhật");
+    }
+    for date in &dropped {
+        assert!(
+            !rows.iter().any(|row| &row.0 == date),
+            "{date} phải bị xoá hẳn khỏi bảng"
+        );
+    }
+
+    let created_at: Vec<String> =
+        sqlx::query_scalar("SELECT created_at FROM special_dates ORDER BY date")
+            .fetch_all(&db.pool)
+            .await
+            .expect("đọc created_at");
+    assert!(
+        created_at
+            .iter()
+            .all(|value| value == "2026-01-15T09:00:00+07:00"),
+        "ngày giữ lại phải là dòng cũ được sửa tại chỗ, không phải dòng mới: {created_at:?}"
+    );
+
+    db.close().await;
+}
+
+// ─── 5. Xoá hẳn một mùa ───
+
+/// Khai 01/03→05/03 (+30%), tính giá kỳ ở 02/03→04/03 (2 đêm, cả hai trong mùa):
+///
+///   base             = 500.000 × 2 đêm      = 1.000.000
+///   mức bình quân    = (30 + 30) / 2        =        30%
+///   phụ thu cao điểm = 1.000.000 × 30%      =   300.000
+///   tổng                                    = 1.300.000
+///
+/// Xoá cả mùa rồi tính lại: không còn ngày nào được khai, nên
+///   tổng = base = 1.000.000, phụ thu = 0.
+#[tokio::test]
+async fn deleting_a_whole_season_puts_the_price_back_to_no_uplift() {
+    let db = migrated_db("delete-season").await;
+    seed_room(&db.pool, "P401", "Phòng đôi", 500_000, 2, 0).await;
+    declare_season(&db.pool, "2026-03-01", "2026-03-05", "Cao điểm hè", 30.0).await;
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let with_season =
+        calculate_stay_price_tx(&mut tx, "P401", "2026-03-02", "2026-03-04", "nightly", None)
+            .await
+            .expect("tính giá khi còn mùa");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(with_season.base_amount, 1_000_000);
+    assert_eq!(with_season.surcharge_amount, 300_000);
+    assert_eq!(with_season.total, 1_300_000);
+
+    let whole_season: Vec<String> = (1..=5).map(|day| format!("2026-03-{day:02}")).collect();
+    pricing_service::delete_special_dates(&db.pool, whole_season)
+        .await
+        .expect("xoá cả mùa");
+
+    assert!(
+        stored_dates(&db.pool).await.is_empty(),
+        "bảng phải trống sau khi xoá mùa"
+    );
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let without_season =
+        calculate_stay_price_tx(&mut tx, "P401", "2026-03-02", "2026-03-04", "nightly", None)
+            .await
+            .expect("tính giá sau khi xoá");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(without_season.base_amount, 1_000_000);
+    assert_eq!(
+        without_season.surcharge_amount, 0,
+        "hết mùa thì hết phụ thu"
+    );
+    assert_eq!(without_season.total, 1_000_000);
+
+    db.close().await;
+}
+
+// ─── 6. Xem trước phải bằng số thu ───
+
+/// Lời hứa mà cả thiết kế đặt cược vào. Cùng phòng, cùng ngày, cùng số khách:
+/// `calculate_room_price_preview` và `calculate_stay_price_tx` phải trả về y
+/// hệt nhau — từng dòng breakdown, không chỉ tổng.
+///
+/// Dùng lại đúng ca của chủ nhà, nên con số phải là 1.400.000 (xem phép tính ở
+/// test đầu file). So sánh mà cả hai cùng rỗng thì vô nghĩa, nên tổng được
+/// khoá vào con số tính tay.
+#[tokio::test]
+async fn the_preview_and_the_transactional_charge_return_the_identical_total() {
+    let db = migrated_db("preview-equals-charge").await;
+    seed_room(&db.pool, "P501", "Phòng đôi", 500_000, 2, 50_000).await;
+    declare_season(&db.pool, "2026-03-01", "2026-03-05", "Cao điểm hè", 20.0).await;
+
+    let preview = pricing_service::calculate_room_price_preview(
+        &db.pool,
+        "P501",
+        "2026-03-02",
+        "2026-03-04",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .expect("xem trước");
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let charged = calculate_stay_price_tx(
+        &mut tx,
+        "P501",
+        "2026-03-02",
+        "2026-03-04",
+        "nightly",
+        Some(4),
+    )
+    .await
+    .expect("thu tiền");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(preview.total, charged.total);
+    assert_eq!(preview.base_amount, charged.base_amount);
+    assert_eq!(preview.surcharge_amount, charged.surcharge_amount);
+    assert_eq!(preview.weekend_amount, charged.weekend_amount);
+    assert_eq!(preview.pricing_type, charged.pricing_type);
+    assert_eq!(preview.breakdown.len(), charged.breakdown.len());
+    for (left, right) in preview.breakdown.iter().zip(charged.breakdown.iter()) {
+        assert_eq!(left.label, right.label);
+        assert_eq!(left.amount, right.amount);
+    }
+
+    assert_eq!(charged.total, 1_400_000, "so sánh phải neo vào số tính tay");
+    assert_eq!(charged.surcharge_amount, 200_000);
+
+    db.close().await;
+}
+
+// ─── 7. Schema thật ───
+
+/// `special_dates` do migration thật tạo ra phải đúng những gì code giả định:
+/// `id TEXT PRIMARY KEY`, `date TEXT NOT NULL` có `UNIQUE`, `label TEXT NOT
+/// NULL`, `uplift_pct REAL NOT NULL`, `created_at TEXT NOT NULL`.
+#[tokio::test]
+async fn the_migrated_special_dates_table_matches_what_the_code_assumes() {
+    let db = migrated_db("schema").await;
+
+    let columns: Vec<(String, String, i64, i64)> = sqlx::query_as(
+        "SELECT name, type, \"notnull\", pk FROM pragma_table_info('special_dates')",
+    )
+    .fetch_all(&db.pool)
+    .await
+    .expect("pragma_table_info");
+
+    let names: Vec<&str> = columns.iter().map(|row| row.0.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["id", "date", "label", "uplift_pct", "created_at"],
+        "tên và thứ tự cột"
+    );
+
+    let by_name = |name: &str| {
+        columns
+            .iter()
+            .find(|row| row.0 == name)
+            .unwrap_or_else(|| panic!("thiếu cột {name}"))
+            .clone()
+    };
+    assert_eq!(by_name("id").1, "TEXT");
+    assert_eq!(by_name("id").3, 1, "id là PRIMARY KEY");
+    assert_eq!(by_name("date").1, "TEXT");
+    assert_eq!(by_name("date").2, 1, "date NOT NULL");
+    assert_eq!(by_name("label").1, "TEXT");
+    assert_eq!(by_name("label").2, 1, "label NOT NULL");
+    assert_eq!(by_name("uplift_pct").1, "REAL");
+    assert_eq!(by_name("uplift_pct").2, 1, "uplift_pct NOT NULL");
+    assert_eq!(by_name("created_at").1, "TEXT");
+    assert_eq!(by_name("created_at").2, 1, "created_at NOT NULL");
+
+    // UNIQUE(date): có index unique và index ấy đúng trên cột `date`.
+    let unique_indexes: Vec<String> = sqlx::query_scalar(
+        "SELECT name FROM pragma_index_list('special_dates') WHERE \"unique\" = 1",
+    )
+    .fetch_all(&db.pool)
+    .await
+    .expect("pragma_index_list");
+    let mut unique_columns: Vec<String> = Vec::new();
+    for index in &unique_indexes {
+        let cols: Vec<String> =
+            sqlx::query_scalar("SELECT name FROM pragma_index_info(?) ORDER BY seqno")
+                .bind(index)
+                .fetch_all(&db.pool)
+                .await
+                .expect("pragma_index_info");
+        if cols.len() == 1 {
+            unique_columns.push(cols[0].clone());
+        }
+    }
+    assert!(
+        unique_columns.iter().any(|column| column == "date"),
+        "phải có UNIQUE trên cột date, thấy: {unique_columns:?}"
+    );
+
+    // Và ràng buộc ấy phải thật sự chặn, không chỉ có tên.
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES ('a', '2026-03-01', 'Lễ', 10.0, '2026-01-01T00:00:00+07:00')",
+    )
+    .execute(&db.pool)
+    .await
+    .expect("dòng đầu");
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES ('b', '2026-03-01', 'Lễ', 10.0, '2026-01-01T00:00:00+07:00')",
+    )
+    .execute(&db.pool)
+    .await
+    .expect_err("ngày trùng phải bị UNIQUE(date) chặn");
+
+    db.close().await;
+}
+
+/// Nhánh này không được thêm hay sửa migration nào: phiên bản schema phải đứng
+/// yên ở 22, đúng như trên `main`.
+#[tokio::test]
+async fn the_branch_does_not_move_the_schema_version() {
+    let db = migrated_db("schema-version").await;
+
+    let version: i64 = sqlx::query_scalar("SELECT version FROM schema_version LIMIT 1")
+        .fetch_one(&db.pool)
+        .await
+        .expect("đọc schema_version");
+
+    assert_eq!(version, 22, "nhánh mùa cao điểm không đụng vào migration");
+
+    db.close().await;
+}
+
+// ─── 8. Tương thích ngược ───
+
+/// Dòng do lệnh `save_special_date` (đã bị xoá) ghi ra: một ngày lẻ, `id` là
+/// uuid, `created_at` là rfc3339 của `chrono::Local::now()`.
+async fn insert_the_old_way(pool: &Pool<Sqlite>, date: &str, label: &str, pct: f64) -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(date) DO UPDATE SET label = excluded.label, uplift_pct = excluded.uplift_pct",
+    )
+    .bind(&id)
+    .bind(date)
+    .bind(label)
+    .bind(pct)
+    .bind(Local::now().to_rfc3339())
+    .execute(pool)
+    .await
+    .expect("ghi kiểu lệnh cũ");
+    id
+}
+
+/// Dữ liệu do bản cũ ghi ra phải đọc được, tính giá đúng, và sửa được bằng lệnh
+/// mới mà không mất `id` — mọi tham chiếu bên ngoài còn dùng được.
+///
+/// Ba ngày lẻ 02/03, 03/03, 04/03 cùng +30%. Kỳ ở 02/03→04/03 = 2 đêm (02, 03).
+///
+///   base             = 500.000 × 2 đêm  = 1.000.000
+///   mức bình quân    = (30 + 30) / 2    =        30%
+///   phụ thu          = 1.000.000 × 30%  =   300.000
+///   tổng                                = 1.300.000
+#[tokio::test]
+async fn rows_written_by_the_deleted_single_day_command_still_read_and_price_correctly() {
+    let db = migrated_db("backcompat").await;
+    seed_room(&db.pool, "P601", "Phòng đôi", 500_000, 2, 0).await;
+
+    let mut old_ids = Vec::new();
+    for date in ["2026-03-02", "2026-03-03", "2026-03-04"] {
+        old_ids.push(insert_the_old_way(&db.pool, date, "Lễ cũ", 30.0).await);
+    }
+
+    // Đọc lại qua đúng query mà màn hình cài đặt dùng.
+    let listed = pricing_queries::load_special_dates(&db.pool)
+        .await
+        .expect("load_special_dates");
+    assert_eq!(listed.len(), 3);
+    assert_eq!(listed[0].date, "2026-03-02");
+    assert_eq!(listed[0].label, "Lễ cũ");
+    assert_eq!(listed[0].uplift_pct, 30.0);
+    assert_eq!(
+        listed[0].id, old_ids[0],
+        "id uuid cũ phải đọc lại nguyên vẹn"
+    );
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let charged =
+        calculate_stay_price_tx(&mut tx, "P601", "2026-03-02", "2026-03-04", "nightly", None)
+            .await
+            .expect("tính giá trên dữ liệu cũ");
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(charged.base_amount, 1_000_000);
+    assert_eq!(charged.surcharge_amount, 300_000);
+    assert_eq!(charged.total, 1_300_000);
+
+    // Lệnh mới sửa đè lên dữ liệu cũ: giữ id, đổi nhãn và mức.
+    declare_season(&db.pool, "2026-03-02", "2026-03-04", "Cao điểm mới", 45.0).await;
+
+    let rows: Vec<(String, String, String, f64)> = sqlx::query_as(
+        "SELECT id, date, label, CAST(uplift_pct AS REAL) FROM special_dates ORDER BY date",
+    )
+    .fetch_all(&db.pool)
+    .await
+    .expect("đọc lại sau khi sửa");
+    assert_eq!(rows.len(), 3, "không được đẻ thêm dòng cho ngày đã có");
+    for (index, row) in rows.iter().enumerate() {
+        assert_eq!(row.0, old_ids[index], "id uuid cũ phải được giữ");
+        assert_eq!(row.2, "Cao điểm mới");
+        assert_eq!(row.3, 45.0);
+    }
+
+    // Và xoá được bằng lệnh mới.
+    pricing_service::delete_special_dates(&db.pool, vec!["2026-03-03".to_string()])
+        .await
+        .expect("xoá một ngày cũ");
+    let remaining = stored_dates(&db.pool).await;
+    assert_eq!(
+        remaining
+            .iter()
+            .map(|row| row.0.as_str())
+            .collect::<Vec<_>>(),
+        vec!["2026-03-02", "2026-03-04"]
+    );
+
+    db.close().await;
+}
+
+/// Database đã có sẵn dữ liệu mùa cao điểm từ trước: chạy lại migration (đúng
+/// việc app làm mỗi lần khởi động) không được đụng vào dòng nào, và giá vẫn
+/// phải ra đúng con số cũ.
+#[tokio::test]
+async fn a_database_that_already_had_special_dates_survives_a_migration_rerun() {
+    let db = migrated_db("existing-rows").await;
+    seed_room(&db.pool, "P701", "Phòng đôi", 500_000, 2, 0).await;
+    for date in ["2026-03-02", "2026-03-03"] {
+        insert_the_old_way(&db.pool, date, "Lễ cũ", 30.0).await;
+    }
+
+    let before = stored_dates(&db.pool).await;
+
+    crate::db::run_migrations(&db.pool)
+        .await
+        .expect("chạy lại migration trên db đã có dữ liệu");
+
+    let after = stored_dates(&db.pool).await;
+    assert_eq!(before, after, "migration chạy lại không được sửa dữ liệu");
+
+    let mut tx = db.pool.begin().await.expect("begin");
+    let charged =
+        calculate_stay_price_tx(&mut tx, "P701", "2026-03-02", "2026-03-04", "nightly", None)
+            .await
+            .expect("tính giá sau khi migrate lại");
+    tx.rollback().await.expect("rollback");
+
+    // Y hệt phép tính ở test trên: 1.000.000 base + 30% = 1.300.000.
+    assert_eq!(charged.total, 1_300_000);
+
+    db.close().await;
+}

--- a/mhm/src-tauri/src/services/booking/tests/pricing.rs
+++ b/mhm/src-tauri/src/services/booking/tests/pricing.rs
@@ -44,9 +44,12 @@ async fn calculate_stay_price_tx_applies_special_date_uplift() {
     .unwrap();
 
     assert_eq!(pricing.pricing_type, "nightly");
-    assert_eq!(pricing.total, 1_320_000);
+    // Kỳ ở 20/04→22/04 là hai đêm 20 và 21. Chỉ 20/04 được khai là ngày lễ
+    // (10%); 21/04 thì không. Mức bình quân (10 + 0) / 2 = 5%, không phải 10%
+    // cho cả hai đêm như luật cũ (tính theo ngày check-in).
+    assert_eq!(pricing.total, 1_260_000);
     assert_eq!(pricing.base_amount, 1_200_000);
-    assert_eq!(pricing.surcharge_amount, 120_000);
+    assert_eq!(pricing.surcharge_amount, 60_000);
     assert_eq!(pricing.weekend_amount, 0);
     assert_eq!(pricing.breakdown.len(), 2);
     assert_eq!(pricing.breakdown[0].amount, 1_200_000);
@@ -280,7 +283,9 @@ async fn calculate_stay_price_tx_reads_uncommitted_special_date() {
     .await
     .unwrap();
 
-    assert_eq!(pricing.total, 1_320_000);
+    // Cùng lý do như test ở trên: chỉ đêm 20/04 nằm trong ngày lễ, đêm 21/04
+    // thì không, nên mức bình quân là 5% chứ không phải 10%.
+    assert_eq!(pricing.total, 1_260_000);
 
     tx.rollback().await.unwrap();
 }

--- a/mhm/src/lib/specialDateRanges.test.ts
+++ b/mhm/src/lib/specialDateRanges.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { groupSpecialDates, overlappingDates, type SpecialDateRow } from "./specialDateRanges";
+
+function row(date: string, label = "Tết", uplift_pct = 40): SpecialDateRow {
+    return { id: `id-${date}`, date, label, uplift_pct };
+}
+
+describe("groupSpecialDates", () => {
+    it("gom chín ngày liền nhau thành một khoảng", () => {
+        const rows = Array.from({ length: 9 }, (_, index) => row(`2026-02-${14 + index}`));
+
+        const ranges = groupSpecialDates(rows);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].from).toBe("2026-02-14");
+        expect(ranges[0].to).toBe("2026-02-22");
+        expect(ranges[0].days).toBe(9);
+        expect(ranges[0].dates).toHaveLength(9);
+    });
+
+    it("tách khi hở một ngày", () => {
+        const ranges = groupSpecialDates([row("2026-02-14"), row("2026-02-16")]);
+
+        expect(ranges).toHaveLength(2);
+        expect(ranges.map((range) => range.days)).toEqual([1, 1]);
+    });
+
+    it("tách khi liền ngày nhưng khác nhãn", () => {
+        const ranges = groupSpecialDates([
+            row("2026-02-14", "Tết"),
+            row("2026-02-15", "Hè"),
+        ]);
+
+        expect(ranges).toHaveLength(2);
+    });
+
+    it("tách khi liền ngày, cùng nhãn, nhưng khác mức", () => {
+        const ranges = groupSpecialDates([
+            row("2026-02-14", "Tết", 40),
+            row("2026-02-15", "Tết", 25),
+        ]);
+
+        expect(ranges).toHaveLength(2);
+    });
+
+    it("gom đúng dù đầu vào không theo thứ tự ngày", () => {
+        const ranges = groupSpecialDates([
+            row("2026-02-16"),
+            row("2026-02-14"),
+            row("2026-02-15"),
+        ]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].dates).toEqual(["2026-02-14", "2026-02-15", "2026-02-16"]);
+    });
+
+    it("vắt qua ranh giới tháng", () => {
+        const ranges = groupSpecialDates([row("2026-02-28"), row("2026-03-01")]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].days).toBe(2);
+    });
+
+    it("vắt qua ranh giới năm", () => {
+        const ranges = groupSpecialDates([row("2026-12-31"), row("2027-01-01")]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].days).toBe(2);
+    });
+
+    it("đầu vào rỗng trả mảng rỗng", () => {
+        expect(groupSpecialDates([])).toEqual([]);
+    });
+
+    it("bỏ qua ngày sai định dạng thay vì sập", () => {
+        // Cột `date` không có ràng buộc CHECK dưới DB, nên rác là có thật.
+        const ranges = groupSpecialDates([row("khong-phai-ngay"), row("2026-02-14")]);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0].from).toBe("2026-02-14");
+    });
+});
+
+describe("overlappingDates", () => {
+    it("chỉ trả những ngày đã khai nằm trong khoảng mới", () => {
+        const rows = [row("2026-02-19"), row("2026-02-20"), row("2026-02-21")];
+
+        const clashes = overlappingDates(rows, "2026-02-20", "2026-02-28");
+
+        expect(clashes.map((clash) => clash.date)).toEqual(["2026-02-20", "2026-02-21"]);
+    });
+
+    it("không tính ngày của chính cụm đang sửa là trùng", () => {
+        const rows = [row("2026-02-20"), row("2026-02-21")];
+
+        const clashes = overlappingDates(rows, "2026-02-20", "2026-02-28", [
+            "2026-02-20",
+            "2026-02-21",
+        ]);
+
+        expect(clashes).toEqual([]);
+    });
+});

--- a/mhm/src/lib/specialDateRanges.ts
+++ b/mhm/src/lib/specialDateRanges.ts
@@ -1,0 +1,108 @@
+/**
+ * Dưới DB, `special_dates` là một dòng cho một ngày. Chủ nhà thì nghĩ theo kỳ
+ * nghỉ. Module này bắc cầu giữa hai cách nhìn ấy, và chỉ làm việc đó.
+ */
+
+export type SpecialDateRow = {
+    id: string;
+    date: string;
+    label: string;
+    uplift_pct: number;
+};
+
+export type SpecialDateRange = {
+    from: string;
+    to: string;
+    days: number;
+    label: string;
+    uplift_pct: number;
+    /** Mọi ngày trong cụm — thứ phải gửi đi khi xoá. */
+    dates: string[];
+};
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Ngày kế tiếp của một `YYYY-MM-DD`.
+ *
+ * Tính trên UTC rồi cắt mười ký tự đầu. Tuyệt đối không dùng
+ * `new Date("2026-02-14T00:00:00")` — nó phân tích theo giờ địa phương rồi in
+ * ra UTC, và ở UTC+7 thì lệch mất một ngày.
+ *
+ * Hàm này cố ý để cục bộ chứ không tách sang `src/lib/`:
+ * `ReservationSheet.tsx` đã có một `addDays` nhận và trả `string`, còn nhánh
+ * `refactor/pricing-preview-honesty` đang thêm một `addDays` nhận và trả
+ * `Date`. Dựng thêm một module dùng chung lúc này là chuốc lấy đụng độ trùng
+ * tên với kiểu không tương thích.
+ */
+function nextDay(date: string): string {
+    const [year, month, day] = date.split("-").map(Number);
+    return new Date(Date.UTC(year, month - 1, day + 1)).toISOString().slice(0, 10);
+}
+
+/**
+ * Gom ngày liền nhau, cùng nhãn, cùng mức thành một khoảng.
+ *
+ * Đây là suy đoán chứ không phải dữ liệu: hai kỳ khác nhau tình cờ liền ngày,
+ * cùng nhãn, cùng mức sẽ hiện thành một dòng. Vô hại — xoá cụm ấy đúng là xoá
+ * chừng đó ngày — nhưng đừng coi đó là lỗi.
+ */
+export function groupSpecialDates(rows: SpecialDateRow[]): SpecialDateRange[] {
+    const sorted = rows
+        .filter((row) => DATE_ONLY.test(row.date))
+        .slice()
+        .sort((left, right) => left.date.localeCompare(right.date));
+
+    const ranges: SpecialDateRange[] = [];
+    for (const row of sorted) {
+        const open = ranges[ranges.length - 1];
+        const joinsOpenRange =
+            open !== undefined &&
+            open.label === row.label &&
+            open.uplift_pct === row.uplift_pct &&
+            nextDay(open.to) === row.date;
+
+        if (open !== undefined && joinsOpenRange) {
+            open.to = row.date;
+            open.days += 1;
+            open.dates.push(row.date);
+        } else {
+            ranges.push({
+                from: row.date,
+                to: row.date,
+                days: 1,
+                label: row.label,
+                uplift_pct: row.uplift_pct,
+                dates: [row.date],
+            });
+        }
+    }
+
+    return ranges;
+}
+
+/**
+ * Những ngày đã khai mà một khoảng mới sẽ ghi đè lên.
+ *
+ * `exclude` là các ngày của chính cụm đang sửa — chúng không phải là trùng.
+ * So sánh bằng chuỗi vì `YYYY-MM-DD` xếp theo từ điển đúng bằng xếp theo thời
+ * gian.
+ */
+export function overlappingDates(
+    rows: SpecialDateRow[],
+    from: string,
+    to: string,
+    exclude: string[] = [],
+): SpecialDateRow[] {
+    const excluded = new Set(exclude);
+
+    return rows
+        .filter(
+            (row) =>
+                DATE_ONLY.test(row.date) &&
+                !excluded.has(row.date) &&
+                row.date >= from &&
+                row.date <= to,
+        )
+        .sort((left, right) => left.date.localeCompare(right.date));
+}

--- a/mhm/src/pages/settings/SpecialDatesSection.test.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.test.tsx
@@ -264,6 +264,33 @@ describe("SpecialDatesSection", () => {
         );
     });
 
+    it("sửa cụm khác trong lúc hộp ghi đè của cụm trước còn treo thì hộp đó phải tắt", async () => {
+        invoke.mockResolvedValue([
+            ...tetRows(),
+            { id: "he-1", date: "2026-03-01", label: "Hè", uplift_pct: 20 },
+        ]);
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+        await screen.findByText("Hè");
+
+        // Sửa cụm Tết, kéo dài "Đến ngày" đè lên ngày của cụm Hè để hộp ghi
+        // đè bật lên — nhưng KHÔNG bấm "Tiếp tục" hay "Huỷ" để giải quyết nó.
+        fireEvent.click(screen.getAllByRole("button", { name: "Sửa" })[0]);
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-03-01" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cập nhật" }));
+
+        expect(await screen.findByText(/1 ngày đã khai sẽ bị ghi đè/)).toBeInTheDocument();
+
+        // Bỏ dở hộp đó, chuyển sang sửa cụm Hè — hộp ghi đè của yêu cầu cũ
+        // (mô tả cụm Tết) phải biến mất ngay, vì nó không còn liên quan gì
+        // tới form đang hiển thị (giờ đang hiển thị dữ liệu của cụm Hè).
+        fireEvent.click(screen.getAllByRole("button", { name: "Sửa" })[1]);
+
+        expect(screen.queryByText(/ngày đã khai sẽ bị ghi đè/)).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Tiếp tục" })).not.toBeInTheDocument();
+        expect(invokeWriteCommand).not.toHaveBeenCalled();
+    });
+
     it("để trống % phụ thu thì báo lỗi, không lưu 0% ngầm", async () => {
         const { toast } = await import("sonner");
         render(<SpecialDatesSection />);

--- a/mhm/src/pages/settings/SpecialDatesSection.test.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SpecialDatesSection from "./SpecialDatesSection";
+
+const invokeWriteCommand = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/invokeCommand", () => ({ invokeWriteCommand }));
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function tetRows() {
+    return Array.from({ length: 9 }, (_, index) => ({
+        id: `id-${index}`,
+        date: `2026-02-${14 + index}`,
+        label: "Tết Nguyên đán",
+        uplift_pct: 40,
+    }));
+}
+
+describe("SpecialDatesSection", () => {
+    beforeEach(() => {
+        invokeWriteCommand.mockReset().mockResolvedValue(undefined);
+        invoke.mockReset().mockResolvedValue(tetRows());
+    });
+
+    it("hiện chín ngày Tết thành một dòng", async () => {
+        render(<SpecialDatesSection />);
+
+        expect(await screen.findByText("Tết Nguyên đán")).toBeInTheDocument();
+        expect(screen.getByText(/9 ngày/)).toBeInTheDocument();
+        expect(screen.getAllByRole("button", { name: "Xoá" })).toHaveLength(1);
+    });
+
+    it("khai khoảng không trùng thì gọi thẳng lệnh ghi", async () => {
+        invoke.mockResolvedValue([]);
+        render(<SpecialDatesSection />);
+        await screen.findByText(/Chưa khai đợt cao điểm nào/);
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Lễ 30/4" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-04-30" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-05-03" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "30" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        expect(invokeWriteCommand).toHaveBeenCalledWith("save_special_date_range", {
+            remove: [],
+            from: "2026-04-30",
+            to: "2026-05-03",
+            label: "Lễ 30/4",
+            upliftPct: 30,
+        });
+    });
+
+    it("khai đè lên ngày đã có thì hỏi trước, và huỷ thì không ghi gì", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Hè" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        expect(await screen.findByText(/3 ngày đã khai sẽ bị ghi đè/)).toBeInTheDocument();
+        expect(screen.getByText(/2026-02-20/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Huỷ" }));
+
+        expect(invokeWriteCommand).not.toHaveBeenCalled();
+    });
+
+    it("bấm tiếp tục ở hộp trùng thì mới ghi", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Hè" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+        fireEvent.click(await screen.findByRole("button", { name: "Tiếp tục" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+    });
+
+    it("xoá một cụm gửi đúng chín ngày trong một lần gọi", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Xoá" }));
+        fireEvent.click(await screen.findByRole("button", { name: "Xoá đợt này" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        const [command, args] = invokeWriteCommand.mock.calls[0];
+        expect(command).toBe("delete_special_dates");
+        expect(args.dates).toHaveLength(9);
+    });
+
+    it("sửa cụm cho ngắn lại thì ngày rơi ra đi trong `remove`, không có lệnh xoá riêng", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Sửa" }));
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-19" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cập nhật" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        const [command, args] = invokeWriteCommand.mock.calls[0];
+        expect(command).toBe("save_special_date_range");
+        // 20, 21, 22 rơi ra khỏi khoảng mới 14–19.
+        expect(args.remove).toEqual(["2026-02-20", "2026-02-21", "2026-02-22"]);
+        expect(
+            invokeWriteCommand.mock.calls.some(([name]) => name === "delete_special_dates"),
+        ).toBe(false);
+    });
+
+    it("lệnh lỗi thì báo toast và không đổi danh sách ngầm", async () => {
+        const { toast } = await import("sonner");
+        invokeWriteCommand.mockRejectedValue(new Error("Không đủ quyền"));
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Xoá" }));
+        fireEvent.click(await screen.findByRole("button", { name: "Xoá đợt này" }));
+
+        await waitFor(() => expect(toast.error).toHaveBeenCalled());
+        expect(screen.getByText("Tết Nguyên đán")).toBeInTheDocument();
+    });
+});

--- a/mhm/src/pages/settings/SpecialDatesSection.test.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.test.tsx
@@ -53,6 +53,12 @@ describe("SpecialDatesSection", () => {
             label: "Lễ 30/4",
             upliftPct: 30,
         });
+
+        // Sau khi ghi thành công, màn hình phải đọc lại `get_special_dates`
+        // từ DB — không tự vá `rows` bằng dữ liệu vừa gửi đi. Đây là điều mà
+        // hộp so trùng ghi-đè dựa vào để luôn đúng.
+        await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+        expect(invoke).toHaveBeenLastCalledWith("get_special_dates");
     });
 
     it("khai đè lên ngày đã có thì hỏi trước, và huỷ thì không ghi gì", async () => {
@@ -164,7 +170,53 @@ describe("SpecialDatesSection", () => {
         await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
         const [command, args] = invokeWriteCommand.mock.calls[0];
         expect(command).toBe("delete_special_dates");
-        expect(args.dates).toHaveLength(9);
+        // Không chỉ đúng số lượng — phải đúng từng ngày của cụm Tết, không
+        // phải một cụm khác hay một danh sách chín ngày bị xáo trộn.
+        expect(args.dates).toEqual([
+            "2026-02-14",
+            "2026-02-15",
+            "2026-02-16",
+            "2026-02-17",
+            "2026-02-18",
+            "2026-02-19",
+            "2026-02-20",
+            "2026-02-21",
+            "2026-02-22",
+        ]);
+
+        // Sau khi xoá thành công, màn hình phải tải lại từ DB (không tự vá
+        // state) — đọc lại `get_special_dates` chứ không tin state cũ.
+        await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+        expect(invoke).toHaveBeenLastCalledWith("get_special_dates");
+    });
+
+    it("hộp xoá đang treo cho một cụm bị bỏ dở nếu người dùng lưu một yêu cầu khác trong lúc đó", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        // Bấm Xoá trên cụm Tết để mở hộp xoá — nhưng không xác nhận.
+        fireEvent.click(screen.getByRole("button", { name: "Xoá" }));
+        expect(await screen.findByRole("button", { name: "Xoá đợt này" })).toBeInTheDocument();
+
+        // Trong lúc đó, khai một cụm Hè đè lên đuôi cụm Tết (20–22/02) và xác
+        // nhận ghi đè — mô phỏng đúng kịch bản: chủ nhà bỏ dở việc xoá, quay
+        // sang lưu một yêu cầu khác chẳng liên quan.
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Hè" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        fireEvent.click(await screen.findByRole("button", { name: "Tiếp tục" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+
+        // Hộp xoá của cụm Tết (bản chụp cũ) phải biến mất khỏi màn hình. Nếu
+        // nó còn đó, bấm "Xoá đợt này" bây giờ sẽ gửi delete_special_dates
+        // cho 9 ngày Tết cũ — xoá luôn 20, 21, 22/02 mà cụm Hè vừa mới ghi.
+        await waitFor(() =>
+            expect(screen.queryByRole("button", { name: "Xoá đợt này" })).not.toBeInTheDocument(),
+        );
     });
 
     it("sửa cụm cho ngắn lại thì ngày rơi ra đi trong `remove`, không có lệnh xoá riêng", async () => {

--- a/mhm/src/pages/settings/SpecialDatesSection.test.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.test.tsx
@@ -73,7 +73,7 @@ describe("SpecialDatesSection", () => {
         expect(invokeWriteCommand).not.toHaveBeenCalled();
     });
 
-    it("bấm tiếp tục ở hộp trùng thì mới ghi", async () => {
+    it("bấm tiếp tục ở hộp trùng thì mới ghi, dùng đúng yêu cầu đã chốt chứ không đọc lại form", async () => {
         render(<SpecialDatesSection />);
         await screen.findByText("Tết Nguyên đán");
 
@@ -82,9 +82,76 @@ describe("SpecialDatesSection", () => {
         fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
         fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
         fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
-        fireEvent.click(await screen.findByRole("button", { name: "Tiếp tục" }));
+        await screen.findByRole("button", { name: "Tiếp tục" });
+
+        // Đổi form sau khi hộp trùng đã hiện — lệnh gửi đi phải là yêu cầu đã
+        // chốt lúc bấm "Thêm", không phải đọc lại form lúc bấm "Tiếp tục".
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Đã đổi ý" } });
+
+        fireEvent.click(screen.getByRole("button", { name: "Tiếp tục" }));
 
         await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        expect(invokeWriteCommand).toHaveBeenCalledWith("save_special_date_range", {
+            remove: [],
+            from: "2026-02-20",
+            to: "2026-02-28",
+            label: "Hè",
+            upliftPct: 25,
+        });
+    });
+
+    it("huỷ sửa khi hộp ghi đè đang mở thì hộp ghi đè cũng tắt theo, không còn armed", async () => {
+        invoke.mockResolvedValue([
+            ...tetRows(),
+            { id: "he-1", date: "2026-03-01", label: "Hè", uplift_pct: 20 },
+        ]);
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+        await screen.findByText("Hè");
+
+        // Sửa cụm Tết, kéo dài "Đến ngày" đè lên ngày của cụm Hè để hộp ghi
+        // đè phải bật lên trong lúc đang sửa.
+        fireEvent.click(screen.getAllByRole("button", { name: "Sửa" })[0]);
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-03-01" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cập nhật" }));
+
+        expect(await screen.findByText(/1 ngày đã khai sẽ bị ghi đè/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Huỷ sửa" }));
+
+        expect(screen.queryByText(/ngày đã khai sẽ bị ghi đè/)).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Tiếp tục" })).not.toBeInTheDocument();
+        expect(invokeWriteCommand).not.toHaveBeenCalled();
+    });
+
+    it("đổi sang khoảng không trùng rồi bấm thêm thì hộp ghi đè cũ của yêu cầu trước biến mất ngay", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Hè" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "25" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        expect(await screen.findByText(/3 ngày đã khai sẽ bị ghi đè/)).toBeInTheDocument();
+
+        // Đổi sang khoảng không đụng ngày nào đã khai, rồi bấm Thêm lại —
+        // hộp của yêu cầu cũ (đã bỏ) không được treo lại trên màn hình.
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-04-30" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-05-03" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        expect(screen.queryByText(/ngày đã khai sẽ bị ghi đè/)).not.toBeInTheDocument();
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        expect(invokeWriteCommand).toHaveBeenCalledWith("save_special_date_range", {
+            remove: [],
+            from: "2026-04-30",
+            to: "2026-05-03",
+            label: "Hè",
+            upliftPct: 25,
+        });
     });
 
     it("xoá một cụm gửi đúng chín ngày trong một lần gọi", async () => {
@@ -118,6 +185,49 @@ describe("SpecialDatesSection", () => {
         ).toBe(false);
     });
 
+    it("sửa cụm cho dài ra thì `remove` rỗng, không ngày nào bị coi là rơi ra", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Sửa" }));
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-03-01" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cập nhật" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        const [command, args] = invokeWriteCommand.mock.calls[0];
+        expect(command).toBe("save_special_date_range");
+        expect(args.remove).toEqual([]);
+        expect(
+            invokeWriteCommand.mock.calls.some(([name]) => name === "delete_special_dates"),
+        ).toBe(false);
+    });
+
+    it("sửa cụm cho dịch chuyển thì `remove` đúng là các ngày đầu rơi ra, không đụng ngày còn giữ", async () => {
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.click(screen.getByRole("button", { name: "Sửa" }));
+        // 14–22 dịch thành 20–28: 14..19 rơi ra, 20..22 vẫn còn trong khoảng mới.
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-02-20" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-02-28" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cập nhật" }));
+
+        await waitFor(() => expect(invokeWriteCommand).toHaveBeenCalledTimes(1));
+        const [command, args] = invokeWriteCommand.mock.calls[0];
+        expect(command).toBe("save_special_date_range");
+        expect(args.remove).toEqual([
+            "2026-02-14",
+            "2026-02-15",
+            "2026-02-16",
+            "2026-02-17",
+            "2026-02-18",
+            "2026-02-19",
+        ]);
+        expect(
+            invokeWriteCommand.mock.calls.some(([name]) => name === "delete_special_dates"),
+        ).toBe(false);
+    });
+
     it("lệnh lỗi thì báo toast và không đổi danh sách ngầm", async () => {
         const { toast } = await import("sonner");
         invokeWriteCommand.mockRejectedValue(new Error("Không đủ quyền"));
@@ -129,5 +239,43 @@ describe("SpecialDatesSection", () => {
 
         await waitFor(() => expect(toast.error).toHaveBeenCalled());
         expect(screen.getByText("Tết Nguyên đán")).toBeInTheDocument();
+    });
+
+    it("tải danh sách lỗi thì báo lỗi thay vì nói chưa khai, và chặn lưu để khỏi ghi đè mù", async () => {
+        const { toast } = await import("sonner");
+        invoke.mockRejectedValue(new Error("network down"));
+        render(<SpecialDatesSection />);
+
+        expect(
+            await screen.findByText(/Không tải được danh sách đợt cao điểm/),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/Chưa khai đợt cao điểm nào/)).not.toBeInTheDocument();
+        await waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Lễ 30/4" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-04-30" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-05-03" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "30" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        expect(invokeWriteCommand).not.toHaveBeenCalled();
+        expect(toast.error).toHaveBeenCalledWith(
+            expect.stringMatching(/không thể so trùng|Tải lại/),
+        );
+    });
+
+    it("để trống % phụ thu thì báo lỗi, không lưu 0% ngầm", async () => {
+        const { toast } = await import("sonner");
+        render(<SpecialDatesSection />);
+        await screen.findByText("Tết Nguyên đán");
+
+        fireEvent.change(screen.getByLabelText("Tên đợt"), { target: { value: "Lễ 30/4" } });
+        fireEvent.change(screen.getByLabelText("Từ ngày"), { target: { value: "2026-04-30" } });
+        fireEvent.change(screen.getByLabelText("Đến ngày"), { target: { value: "2026-05-03" } });
+        fireEvent.change(screen.getByLabelText("% phụ thu"), { target: { value: "" } });
+        fireEvent.click(screen.getByRole("button", { name: "Thêm" }));
+
+        expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/% phụ thu/));
+        expect(invokeWriteCommand).not.toHaveBeenCalled();
     });
 });

--- a/mhm/src/pages/settings/SpecialDatesSection.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.tsx
@@ -59,6 +59,16 @@ export default function SpecialDatesSection() {
 
     useEffect(reload, [reload]);
 
+    // `deleting` là một bản chụp đông cứng của một cụm. Bất cứ khi nào `rows`
+    // đổi — sau một lần ghi thành công, sau một lần xoá, sau một lần tải lại
+    // bất kỳ — bản chụp ấy có thể không còn khớp với DB nữa (cụm đã bị cắt,
+    // gộp, hay biến mất). Đóng hộp xoá theo `rows` chứ không chỉ theo từng
+    // hành động rời bỏ riêng lẻ, để không bỏ sót một đường tải lại nào trong
+    // tương lai mà quên tắt hộp theo.
+    useEffect(() => {
+        setDeleting(null);
+    }, [rows]);
+
     const ranges = groupSpecialDates(rows);
 
     const resetForm = () => {
@@ -69,6 +79,7 @@ export default function SpecialDatesSection() {
         setUpliftPct("30");
         setClashes(null);
         setPending(null);
+        setDeleting(null);
     };
 
     const startEdit = (range: SpecialDateRange) => {
@@ -80,8 +91,11 @@ export default function SpecialDatesSection() {
         // Sửa một cụm khác phải bỏ hộp ghi-đè (và yêu cầu đã chốt bên trong
         // nó) của cụm trước — nếu không, "Tiếp tục" của hộp cũ vẫn còn sống
         // và sẽ ghi một yêu cầu chẳng liên quan gì đến form đang hiển thị.
+        // Cùng lý do, hộp xoá của một cụm khác cũng phải tắt — nó không còn
+        // liên quan gì tới form đang hiển thị.
         setClashes(null);
         setPending(null);
+        setDeleting(null);
     };
 
     const write = async (request: PendingWrite) => {

--- a/mhm/src/pages/settings/SpecialDatesSection.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.tsx
@@ -17,6 +17,11 @@ import {
 /** Quá ngần này thì liệt kê hết chỉ tổ rối; phần còn lại đếm số. */
 const MAX_LISTED_CLASHES = 10;
 
+/** Dùng chung cho mọi điểm chặn ghi khi chưa tải được danh sách để so trùng —
+ * để hai chỗ (handleSave và write) không lệch câu chữ theo thời gian. */
+const LOAD_ERROR_MESSAGE =
+    "Chưa tải được danh sách đợt đã khai nên không thể so trùng an toàn. Tải lại trang rồi thử lại.";
+
 type PendingWrite = {
     remove: string[];
     from: string;
@@ -72,9 +77,23 @@ export default function SpecialDatesSection() {
         setFrom(range.from);
         setTo(range.to);
         setUpliftPct(String(range.uplift_pct));
+        // Sửa một cụm khác phải bỏ hộp ghi-đè (và yêu cầu đã chốt bên trong
+        // nó) của cụm trước — nếu không, "Tiếp tục" của hộp cũ vẫn còn sống
+        // và sẽ ghi một yêu cầu chẳng liên quan gì đến form đang hiển thị.
+        setClashes(null);
+        setPending(null);
     };
 
     const write = async (request: PendingWrite) => {
+        // Chặn ở đúng biên ghi: bất kỳ đường nào gọi tới write() — kể cả từ
+        // "Tiếp tục" của hộp ghi đè, không chỉ từ handleSave — đều phải bị
+        // chặn khi danh sách so trùng chưa tải được, để không có đường vòng
+        // nào ghi đè dựa trên dữ liệu so trùng đã cũ/không rõ.
+        if (loadError) {
+            toast.error(LOAD_ERROR_MESSAGE);
+            return;
+        }
+
         try {
             await invokeWriteCommand("save_special_date_range", request);
             toast.success("Đã lưu đợt cao điểm");
@@ -92,9 +111,7 @@ export default function SpecialDatesSection() {
         setPending(null);
 
         if (loadError) {
-            toast.error(
-                "Chưa tải được danh sách đợt đã khai nên không thể so trùng an toàn. Tải lại trang rồi thử lại.",
-            );
+            toast.error(LOAD_ERROR_MESSAGE);
             return;
         }
 

--- a/mhm/src/pages/settings/SpecialDatesSection.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.tsx
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { CalendarDays } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { invokeWriteCommand } from "@/lib/invokeCommand";
+import {
+    groupSpecialDates,
+    overlappingDates,
+    type SpecialDateRange,
+    type SpecialDateRow,
+} from "@/lib/specialDateRanges";
+
+/** Quá ngần này thì liệt kê hết chỉ tổ rối; phần còn lại đếm số. */
+const MAX_LISTED_CLASHES = 10;
+
+type PendingWrite = {
+    remove: string[];
+    from: string;
+    to: string;
+    label: string;
+    upliftPct: number;
+};
+
+export default function SpecialDatesSection() {
+    const [rows, setRows] = useState<SpecialDateRow[]>([]);
+    const [editing, setEditing] = useState<SpecialDateRange | null>(null);
+    const [label, setLabel] = useState("");
+    const [from, setFrom] = useState("");
+    const [to, setTo] = useState("");
+    const [upliftPct, setUpliftPct] = useState("30");
+    const [clashes, setClashes] = useState<SpecialDateRow[] | null>(null);
+    const [pending, setPending] = useState<PendingWrite | null>(null);
+    const [deleting, setDeleting] = useState<SpecialDateRange | null>(null);
+
+    const reload = useCallback(() => {
+        invoke<SpecialDateRow[]>("get_special_dates")
+            .then(setRows)
+            .catch(() => setRows([]));
+    }, []);
+
+    useEffect(reload, [reload]);
+
+    const ranges = groupSpecialDates(rows);
+
+    const resetForm = () => {
+        setEditing(null);
+        setLabel("");
+        setFrom("");
+        setTo("");
+        setUpliftPct("30");
+    };
+
+    const startEdit = (range: SpecialDateRange) => {
+        setEditing(range);
+        setLabel(range.label);
+        setFrom(range.from);
+        setTo(range.to);
+        setUpliftPct(String(range.uplift_pct));
+    };
+
+    const write = async (request: PendingWrite) => {
+        try {
+            await invokeWriteCommand("save_special_date_range", request);
+            toast.success("Đã lưu đợt cao điểm");
+            resetForm();
+            reload();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const handleSave = () => {
+        const trimmed = label.trim();
+        if (!trimmed || !from || !to || to < from) {
+            toast.error("Điền tên đợt và khoảng ngày hợp lệ");
+            return;
+        }
+
+        // Ngày rơi ra khỏi khoảng mới phải bị xoá thật, nếu không nó nằm lại
+        // thành một ngày lễ mồ côi. Chúng đi kèm lệnh ghi chứ không thành một
+        // lệnh xoá riêng, để cả hai nửa chung một transaction.
+        const remove = (editing?.dates ?? []).filter((date) => date < from || date > to);
+        const request: PendingWrite = {
+            remove,
+            from,
+            to,
+            label: trimmed,
+            upliftPct: Number(upliftPct),
+        };
+
+        const conflicts = overlappingDates(rows, from, to, editing?.dates ?? []);
+        if (conflicts.length > 0) {
+            setClashes(conflicts);
+            setPending(request);
+            return;
+        }
+
+        void write(request);
+    };
+
+    const handleDelete = async (range: SpecialDateRange) => {
+        try {
+            await invokeWriteCommand("delete_special_dates", { dates: range.dates });
+            toast.success("Đã xoá đợt cao điểm");
+            resetForm();
+            reload();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : String(error));
+        } finally {
+            setDeleting(null);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-bold mb-1 flex items-center gap-2">
+                    <CalendarDays size={20} className="text-emerald-500" />
+                    Mùa cao điểm
+                </h3>
+                <p className="text-sm text-brand-muted">
+                    Khai những đợt tăng giá theo ngày — Tết, lễ, mùa du lịch. Giá phòng tự cộng
+                    thêm cho đúng những đêm nằm trong đợt.
+                </p>
+            </div>
+
+            {ranges.length === 0 ? (
+                <p className="text-sm text-brand-muted">
+                    Chưa khai đợt cao điểm nào. Thêm một đợt ở dưới.
+                </p>
+            ) : (
+                <div className="space-y-2">
+                    {ranges.map((range) => (
+                        <div
+                            key={`${range.from}-${range.label}`}
+                            className="flex items-center justify-between p-4 bg-slate-50 rounded-xl"
+                        >
+                            <div>
+                                <p className="font-semibold text-sm">{range.label}</p>
+                                <p className="text-xs text-brand-muted">
+                                    {range.from} – {range.to} ({range.days} ngày) &nbsp;|&nbsp; +
+                                    {range.uplift_pct}%
+                                </p>
+                            </div>
+                            <div className="flex gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="rounded-lg"
+                                    onClick={() => startEdit(range)}
+                                >
+                                    Sửa
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="rounded-lg text-red-600"
+                                    onClick={() => setDeleting(range)}
+                                >
+                                    Xoá
+                                </Button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <div className="p-5 bg-slate-50 rounded-2xl space-y-4">
+                <h4 className="font-bold text-sm">
+                    {editing ? `Sửa: ${editing.label}` : "Thêm đợt cao điểm"}
+                </h4>
+                <div className="grid grid-cols-2 gap-3">
+                    <div>
+                        <Label htmlFor="special-label">Tên đợt</Label>
+                        <Input
+                            id="special-label"
+                            value={label}
+                            onChange={(event) => setLabel(event.target.value)}
+                            placeholder="Tết Nguyên đán"
+                            className="mt-1.5"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="special-uplift">% phụ thu</Label>
+                        <Input
+                            id="special-uplift"
+                            type="number"
+                            min={0}
+                            max={500}
+                            value={upliftPct}
+                            onChange={(event) => setUpliftPct(event.target.value)}
+                            className="mt-1.5 w-24"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="special-from">Từ ngày</Label>
+                        <Input
+                            id="special-from"
+                            type="date"
+                            value={from}
+                            onChange={(event) => setFrom(event.target.value)}
+                            className="mt-1.5"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="special-to">Đến ngày</Label>
+                        <Input
+                            id="special-to"
+                            type="date"
+                            min={from || undefined}
+                            value={to}
+                            onChange={(event) => setTo(event.target.value)}
+                            className="mt-1.5"
+                        />
+                    </div>
+                </div>
+                <div className="flex gap-2">
+                    <Button
+                        onClick={handleSave}
+                        className="bg-brand-primary text-white rounded-xl"
+                    >
+                        {editing ? "Cập nhật" : "Thêm"}
+                    </Button>
+                    {editing && (
+                        <Button variant="outline" className="rounded-xl" onClick={resetForm}>
+                            Huỷ sửa
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            {clashes && pending && (
+                <div className="p-5 border border-amber-300 bg-amber-50 rounded-2xl space-y-3">
+                    <p className="text-sm font-semibold">
+                        {clashes.length} ngày đã khai sẽ bị ghi đè
+                    </p>
+                    <ul className="text-xs text-brand-muted space-y-0.5">
+                        {clashes.slice(0, MAX_LISTED_CLASHES).map((clash) => (
+                            <li key={clash.date}>
+                                {clash.date} — {clash.label} +{clash.uplift_pct}% → {pending.label} +
+                                {pending.upliftPct}%
+                            </li>
+                        ))}
+                        {clashes.length > MAX_LISTED_CLASHES && (
+                            <li>…và {clashes.length - MAX_LISTED_CLASHES} ngày nữa</li>
+                        )}
+                    </ul>
+                    <div className="flex gap-2">
+                        <Button
+                            className="bg-brand-primary text-white rounded-xl"
+                            onClick={() => {
+                                const request = pending;
+                                setClashes(null);
+                                setPending(null);
+                                void write(request);
+                            }}
+                        >
+                            Tiếp tục
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className="rounded-xl"
+                            onClick={() => {
+                                setClashes(null);
+                                setPending(null);
+                            }}
+                        >
+                            Huỷ
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {deleting && (
+                <div className="p-5 border border-red-300 bg-red-50 rounded-2xl space-y-3">
+                    <p className="text-sm font-semibold">
+                        Xoá &quot;{deleting.label}&quot; ({deleting.days} ngày)?
+                    </p>
+                    <div className="flex gap-2">
+                        <Button
+                            className="bg-red-600 text-white rounded-xl"
+                            onClick={() => void handleDelete(deleting)}
+                        >
+                            Xoá đợt này
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className="rounded-xl"
+                            onClick={() => setDeleting(null)}
+                        >
+                            Giữ lại
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/mhm/src/pages/settings/SpecialDatesSection.tsx
+++ b/mhm/src/pages/settings/SpecialDatesSection.tsx
@@ -35,11 +35,21 @@ export default function SpecialDatesSection() {
     const [clashes, setClashes] = useState<SpecialDateRow[] | null>(null);
     const [pending, setPending] = useState<PendingWrite | null>(null);
     const [deleting, setDeleting] = useState<SpecialDateRange | null>(null);
+    const [loadError, setLoadError] = useState(false);
 
     const reload = useCallback(() => {
         invoke<SpecialDateRow[]>("get_special_dates")
-            .then(setRows)
-            .catch(() => setRows([]));
+            .then((data) => {
+                setRows(data);
+                setLoadError(false);
+            })
+            .catch(() => {
+                // Không rõ DB có gì — tuyệt đối không giả vờ là "rỗng", vì đó
+                // là dữ liệu mà bảng ghi-đè dùng để so trùng. Rỗng giả sẽ vô
+                // hiệu hoá cảnh báo ghi đè.
+                setLoadError(true);
+                toast.error("Không tải được danh sách đợt cao điểm đã khai");
+            });
     }, []);
 
     useEffect(reload, [reload]);
@@ -52,6 +62,8 @@ export default function SpecialDatesSection() {
         setFrom("");
         setTo("");
         setUpliftPct("30");
+        setClashes(null);
+        setPending(null);
     };
 
     const startEdit = (range: SpecialDateRange) => {
@@ -74,9 +86,33 @@ export default function SpecialDatesSection() {
     };
 
     const handleSave = () => {
+        // Bất kỳ lần bấm lưu nào cũng coi như từ bỏ hộp ghi-đè cũ (nếu có) —
+        // nó có thể đang mô tả một yêu cầu đã lỗi thời.
+        setClashes(null);
+        setPending(null);
+
+        if (loadError) {
+            toast.error(
+                "Chưa tải được danh sách đợt đã khai nên không thể so trùng an toàn. Tải lại trang rồi thử lại.",
+            );
+            return;
+        }
+
         const trimmed = label.trim();
         if (!trimmed || !from || !to || to < from) {
             toast.error("Điền tên đợt và khoảng ngày hợp lệ");
+            return;
+        }
+
+        const trimmedUplift = upliftPct.trim();
+        const upliftValue = Number(trimmedUplift);
+        if (
+            trimmedUplift === "" ||
+            !Number.isFinite(upliftValue) ||
+            upliftValue < 0 ||
+            upliftValue > 500
+        ) {
+            toast.error("Nhập % phụ thu hợp lệ, từ 0 đến 500");
             return;
         }
 
@@ -89,7 +125,7 @@ export default function SpecialDatesSection() {
             from,
             to,
             label: trimmed,
-            upliftPct: Number(upliftPct),
+            upliftPct: upliftValue,
         };
 
         const conflicts = overlappingDates(rows, from, to, editing?.dates ?? []);
@@ -128,7 +164,12 @@ export default function SpecialDatesSection() {
                 </p>
             </div>
 
-            {ranges.length === 0 ? (
+            {loadError ? (
+                <p className="text-sm text-red-600">
+                    Không tải được danh sách đợt cao điểm đã khai. Tải lại trang trước khi thêm
+                    hoặc sửa, để tránh ghi đè nhầm ngày đã khai.
+                </p>
+            ) : ranges.length === 0 ? (
                 <p className="text-sm text-brand-muted">
                     Chưa khai đợt cao điểm nào. Thêm một đợt ở dưới.
                 </p>

--- a/mhm/src/pages/settings/index.tsx
+++ b/mhm/src/pages/settings/index.tsx
@@ -3,6 +3,7 @@ import {
   BedDouble,
   Bot,
   Building2,
+  CalendarDays,
   Camera,
   Clock,
   Database,
@@ -28,6 +29,7 @@ import OcrConfigSection from "./OcrConfigSection";
 import PricingSection from "./PricingSection";
 import RoomConfigSection from "./RoomConfigSection";
 import SoftwareUpdateSection from "./SoftwareUpdateSection";
+import SpecialDatesSection from "./SpecialDatesSection";
 import UserManagement from "./UserManagement";
 
 type SettingsSectionKey =
@@ -42,6 +44,7 @@ type SettingsSectionKey =
   | "ceo-agent"
   | "updates"
   | "pricing"
+  | "peak-season"
   | "users";
 
 export default function SettingsPage() {
@@ -68,6 +71,7 @@ export default function SettingsPage() {
     ...(isCurrentAdmin
       ? [
         { key: "pricing" as const, label: "Pricing", icon: DollarSign },
+        { key: "peak-season" as const, label: "Peak Season", icon: CalendarDays },
         { key: "users" as const, label: "Users", icon: Users },
       ]
       : []),
@@ -130,6 +134,7 @@ export default function SettingsPage() {
             <CeoAgentSection />
           )}
         {activeSection === "pricing" && isCurrentAdmin && <PricingSection />}
+        {activeSection === "peak-season" && isCurrentAdmin && <SpecialDatesSection />}
         {activeSection === "users" && isCurrentAdmin && <UserManagement />}
       </Card>
     </div>

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -50,6 +50,7 @@ const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
   get_rooms: "read-only room list lookup",
   get_rooms_availability: "read-only room availability lookup",
   get_settings: "read-only settings lookup",
+  get_special_dates: "read-only peak-season lookup",
   get_stay_info_text: "read-only stay info lookup",
   logout: "auth runtime action excluded from PMS write wrapper scope",
   mark_crash_report_dismissed: "diagnostics lifecycle action",


### PR DESCRIPTION
Nốt còn lại của lời than gốc: *"ngày đặt là mùa cao điểm với 4 người, nên anh lấy giá 600k, nhưng ko cách nào thay đổi giá tiền phòng được"*. Nửa **"4 người"** đã xong ở #185/#186. Đây là nửa **"mùa cao điểm"**.

Hai việc, việc thứ hai mới là việc quan trọng.

## 1. Không có chỗ nào để khai

`special_dates` tồn tại từ migration đầu tiên, có sẵn `get_special_dates` và `save_special_date` ở backend, mà **giao diện chưa hề có màn hình nào gọi tới** — cả `mhm/src/` chỉ có đúng một tham chiếu, nằm trong file mock. Cũng **chưa hề có lệnh xoá**, nên khai sai là kẹt vĩnh viễn.

## 2. Khai được cũng ra giá sai

Engine tra `special_dates` bằng **đúng ngày nhận phòng**, rồi nhân mức % ấy cho **toàn bộ** số đêm. Lấy Tết khai 14/02–22/02 +40%:

| Khách ở | Đêm trong Tết | Engine cũ | Đúng ra |
|---|---|---|---|
| 12/02 → 16/02 | 2 / 4 đêm | **+0%** — ngày đến 12/02 không phải lễ | +40% cho 2 đêm |
| 22/02 → 25/02 | 1 / 3 đêm | **+40% cả 3 đêm** | +40% cho 1 đêm |

Chiều thứ nhất mất tiền của nhà, chiều thứ hai thu lố của khách.

## Cách sửa

Luật mới đi **từng ngày** của kỳ ở rồi đưa `calculate_price` mức **bình quân**:

```
base × (Σ pct_d / N) = Σ ( (base/N) × pct_d )
```

Đây là đẳng thức đại số, không phải xấp xỉ. Với `nightly`/`overnight`/`daily` thì `base/N` đúng bằng giá một đêm đã cấu hình, nên "chia đều theo ngày" **chính là** "từng đêm chịu mức của nó" — và `crate::pricing` **không phải sửa một dòng nào**.

**`hourly` là ngoại lệ có chủ ý.** `base` của nó tính theo giờ hoặc theo mức trần, không tỉ lệ với số ngày lịch. Kỳ ở theo giờ trong cùng một ngày ra kết quả y như cũ; kỳ ở theo giờ **dài quá 24 tiếng** thì đổi số. Diện ảnh hưởng hẹp: nhánh chặn trần về `overnight_rate` chỉ chạy khi ≤13 giờ nên không bao giờ với tới. Có test riêng khoá lại.

## Màn hình khai báo

Cài đặt → **Peak Season** (chỉ admin). Dưới DB vẫn một dòng một ngày; màn hình gom ngày liền nhau + cùng nhãn + cùng % thành một dòng:

```
Tết Nguyên đán    14/02 – 22/02  (9 ngày)   +40%   [Sửa] [Xoá]
```

Không đổi bảng, không migration.

**Trùng ngày thì hỏi trước** — liệt kê thẳng ngày nào bị ghi đè, từ mức nào sang mức nào. Backend vẫn `ON CONFLICT(date) DO UPDATE`, nhưng giờ người dùng thấy trước khi bấm.

## `remove` — chỗ đáng soi nhất

`save_special_date_range(remove, from, to, label, uplift_pct)` gộp việc xoá vào cùng lệnh ghi **có chủ ý**. Rút ngắn một mùa thì mấy ngày rơi ra phải biến mất **trong cùng một transaction** với khoảng mới. Tách thành hai lệnh là hai transaction: xoá xong mà ghi hỏng là mất hẳn mấy ngày đã khai, màn hình tải lại hiện một mùa bị cụt, không ai biết.

Test `a_failed_write_leaves_every_removed_day_in_place` ép lỗi khoá chính **giữa** transaction rồi khẳng định ngày trong `remove` còn nguyên — và khẳng định cả mã lỗi, để một luật kiểm tra đầu vào thêm sau này không làm nó xanh vì lý do sai.

## Kiểm chứng

- **984 test Rust**, `verify:full` exit 0 (73 file test), `cargo fmt --check` sạch, không warning.
- **QA riêng trên CSDL thật đã chạy migration** (`peak_season_e2e.rs`, 11 test) — không phải bảng dựng tay. Ca của chủ nhà: phòng 500k, `max_guests=2`, phụ thu 50k/người, mùa +20%, ở 2 đêm, 4 khách → base 1.000.000 + phụ thu mùa 200.000 + phụ thu khách 200.000 = **1.400.000**. Phụ thu mùa **không** nhân lên tiền thêm khách; con số sai 1.440.000 được khẳng định là không xảy ra.
- Độ chặt của test được chứng minh bằng cách **cố ý phá code** rồi xem test có đỏ không — cả ở QA lẫn ở hai vòng sửa review.
- Preview và số thực thu đọc `special_dates` qua **cùng một hằng SQL và cùng một bộ ánh xạ**, nên không thể lệch nhau.

## Không đổi

- Không có migration mới. Schema version vẫn 22.
- Đêm vừa là T7/CN vừa là ngày lễ **ăn cả hai** phụ thu — hành vi cũ, có test khoá.
- Dòng cũ trong `special_dates` (kể cả nhãn rỗng) đọc, sửa, xoá bình thường.

## Đáng biết trước khi merge

Khai một mùa **trong lúc khách đang ở** sẽ đổi số tiền họ trả lúc trả phòng — `CheckoutSettlementMode::ActualNights` tính lại cả kỳ ở. Đây là chủ ý (luật cũ sai thì số cũ cũng sai), nhưng là tiền thật nên ghi ra đây.

Rebase thẳng lên `main` sau khi #185/#186 đã vào; lịch sử tuyến tính, 20 commit, không có merge commit. Bốn chỗ conflict đều ở `pricing_queries.rs` và `pricing_service.rs`, gỡ theo luật chốt sẵn trong spec: **giữ kiểu dữ liệu của nhánh này, giữ cách xử lỗi nghiêm của #185**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)