### PR TITLE
The night shift: three day derivations, three ways to be wrong

### DIFF
--- a/mhm/src/components/CheckinSheet.pricing.test.tsx
+++ b/mhm/src/components/CheckinSheet.pricing.test.tsx
@@ -170,3 +170,61 @@ describe("CheckinSheet total price", () => {
     expect(option).not.toHaveTextContent("500.000");
   });
 });
+
+describe("CheckinSheet and the local day", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+    useHotelStore.setState({ isCheckinOpen: true, rooms: [] });
+    setMockResponse("get_rooms", () => [ROOM]);
+    setMockResponse("calculate_room_price_preview", () => pricingResult(BACKEND_TOTAL));
+    setMockResponse("check_availability", () => ({ available: true, conflicts: [] }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function availabilityArgs(): { fromDate: string; toDate: string }[] {
+    return invoke.mock.calls
+      .filter(([command]) => command === "check_availability")
+      .map(([, args]) => args as never);
+  }
+
+  /// At 02:00 in Vietnam the UTC day is still yesterday, so a `toISOString()`
+  /// window asked whether the room was free *the day before* the guest is
+  /// standing at the desk.
+  it("checks availability for the local day, not the UTC day", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-21T02:00:00+07:00"));
+
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await vi.waitFor(() => expect(availabilityArgs().length).toBeGreaterThan(0));
+    expect(availabilityArgs()[0].fromDate).toBe("2026-04-21");
+    expect(availabilityArgs()[0].toDate).toBe("2026-04-22");
+  });
+
+  /// A sheet opened before midnight and submitted after it quoted yesterday
+  /// while `check_in` charged from today's `Local::now()` — different
+  /// `special_dates` row, different weekend uplift. The night shift is a shift,
+  /// not an edge case.
+  it("re-quotes when the local day turns under an open sheet", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-21T23:59:00+07:00"));
+
+    render(<CheckinSheet preSelectedRoomId="R101" />);
+
+    await vi.waitFor(() => expect(previewArgs().length).toBeGreaterThan(0));
+    expect(previewArgs()[0].checkIn).toContain("2026-04-21");
+
+    const before = previewArgs().length;
+    await vi.advanceTimersByTimeAsync(62_000);
+
+    await vi.waitFor(() => expect(previewArgs().length).toBeGreaterThan(before));
+    const latest = previewArgs()[previewArgs().length - 1];
+    expect(latest.checkIn).toContain("2026-04-22");
+    // Vẫn là mốc địa phương có độ lệch, không phải ngày trần hay `Z`.
+    expect(latest.checkIn).toMatch(/[+-]\d{2}:\d{2}$/);
+  });
+});

--- a/mhm/src/components/CheckinSheet.tsx
+++ b/mhm/src/components/CheckinSheet.tsx
@@ -11,7 +11,8 @@ import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
 import { fmtMoney } from "@/lib/format";
 import { createDeferredCleanup } from "@/lib/deferredCleanup";
-import { addDays, localRfc3339 } from "@/lib/timelineSelection";
+import { addDays, addDaysIso, localRfc3339 } from "@/lib/timelineSelection";
+import { useLocalDay } from "@/hooks/useLocalDay";
 import { usePricePreview } from "@/hooks/usePricePreview";
 import { toast } from "sonner";
 import type { CccdInfo, GuestInput, GuestSummary } from "@/types";
@@ -148,17 +149,22 @@ export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: {
     }, [rooms, selectedRoom, vacantRooms]);
 
     const selectedRoomData = rooms.find((r) => r.id === selectedRoom);
+    const localDay = useLocalDay();
 
     // Nhận phòng vãng lai được tính tiền từ `Local::now()` cho `nights` ngày
     // (`stay_lifecycle.rs`), nên bản xem trước phải hỏi đúng hai mốc đó — không
     // phải ngày trần, vốn là cách đặt phòng trước được tính.
+    // `localDay` nằm trong deps để mốc báo giá được tính lại khi qua nửa đêm.
+    // Không có nó, sheet mở lúc 23:5x vẫn báo giá theo hôm qua trong khi
+    // `check_in` thu tiền từ `Local::now()` của hôm nay — lệch ngày lễ và lệch
+    // phụ thu cuối tuần, đúng thứ mạch báo giá này dựng lên để chặn.
     const { quoteCheckIn, quoteCheckOut } = useMemo(() => {
         const now = new Date();
         return {
             quoteCheckIn: localRfc3339(now),
             quoteCheckOut: localRfc3339(addDays(now, Math.max(nights, 0))),
         };
-    }, [nights]);
+    }, [localDay, nights]);
 
     // Con số phải do engine trả về. `base_price × nights` bỏ qua bảng giá đã
     // cấu hình, phụ thu cuối tuần và phụ thu ngày lễ — những thứ lúc thu tiền
