### PR TITLE
One answer for what an overpayment means

### DIFF
--- a/mhm/src/components/BackfillSheet.tsx
+++ b/mhm/src/components/BackfillSheet.tsx
@@ -9,6 +9,7 @@ import { formatAppError } from "@/lib/appError";
 import { createCorrelationId } from "@/lib/correlationId";
 import { invokeWriteCommand } from "@/lib/invokeCommand";
 import { getRoomTypeLabel } from "@/lib/constants";
+import { bookingBalance } from "@/lib/bookingBalance";
 import { fmtNumber } from "@/lib/format";
 import { addDaysIso, localDateIso, nightsBetween } from "@/lib/timelineSelection";
 import { toast } from "sonner";
@@ -148,7 +149,10 @@ export default function BackfillSheet({ open, onOpenChange, prefill }: Props) {
     // ra "đã trả phòng" lại nằm sau hôm nay).
     const todayIso = localDateIso(new Date());
 
-    const paidTooHigh = paid > total;
+    // Cùng vị từ với `CheckoutSettlementModal` và hai màn hình hiện số dư: thu
+    // nhiều hơn tiền phòng là "thu quá". Chỗ này từng viết lại `paid > total`
+    // bằng tay — cùng một câu hỏi, phát biểu lần thứ tư.
+    const paidTooHigh = bookingBalance(total, paid).kind === "overpaid";
     const paidNegative = paid < 0;
     const canSubmit =
         !!roomId &&

--- a/mhm/src/components/CheckoutSettlementModal.tsx
+++ b/mhm/src/components/CheckoutSettlementModal.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 import InfoItem from "@/components/shared/InfoItem";
 import Modal from "@/components/ui/Modal";
+import { bookingBalance } from "@/lib/bookingBalance";
 import { fmtMoney } from "@/lib/format";
 import type {
     Booking,
@@ -94,7 +95,11 @@ export default function CheckoutSettlementModal({
         return null;
     }
 
-    const overpaid = booking.paid_amount > finalTotal;
+    // Cùng một hàm với hai màn hình hiện số dư, nên "đã thu quá" ở đây và
+    // "Trả lại khách" ở đó luôn là cùng một điều kiện. Tổng đem so là
+    // `finalTotal` — số đang được chốt, có thể sửa tay — không phải
+    // `booking.total_price`; hai câu hỏi khác nhau, cùng một phép so.
+    const overpaid = bookingBalance(finalTotal, booking.paid_amount).kind === "overpaid";
     const confirmDisabled =
         loadingPreview || submitting || preview === null || finalTotal < 0 || overpaid;
 

--- a/mhm/src/components/RoomDetailPanel.test.tsx
+++ b/mhm/src/components/RoomDetailPanel.test.tsx
@@ -147,3 +147,66 @@ describe("RoomDetailPanel nightly rate", () => {
         expect(screen.getByTestId("room-detail-nightly-rate").textContent).toBe("—");
     });
 });
+
+describe("RoomDetailPanel payment balance", () => {
+    function renderWithPayment(totalPrice: number, paidAmount: number) {
+        return render(
+            <RoomDetailPanel
+                mode="page"
+                roomDetail={{
+                    room: {
+                        id: "101",
+                        name: "101",
+                        type: "standard",
+                        floor: 1,
+                        has_balcony: false,
+                        base_price: 500000,
+                        max_guests: 2,
+                        extra_person_fee: 0,
+                        status: "occupied",
+                    },
+                    booking: {
+                        id: "B700",
+                        room_id: "101",
+                        primary_guest_id: "G1",
+                        check_in_at: "2026-04-20T08:00:00+07:00",
+                        expected_checkout: "2026-04-22T12:00:00+07:00",
+                        nights: 2,
+                        total_price: totalPrice,
+                        paid_amount: paidAmount,
+                        status: "active",
+                        created_at: "2026-04-20T08:00:00+07:00",
+                    },
+                    guests: [],
+                }}
+            />,
+        );
+    }
+
+    /// The panel rendered "Còn nợ −3.800.000đ" in slate grey, which reads as
+    /// *nothing owed*. Meanwhile `CheckoutSettlementModal` refuses to check the
+    /// booking out until the refund is handled — so the screen the desk looks at
+    /// first gave no sign of the state that blocks them.
+    it("names an overpayment as money owed back to the guest", () => {
+        renderWithPayment(1_200_000, 5_000_000);
+
+        expect(screen.getByText("Trả lại khách")).toBeInTheDocument();
+        expect(screen.getByText("3.800.000đ")).toBeInTheDocument();
+        expect(screen.queryByText(/-3\.800\.000/)).not.toBeInTheDocument();
+        expect(screen.queryByText("Còn nợ")).not.toBeInTheDocument();
+    });
+
+    it("still names a real debt a debt", () => {
+        renderWithPayment(1_200_000, 500_000);
+
+        expect(screen.getByText("Còn nợ")).toBeInTheDocument();
+        expect(screen.getByText("700.000đ")).toBeInTheDocument();
+    });
+
+    it("says a fully paid booking is settled rather than owing zero", () => {
+        renderWithPayment(1_200_000, 1_200_000);
+
+        expect(screen.getByText("Đã đủ")).toBeInTheDocument();
+    });
+});
+

--- a/mhm/src/components/RoomDetailPanel.tsx
+++ b/mhm/src/components/RoomDetailPanel.tsx
@@ -25,6 +25,7 @@ import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
+import { BALANCE_TONE_CLASS, balanceDisplay } from "@/lib/bookingBalance";
 import { fmtDate, fmtDateShort, fmtMoney } from "@/lib/format";
 import { nightlyRateDisplay } from "@/lib/roomTypeRate";
 import { useHotelStore } from "@/stores/useHotelStore";
@@ -126,7 +127,10 @@ export default function RoomDetailPanel({
   // số engine bỏ qua khi loại phòng có bảng giá.
   const nightlyRate = nightlyRateDisplay(roomTypeRates, room.type);
   const derivedRateHint = nightlyRate.derived ? " (chưa cấu hình bảng giá)" : "";
-  const outstandingAmount = booking ? booking.total_price - booking.paid_amount : 0;
+  // Một chỗ duy nhất quyết định nhãn và màu của số dư. Trước đây chỗ này hiện
+  // "Còn nợ −3.800.000đ" màu xám khi thu quá — trong khi đúng trạng thái đó lại
+  // đang chặn trả phòng ở `CheckoutSettlementModal`.
+  const balance = booking ? balanceDisplay(booking.total_price, booking.paid_amount) : null;
 
   const guestSection = <RoomGuestsSection guests={guests} mode={mode} />;
 
@@ -186,11 +190,13 @@ export default function RoomDetailPanel({
               <div className="grid grid-cols-3 gap-3 text-center">
                 <PaymentBlock label="Tổng tiền" value={fmtMoney(booking.total_price)} color="text-slate-900" />
                 <PaymentBlock label="Đã trả" value={fmtMoney(booking.paid_amount)} color="text-emerald-600" />
-                <PaymentBlock
-                  label="Còn nợ"
-                  value={fmtMoney(outstandingAmount)}
-                  color={outstandingAmount > 0 ? "text-red-600" : "text-slate-400"}
-                />
+                {balance && (
+                  <PaymentBlock
+                    label={balance.label}
+                    value={balance.text}
+                    color={BALANCE_TONE_CLASS[balance.tone]}
+                  />
+                )}
               </div>
             </Section>
 

--- a/mhm/src/lib/bookingBalance.test.ts
+++ b/mhm/src/lib/bookingBalance.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { BALANCE_TONE_CLASS, balanceDisplay, bookingBalance } from "./bookingBalance";
+
+describe("bookingBalance", () => {
+    it("reports what is still owed", () => {
+        expect(bookingBalance(1_200_000, 500_000)).toEqual({ kind: "owed", amount: 700_000 });
+    });
+
+    it("reports a settled booking as settled, not as owing zero", () => {
+        // Khác nhau ở nhãn: "Đã đủ" và "Còn nợ 0đ" không đọc giống nhau ở quầy.
+        expect(bookingBalance(1_200_000, 1_200_000)).toEqual({ kind: "settled" });
+    });
+
+    it("reports an overpayment as a refund owed to the guest", () => {
+        expect(bookingBalance(1_200_000, 5_000_000)).toEqual({
+            kind: "overpaid",
+            refund: 3_800_000,
+        });
+    });
+
+    it("counts a refund as positive, never as a negative debt", () => {
+        const balance = bookingBalance(1_200_000, 5_000_000);
+
+        // Cả hai màn hình cũ đều hiện −3.800.000đ. Con số có nghĩa là 3.800.000đ
+        // phải trả lại khách; dấu trừ thuộc về nhãn, không thuộc về số tiền.
+        expect(balance.kind === "overpaid" && balance.refund).toBeGreaterThan(0);
+    });
+
+    it("treats a zero-total booking with a payment as overpaid", () => {
+        expect(bookingBalance(0, 100_000)).toEqual({ kind: "overpaid", refund: 100_000 });
+    });
+});
+
+describe("balanceDisplay", () => {
+    it("labels an overpayment as money going back to the guest", () => {
+        const display = balanceDisplay(1_200_000, 5_000_000);
+
+        expect(display.label).toBe("Trả lại khách");
+        expect(display.text).toContain("3.800.000");
+        expect(display.text).not.toContain("-");
+        expect(display.tone).toBe("overpaid");
+    });
+
+    it("labels a debt as a debt", () => {
+        const display = balanceDisplay(1_200_000, 500_000);
+
+        expect(display.label).toBe("Còn nợ");
+        expect(display.text).toContain("700.000");
+        expect(display.tone).toBe("owed");
+    });
+
+    it("does not paint an overpayment the same colour as a debt", () => {
+        // Đỏ ở đây là sai nghĩa: không ai đang nợ tiền nhà.
+        expect(BALANCE_TONE_CLASS.overpaid).not.toBe(BALANCE_TONE_CLASS.owed);
+        expect(BALANCE_TONE_CLASS.overpaid).not.toBe(BALANCE_TONE_CLASS.settled);
+    });
+});

--- a/mhm/src/lib/bookingBalance.ts
+++ b/mhm/src/lib/bookingBalance.ts
@@ -1,0 +1,65 @@
+import { fmtMoney } from "@/lib/format";
+import type { MoneyVnd } from "@/lib/money";
+
+/**
+ * Một booking đứng ở đâu giữa số đã thu và số phải thu.
+ *
+ * Ba trạng thái, và trạng thái thứ ba **chặn** việc trả phòng:
+ * `CheckoutSettlementModal` không cho bấm xác nhận khi đã thu quá và bảo xử lý
+ * hoàn tiền trước. Nhưng luật đó chỉ nằm trong phần render của đúng cái modal ấy
+ * — nên hai màn hình mà lễ tân nhìn thấy trước lại vẽ cùng trạng thái đó theo hai
+ * kiểu khác nhau, không kiểu nào nói rằng nó đang chặn:
+ *
+ * - `RoomDetailPanel` hiện "Còn nợ −3.800.000đ" màu xám nhạt — đọc như *không nợ gì*.
+ * - `GroupManagement` hiện "Còn lại −3.800.000đ" đỏ đậm — đọc như khách nợ một số âm.
+ *
+ * Cả hai đều là số vô nghĩa. Số có nghĩa là **3.800.000đ phải trả lại khách**.
+ */
+export type BookingBalance =
+  | { kind: "owed"; amount: MoneyVnd }
+  | { kind: "settled" }
+  | { kind: "overpaid"; refund: MoneyVnd };
+
+export function bookingBalance(total: MoneyVnd, paid: MoneyVnd): BookingBalance {
+  if (paid > total) return { kind: "overpaid", refund: paid - total };
+  if (paid === total) return { kind: "settled" };
+
+  return { kind: "owed", amount: total - paid };
+}
+
+export type BalanceTone = "owed" | "settled" | "overpaid";
+
+export interface BalanceDisplay {
+  /** Nhãn đổi theo trạng thái: "Còn nợ" và "Trả lại khách" không cùng nghĩa. */
+  label: string;
+  /** Luôn là số dương — dấu đã nằm trong nhãn. */
+  text: string;
+  tone: BalanceTone;
+}
+
+export function balanceDisplay(total: MoneyVnd, paid: MoneyVnd): BalanceDisplay {
+  const balance = bookingBalance(total, paid);
+
+  switch (balance.kind) {
+    case "overpaid":
+      return { label: "Trả lại khách", text: fmtMoney(balance.refund), tone: "overpaid" };
+    case "settled":
+      return { label: "Đã đủ", text: fmtMoney(0), tone: "settled" };
+    default:
+      return { label: "Còn nợ", text: fmtMoney(balance.amount), tone: "owed" };
+  }
+}
+
+/**
+ * Một bảng màu duy nhất. Trước đây mỗi màn hình tự chọn: `text-red-600` ở panel,
+ * `text-red-500` ở màn hình đoàn, và cả hai dùng đỏ cho một trạng thái mà đỏ là
+ * sai nghĩa. Trả về `tone` mà để mỗi màn hình tự map thì chúng lại lệch nhau lần
+ * nữa, nên map nằm ở đây.
+ */
+export const BALANCE_TONE_CLASS: Record<BalanceTone, string> = {
+  owed: "text-red-600",
+  settled: "text-slate-400",
+  // Hổ phách, không phải đỏ: đây không phải khoản khách nợ, mà là việc nhà phải
+  // làm trước khi trả phòng được.
+  overpaid: "text-amber-600",
+};

--- a/mhm/src/pages/GroupManagement.tsx
+++ b/mhm/src/pages/GroupManagement.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import EmptyState from "@/components/shared/EmptyState";
 import SlideDrawer from "@/components/shared/SlideDrawer";
 import { formatAppError } from "@/lib/appError";
+import { BALANCE_TONE_CLASS, balanceDisplay } from "@/lib/bookingBalance";
 import { fmtMoney, fmtDateShort } from "@/lib/format";
 import { toast } from "sonner";
 import { Users, Plus, Trash2, FileText, LogOut, ChevronRight } from "lucide-react";
@@ -347,12 +348,20 @@ export default function GroupManagement() {
                                 <span>Đã thanh toán</span>
                                 <span className="font-semibold text-emerald-600">{fmtMoney(detail.paid_amount)}</span>
                             </div>
-                            <div className="flex justify-between text-sm">
-                                <span>Còn lại</span>
-                                <span className="font-bold text-red-500">
-                                    {fmtMoney(detail.grand_total - detail.paid_amount)}
-                                </span>
-                            </div>
+                            {(() => {
+                                // Cùng một hàm với `RoomDetailPanel` và với luật
+                                // chặn trả phòng, nên ba chỗ không thể mô tả một
+                                // trạng thái theo ba kiểu nữa.
+                                const balance = balanceDisplay(detail.grand_total, detail.paid_amount);
+                                return (
+                                    <div className="flex justify-between text-sm">
+                                        <span>{balance.label}</span>
+                                        <span className={`font-bold ${BALANCE_TONE_CLASS[balance.tone]}`}>
+                                            {balance.text}
+                                        </span>
+                                    </div>
+                                );
+                            })()}
                         </div>
 
                         {/* Invoice button */}


### PR DESCRIPTION
**Stacked on #190** — it edits the same region of `RoomDetailPanel.tsx`, so I
rebased onto that branch rather than leaving you a conflict to resolve. I checked
empirically: branched off `main` it conflicts on `RoomDetailPanel.tsx` and its test.
GitHub retargets this to `main` once #190 merges. Only my commit shows in the diff.

## The state that blocks checkout was invisible

`CheckoutSettlementModal` refuses to check a booking out when more has been paid
than is being settled, and tells the operator to handle the refund first. **That
rule lives in that modal's render and nowhere else.** So the two screens a
receptionist looks at first drew the same state two different ways, and neither
said it was blocking anything:

| screen | showed | reads as |
|---|---|---|
| `RoomDetailPanel` | "Còn nợ **−3.800.000đ**" in slate grey | nothing owed |
| `GroupManagement` | "Còn lại **−3.800.000đ**" in bold red | the guest owes a negative amount |

Both numbers are meaningless. The meaningful one is 3.800.000đ **owed back to the
guest** — and the desk finds that out only after pressing Check-out and being
refused.

## The fix

`bookingBalance` names the three states — owed, settled, overpaid — and
`balanceDisplay` gives each a label, a **positive** amount and a tone. The minus
sign belongs in the label, not in the money.

Amber for an overpayment, not red: nobody owes the house anything. There is
something the house has to do before the room can be released.

The modal derives its own flag from the same function, so "overpaid" there and
"Trả lại khách" on the panels cannot drift apart. It keeps comparing against
`finalTotal` — the editable amount being settled — rather than
`booking.total_price`: two different questions, one predicate.

`BALANCE_TONE_CLASS` is one palette. The screens had independently picked
`text-red-600` and `text-red-500`, which is how two screens come to disagree about
a colour that carries meaning.

## Found and deliberately not fixed

**There is no backend guard at all.** The overpayment block is purely this modal's
UI, so `check_out` accepts an overpaid settlement from any other caller, and the
group checkout path has no equivalent block. Whether an overpaid checkout should
be rejected in the service — and what a refund record would look like — is a
product decision, not a refactor. I've made the state visible and consistent; I
have not changed what the system permits.

## Evidence

7 mutations, all caught:

| mutation | caught by |
|---|---|
| overpaid collapses into a negative debt | `reports an overpayment as a refund owed…` |
| refund's sign flipped | `counts a refund as positive, never as a negative debt` |
| settled folded into owed | `reports a settled booking as settled…` |
| overpayment painted like a debt | `does not paint an overpayment the same colour as a debt` |
| overpayment relabelled "Còn nợ" | `names an overpayment as money owed back to the guest` |
| modal stops blocking overpaid | the pre-existing `blocks confirm when…already overpaid` |
| modal points at the wrong total | same test |

479 frontend tests · 954 Rust tests · `npm run verify:full` exit 0 against the real
Tauri app, re-run after the rebase since the conflict resolution changed real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
