### PR TITLE
A Vietnamese room type name silently lost its configured price

### DIFF
--- a/docs/architecture/core-pms-boundaries.md
+++ b/docs/architecture/core-pms-boundaries.md
@@ -134,7 +134,21 @@ the same night, whichever key the guest is handed.
   `special_dates` surcharge and the extra-person fee — all of which check-in
   charges;
 - a preview that cannot read the prices must fail, not quote a default. Guessing
-  a 0% holiday uplift produces a figure below what the desk will collect.
+  a 0% holiday uplift produces a figure below what the desk will collect;
+- a screen with no stay to price — a room card, the room drawer, the detail panel
+  — shows the *listed* rate from `get_room_type_rates`, which resolves through
+  `build_effective_pricing_rule`, the same function the charge builds its rule
+  with. It is not a quote: uplifts and the extra-person fee depend on dates and
+  guests those screens do not have;
+- when the rate cannot be read, show that it is unknown. There is no fallback
+  number — falling back to `base_price` reintroduces the exact defect, and
+  falling back to 0 reads as a free room;
+- **room types are matched case-insensitively, and both sides of the comparison
+  must be folded by the same function.** SQL's `LOWER` is ASCII-only; Rust's
+  `str::to_lowercase` is not. Folding one side in each meant a type named
+  `Phòng Đôi` never matched itself, so its configured rule was never found and
+  the stay was quoted *and charged* at the 350k house default while settings
+  displayed the real rate. Every type lookup now reads `LOWER(x) = LOWER(?)`.
 
 ## Implementation Path And Rename Debt
 

--- a/mhm/src-tauri/src/commands/pricing.rs
+++ b/mhm/src-tauri/src/commands/pricing.rs
@@ -50,6 +50,33 @@ pub async fn get_pricing_rules(
     do_get_pricing_rules(&state.db).await
 }
 