@@ -176,15 +182,16 @@ export default function CheckinSheet({ preSelectedRoomId, preSelectedNights }: {
         guests: null,
     });
 
-    const { fromDate, toDate } = useMemo(() => {
-        const now = new Date();
-        const next = new Date(now.getTime() + Math.max(nights, 0) * 86400000);
-
-        return {
-            fromDate: now.toISOString().split("T")[0],
-            toDate: next.toISOString().split("T")[0],
-        };
-    }, [nights]);
+    // Ngày địa phương, không phải `toISOString()`: trước 07:00 giờ Việt Nam thì
+    // ngày UTC vẫn là hôm qua, nên cửa sổ này đi tra tình trạng phòng của ngày
+    // hôm trước — trong khi phòng đang được nhận hôm nay.
+    const { fromDate, toDate } = useMemo(
+        () => ({
+            fromDate: localDay,
+            toDate: addDaysIso(localDay, Math.max(nights, 0)),
+        }),
+        [localDay, nights],
+    );
 
     const { availability } = useAvailability({
         roomId: selectedRoom,

--- a/mhm/src/components/GroupCheckinSheet.pricing.test.tsx
+++ b/mhm/src/components/GroupCheckinSheet.pricing.test.tsx
@@ -13,6 +13,8 @@ import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-c
 const autoAssignRooms = vi.hoisted(() => vi.fn());
 const groupCheckIn = vi.hoisted(() => vi.fn());
 const setGroupCheckinOpen = vi.hoisted(() => vi.fn());
+/** Mutable so a test can close the sheet and observe the form reset. */
+const sheetState = vi.hoisted(() => ({ open: true }));
 
 // Two rooms, two prices, and a multi-word type name. Deliberately not tidier
 // than production data: the shipped type names contain spaces, and a fixture
@@ -46,7 +48,7 @@ const ROOMS = [
 
 vi.mock("@/stores/useHotelStore", () => ({
   useHotelStore: () => ({
-    isGroupCheckinOpen: true,
+    isGroupCheckinOpen: sheetState.open,
     setGroupCheckinOpen,
     rooms: ROOMS,
     groupCheckIn,
@@ -238,5 +240,105 @@ describe("GroupCheckinSheet total price", () => {
     // price successfully.
     expect(screen.queryByText(/1\.300\.000/)).not.toBeInTheDocument();
     expect(screen.queryByText(/632\.500/)).not.toBeInTheDocument();
+  });
+});
+
+describe("GroupCheckinSheet and the local day turning", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+    autoAssignRooms.mockReset();
+    groupCheckIn.mockReset();
+    setMockResponse("calculate_room_price_preview", () => pricingResult(632_500));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /// `todayStr` used to be captured once per render with no reason to re-render,
+  /// so an arrival date of "tomorrow" stayed classified as a reservation after
+  /// midnight had made it *today*. The two classifications send different date
+  /// shapes: bare `YYYY-MM-DD` for a reservation, an offset stamp for a walk-in.
+  /// `group_lifecycle.rs` branches the same way against its own local today, so
+  /// the desk and the ledger disagreed about which stay was being priced.
+  it("reclassifies tomorrow's group as a walk-in once midnight makes it today", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 20, 23, 59, 0));
+
+    const user = userEvent.setup();
+    render(<GroupCheckinSheet />);
+
+    // Ngày nhận phòng nằm ở bước 0, nên phải đặt trước khi đi tiếp. Ngày mai lúc
+    // này là 21, nên đây là đặt trước: ngày trần, không có độ lệch.
+    const arrival = screen.getByDisplayValue("2026-04-20") as HTMLInputElement;
+    await user.clear(arrival);
+    await user.type(arrival, "2026-04-21");
+
+    const textboxes = screen.getAllByRole("textbox");
+    await user.type(textboxes[0], "Đoàn Hà Nội");
+    await user.type(textboxes[1], "Trần Văn B");
+    await user.click(screen.getByRole("button", { name: /Tiếp theo/i }));
+    await user.click(screen.getByRole("button", { name: /Chọn tay/i }));
+    await user.click(screen.getByRole("button", { name: /R101/ }));
+    await user.click(screen.getByRole("button", { name: /R202/ }));
+    const masterCandidates = screen.getAllByRole("button", { name: /R101/ });
+    await user.click(masterCandidates[masterCandidates.length - 1]);
+
+    await vi.waitFor(() =>
+      expect(previewArgs().some((a) => a.checkIn === "2026-04-21")).toBe(true),
+    );
+
+    const beforeMidnight = previewArgs().length;
+    await vi.advanceTimersByTimeAsync(62_000);
+
+    // Qua nửa đêm, 21 chính là hôm nay, nên phải chuyển sang nhánh vãng lai —
+    // đúng nhánh backend sẽ tính tiền.
+    await vi.waitFor(() => expect(previewArgs().length).toBeGreaterThan(beforeMidnight));
+    const latest = previewArgs()[previewArgs().length - 1];
+    expect(latest.checkIn).toMatch(/T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+    expect(latest.checkIn.slice(0, 10)).toBe("2026-04-21");
+  });
+});
+
+describe("GroupCheckinSheet form reset", () => {
+  beforeEach(() => {
+    clearMockResponses();
+    invoke.mockClear();
+    sheetState.open = true;
+    setMockResponse("calculate_room_price_preview", () => pricingResult(632_500));
+  });
+
+  afterEach(() => {
+    sheetState.open = true;
+    vi.useRealTimers();
+  });
+
+  /// The reset ran `new Date().toISOString().split("T")[0]` — the UTC day —
+  /// three lines below a comment explaining why that is wrong. Before 07:00 in
+  /// Vietnam the UTC day is still yesterday, so closing and reopening the sheet
+  /// on the night shift put *yesterday* in the arrival field, which then reads as
+  /// a backfill rather than today's walk-in.
+  it("resets the arrival date to the local day, not the UTC day", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 21, 2, 0, 0));
+
+    const user = userEvent.setup();
+    const { container, rerender } = render(<GroupCheckinSheet />);
+    const dateInput = () => container.querySelector('input[type="date"]') as HTMLInputElement;
+
+    const arrival = screen.getByDisplayValue("2026-04-21") as HTMLInputElement;
+    await user.clear(arrival);
+    await user.type(arrival, "2026-04-25");
+    expect((screen.getByDisplayValue("2026-04-25") as HTMLInputElement).value).toBe("2026-04-25");
+
+    sheetState.open = false;
+    rerender(<GroupCheckinSheet />);
+    sheetState.open = true;
+    rerender(<GroupCheckinSheet />);
+
+    await vi.waitFor(() => expect(dateInput().value).toBe("2026-04-21"));
+    // 2026-04-20 là ngày UTC lúc 02:00 giờ Việt Nam — chính con số mà bản cũ đặt.
+    expect(dateInput().value).not.toBe("2026-04-20");
   });
 });

--- a/mhm/src/components/GroupCheckinSheet.tsx
+++ b/mhm/src/components/GroupCheckinSheet.tsx
@@ -13,6 +13,7 @@ import { FormField, FormFieldSelect } from "@/components/shared/FormField";
 import { formatAppError } from "@/lib/appError";
 import { fmtMoney } from "@/lib/format";
 import { addDays, addDaysIso, localDateIso, localRfc3339 } from "@/lib/timelineSelection";
+import { useLocalDay } from "@/hooks/useLocalDay";
 import { sumRoomPrices, useRoomPrices } from "@/hooks/useRoomPrices";
 import { toast } from "sonner";
 import { Sparkles, Hand, Check, ChevronLeft, ChevronRight, Users, Star, CalendarClock } from "lucide-react";
@@ -45,7 +46,10 @@ export default function GroupCheckinSheet() {
     // `isReservation` phán nhầm chế độ ngay trong ca đêm.
     const [checkInDate, setCheckInDate] = useState(() => localDateIso(new Date()));
 
-    const todayStr = localDateIso(new Date());
+    // Qua nửa đêm là `todayStr` đổi theo, nên một sheet mở xuyên ca đêm không
+    // còn phân loại một đoàn khách vãng lai thành đặt trước (hoặc ngược lại) —
+    // hai nhánh đó gửi hai dạng ngày khác nhau xuống backend.
+    const todayStr = useLocalDay();
     const isReservation = checkInDate > todayStr;
 
     // Step 2: Room selection
@@ -72,7 +76,10 @@ export default function GroupCheckinSheet() {
             setRoomType("all");
             setNights(1);
             setSource("walk-in");
-            setCheckInDate(new Date().toISOString().split("T")[0]);
+            // Ngày địa phương, cùng lý do đã ghi ở chỗ khởi tạo state phía trên:
+            // `toISOString()` trả ngày UTC, mà trước 07:00 giờ Việt Nam vẫn là
+            // hôm qua — reset form trong ca đêm sẽ đặt sai ngày nhận phòng.
+            setCheckInDate(localDateIso(new Date()));
             setSelectedRooms([]);
             setMasterRoomId("");
             setAssignMode("auto");

--- a/mhm/src/hooks/useLocalDay.test.tsx
+++ b/mhm/src/hooks/useLocalDay.test.tsx
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLocalDay } from "./useLocalDay";
+
+/** Giờ địa phương (test chạy ở Asia/Ho_Chi_Minh, ghim trong vitest.config.ts). */
+function localTime(iso: string) {
+    return new Date(iso);
+}
+
+describe("useLocalDay", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("reports the local day, not the UTC day", () => {
+        // 02:00 giờ Việt Nam ngày 21 = 19:00 UTC ngày 20. `toISOString()` sẽ trả
+        // ngày 20 — đó là cả lý do hook này tồn tại.
+        vi.setSystemTime(localTime("2026-04-21T02:00:00+07:00"));
+
+        const { result } = renderHook(() => useLocalDay());
+
+        expect(result.current).toBe("2026-04-21");
+    });
+
+    it("moves to the new day when local midnight passes", () => {
+        vi.setSystemTime(localTime("2026-04-21T23:59:00+07:00"));
+
+        const { result } = renderHook(() => useLocalDay());
+        expect(result.current).toBe("2026-04-21");
+
+        // Ca đêm: sheet mở từ trước nửa đêm, bấm nhận phòng sau nửa đêm.
+        act(() => {
+            vi.advanceTimersByTime(61_000 + 1_000);
+        });
+
+        expect(result.current).toBe("2026-04-22");
+    });
+
+    it("does not change before midnight, however long the form sits open", () => {
+        vi.setSystemTime(localTime("2026-04-21T08:00:00+07:00"));
+
+        const { result } = renderHook(() => useLocalDay());
+
+        act(() => {
+            vi.advanceTimersByTime(10 * 60 * 60 * 1_000);
+        });
+
+        // Không phải hook hết hạn theo thời gian — nó chỉ đổi khi *ngày* đổi.
+        expect(result.current).toBe("2026-04-21");
+    });
+
+    it("keeps ticking across a second midnight", () => {
+        vi.setSystemTime(localTime("2026-04-21T23:59:59+07:00"));
+
+        const { result } = renderHook(() => useLocalDay());
+
+        act(() => {
+            vi.advanceTimersByTime(2_000);
+        });
+        expect(result.current).toBe("2026-04-22");
+
+        // Hẹn lại được, chứ không phải chỉ bắn một lần: một máy để mở nhiều ngày
+        // vẫn phải đúng ngày.
+        act(() => {
+            vi.advanceTimersByTime(24 * 60 * 60 * 1_000);
+        });
+        expect(result.current).toBe("2026-04-23");
+    });
+
+    it("stops its timer when unmounted", () => {
+        vi.setSystemTime(localTime("2026-04-21T23:59:00+07:00"));
+
+        const { unmount } = renderHook(() => useLocalDay());
+        unmount();
+
+        // Cập nhật state sau khi unmount là một cảnh báo React và một rò rỉ;
+        // không có timer nào còn treo thì `getTimerCount()` phải về 0.
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/mhm/src/hooks/useLocalDay.ts
+++ b/mhm/src/hooks/useLocalDay.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+import { localDateIso } from "@/lib/timelineSelection";
+
+/** Nửa đêm kế tiếp theo giờ địa phương, tính từ `from`. */
+function nextLocalMidnight(from: Date): Date {
+    const midnight = new Date(from);
+    midnight.setHours(24, 0, 0, 0);
+    return midnight;
+}
+
+/**
+ * Ngày địa phương hiện tại (`YYYY-MM-DD`), **tự cập nhật khi qua nửa đêm**.
+ *
+ * Sinh ra vì mỗi form tự chụp `new Date()` một lần rồi giữ nguyên. Một sheet mở
+ * lúc 23:5x và bấm nhận phòng lúc 00:0x sẽ báo giá theo ngày hôm qua, trong khi
+ * backend thu tiền từ `Local::now()` — tức hôm nay. Hai mốc khác nhau nghĩa là
+ * tra `special_dates` khác nhau và phụ thu cuối tuần khác nhau, đúng cái bất biến
+ * mà cả mạch báo giá này dựng lên để bảo vệ.
+ *
+ * Quầy lễ tân trực đêm không phải trường hợp biên: đó là ca làm việc.
+ *
+ * Hẹn đúng tới nửa đêm kế tiếp chứ không polling: một `setTimeout` mỗi ngày,
+ * không có tick nào chạy không. `setHours(24, 0, 0, 0)` cho nửa đêm địa phương kể
+ * cả ngày đổi giờ, vì nó đi qua đúng lịch địa phương thay vì cộng 86.400.000ms.
+ */
+export function useLocalDay(): string {
+    const [day, setDay] = useState(() => localDateIso(new Date()));
+
+    useEffect(() => {
+        // +1s: hẹn *sau* mốc nửa đêm, không phải đúng mốc, để lần đọc lại chắc
+        // chắn đã sang ngày mới kể cả khi timer nhả sớm vài ms.
+        const delay = nextLocalMidnight(new Date()).getTime() - Date.now() + 1_000;
+        const timer = window.setTimeout(() => setDay(localDateIso(new Date())), delay);
+
+        return () => clearTimeout(timer);
+        // Chạy lại sau mỗi lần đổi ngày để hẹn tiếp nửa đêm sau.
+    }, [day]);
+
+    return day;
+}


### PR DESCRIPTION
Independent of #190 — no overlapping files, branched off `main`.

## The night shift is a shift, not an edge case

Three separate day derivations in the two sheets that take money at a front desk,
each wrong in its own way.

**1. The quote went stale at midnight.** `CheckinSheet` captured `new Date()` in a
memo keyed on `nights`. A sheet opened at 23:5x and submitted at 00:0x quoted
*yesterday*, while `check_in` charges from today's `Local::now()` — a different
`special_dates` row and a different weekend uplift. That is precisely the
invariant the preview mechanism exists to hold, broken by the clock instead of by
arithmetic.

**2. The availability window was on the UTC day.**
`now.toISOString().split("T")[0]`, so before 07:00 in Vietnam it asked whether the
room was free *the day before* the guest standing at the desk. **This one is a
regression I introduced**: I fixed it on the branch #185 abandoned, and did not
carry it across when rebuilding on `main`.

**3. The group form reset to the UTC day.** `setCheckInDate(new Date().toISOString()…)`
sat three lines below a comment explaining why that is wrong. Closing and
reopening the sheet on the night shift put yesterday in the arrival field, which
then reads as a backfill rather than today's walk-in.

**4. And `todayStr` was frozen.** `isReservation` compares the arrival against it;
with nothing to trigger a re-render, an arrival of "tomorrow" stayed classified as
a *reservation* after midnight had made it *today*. The two classifications send
different date shapes — bare `YYYY-MM-DD` versus an offset stamp — and
`group_lifecycle.rs` branches the same way against its own local today. Two
branches, one stay.

## The fix

`useLocalDay` answers "what local day is it" in one place, and re-answers when
midnight passes: a single `setTimeout` aimed at the next local midnight,
rescheduled after each turn, cleared on unmount. `setHours(24, 0, 0, 0)` rather
than `+86_400_000`, so a DST change cannot skew it. No polling — one timer per
day, no idle ticks.

Both sheets then derive their quote windows, their availability window and their
walk-in/reservation classification from it.

## Evidence

7 mutations. Six caught immediately. One **survived**:

| mutation | result |
|---|---|
| hook reads the UTC day | caught |
| hook never reschedules after the first turn | caught |
| hook leaks its timer on unmount | caught |
| check-in quote ignores the day turn | caught |
| availability window back to `toISOString()` | caught |
| `todayStr` frozen at first render | caught |
| **group form reset back to `toISOString()`** | **SURVIVED** |

The reset had no test at all — which is exactly how the `toISOString()` got there
and stayed under a comment saying not to do it. Adding one (close the sheet,
reopen it, read the arrival field at 02:00 local) makes it 7 of 7.

445 frontend tests · `npm run verify:full` exit 0 against the real Tauri app.

## Not fixed here

- `usePricePreview` still re-quotes only when its inputs change. Pinning the quote
  to the *day* is what matters for `special_dates` and the weekend uplift; the
  time-of-day component still drifts within a day, which affects early-check-in
  surcharge windows. Worth a look, but it is a different question from the one
  this fixes.
- `docs/` is gitignored at the repo root while `docs/architecture/` is tracked, so
  `git add` on those paths exits non-zero. It has already silently swallowed a
  commit in an earlier session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