+pub async fn do_get_room_type_rates(pool: &Pool<Sqlite>) -> Result<Vec<serde_json::Value>, String> {
+    let rates = pricing_service::list_room_type_rates(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(rates
+        .iter()
+        .map(|rate| {
+            serde_json::json!({
+                "room_type": rate.room_type,
+                "nightly_rate": rate.nightly_rate,
+                "configured": rate.configured,
+            })
+        })
+        .collect())
+}
+
+/// The listed nightly rate per room type. Not admin-gated: the room grid every
+/// receptionist works from shows it, and it is the same figure they read off a
+/// booking sheet.
+#[tauri::command]
+pub async fn get_room_type_rates(
+    state: State<'_, AppState>,
+) -> Result<Vec<serde_json::Value>, String> {
+    do_get_room_type_rates(&state.db).await
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn save_pricing_rule(
@@ -184,4 +211,47 @@ pub async fn save_special_date(
     )
     .await
     .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::do_get_room_type_rates;
+    use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
+
+    async fn migrated_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory sqlite");
+        crate::db::run_migrations(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    /// The three keys the room grid reads. Renaming one here is invisible to the
+    /// Rust compiler and shows up in the app as a blank price, so the contract is
+    /// pinned on this side of the wire too.
+    #[tokio::test]
+    async fn the_rate_listing_names_the_fields_the_room_grid_reads() {
+        let pool = migrated_pool().await;
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES ('R-101', 'Room R-101', 'Phòng Đôi', 1, 0, 640000, 2, 0, 'vacant')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed room");
+
+        let listed = do_get_room_type_rates(&pool).await.expect("rate listing");
+
+        assert_eq!(listed.len(), 1, "one room type, one row: {listed:?}");
+        assert_eq!(listed[0]["room_type"], "Phòng Đôi");
+        assert_eq!(listed[0]["nightly_rate"], 640_000);
+        assert_eq!(
+            listed[0]["configured"], false,
+            "no pricing_rules row, so the rate is derived and must say so"
+        );
+    }
 }

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -65,17 +65,24 @@ impl StoredPricingRule {
 
 /// A configured rule wins outright; otherwise derive one from the room's base
 /// price, falling back to a house default when the room has no price either.
+///
+/// Takes the three fields it reads rather than a whole `StayPricingInputs`,
+/// because resolving a type's rule does not need a stay. The rate a room card
+/// prints has to be this function's `daily_rate` and nothing else — the moment a
+/// second place decides what a type costs, the card and the bill can disagree.
 pub(crate) fn build_effective_pricing_rule(
-    inputs: &StayPricingInputs,
+    room_type: &str,
+    stored_rule: Option<&StoredPricingRule>,
+    fallback_base_price: Option<MoneyVnd>,
 ) -> crate::pricing::PricingRule {
-    if let Some(stored_rule) = &inputs.stored_rule {
+    if let Some(stored_rule) = stored_rule {
         return stored_rule.to_pricing_rule();
     }
 
-    let fallback_price = inputs.fallback_base_price.unwrap_or(350_000);
+    let fallback_price = fallback_base_price.unwrap_or(350_000);
 
     crate::pricing::PricingRule {
-        room_type: inputs.room_type.clone(),
+        room_type: room_type.to_string(),
         hourly_rate: fallback_price / 5,
         overnight_rate: fallback_price * 75 / 100,
         daily_rate: fallback_price,
@@ -127,7 +134,11 @@ fn extra_guest_charge(inputs: &StayPricingInputs, nights: i64) -> BookingResult<
 pub(crate) fn calculate_from_loaded_inputs(
     inputs: &StayPricingInputs,
 ) -> BookingResult<crate::pricing::PricingResult> {
-    let rule = build_effective_pricing_rule(inputs);
+    let rule = build_effective_pricing_rule(
+        &inputs.room_type,
+        inputs.stored_rule.as_ref(),
+        inputs.fallback_base_price,
+    );
 
     let mut result = crate::pricing::calculate_price(
         &rule,
@@ -194,7 +205,11 @@ mod tests {
             weekend_uplift_pct: 12.5,
         });
 
-        let rule = build_effective_pricing_rule(&inputs);
+        let rule = build_effective_pricing_rule(
+            &inputs.room_type,
+            inputs.stored_rule.as_ref(),
+            inputs.fallback_base_price,
+        );
 
         assert_eq!(rule.room_type, "deluxe");
         assert_eq!(rule.hourly_rate, 120_000);
@@ -215,7 +230,11 @@ mod tests {
         inputs.room_type = "deluxe".to_string();
         inputs.fallback_base_price = Some(500_000);
 
-        let rule = build_effective_pricing_rule(&inputs);
+        let rule = build_effective_pricing_rule(
+            &inputs.room_type,
+            inputs.stored_rule.as_ref(),
+            inputs.fallback_base_price,
+        );
 
         assert_eq!(rule.room_type, "deluxe");
         assert_eq!(rule.hourly_rate, 100_000);
@@ -232,7 +251,12 @@ mod tests {
 
     #[test]
     fn build_effective_pricing_rule_uses_default_price_and_metadata_when_base_price_missing() {
-        let rule = build_effective_pricing_rule(&sample_inputs());
+        let inputs = sample_inputs();
+        let rule = build_effective_pricing_rule(
+            &inputs.room_type,
+            inputs.stored_rule.as_ref(),
+            inputs.fallback_base_price,
+        );
 
         assert_eq!(rule.room_type, "standard");
         assert_eq!(rule.hourly_rate, 70_000);

--- a/mhm/src-tauri/src/domain/booking/pricing.rs
+++ b/mhm/src-tauri/src/domain/booking/pricing.rs
@@ -63,6 +63,35 @@ impl StoredPricingRule {
     }
 }
 
+/// The three rates a room type gets when the only thing anyone has stated is its
+/// nightly price.
+///
+/// One function, because there are two callers and they used to disagree.
+/// Onboarding wrote `overnight_rate = base_price` while the fallback here derived
+/// `base_price * 75 / 100` — the same input producing two different overnight
+/// rates depending on whether a hotel was onboarded or had its rule go missing.
+/// Nothing asserted either, which is why it went unnoticed.
+///
+/// 0.75 is the deliberate one: an overnight block (22:00–11:00) is a *shorter*
+/// stay than a full day, so charging it the full nightly rate is wrong on the
+/// merits. Onboarding's was the accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DerivedRates {
+    pub(crate) hourly: MoneyVnd,
+    pub(crate) overnight: MoneyVnd,
+    pub(crate) daily: MoneyVnd,
+}
+
+pub(crate) fn derive_rates_from_base_price(base_price: MoneyVnd) -> DerivedRates {
+    let base = base_price.max(0);
+
+    DerivedRates {
+        hourly: base / 5,
+        overnight: base * 75 / 100,
+        daily: base,
+    }
+}
+
 /// A configured rule wins outright; otherwise derive one from the room's base
 /// price, falling back to a house default when the room has no price either.
 ///
@@ -79,13 +108,13 @@ pub(crate) fn build_effective_pricing_rule(
         return stored_rule.to_pricing_rule();
     }
 
-    let fallback_price = fallback_base_price.unwrap_or(350_000);
+    let rates = derive_rates_from_base_price(fallback_base_price.unwrap_or(350_000));
 
     crate::pricing::PricingRule {
         room_type: room_type.to_string(),
-        hourly_rate: fallback_price / 5,
-        overnight_rate: fallback_price * 75 / 100,
-        daily_rate: fallback_price,
+        hourly_rate: rates.hourly,
+        overnight_rate: rates.overnight,
+        daily_rate: rates.daily,
         ..Default::default()
     }
 }

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -390,6 +390,7 @@ pub fn run() {
             commands::auth::search_guest_by_phone,
             // Pricing Engine
             commands::pricing::get_pricing_rules,
+            commands::pricing::get_room_type_rates,
             commands::pricing::save_pricing_rule,
             commands::pricing::calculate_price_preview,
             commands::pricing::calculate_room_price_preview,

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -49,9 +49,18 @@ const ROOM_GUEST_PRICING_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_gues
             COALESCE(extra_person_fee, 0) AS extra_person_fee
      FROM rooms WHERE id = ?";
 
+/// Guest limits for a room type, derived the same way the type price is.
+///
+/// `ORDER BY id` for the reason `FALLBACK_BASE_PRICE_SQL` has it: no room is
+/// chosen yet, so a room of the type has to stand in for it, and *which* room
+/// must not depend on how SQLite feels about page order. Without it a type whose
+/// rooms disagree about `max_guests` quotes one extra-person surcharge today and
+/// a different one after a restart — and it is the lowest id that supplies the
+/// base price, so anything else here would take the two halves of one quote from
+/// two different rooms.
 const ROOM_GUEST_PRICING_BY_TYPE_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_guests,
             COALESCE(extra_person_fee, 0) AS extra_person_fee
-     FROM rooms WHERE LOWER(type) = ? LIMIT 1";
+     FROM rooms WHERE LOWER(type) = ? ORDER BY id LIMIT 1";
 
 const SPECIAL_UPLIFT_SQL: &str =
     "SELECT CAST(uplift_pct AS REAL) FROM special_dates WHERE date = ?";

--- a/mhm/src-tauri/src/queries/booking/pricing_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/pricing_queries.rs
@@ -14,11 +14,27 @@ use crate::domain::booking::pricing::{StayPricingInputs, StoredPricingRule};
 use crate::domain::booking::{BookingError, BookingResult};
 use crate::money::MoneyVnd;
 
+/// Room types are matched case-insensitively, and **both sides of the
+/// comparison must be folded by the same function.**
+///
+/// Every type lookup here reads `LOWER(x) = LOWER(?)`. It used to bind
+/// `str::to_lowercase()` against SQL's `LOWER(x)`, which is two different
+/// functions: SQLite's `LOWER` is ASCII-only and leaves `Đ` alone, Rust's lowers
+/// it to `đ`. So for any type whose name carries a non-ASCII capital — `Phòng
+/// Đôi`, `Phòng Đơn`, most of a Vietnamese hotel's room list — the two strings
+/// could never be equal. Not "matched loosely": *never matched*. The configured
+/// rule was not found, no room supplied a fallback price, and the stay was quoted
+/// and charged at the 350k house default while settings showed something else.
+///
+/// Folding inside SQL keeps the two sides one function by construction. It is
+/// still ASCII-only, so `PHÒNG ĐÔI` will not match `phòng đôi` — but a type now
+/// always matches itself, which is the case that actually occurs, since callers
+/// pass a name read straight back out of `rooms.type`.
 const STORED_PRICING_RULE_SQL: &str = "SELECT room_type, hourly_rate, overnight_rate, daily_rate,
                 overnight_start, overnight_end, daily_checkin, daily_checkout,
                 early_checkin_surcharge_pct, late_checkout_surcharge_pct,
                 weekend_uplift_pct
-         FROM pricing_rules WHERE LOWER(room_type) = ?";
+         FROM pricing_rules WHERE LOWER(room_type) = LOWER(?)";
 
 const ROOM_TYPE_SQL: &str = "SELECT type FROM rooms WHERE id = ? LIMIT 1";
 
@@ -43,7 +59,7 @@ const ROOM_TYPE_SQL: &str = "SELECT type FROM rooms WHERE id = ? LIMIT 1";
 /// Both loaders share this constant, so the quote and the charge cannot
 /// disagree about which room they derived from.
 const FALLBACK_BASE_PRICE_SQL: &str =
-    "SELECT base_price FROM rooms WHERE LOWER(type) = ? ORDER BY id LIMIT 1";
+    "SELECT base_price FROM rooms WHERE LOWER(type) = LOWER(?) ORDER BY id LIMIT 1";
 
 const ROOM_GUEST_PRICING_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_guests,
             COALESCE(extra_person_fee, 0) AS extra_person_fee
@@ -60,10 +76,14 @@ const ROOM_GUEST_PRICING_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_gues
 /// two different rooms.
 const ROOM_GUEST_PRICING_BY_TYPE_SQL: &str = "SELECT COALESCE(max_guests, 2) AS max_guests,
             COALESCE(extra_person_fee, 0) AS extra_person_fee
-     FROM rooms WHERE LOWER(type) = ? ORDER BY id LIMIT 1";
+     FROM rooms WHERE LOWER(type) = LOWER(?) ORDER BY id LIMIT 1";
 
 const SPECIAL_UPLIFT_SQL: &str =
     "SELECT CAST(uplift_pct AS REAL) FROM special_dates WHERE date = ?";
+
+/// Every room type the house actually has rooms in. A type with a
+/// `pricing_rules` row but no rooms prices nothing, so it is not listed.
+const ROOM_TYPE_NAMES_SQL: &str = "SELECT DISTINCT type FROM rooms ORDER BY type";
 
 const PRICING_RULE_LISTING_SQL: &str =
     "SELECT id, room_type, hourly_rate, overnight_rate, daily_rate,
@@ -74,6 +94,16 @@ const PRICING_RULE_LISTING_SQL: &str =
 
 const SPECIAL_DATES_SQL: &str =
     "SELECT id, date, label, uplift_pct FROM special_dates ORDER BY date";
+
+/// What it takes to resolve a room type's rule, and nothing about a stay.
+///
+/// The two loaders below and the room-type rate listing all need exactly this
+/// pair, and all three must load it the same way: the fallback is only read when
+/// no rule is stored, so a configured type never touches `rooms.base_price`.
+pub(crate) struct TypeRuleInputs {
+    pub(crate) stored_rule: Option<StoredPricingRule>,
+    pub(crate) fallback_base_price: Option<MoneyVnd>,
+}
 
 /// A stored rule plus its row id, which the settings screen needs and the
 /// pricing rules themselves do not.
@@ -151,7 +181,7 @@ async fn load_room_guest_pricing_for_type(
     room_type: &str,
 ) -> BookingResult<RoomGuestPricing> {
     let row = sqlx::query(ROOM_GUEST_PRICING_BY_TYPE_SQL)
-        .bind(room_type.to_lowercase())
+        .bind(room_type)
         .fetch_optional(pool)
         .await
         .map_err(database_error)?;
@@ -233,19 +263,14 @@ pub(crate) async fn load_stay_pricing_inputs_for_room_type(
     pricing_type: &str,
     guests: Option<i32>,
 ) -> BookingResult<StayPricingInputs> {
-    let stored_rule = load_stored_pricing_rule(pool, room_type).await?;
-    let fallback_base_price = if stored_rule.is_none() {
-        load_fallback_base_price(pool, room_type).await?
-    } else {
-        None
-    };
+    let rule_inputs = load_type_rule_inputs(pool, room_type).await?;
     let special_uplift_pct = load_special_uplift(pool, check_in).await?;
     let guest_pricing = load_room_guest_pricing_for_type(pool, room_type).await?;
 
     Ok(StayPricingInputs {
         room_type: room_type.to_string(),
-        stored_rule,
-        fallback_base_price,
+        stored_rule: rule_inputs.stored_rule,
+        fallback_base_price: rule_inputs.fallback_base_price,
         special_uplift_pct,
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
@@ -273,19 +298,14 @@ pub(crate) async fn load_stay_pricing_inputs_for_room(
     guests: Option<i32>,
 ) -> BookingResult<StayPricingInputs> {
     let room_type = load_room_type(pool, room_id).await?;
-    let stored_rule = load_stored_pricing_rule(pool, &room_type).await?;
-    let fallback_base_price = if stored_rule.is_none() {
-        load_fallback_base_price(pool, &room_type).await?
-    } else {
-        None
-    };
+    let rule_inputs = load_type_rule_inputs(pool, &room_type).await?;
     let special_uplift_pct = load_special_uplift(pool, check_in).await?;
     let guest_pricing = load_room_guest_pricing(pool, room_id).await?;
 
     Ok(StayPricingInputs {
         room_type,
-        stored_rule,
-        fallback_base_price,
+        stored_rule: rule_inputs.stored_rule,
+        fallback_base_price: rule_inputs.fallback_base_price,
         special_uplift_pct,
         check_in: check_in.to_string(),
         check_out: check_out.to_string(),
@@ -321,12 +341,36 @@ async fn load_room_guest_pricing(
         .unwrap_or_default())
 }
 
+pub(crate) async fn load_room_type_names(pool: &Pool<Sqlite>) -> BookingResult<Vec<String>> {
+    sqlx::query_scalar::<_, String>(ROOM_TYPE_NAMES_SQL)
+        .fetch_all(pool)
+        .await
+        .map_err(database_error)
+}
+
+pub(crate) async fn load_type_rule_inputs(
+    pool: &Pool<Sqlite>,
+    room_type: &str,
+) -> BookingResult<TypeRuleInputs> {
+    let stored_rule = load_stored_pricing_rule(pool, room_type).await?;
+    let fallback_base_price = if stored_rule.is_none() {
+        load_fallback_base_price(pool, room_type).await?
+    } else {
+        None
+    };
+
+    Ok(TypeRuleInputs {
+        stored_rule,
+        fallback_base_price,
+    })
+}
+
 async fn load_stored_pricing_rule(
     pool: &Pool<Sqlite>,
     room_type: &str,
 ) -> BookingResult<Option<StoredPricingRule>> {
     let row = sqlx::query(STORED_PRICING_RULE_SQL)
-        .bind(room_type.to_lowercase())
+        .bind(room_type)
         .fetch_optional(pool)
         .await
         .map_err(database_error)?;
@@ -339,7 +383,7 @@ async fn load_fallback_base_price(
     room_type: &str,
 ) -> BookingResult<Option<MoneyVnd>> {
     let row = sqlx::query(FALLBACK_BASE_PRICE_SQL)
-        .bind(room_type.to_lowercase())
+        .bind(room_type)
         .fetch_optional(pool)
         .await
         .map_err(database_error)?;
@@ -404,7 +448,7 @@ async fn load_stored_pricing_rule_tx(
     room_type: &str,
 ) -> BookingResult<Option<StoredPricingRule>> {
     let row = sqlx::query(STORED_PRICING_RULE_SQL)
-        .bind(room_type.to_lowercase())
+        .bind(room_type)
         .fetch_optional(&mut **tx)
         .await
         .map_err(database_error)?;
@@ -417,7 +461,7 @@ async fn load_fallback_base_price_tx(
     room_type: &str,
 ) -> BookingResult<Option<MoneyVnd>> {
     let fallback_row = sqlx::query(FALLBACK_BASE_PRICE_SQL)
-        .bind(room_type.to_lowercase())
+        .bind(room_type)
         .fetch_optional(&mut **tx)
         .await
         .map_err(database_error)?;

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -194,6 +194,31 @@ mod tests {
         .expect("seed room");
     }
 
+    /// `seed_room` with the guest columns opened up: the type-keyed preview has
+    /// to stand a room in for the type, so tests need rooms that disagree.
+    async fn seed_room_with_guests(
+        pool: &Pool<Sqlite>,
+        room_id: &str,
+        room_type: &str,
+        base_price: i64,
+        max_guests: i32,
+        extra_person_fee: i64,
+    ) {
+        sqlx::query(
+            "INSERT INTO rooms (id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status)
+             VALUES (?, ?, ?, 1, 0, ?, ?, ?, 'vacant')",
+        )
+        .bind(room_id)
+        .bind(format!("Room {room_id}"))
+        .bind(room_type)
+        .bind(base_price)
+        .bind(max_guests)
+        .bind(extra_person_fee)
+        .execute(pool)
+        .await
+        .expect("seed room with guests");
+    }
+
     async fn seed_special_date(pool: &Pool<Sqlite>, date: &str, uplift_pct: f64) {
         sqlx::query(
             "INSERT INTO special_dates (id, date, label, uplift_pct, created_at)
@@ -275,6 +300,66 @@ mod tests {
         assert_ne!(
             preview.total, lone_800.total,
             "a type cannot hold two prices: the 800k room bills at its sibling's rate"
+        );
+    }
+
+    /// A type-keyed quote must take *all* of its per-room stand-ins from one
+    /// room. `FALLBACK_BASE_PRICE_SQL` picks the lowest id; the guest limits used
+    /// to be picked by `LIMIT 1` with no `ORDER BY`, so SQLite was free to supply
+    /// them from a different room than the base price came from — a total
+    /// assembled from two rooms, and one that could change on restart.
+    #[tokio::test]
+    async fn a_type_keyed_quote_takes_its_base_price_and_its_guest_limits_from_one_room() {
+        let pool = migrated_pool().await;
+        // Inserted high-id first, and the two rooms disagree about every column
+        // the derivation reads, so a mismatched pick shows up as a wrong total
+        // rather than cancelling out.
+        seed_room_with_guests(&pool, "R-912", "mixed-guests", 800_000, 4, 0).await;
+        seed_room_with_guests(&pool, "R-911", "mixed-guests", 600_000, 2, 150_000).await;
+
+        let quoted = calculate_price_preview(
+            &pool,
+            "mixed-guests",
+            CHECK_IN,
+            CHECK_OUT,
+            "nightly",
+            Some(3),
+        )
+        .await
+        .expect("type preview for 3 guests");
+
+        // R-911 holds the lowest id, so it is the room the type stands on: its
+        // 600k base *and* its 150k surcharge, not one of each.
+        let lowest_id =
+            calculate_room_price_preview(&pool, "R-911", CHECK_IN, CHECK_OUT, "nightly", Some(3))
+                .await
+                .expect("R-911 preview");
+        let other_room =
+            calculate_room_price_preview(&pool, "R-912", CHECK_IN, CHECK_OUT, "nightly", Some(3))
+                .await
+                .expect("R-912 preview");
+
+        assert_eq!(
+            quoted.total, lowest_id.total,
+            "the type quote should match the room its price is derived from"
+        );
+        assert_ne!(
+            quoted.total, other_room.total,
+            "R-912 seats 4, so it charges no surcharge for a third guest — if the \
+             type quote matches it, the guest limits came from the wrong room"
+        );
+
+        // And the surcharge is genuinely in there: without it the two rooms would
+        // agree, and the assertion above would pass on an empty difference.
+        let no_guest_count =
+            calculate_price_preview(&pool, "mixed-guests", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("type preview with no guest count");
+        assert!(
+            quoted.total > no_guest_count.total,
+            "third guest cost nothing: {} vs {}",
+            quoted.total,
+            no_guest_count.total
         );
     }
 

--- a/mhm/src-tauri/src/services/booking/pricing_service.rs
+++ b/mhm/src-tauri/src/services/booking/pricing_service.rs
@@ -13,12 +13,12 @@
 use sqlx::{Pool, Sqlite, Transaction};
 
 use crate::app_error::CommandResult;
-use crate::domain::booking::pricing::calculate_from_loaded_inputs;
+use crate::domain::booking::pricing::{build_effective_pricing_rule, calculate_from_loaded_inputs};
 use crate::domain::booking::BookingResult;
 use crate::money::{validate_non_negative_money_vnd, MoneyVnd};
 use crate::queries::booking::pricing_queries::{
-    load_stay_pricing_inputs_for_room, load_stay_pricing_inputs_for_room_type,
-    load_stay_pricing_inputs_tx,
+    load_room_type_names, load_stay_pricing_inputs_for_room,
+    load_stay_pricing_inputs_for_room_type, load_stay_pricing_inputs_tx, load_type_rule_inputs,
 };
 use crate::repositories::booking::pricing_repository::{self, PricingRuleUpsert};
 
@@ -73,6 +73,50 @@ pub async fn calculate_room_price_preview(
         load_stay_pricing_inputs_for_room(pool, room_id, check_in, check_out, pricing_type, guests)
             .await?;
     calculate_from_loaded_inputs(&inputs)
+}
+
+/// The nightly rate a room type lists, before any date-dependent uplift.
+pub struct RoomTypeRate {
+    pub room_type: String,
+    pub nightly_rate: MoneyVnd,
+    /// `false` means no `pricing_rules` row: the rate below was *derived* from a
+    /// room's `base_price` (or the house default). The UI says so, because a
+    /// derived rate is a number nobody chose and the fix is to configure one.
+    pub configured: bool,
+}
+
+/// Every room type's listed nightly rate, for screens that show a rate without
+/// having a stay to price — room cards, the room drawer, the detail panel.
+///
+/// Goes through `build_effective_pricing_rule`, the same function the charge
+/// resolves its rule with, so the figure on a card is the figure a nightly stay
+/// starts from. Those screens used to print `rooms.base_price`, which the engine
+/// ignores outright once a type has a rule: a card could read 300k beside a desk
+/// collecting 480k.
+///
+/// It is the *list* rate, not a quote — weekend uplift, `special_dates` and the
+/// extra-person fee all depend on dates and guests this call does not have. A
+/// number attached to actual dates has to come from a preview command.
+pub async fn list_room_type_rates(pool: &Pool<Sqlite>) -> BookingResult<Vec<RoomTypeRate>> {
+    let mut rates = Vec::new();
+
+    for room_type in load_room_type_names(pool).await? {
+        let inputs = load_type_rule_inputs(pool, &room_type).await?;
+        let configured = inputs.stored_rule.is_some();
+        let rule = build_effective_pricing_rule(
+            &room_type,
+            inputs.stored_rule.as_ref(),
+            inputs.fallback_base_price,
+        );
+
+        rates.push(RoomTypeRate {
+            room_type,
+            nightly_rate: rule.daily_rate,
+            configured,
+        });
+    }
+
+    Ok(rates)
 }
 
 /// The values a caller may leave unset, and what the house uses instead.
@@ -303,6 +347,65 @@ mod tests {
         );
     }
 
+    /// A room type named in Vietnamese must be able to hold a price.
+    ///
+    /// The lookups fold case on both sides — `LOWER(type) = ?` in SQL against a
+    /// `str::to_lowercase()` bind — and the two folds are not the same function.
+    /// SQLite's `LOWER` is ASCII-only, so it leaves `Đ` alone; Rust's lowers it to
+    /// `đ`. For any type whose name carries a non-ASCII capital, the two strings
+    /// could never be equal, so *every* lookup missed: no stored rule was found,
+    /// no room supplied a fallback, and the quote came out at the 350k house
+    /// default. An operator could set 900k in settings and watch the desk read
+    /// 350k to the guest, with nothing anywhere reporting a problem.
+    ///
+    /// `Đ` is not an exotic character here. It opens `Đôi` and `Đơn` — double and
+    /// single — which is what half the room types in a Vietnamese hotel are called.
+    #[tokio::test]
+    async fn a_room_type_named_in_vietnamese_keeps_the_price_configured_for_it() {
+        let pool = migrated_pool().await;
+        seed_room(&pool, "R-201", "Phòng Đôi", 640_000).await;
+        save_pricing_rule(
+            &pool,
+            SavePricingRule {
+                room_type: "Phòng Đôi".to_string(),
+                hourly_rate: 100_000,
+                overnight_rate: 500_000,
+                daily_rate: 900_000,
+                ..request(0, 0, 0)
+            },
+            "rule-vn".to_string(),
+            "2026-04-01T00:00:00+07:00".to_string(),
+        )
+        .await
+        .expect("save rule");
+
+        let quoted =
+            calculate_room_price_preview(&pool, "R-201", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("preview");
+
+        // Two nights at the configured 900k. Stated against the arithmetic
+        // rather than a magic number, because what is being asserted is *which
+        // rate was found*, and the two candidates are far apart: 900k configured,
+        // 640k derived from the room, 350k the house default.
+        assert_eq!(
+            quoted.total,
+            900_000 * 2,
+            "the rule configured for Phòng Đôi was not the rule applied"
+        );
+
+        // And the type-keyed preview agrees, so the miss is not hiding in one of
+        // the two lookup paths.
+        let by_type =
+            calculate_price_preview(&pool, "Phòng Đôi", CHECK_IN, CHECK_OUT, "nightly", None)
+                .await
+                .expect("type preview");
+        assert_eq!(
+            by_type.total, quoted.total,
+            "the type-keyed and room-keyed previews found different rules"
+        );
+    }
+
     /// A type-keyed quote must take *all* of its per-room stand-ins from one
     /// room. `FALLBACK_BASE_PRICE_SQL` picks the lowest id; the guest limits used
     /// to be picked by `LIMIT 1` with no `ORDER BY`, so SQLite was free to supply
@@ -314,19 +417,15 @@ mod tests {
         // Inserted high-id first, and the two rooms disagree about every column
         // the derivation reads, so a mismatched pick shows up as a wrong total
         // rather than cancelling out.
-        seed_room_with_guests(&pool, "R-912", "mixed-guests", 800_000, 4, 0).await;
-        seed_room_with_guests(&pool, "R-911", "mixed-guests", 600_000, 2, 150_000).await;
+        // Named in Vietnamese on purpose: this test also holds the case-fold, so a
+        // lookup that stops matching `Đ` fails here as well as in the rule test.
+        seed_room_with_guests(&pool, "R-912", "Phòng Đôi", 800_000, 4, 0).await;
+        seed_room_with_guests(&pool, "R-911", "Phòng Đôi", 600_000, 2, 150_000).await;
 
-        let quoted = calculate_price_preview(
-            &pool,
-            "mixed-guests",
-            CHECK_IN,
-            CHECK_OUT,
-            "nightly",
-            Some(3),
-        )
-        .await
-        .expect("type preview for 3 guests");
+        let quoted =
+            calculate_price_preview(&pool, "Phòng Đôi", CHECK_IN, CHECK_OUT, "nightly", Some(3))
+                .await
+                .expect("type preview for 3 guests");
 
         // R-911 holds the lowest id, so it is the room the type stands on: its
         // 600k base *and* its 150k surcharge, not one of each.
@@ -352,7 +451,7 @@ mod tests {
         // And the surcharge is genuinely in there: without it the two rooms would
         // agree, and the assertion above would pass on an empty difference.
         let no_guest_count =
-            calculate_price_preview(&pool, "mixed-guests", CHECK_IN, CHECK_OUT, "nightly", None)
+            calculate_price_preview(&pool, "Phòng Đôi", CHECK_IN, CHECK_OUT, "nightly", None)
                 .await
                 .expect("type preview with no guest count");
         assert!(

--- a/mhm/src-tauri/src/services/setup/provisioning.rs
+++ b/mhm/src-tauri/src/services/setup/provisioning.rs
@@ -1,5 +1,6 @@
 use sqlx::{Pool, Sqlite, Transaction};
 
+use crate::domain::booking::pricing::derive_rates_from_base_price;
 use crate::models::{
     BootstrapStatus, OnboardingAppLockInput, OnboardingCompleteRequest, OnboardingRoomInput,
     OnboardingRoomTypeInput, User,
@@ -275,6 +276,11 @@ async fn insert_pricing_rules(
     let now = chrono::Local::now().to_rfc3339();
 
     for room_type in room_types {
+        // Cùng một hàm suy ra với bảng giá dự phòng của engine. Trước đây chỗ này
+        // ghi `overnight_rate = base_price` còn engine suy ra 0.75×, nên hai khách
+        // sạn cùng giá đêm lại tính giá qua đêm khác nhau.
+        let rates = derive_rates_from_base_price(room_type.base_price);
+
         sqlx::query(
             "INSERT INTO pricing_rules
              (id, room_type, hourly_rate, overnight_rate, daily_rate,
@@ -285,9 +291,9 @@ async fn insert_pricing_rules(
         )
         .bind(uuid::Uuid::new_v4().to_string())
         .bind(room_type.name.trim())
-        .bind((room_type.base_price / 5).max(0))
-        .bind(room_type.base_price)
-        .bind(room_type.base_price)
+        .bind(rates.hourly)
+        .bind(rates.overnight)
+        .bind(rates.daily)
         .bind("22:00")
         .bind("11:00")
         .bind(default_checkin_time)

--- a/mhm/src-tauri/src/services/setup/tests.rs
+++ b/mhm/src-tauri/src/services/setup/tests.rs
@@ -326,3 +326,45 @@ async fn complete_setup_rejects_repeated_setup() {
 
     assert_eq!(error, "Setup đã hoàn thành, không thể thực hiện lại.");
 }
+
+/// A hotel that has just been onboarded must be priced the same way as one whose
+/// rule went missing, given the same nightly price.
+///
+/// Onboarding wrote `overnight_rate = base_price` while the engine's fallback
+/// derived `base_price * 75 / 100`. Same input, two overnight rates, and nothing
+/// asserted either — which is how they drifted. Both now go through
+/// `derive_rates_from_base_price`, and this test compares them rather than
+/// restating the arithmetic, so it fails if either side moves alone.
+#[tokio::test]
+async fn onboarding_derives_the_same_rates_the_engine_would_have_fallen_back_to() {
+    let pool = test_pool().await;
+    complete_setup(&pool, sample_onboarding_request(false))
+        .await
+        .expect("complete setup");
+
+    let stored: (i64, i64, i64) = sqlx::query_as(
+        "SELECT hourly_rate, overnight_rate, daily_rate FROM pricing_rules WHERE room_type = ?",
+    )
+    .bind("Deluxe")
+    .fetch_one(&pool)
+    .await
+    .expect("read the rule onboarding wrote");
+
+    let derived = crate::domain::booking::pricing::derive_rates_from_base_price(500_000);
+
+    assert_eq!(
+        (stored.0, stored.1, stored.2),
+        (derived.hourly, derived.overnight, derived.daily),
+        "onboarding and the engine's fallback disagree about the rates for one nightly price"
+    );
+
+    // And the overnight block is genuinely cheaper than a full day. This is the
+    // property the old onboarding value broke: it charged a 22:00–11:00 stay the
+    // same as a whole night.
+    assert!(
+        stored.1 < stored.2,
+        "an overnight block should cost less than a full day: {} vs {}",
+        stored.1,
+        stored.2
+    );
+}

--- a/mhm/src/__mocks__/tauri-core.ts
+++ b/mhm/src/__mocks__/tauri-core.ts
@@ -114,6 +114,7 @@ export const invoke = vi.fn(async (command: string, args?: Record<string, unknow
         get_revenue_stats: { total_revenue: 0, rooms_sold: 0, occupancy_rate: 0, daily_revenue: [] },
         get_expenses: [],
         get_pricing_rules: [],
+        get_room_type_rates: [],
         get_special_dates: [],
         get_audit_logs: [],
         record_js_crash: undefined,

--- a/mhm/src/components/RoomDetailPanel.test.tsx
+++ b/mhm/src/components/RoomDetailPanel.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import RoomDetailPanel from "./RoomDetailPanel";
 
 const checkOut = vi.fn();
+let roomTypeRates: Record<string, { room_type: string; nightly_rate: number; configured: boolean }> | null =
+    null;
 
 vi.mock("@/components/CheckoutSettlementModal", () => ({
     default: ({ open }: { open: boolean }) =>
@@ -19,6 +21,7 @@ vi.mock("@/stores/useHotelStore", () => ({
         setTab: vi.fn(),
         setCheckinOpen: vi.fn(),
         loading: false,
+        roomTypeRates,
     }),
 }));
 
@@ -75,5 +78,72 @@ describe("RoomDetailPanel checkout settlement", () => {
         await user.click(screen.getByRole("button", { name: /check-out/i }));
 
         expect(screen.getByTestId("checkout-settlement-modal")).toBeInTheDocument();
+    });
+});
+
+describe("RoomDetailPanel nightly rate", () => {
+    const roomDetail = {
+        room: {
+            id: "101",
+            name: "101",
+            type: "Phòng Đôi",
+            floor: 1,
+            has_balcony: false,
+            // Lệch xa giá loại phòng, để thấy ngay nếu panel in số này.
+            base_price: 300000,
+            max_guests: 2,
+            extra_person_fee: 0,
+            status: "vacant" as const,
+        },
+        booking: null,
+        guests: [],
+    };
+
+    beforeEach(() => {
+        roomTypeRates = null;
+    });
+
+    it("shows the room type's rate, not the room's base_price", () => {
+        roomTypeRates = {
+            "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 480000, configured: true },
+        };
+
+        render(<RoomDetailPanel mode="page" roomDetail={roomDetail} />);
+
+        expect(screen.getByTestId("room-detail-nightly-rate").textContent).toContain("480");
+        expect(screen.getByTestId("room-detail-nightly-rate").textContent).not.toContain("300");
+    });
+
+    it("marks a rate nobody configured, because the fix is to configure one", () => {
+        roomTypeRates = {
+            "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 300000, configured: false },
+        };
+
+        render(<RoomDetailPanel mode="page" roomDetail={roomDetail} />);
+
+        expect(screen.getByTestId("room-detail-nightly-rate").textContent).toContain(
+            "chưa cấu hình bảng giá",
+        );
+    });
+
+    it("shows the same type rate in sheet mode, which renders its own price line", () => {
+        // Hai nhánh render riêng, nên phải chốt cả hai: sửa một nhánh về
+        // `base_price` mà nhánh kia vẫn xanh là đúng cái bẫy ở đây.
+        roomTypeRates = {
+            "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 480000, configured: true },
+        };
+
+        render(<RoomDetailPanel mode="sheet" roomDetail={roomDetail} onClose={vi.fn()} />);
+
+        const rate = screen.getByTestId("room-sheet-nightly-rate");
+        expect(rate.textContent).toContain("480");
+        expect(rate.textContent).not.toContain("300");
+    });
+
+    it("shows a dash and drops the /đêm suffix when the rate is unknown", () => {
+        render(<RoomDetailPanel mode="page" roomDetail={roomDetail} />);
+
+        // "—/đêm" đọc như giá bằng không mỗi đêm; bỏ hậu tố khi không biết giá.
+        expect(screen.getByTestId("room-detail-nightly-rate").textContent).toBe("—");
     });
 });

--- a/mhm/src/components/RoomDetailPanel.tsx
+++ b/mhm/src/components/RoomDetailPanel.tsx
@@ -26,6 +26,7 @@ import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtDate, fmtDateShort, fmtMoney } from "@/lib/format";
+import { nightlyRateDisplay } from "@/lib/roomTypeRate";
 import { useHotelStore } from "@/stores/useHotelStore";
 import type { CheckoutSettlementPayload, RoomWithBooking } from "@/types";
 
@@ -49,6 +50,7 @@ export default function RoomDetailPanel({
     setTab,
     setCheckinOpen,
     loading,
+    roomTypeRates,
   } = useHotelStore();
   const [showCheckout, setShowCheckout] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -120,6 +122,10 @@ export default function RoomDetailPanel({
   };
 
   const roomTypeLabel = getRoomTypeLabel(room.type);
+  // Giá của loại phòng, từ engine tính giá. `room.base_price` từng in ở đây là
+  // số engine bỏ qua khi loại phòng có bảng giá.
+  const nightlyRate = nightlyRateDisplay(roomTypeRates, room.type);
+  const derivedRateHint = nightlyRate.derived ? " (chưa cấu hình bảng giá)" : "";
   const outstandingAmount = booking ? booking.total_price - booking.paid_amount : 0;
 
   const guestSection = <RoomGuestsSection guests={guests} mode={mode} />;
@@ -142,7 +148,12 @@ export default function RoomDetailPanel({
             <div>
               <h2 className="text-lg font-bold text-slate-900">{room.name}</h2>
               <p className="text-[12px] text-slate-400">
-                {roomTypeLabel} · Tầng {room.floor} · {fmtMoney(room.base_price)}/đêm
+                {roomTypeLabel} · Tầng {room.floor} ·{" "}
+                <span data-testid="room-detail-nightly-rate">
+                  {nightlyRate.text}
+                  {nightlyRate.unknown ? "" : "/đêm"}
+                  {derivedRateHint}
+                </span>
               </p>
             </div>
           </div>
@@ -218,7 +229,14 @@ export default function RoomDetailPanel({
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         <div className="flex items-center justify-between">
           <StatusBadge status={room.status} variant="badge" />
-          <span className="text-lg font-bold text-brand-primary">{fmtMoney(room.base_price)}/đêm</span>
+          <span
+            className="text-lg font-bold text-brand-primary"
+            data-testid="room-sheet-nightly-rate"
+            title={nightlyRate.derived ? "Suy ra từ giá phòng, chưa có bảng giá cho loại này" : undefined}
+          >
+            {nightlyRate.text}
+            {nightlyRate.unknown ? "" : "/đêm"}
+          </span>
         </div>
 
         <div className="grid grid-cols-2 gap-3">

--- a/mhm/src/components/RoomDrawer.test.tsx
+++ b/mhm/src/components/RoomDrawer.test.tsx
@@ -8,6 +8,9 @@ const { invoke } = vi.hoisted(() => ({
     invoke: vi.fn(),
 }));
 
+let roomTypeRates: Record<string, { room_type: string; nightly_rate: number; configured: boolean }> | null =
+    null;
+
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 vi.mock("@/components/CheckoutSettlementModal", () => ({
     default: ({ open }: { open: boolean }) =>
@@ -21,6 +24,7 @@ vi.mock("@/stores/useHotelStore", () => ({
         setCheckinOpen: vi.fn(),
         fetchRooms: vi.fn(),
         updateHousekeeping: vi.fn(),
+        roomTypeRates,
     }),
 }));
 vi.mock("@/hooks/useInvoiceDialog", () => ({
@@ -75,5 +79,47 @@ describe("RoomDrawer checkout settlement", () => {
         await user.click(screen.getByRole("button", { name: /check-out/i }));
 
         expect(screen.getByTestId("checkout-settlement-modal")).toBeInTheDocument();
+    });
+});
+
+describe("RoomDrawer nightly rate", () => {
+    beforeEach(() => {
+        invoke.mockReset();
+        roomTypeRates = null;
+        invoke
+            .mockResolvedValueOnce({
+                room: {
+                    id: "101",
+                    name: "101",
+                    type: "Phòng Đôi",
+                    floor: 1,
+                    has_balcony: false,
+                    // Lệch xa giá loại phòng, để thấy ngay nếu drawer in số này.
+                    base_price: 300000,
+                    status: "vacant",
+                },
+                booking: null,
+                guests: [],
+            })
+            .mockResolvedValue([]);
+    });
+
+    it("shows the room type's rate, not the room's base_price", async () => {
+        roomTypeRates = {
+            "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 480000, configured: true },
+        };
+
+        render(<RoomDrawer open onClose={vi.fn()} roomId="101" />);
+
+        const rate = await screen.findByTestId("room-drawer-nightly-rate");
+        expect(rate.textContent).toContain("480");
+        expect(rate.textContent).not.toContain("300");
+    });
+
+    it("shows a dash without the /đêm suffix when the rate is unknown", async () => {
+        render(<RoomDrawer open onClose={vi.fn()} roomId="101" />);
+
+        const rate = await screen.findByTestId("room-drawer-nightly-rate");
+        expect(rate.textContent).toBe("—");
     });
 });

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -26,6 +26,7 @@ import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtDateShort, fmtMoney } from "@/lib/format";
+import { nightlyRateDisplay } from "@/lib/roomTypeRate";
 import { useHotelStore } from "@/stores/useHotelStore";
 import type { CheckoutSettlementPayload, RoomWithBooking, HousekeepingTask } from "@/types";
 
@@ -43,6 +44,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         setCheckinOpen,
         fetchRooms,
         updateHousekeeping,
+        roomTypeRates,
     } = useHotelStore();
 
     const [roomDetail, setRoomDetail] = useState<RoomWithBooking | null>(null);
@@ -93,6 +95,8 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
 
     const { room, booking, guests } = roomDetail;
     const roomTypeLabel = getRoomTypeLabel(room.type);
+    // Giá loại phòng từ engine, không phải `room.base_price`.
+    const nightlyRate = nightlyRateDisplay(roomTypeRates, room.type);
 
     const handleCopyStayInfo = async () => {
         if (!booking) return;
@@ -296,7 +300,14 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
                     {/* Status + Price row */}
                     <div className="flex items-center justify-between">
                         <StatusBadge status={room.status} variant="badge" />
-                        <span className="text-lg font-bold text-brand-primary">{fmtMoney(room.base_price)}/đêm</span>
+                        <span
+                            className="text-lg font-bold text-brand-primary"
+                            data-testid="room-drawer-nightly-rate"
+                            title={nightlyRate.derived ? "Suy ra từ giá phòng, chưa có bảng giá cho loại này" : undefined}
+                        >
+                            {nightlyRate.text}
+                            {nightlyRate.unknown ? "" : "/đêm"}
+                        </span>
                     </div>
 
                     {/* Room info */}

--- a/mhm/src/components/UnifiedRoomCard.test.tsx
+++ b/mhm/src/components/UnifiedRoomCard.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import UnifiedRoomCard from "./UnifiedRoomCard";
+import { useHotelStore } from "@/stores/useHotelStore";
+import type { Room, RoomTypeRate } from "@/types";
+
+const room: Room = {
+    id: "R-101",
+    name: "Phòng 101",
+    type: "Phòng Đôi",
+    floor: 1,
+    has_balcony: false,
+    // Cố ý lệch xa giá loại phòng: nếu thẻ in số này thì thấy ngay.
+    base_price: 300_000,
+    max_guests: 2,
+    extra_person_fee: 0,
+    status: "vacant",
+};
+
+function setRates(rates: Record<string, RoomTypeRate> | null) {
+    useHotelStore.setState({ roomTypeRates: rates });
+}
+
+function renderCard() {
+    return render(
+        <UnifiedRoomCard room={room} onOpenDrawer={vi.fn()} onQuickAction={vi.fn()} />,
+    );
+}
+
+describe("UnifiedRoomCard nightly rate", () => {
+    beforeEach(() => {
+        setRates(null);
+    });
+
+    it("shows the room type's rate from the pricing engine, not the room's base_price", () => {
+        setRates({
+            "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 480_000, configured: true },
+        });
+
+        renderCard();
+
+        const rate = screen.getByTestId("room-card-nightly-rate");
+        expect(rate.textContent).toContain("480");
+        // Đây là cả lý do của thay đổi này: 300k là `base_price`, engine bỏ qua nó
+        // khi loại phòng có bảng giá, nên in nó ra là đọc sai giá cho khách.
+        expect(rate.textContent).not.toContain("300");
+    });
+
+    it("shows a dash instead of a price when the rates could not be loaded", () => {
+        renderCard();
+
+        expect(screen.getByTestId("room-card-nightly-rate").textContent).toBe("—");
+    });
+
+    it("never prints base_price anywhere on the card, even with no rate to show", () => {
+        // Chốt trên toàn thẻ, không chỉ ô giá: kéo `base_price` sang một chỗ khác
+        // trên thẻ thì test ô giá vẫn xanh.
+        const { container } = renderCard();
+
+        expect(container.textContent).not.toContain("300");
+    });
+});

--- a/mhm/src/components/UnifiedRoomCard.tsx
+++ b/mhm/src/components/UnifiedRoomCard.tsx
@@ -1,6 +1,8 @@
 import { BedDouble, CalendarClock, LogIn, Sparkles, User, Eye } from "lucide-react";
 import { ROOM_STATUS_CARD_BG, ROOM_STATUS_TEXT, STATUS_DOT_COLORS, STATUS_LABELS, getRoomTypeLabel } from "@/lib/constants";
-import { fmtMoney, fmtDateShort } from "@/lib/format";
+import { fmtDateShort } from "@/lib/format";
+import { nightlyRateDisplay } from "@/lib/roomTypeRate";
+import { useHotelStore } from "@/stores/useHotelStore";
 import type { Room, BookingWithGuest } from "@/types";
 
 interface UnifiedRoomCardProps {
@@ -29,6 +31,8 @@ export default function UnifiedRoomCard({
 }: UnifiedRoomCardProps) {
     const qa = QUICK_ACTION_CONFIG[room.status] ?? QUICK_ACTION_CONFIG.vacant;
     const QaIcon = qa.icon;
+    const roomTypeRates = useHotelStore((state) => state.roomTypeRates);
+    const nightlyRate = nightlyRateDisplay(roomTypeRates, room.type);
 
     const summaryLine = (() => {
         switch (room.status) {
@@ -100,8 +104,13 @@ export default function UnifiedRoomCard({
                 </span>
             </div>
 
-            <div className={`${compact ? "text-[12px]" : "text-[13px]"} font-semibold text-text-primary mb-1.5`}>
-                {fmtMoney(room.base_price)}
+            {/* Giá của **loại phòng**, do engine tính giá trả về — không phải
+                `room.base_price`, thứ engine bỏ qua khi loại phòng có bảng giá. */}
+            <div
+                className={`${compact ? "text-[12px]" : "text-[13px]"} font-semibold mb-1.5 ${nightlyRate.unknown ? "text-text-muted" : "text-text-primary"}`}
+                data-testid="room-card-nightly-rate"
+            >
+                {nightlyRate.text}
             </div>
 
             {/* Status label */}

--- a/mhm/src/lib/roomTypeRate.test.ts
+++ b/mhm/src/lib/roomTypeRate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { nightlyRateDisplay } from "./roomTypeRate";
+import type { RoomTypeRate } from "@/types";
+
+const rates: Record<string, RoomTypeRate> = {
+    "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 640_000, configured: true },
+    "Phòng Đơn": { room_type: "Phòng Đơn", nightly_rate: 420_000, configured: false },
+};
+
+describe("nightlyRateDisplay", () => {
+    it("formats the rate configured for the room type", () => {
+        const display = nightlyRateDisplay(rates, "Phòng Đôi");
+
+        expect(display.text).toContain("640");
+        expect(display.unknown).toBe(false);
+        expect(display.derived).toBe(false);
+    });
+
+    it("flags a rate nobody configured, so a screen with room can say so", () => {
+        expect(nightlyRateDisplay(rates, "Phòng Đơn").derived).toBe(true);
+    });
+
+    it("says it does not know rather than inventing a number when rates failed to load", () => {
+        const display = nightlyRateDisplay(null, "Phòng Đôi");
+
+        expect(display.text).toBe("—");
+        expect(display.unknown).toBe(true);
+    });
+
+    it("says it does not know for a type the rate listing has no row for", () => {
+        // Không rơi về 0đ: một loại phòng thiếu trong bảng giá là "chưa biết",
+        // và 0đ đọc như phòng miễn phí.
+        const display = nightlyRateDisplay(rates, "Phòng VIP");
+
+        expect(display.text).toBe("—");
+        expect(display.unknown).toBe(true);
+    });
+
+    it("shows a genuine zero as a price, not as unknown", () => {
+        const free: Record<string, RoomTypeRate> = {
+            Free: { room_type: "Free", nightly_rate: 0, configured: true },
+        };
+
+        const display = nightlyRateDisplay(free, "Free");
+
+        expect(display.unknown).toBe(false);
+        expect(display.text).not.toBe("—");
+    });
+});

--- a/mhm/src/lib/roomTypeRate.test.ts
+++ b/mhm/src/lib/roomTypeRate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { nightlyRateDisplay } from "./roomTypeRate";
+import { basePriceIsUnused, basePriceRole, nightlyRateDisplay } from "./roomTypeRate";
 import type { RoomTypeRate } from "@/types";
 
 const rates: Record<string, RoomTypeRate> = {
@@ -46,5 +46,42 @@ describe("nightlyRateDisplay", () => {
 
         expect(display.unknown).toBe(false);
         expect(display.text).not.toBe("—");
+    });
+});
+
+describe("basePriceRole", () => {
+    it("reports base_price as ignored, with the rate that wins instead", () => {
+        const role = basePriceRole(rates, "Phòng Đôi");
+
+        expect(role.kind).toBe("ignored");
+        expect(role.kind === "ignored" && role.typeRateText).toContain("640");
+    });
+
+    it("reports base_price as deriving the type price when no rule is configured", () => {
+        // Khác biệt quan trọng: ở trạng thái này số admin gõ *có* tác dụng —
+        // nhưng chỉ với phòng có mã nhỏ nhất trong loại.
+        expect(basePriceRole(rates, "Phòng Đơn").kind).toBe("derives-type-price");
+    });
+
+    it("claims nothing when the rates are unavailable", () => {
+        expect(basePriceRole(null, "Phòng Đôi").kind).toBe("unknown");
+        expect(basePriceRole(rates, "Phòng VIP").kind).toBe("unknown");
+    });
+});
+
+describe("basePriceIsUnused", () => {
+    it("is true when the type charges something other than the room's base price", () => {
+        expect(basePriceIsUnused(rates, "Phòng Đôi", 300_000)).toBe(true);
+    });
+
+    it("is false when the room's base price is exactly what the type charges", () => {
+        expect(basePriceIsUnused(rates, "Phòng Đôi", 640_000)).toBe(false);
+    });
+
+    it("stays quiet when the rates are unavailable", () => {
+        // Cảnh báo đoán mò tệ hơn không cảnh báo: không biết giá loại phòng thì
+        // không kết luận được số của phòng có được dùng hay không.
+        expect(basePriceIsUnused(null, "Phòng Đôi", 300_000)).toBe(false);
+        expect(basePriceIsUnused(rates, "Phòng VIP", 300_000)).toBe(false);
     });
 });

--- a/mhm/src/lib/roomTypeRate.ts
+++ b/mhm/src/lib/roomTypeRate.ts
@@ -1,0 +1,39 @@
+import { fmtMoney } from "@/lib/format";
+import type { RoomTypeRate } from "@/types";
+
+/**
+ * Giá niêm yết một màn hình được phép in cạnh một phòng.
+ *
+ * Một chỗ duy nhất quyết định chuyện này, vì bốn màn hình đang hỏi cùng câu hỏi
+ * và câu trả lời có một luật khó chịu: **không có số dự phòng.** Chưa đọc được
+ * bảng giá thì in "—". `room.base_price` không phải giá — engine bỏ qua nó ngay
+ * khi loại phòng có `pricing_rules`, nên lấy nó ra lấp chỗ trống là quay lại
+ * đúng thứ vừa gỡ: thẻ phòng đọc 300k trong khi quầy thu 480k.
+ */
+export interface NightlyRateDisplay {
+  /** Đã format sẵn, hoặc "—" khi chưa biết. */
+  text: string;
+  /** Chưa đọc được giá — khác với "giá bằng 0". */
+  unknown: boolean;
+  /**
+   * Giá này suy ra từ `base_price` của một phòng (hoặc mặc định nhà), không ai
+   * đặt. Màn hình nào có chỗ thì nói rõ, vì cách sửa là vào cấu hình bảng giá.
+   */
+  derived: boolean;
+}
+
+const UNKNOWN: NightlyRateDisplay = { text: "—", unknown: true, derived: false };
+
+export function nightlyRateDisplay(
+  rates: Record<string, RoomTypeRate> | null,
+  roomType: string,
+): NightlyRateDisplay {
+  const rate = rates?.[roomType];
+  if (!rate) return UNKNOWN;
+
+  return {
+    text: fmtMoney(rate.nightly_rate),
+    unknown: false,
+    derived: !rate.configured,
+  };
+}

--- a/mhm/src/lib/roomTypeRate.ts
+++ b/mhm/src/lib/roomTypeRate.ts
@@ -1,4 +1,5 @@
 import { fmtMoney } from "@/lib/format";
+import type { MoneyVnd } from "@/lib/money";
 import type { RoomTypeRate } from "@/types";
 
 /**
@@ -36,4 +37,55 @@ export function nightlyRateDisplay(
     unknown: false,
     derived: !rate.configured,
   };
+}
+
+/**
+ * `rooms.base_price` thực sự làm gì với một loại phòng cụ thể.
+ *
+ * Có ba khả năng và người sửa phòng không có cách nào đoán được đang ở khả năng
+ * nào — trong khi khác biệt là "số vừa gõ có thành tiền khách trả hay không":
+ *
+ * - `ignored`: loại phòng đã có `pricing_rules`. Engine bỏ qua `base_price`
+ *   hoàn toàn. Gõ 800.000 vào đây rồi tưởng đã tăng giá là mất tiền thật.
+ * - `derives-type-price`: loại phòng chưa có bảng giá, nên `base_price` của
+ *   phòng có **mã nhỏ nhất** trong loại trở thành giá của cả loại. Sửa phòng
+ *   khác thì không có tác dụng gì.
+ * - `unknown`: chưa đọc được bảng giá, nên không khẳng định được điều gì.
+ */
+export type BasePriceRole =
+  | { kind: "unknown" }
+  | { kind: "ignored"; typeRateText: string }
+  | { kind: "derives-type-price" };
+
+/**
+ * `true` khi giá gốc của một phòng không phải số khách trả cho phòng đó.
+ *
+ * Đúng cho cả hai lý do: loại phòng đã có bảng giá (nên `base_price` là dữ liệu
+ * chết), hoặc chưa có bảng giá nhưng một phòng khác cùng loại có mã nhỏ hơn và
+ * giá của nó thắng. Cả hai đều nghĩa là số admin gõ vào phòng này không được thu.
+ *
+ * Không đọc được bảng giá thì trả `false`: không biết giá loại phòng thì không
+ * kết luận được `base_price` có được dùng hay không, và một cảnh báo đoán mò còn
+ * tệ hơn không cảnh báo.
+ */
+export function basePriceIsUnused(
+  rates: Record<string, RoomTypeRate> | null,
+  roomType: string,
+  basePrice: MoneyVnd,
+): boolean {
+  const rate = rates?.[roomType];
+  if (!rate) return false;
+
+  return rate.nightly_rate !== basePrice;
+}
+
+export function basePriceRole(
+  rates: Record<string, RoomTypeRate> | null,
+  roomType: string,
+): BasePriceRole {
+  const rate = rates?.[roomType];
+  if (!rate) return { kind: "unknown" };
+  if (!rate.configured) return { kind: "derives-type-price" };
+
+  return { kind: "ignored", typeRateText: fmtMoney(rate.nightly_rate) };
 }

--- a/mhm/src/pages/settings/RoomConfigSection.pricing.test.tsx
+++ b/mhm/src/pages/settings/RoomConfigSection.pricing.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RoomConfigSection from "./RoomConfigSection";
+import { clearMockResponses, setMockResponse } from "@test-mocks/tauri-core";
+import { useHotelStore } from "@/stores/useHotelStore";
+import type { RoomTypeRate } from "@/types";
+
+const invokeCommand = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/invokeCommand", () => ({ invokeCommand }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const ROOM = {
+    id: "R-101",
+    name: "Phòng 101",
+    type: "Phòng Đôi",
+    floor: 1,
+    has_balcony: false,
+    // Lệch xa giá loại phòng, để thấy ngay nếu màn hình cấu hình in số này.
+    base_price: 300_000,
+    max_guests: 2,
+    extra_person_fee: 0,
+    status: "vacant",
+};
+
+/**
+ * Trả bảng giá qua đúng lệnh thật, không set thẳng vào store: màn hình này gọi
+ * `fetchRoomTypeRates` lúc mount, nên state đặt tay sẽ bị ghi đè — và chính việc
+ * bị ghi đè đó là bằng chứng đường dây mount hoạt động.
+ */
+function respondWithRates(rates: RoomTypeRate[]) {
+    setMockResponse("get_room_type_rates", () => rates);
+}
+
+/** Đọc bảng giá thất bại thật, không phải "loại phòng thiếu trong danh sách". */
+function failTheRateRead() {
+    setMockResponse("get_room_type_rates", () => {
+        throw new Error("db locked");
+    });
+}
+
+const CONFIGURED: RoomTypeRate[] = [
+    { room_type: "Phòng Đôi", nightly_rate: 480_000, configured: true },
+];
+const DERIVED_AT_BASE_PRICE: RoomTypeRate[] = [
+    { room_type: "Phòng Đôi", nightly_rate: 300_000, configured: false },
+];
+
+describe("RoomConfigSection room row price", () => {
+    beforeEach(() => {
+        invokeCommand.mockReset();
+        invokeCommand.mockImplementation(async (command: string) => {
+            if (command === "get_rooms") return [ROOM];
+            if (command === "get_room_types") return [{ id: "T1", name: "Phòng Đôi" }];
+            return [];
+        });
+        clearMockResponses();
+        useHotelStore.setState({ roomTypeRates: null });
+    });
+
+    it("shows the type's rate as the room's price, not the room's base_price", async () => {
+        respondWithRates(CONFIGURED);
+
+        render(<RoomConfigSection />);
+
+        const price = await screen.findByTestId("room-row-nightly-rate");
+        expect(price.textContent).toContain("480");
+        expect(price.textContent).not.toContain("300");
+    });
+
+    it("warns that the room's own base_price is not the number being charged", async () => {
+        respondWithRates(CONFIGURED);
+
+        render(<RoomConfigSection />);
+
+        // Cảnh báo này là thứ duy nhất nói cho admin biết 300.000 họ đã gõ vào
+        // đang không có tác dụng gì.
+        const warning = await screen.findByTestId("room-row-base-price-unused");
+        expect(warning.textContent).toContain("300");
+        expect(warning.textContent).toContain("không được dùng");
+    });
+
+    it("does not warn when the room's base_price is what the type charges", async () => {
+        respondWithRates(DERIVED_AT_BASE_PRICE);
+
+        render(<RoomConfigSection />);
+
+        await screen.findByTestId("room-row-nightly-rate");
+        expect(screen.queryByTestId("room-row-base-price-unused")).not.toBeInTheDocument();
+    });
+
+    it("shows a dash rather than a price it could not read", async () => {
+        failTheRateRead();
+
+        render(<RoomConfigSection />);
+
+        const price = await screen.findByTestId("room-row-nightly-rate");
+        expect(price.textContent).toBe("—");
+        // Và không cảnh báo bịa: không biết giá loại phòng thì không kết luận
+        // được `base_price` có được dùng hay không.
+        expect(screen.queryByTestId("room-row-base-price-unused")).not.toBeInTheDocument();
+    });
+
+    it("asks for the type rates on mount, since this screen has its own room list", async () => {
+        // Không có bước này thì màn hình sửa giá — chỗ cần bảng giá nhất — luôn
+        // hiện "chưa đọc được", vì nó không dùng danh sách phòng của store.
+        respondWithRates(CONFIGURED);
+
+        render(<RoomConfigSection />);
+
+        await waitFor(() => {
+            expect(useHotelStore.getState().roomTypeRates?.["Phòng Đôi"]?.nightly_rate).toBe(
+                480_000,
+            );
+        });
+    });
+});
+
+describe("RoomFormDialog base price role", () => {
+    beforeEach(() => {
+        invokeCommand.mockReset();
+        invokeCommand.mockImplementation(async (command: string) => {
+            if (command === "get_rooms") return [ROOM];
+            if (command === "get_room_types") return [{ id: "T1", name: "Phòng Đôi" }];
+            return [];
+        });
+        clearMockResponses();
+        useHotelStore.setState({ roomTypeRates: null });
+    });
+
+    async function openForm() {
+        const user = userEvent.setup();
+        render(<RoomConfigSection />);
+        await screen.findByTestId("room-row-nightly-rate");
+        await user.click(screen.getByRole("button", { name: /thêm phòng/i }));
+        return user;
+    }
+
+    it("says the number will not affect what guests pay when the type has a rule", async () => {
+        respondWithRates(CONFIGURED);
+
+        await openForm();
+
+        const role = await screen.findByTestId("base-price-role");
+        expect(role.textContent).toContain("đã có bảng giá");
+        expect(role.textContent).toContain("480");
+        expect(role.textContent).toContain("không");
+    });
+
+    it("says the lowest room id decides the type price when the type has no rule", async () => {
+        respondWithRates(DERIVED_AT_BASE_PRICE);
+
+        await openForm();
+
+        const role = await screen.findByTestId("base-price-role");
+        expect(role.textContent).toContain("chưa có bảng giá");
+        expect(role.textContent).toContain("mã nhỏ nhất");
+    });
+
+    it("admits it does not know when the rates could not be read", async () => {
+        failTheRateRead();
+
+        await openForm();
+
+        const role = await screen.findByTestId("base-price-role");
+        expect(role.textContent).toContain("Chưa đọc được bảng giá");
+    });
+
+    it("no longer labels the field as the room's price", async () => {
+        respondWithRates(CONFIGURED);
+
+        await openForm();
+
+        // "Giá cơ bản" đọc như giá khách trả. Nhãn phải nói đây là giá gốc của
+        // phòng, thứ engine có thể bỏ qua.
+        expect(screen.getByText(/Giá gốc của phòng/)).toBeInTheDocument();
+        expect(screen.queryByText(/Giá cơ bản/)).not.toBeInTheDocument();
+    });
+});

--- a/mhm/src/pages/settings/RoomConfigSection.tsx
+++ b/mhm/src/pages/settings/RoomConfigSection.tsx
@@ -3,6 +3,8 @@ import { BedDouble, Pencil, Plus, Tag, Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { fmtMoney } from "@/lib/format";
+import { basePriceIsUnused, nightlyRateDisplay } from "@/lib/roomTypeRate";
+import { useHotelStore } from "@/stores/useHotelStore";
 
 import RoomFormDialog from "./RoomFormDialog";
 import useRoomConfig from "./useRoomConfig";
@@ -25,6 +27,7 @@ export default function RoomConfigSection() {
     handleSaveRoom,
     handleDeleteRoom,
   } = useRoomConfig();
+  const roomTypeRates = useHotelStore((state) => state.roomTypeRates);
 
   return (
     <div className="space-y-8">
@@ -85,7 +88,14 @@ export default function RoomConfigSection() {
         />
 
         <div className="space-y-2">
-          {rooms.map((room) => (
+          {rooms.map((room) => {
+            // Con số to nhất trên hàng phải là số khách trả, tức giá của loại
+            // phòng. `room.base_price` từng đứng ở đây là dữ liệu engine bỏ qua
+            // ngay khi loại phòng có bảng giá.
+            const nightlyRate = nightlyRateDisplay(roomTypeRates, room.type);
+            const basePriceUnused = basePriceIsUnused(roomTypeRates, room.type, room.base_price);
+
+            return (
             <div key={room.id} className="flex items-center justify-between p-4 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors">
               <div className="flex items-center gap-4">
                 <div className="w-10 h-10 rounded-lg bg-brand-primary/10 flex items-center justify-center font-bold text-brand-primary text-sm">
@@ -100,7 +110,15 @@ export default function RoomConfigSection() {
               </div>
               <div className="flex items-center gap-3">
                 <div className="text-right">
-                  <p className="text-sm font-bold text-brand-primary">{fmtMoney(room.base_price)}</p>
+                  <p className="text-sm font-bold text-brand-primary" data-testid="room-row-nightly-rate">
+                    {nightlyRate.text}
+                    {nightlyRate.unknown ? "" : "/đêm"}
+                  </p>
+                  {basePriceUnused && (
+                    <p className="text-[10px] text-amber-600" data-testid="room-row-base-price-unused">
+                      giá gốc {fmtMoney(room.base_price)} không được dùng
+                    </p>
+                  )}
                   {room.extra_person_fee > 0 && <p className="text-[10px] text-brand-muted">+{fmtMoney(room.extra_person_fee)}/người thêm</p>}
                 </div>
                 <button onClick={() => openEdit(room)} className="p-2 hover:bg-slate-200 rounded-lg transition-colors cursor-pointer">
@@ -111,7 +129,8 @@ export default function RoomConfigSection() {
                 </button>
               </div>
             </div>
-          ))}
+            );
+          })}
 
           {rooms.length === 0 && (
             <div className="text-center py-12 text-brand-muted">

--- a/mhm/src/pages/settings/RoomFormDialog.tsx
+++ b/mhm/src/pages/settings/RoomFormDialog.tsx
@@ -3,6 +3,8 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { basePriceRole } from "@/lib/roomTypeRate";
+import { useHotelStore } from "@/stores/useHotelStore";
 import type { RoomTypeItem } from "@/types";
 
 import type { RoomFormValues } from "./useRoomConfig";
@@ -26,6 +28,9 @@ export default function RoomFormDialog({
   onClose,
   onSubmit,
 }: RoomFormDialogProps) {
+  const roomTypeRates = useHotelStore((state) => state.roomTypeRates);
+  const role = basePriceRole(roomTypeRates, form.room_type);
+
   if (!open) return null;
 
   return (
@@ -95,13 +100,31 @@ export default function RoomFormDialog({
         </div>
         <div />
         <div>
-          <Label>💰 Giá cơ bản (VNĐ)</Label>
+          {/* Không gọi là "giá cơ bản": nhãn đó ngụ ý đây là giá khách trả, mà
+              engine bỏ qua nó ngay khi loại phòng có bảng giá. Dòng chú thích
+              dưới đây nói rõ số này đang có tác dụng gì. */}
+          <Label>💰 Giá gốc của phòng (VNĐ)</Label>
           <Input
             type="number"
             value={form.base_price}
             onChange={(event) => onChange({ ...form, base_price: Number(event.target.value) })}
             className="mt-1.5"
           />
+          <p className="mt-1.5 text-[11px] leading-snug text-brand-muted" data-testid="base-price-role">
+            {role.kind === "ignored" && (
+              <>
+                Loại phòng này đã có bảng giá ({role.typeRateText}/đêm), nên số ở đây{" "}
+                <strong>không</strong> ảnh hưởng tiền khách trả. Sửa giá ở mục Bảng giá.
+              </>
+            )}
+            {role.kind === "derives-type-price" && (
+              <>
+                Loại phòng này chưa có bảng giá, nên giá gốc của phòng có mã nhỏ nhất
+                trong loại sẽ thành giá của cả loại.
+              </>
+            )}
+            {role.kind === "unknown" && <>Chưa đọc được bảng giá, chưa rõ số này có được dùng hay không.</>}
+          </p>
         </div>
         <div>
           <Label>👥 Số khách tính giá base</Label>

--- a/mhm/src/pages/settings/useRoomConfig.ts
+++ b/mhm/src/pages/settings/useRoomConfig.ts
@@ -4,6 +4,7 @@ import type { ConfigurableRoom, RoomTypeItem } from "@/types";
 import { formatAppError } from "@/lib/appError";
 import { invokeCommand } from "@/lib/invokeCommand";
 import { assertNonNegativeMoneyVnd, type MoneyVnd } from "@/lib/money";
+import { useHotelStore } from "@/stores/useHotelStore";
 
 export interface RoomFormValues {
     id: string;
@@ -38,6 +39,12 @@ export default function useRoomConfig() {
     const loadData = () => {
         invokeCommand<ConfigurableRoom[]>("get_rooms").then(setRooms).catch(() => { });
         invokeCommand<RoomTypeItem[]>("get_room_types").then(setRoomTypes).catch(() => { });
+        // Màn hình này có danh sách phòng riêng, không đi qua store, nên phải tự
+        // xin bảng giá theo loại phòng — đây đúng là chỗ cần nó nhất: nó là nơi
+        // người ta sửa `base_price` và cần biết số đó có tác dụng gì.
+        // Refresh sau khi ghi thì đã có: mọi lệnh ghi phòng phát "db-updated",
+        // RuntimeStateProvider gọi fetchRooms, fetchRooms kéo bảng giá theo.
+        void useHotelStore.getState().fetchRoomTypeRates();
     };
 
     useEffect(loadData, []);

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -435,3 +435,52 @@ describe("useHotelStore navigation side effects", () => {
     expect(useHotelStore.getState().dashboardRefreshVersion).toBe(1);
   });
 });
+
+describe("useHotelStore room type rates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useHotelStore.setState({ rooms: [], roomTypeRates: null });
+  });
+
+  it("loads the type rates alongside the rooms they annotate", async () => {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_rooms") return [{ id: "R-101", type: "Phòng Đôi" }];
+      if (command === "get_room_type_rates")
+        return [{ room_type: "Phòng Đôi", nightly_rate: 640000, configured: true }];
+      throw new Error(`unexpected ${command}`);
+    });
+
+    await useHotelStore.getState().fetchRooms();
+
+    // Keyed on `rooms.type`, because that is what every card looks up by.
+    expect(useHotelStore.getState().roomTypeRates?.["Phòng Đôi"]?.nightly_rate).toBe(640000);
+  });
+
+  it("still shows the rooms when the rate lookup fails", async () => {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_rooms") return [{ id: "R-101", type: "Phòng Đôi" }];
+      throw new Error("db locked");
+    });
+
+    // Không throw: mất giá thì màn hình phòng vẫn phải dùng được, chỉ là không
+    // có số để in. `fetchRooms` được gọi sau mọi lệnh ghi nên nó không được vỡ.
+    await useHotelStore.getState().fetchRooms();
+
+    expect(useHotelStore.getState().rooms).toHaveLength(1);
+    expect(useHotelStore.getState().roomTypeRates).toBeNull();
+  });
+
+  it("clears the rates it had when a later lookup fails", async () => {
+    useHotelStore.setState({
+      roomTypeRates: {
+        "Phòng Đôi": { room_type: "Phòng Đôi", nightly_rate: 640000, configured: true },
+      },
+    });
+    invoke.mockRejectedValue(new Error("db locked"));
+
+    await useHotelStore.getState().fetchRoomTypeRates();
+
+    // Giá cũ còn lại thì thẻ phòng in giá của một bảng giá đã đổi — tệ hơn "—".
+    expect(useHotelStore.getState().roomTypeRates).toBeNull();
+  });
+});

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -19,10 +19,19 @@ import type {
   AutoAssignResult,
   CheckoutSettlementMode,
   GroupInvoiceData,
+  RoomTypeRate,
 } from "@/types";
 
 interface HotelStore {
   rooms: Room[];
+  /**
+   * Giá niêm yết theo loại phòng, key là `rooms.type`.
+   *
+   * `null` = chưa tải được. Cố ý không có giá trị mặc định: màn hình nào không
+   * đọc được giá thì hiện "—", chứ không bịa một số ra. `room.base_price` không
+   * dùng làm giá dự phòng — engine bỏ qua nó ngay khi loại phòng có bảng giá.
+   */
+  roomTypeRates: Record<string, RoomTypeRate> | null;
   stats: DashboardStats | null;
   dashboardRefreshVersion: number;
   roomDetail: RoomWithBooking | null;
@@ -36,6 +45,8 @@ interface HotelStore {
   groups: BookingGroup[];
 
   fetchRooms: () => Promise<void>;
+  /** Không bao giờ throw: thất bại thì đặt `roomTypeRates` về `null`. */
+  fetchRoomTypeRates: () => Promise<void>;
   fetchStats: () => Promise<void>;
   markDashboardDataChanged: () => void;
   setTab: (tab: HotelTab) => void;
@@ -76,6 +87,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
 
   return {
     rooms: [],
+    roomTypeRates: null,
     stats: null,
     dashboardRefreshVersion: 0,
     roomDetail: null,
@@ -91,6 +103,21 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     fetchRooms: async () => {
       const rooms = await invoke<Room[]>("get_rooms");
       set({ rooms });
+      // Cùng một lệnh tải: mọi màn hình hiện giá cạnh phòng đều đọc hai thứ này
+      // cùng lúc, và `fetchRooms` đã được gọi sau mọi lệnh ghi. Giá tải lỗi thì
+      // danh sách phòng vẫn hiện — nên `fetchRoomTypeRates` không throw.
+      await get().fetchRoomTypeRates();
+    },
+
+    fetchRoomTypeRates: async () => {
+      try {
+        const rates = await invoke<RoomTypeRate[]>("get_room_type_rates");
+        set({
+          roomTypeRates: Object.fromEntries(rates.map((rate) => [rate.room_type, rate])),
+        });
+      } catch {
+        set({ roomTypeRates: null });
+      }
     },
 
     fetchStats: async () => {

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -27,6 +27,20 @@ export interface Room {
   status: RoomStatus;
 }
 
+/**
+ * Giá niêm yết của một **loại phòng**, do `get_room_type_rates` trả về.
+ *
+ * Không phải báo giá: uplift cuối tuần, `special_dates` và phụ thu thêm người
+ * đều phụ thuộc ngày và số khách. Con số gắn với một kỳ nghỉ cụ thể phải đi qua
+ * lệnh xem trước (`usePricePreview` / `useRoomPrices`).
+ */
+export interface RoomTypeRate {
+  room_type: string;
+  nightly_rate: MoneyVnd;
+  /** `false` = chưa có bảng giá cho loại này, số trên là suy ra chứ không ai đặt. */
+  configured: boolean;
+}
+
 export interface Guest {
   id: string;
   guest_type: string;

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -46,6 +46,7 @@ const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
   get_recent_activity: "read-only activity feed lookup",
   get_room_detail: "read-only room detail lookup",
   get_room_types: "read-only room type lookup",
+  get_room_type_rates: "read-only listed nightly rate per room type",
   get_rooms: "read-only room list lookup",
   get_rooms_availability: "read-only room availability lookup",
   get_settings: "read-only settings lookup",


### PR DESCRIPTION
## The bug this turned into

I set out to fix four screens printing `rooms.base_price` as a room's price. A
test for the new rate listing seeded a room of type **`Phòng Đôi`** at 640 000
and got back **350 000** — the house default.

Every room-type lookup folded case on **both sides of the comparison, using two
different functions**: SQL `LOWER(type) = ?` against a Rust `str::to_lowercase()`
bind. SQLite's `LOWER` is ASCII-only and leaves `Đ` alone; Rust's lowers it to
`đ`. For any type whose name carries a non-ASCII capital, the two strings could
never be equal. Not matched loosely — *never matched.*

All three lookups missed together, so:

- the configured `pricing_rules` row was not found,
- no room supplied a fallback `base_price`,
- the stay was quoted **and charged** at the 350k house default,
- while the settings screen went on displaying the real rate.

An operator setting 900k for `Phòng Đôi` watched the desk read 700k for two
nights, with nothing anywhere reporting a problem — from the engine's side the
type simply had no price.

`Đ` opens `Đôi` and `Đơn`, double and single. It is most of the room list in a
Vietnamese hotel. **The live database happens to hold ASCII type names
(`Deluxe Balcony`, `Standard Room`), which is the only reason this has not been
costing money.**

Fix: fold inside SQL — `LOWER(x) = LOWER(?)` — which makes the two sides one
function by construction.

## Also here

**A type-keyed quote assembled from two rooms.** The type-keyed preview stands a
room in for the type. `FALLBACK_BASE_PRICE_SQL` picks it with `ORDER BY id`;
`ROOM_GUEST_PRICING_BY_TYPE_SQL` picked it with a bare `LIMIT 1`, so SQLite was
free to take `max_guests` and `extra_person_fee` from a different room than the
base price came from — 600k base from the low room, "seats 4, no surcharge" from
the high one, and the result free to change on restart.

**The four display sites.** Room card, room drawer, and *both* render branches of
the detail panel now read `get_room_type_rates`, which resolves through
`build_effective_pricing_rule` — the same function the charge builds its rule
with. The engine ignores `base_price` outright once a type has a rule, so a card
could read 300k next to a desk collecting 480k. After the case-fold fix, a
Vietnamese-named type now finds its rule, which makes that gap wider.

The rule those screens must not break: **there is no fallback number.** When the
rate cannot be read they show "—". Falling back to `base_price` reintroduces
exactly the defect; falling back to 0 reads as a free room. `nightlyRateDisplay`
is the single place that decides it, so four screens cannot drift.

Rates ride along inside `fetchRooms`, which is what makes a price saved in
settings reach the cards: `save_pricing_rule` emits `db-updated`,
`RuntimeStateProvider` calls `fetchRooms`. A failed rate read does not fail
`fetchRooms` — `fetchRooms` runs after every write, so the room grid stays usable
with no price rather than not at all.

## Evidence

**9 mutations, all caught.**

| mutation | caught by |
|---|---|
| drop `ORDER BY id` from the guest-limits SQL | `a_type_keyed_quote_..._from_one_room` (1.2M vs 1.5M) |
| revert either half of the case-fold | same test, plus the rule test (700k vs 1.8M) |
| revert any of the four price lines to `base_price` | one named test per line, both panel branches separately |
| drop the rate fetch from `fetchRooms` | `loads the type rates alongside the rooms they annotate` |
| let a stale rate map survive a failed reload | `clears the rates it had when a later lookup fails` |
| turn unknown into `0đ` | two `nightlyRateDisplay` tests |
| clear the derived flag | `flags a rate nobody configured` |

953 Rust tests · 453 frontend tests · `clippy --all-targets -D warnings` clean ·
`fmt --check` clean · `npm run verify:full` **exit 0** against the real Tauri app.

`get_room_type_rates` probed against a **copy** of the live database (never the
live file) returns the two configured rates. On this hotel's data `base_price`
and `daily_rate` happen to agree, so the visible change is nil today — the bug
was latent, not active.

## Not fixed here

- **`RoomFormDialog` / `RoomConfigSection` still edit and display a per-room
  `base_price` the engine ignores.** This is the write-side twin and the bigger
  remaining problem: an admin types 800 000 for room 102 and the system charges
  the type rate. Read side first, because it establishes the rate source the
  write side needs.
- ASCII-only folding means `PHÒNG ĐÔI` still will not match `phòng đôi`. A real
  fix is a normalised key column plus a migration. A type now always matches
  *itself*, which is the case that occurs — every caller passes a name read
  straight back out of `rooms.type`.
- The derived-rate hint is visible text on the detail page but only a `title`
  tooltip on the card and drawer — invisible to touch and keyboard.
- Carried over from #185: no re-quote when the local date turns, `paidAmount`
  accepting a deposit above the total, and whether walk-in check-in *should*
  charge the extra-person fee (a product question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
