### PR TITLE
The night audit defaulted to a UTC-derived day

### DIFF
--- a/mhm/src/pages/Dashboard.expenseRange.test.tsx
+++ b/mhm/src/pages/Dashboard.expenseRange.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearMockResponses, invoke, setMockResponse } from "@test-mocks/tauri-core";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import Dashboard from "./Dashboard";
+
+function expenseRange(): { from: string; to: string } | null {
+    const call = invoke.mock.calls.find(([command]) => command === "get_expenses");
+    return call ? (call[1] as { from: string; to: string }) : null;
+}
+
+describe("Dashboard expense range", () => {
+    beforeEach(() => {
+        clearMockResponses();
+        invoke.mockClear();
+        setMockResponse("get_analytics", () => ({ daily_revenue: [] }));
+        setMockResponse("get_expenses", () => []);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    /// The backend buckets revenue and expenses by `substr(created_at, 1, 10)` of
+    /// a **local** rfc3339 stamp (`revenue_queries::local_date_sql`). A range built
+    /// from `toISOString()` is a UTC range, so for the first seven hours of every
+    /// Vietnamese day it asked about a window shifted a day back.
+    it("asks for a local-day window, not a UTC one", async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-04-22T02:00:00+07:00"));
+
+        render(<Dashboard />);
+
+        await vi.waitFor(() => expect(expenseRange()).not.toBeNull());
+        // 02:00 local on the 22nd is 19:00 UTC on the 21st — `toISOString()` would
+        // have said "2026-04-21" here.
+        expect(expenseRange()!.to).toBe("2026-04-22");
+    });
+
+    it("spans thirty days through the calendar, across a month boundary", async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-05-01T02:00:00+07:00"));
+
+        render(<Dashboard />);
+
+        await vi.waitFor(() => expect(expenseRange()).not.toBeNull());
+        expect(expenseRange()).toEqual({ from: "2026-04-01", to: "2026-05-01" });
+    });
+});

--- a/mhm/src/pages/Dashboard.tsx
+++ b/mhm/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { Users, DoorOpen, Paintbrush, TrendingUp, ShieldCheck } from "lucide-rea
 import { invokeCommand } from "@/lib/invokeCommand";
 import { invoke } from "@tauri-apps/api/core";
 import { fmtDateShort, fmtMoney, fmtNumber } from "@/lib/format";
+import { addDaysIso, localDateIso } from "@/lib/timelineSelection";
 import type { ActivityItem, BookingWithGuest, ChartDataPoint, ExpenseItem, RoomAvailability } from "@/types";
 
 const DAY_NAMES = ["CN", "T2", "T3", "T4", "T5", "T6", "T7"];
@@ -45,9 +46,12 @@ export default function Dashboard() {
         }
         setRoomAvailability(map);
       }).catch(() => { });
-    const today = new Date();
-    const from = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
-    const to = today.toISOString().split("T")[0];
+    // Ngày địa phương: backend gom doanh thu theo `substr(created_at, 1, 10)` của
+    // mốc giờ địa phương (`revenue_queries::local_date_sql`), nên một khoảng ngày
+    // UTC lệch mất một ngày trong bảy giờ đầu mỗi ngày ở Việt Nam. `addDaysIso`
+    // đi qua lịch địa phương thay vì trừ 30 × 86.400.000ms.
+    const to = localDateIso(new Date());
+    const from = addDaysIso(to, -30);
     invoke<{ daily_revenue: { date: string; revenue: number }[] }>("get_analytics", { period: "7d" })
       .then((data) => {
         const mapped = data.daily_revenue.map((d) => {

--- a/mhm/src/pages/NightAudit.test.tsx
+++ b/mhm/src/pages/NightAudit.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createAppErrorException,
@@ -134,5 +134,58 @@ describe("NightAudit", () => {
       );
     });
     expect(toastError).toHaveBeenCalledWith(formatAppError(error));
+  });
+});
+
+describe("NightAudit default audit date", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invokeCommand.mockReset();
+    invoke.mockResolvedValue([]);
+    useAuthStore.setState({
+      user: { id: "u1", name: "Admin", role: "admin", active: true, created_at: "" },
+      isAuthenticated: true,
+      loading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function renderAt(when: Date) {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(when);
+    const { container } = render(<NightAudit />);
+    return (container.querySelector('input[type="date"]') as HTMLInputElement).value;
+  }
+
+  /// The audit is one-shot per date — `run_night_audit` refuses a re-run and
+  /// `mark_bookings_audited_tx` stamps the bookings — and nothing stops it
+  /// auditing a day still in progress. So the default date decides whether a
+  /// date gets permanently closed with partial revenue.
+  it("defaults to the local day that has ended, on the night shift", () => {
+    // 01:00 on the 22nd in Vietnam. The day that just ended is the 21st.
+    expect(renderAt(new Date("2026-04-22T01:00:00+07:00"))).toBe("2026-04-21");
+  });
+
+  it("defaults to the same completed day during the working day", () => {
+    // The old `toISOString()` value flipped here — 09:00 gave the 22nd, 01:00
+    // gave the 21st — a rule that changes at 07:00 for no stateable reason.
+    expect(renderAt(new Date("2026-04-22T09:00:00+07:00"))).toBe("2026-04-21");
+  });
+
+  it("never defaults to a day still in progress", () => {
+    for (const hour of ["00:30", "06:59", "07:01", "23:30"]) {
+      vi.useRealTimers();
+      const value = renderAt(new Date(`2026-04-22T${hour}:00+07:00`));
+      expect(value).not.toBe("2026-04-22");
+      expect(value).toBe("2026-04-21");
+    }
+  });
+
+  it("crosses a month boundary through the calendar, not by subtracting a day of milliseconds", () => {
+    expect(renderAt(new Date("2026-05-01T02:00:00+07:00"))).toBe("2026-04-30");
   });
 });

--- a/mhm/src/pages/NightAudit.tsx
+++ b/mhm/src/pages/NightAudit.tsx
@@ -10,15 +10,26 @@ import { invokeCommand } from "@/lib/invokeCommand";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { Moon, TrendingUp, Home, DollarSign, AlertCircle } from "lucide-react";
 import { fmtMoney } from "@/lib/format";
+import { addDaysIso, localDateIso } from "@/lib/timelineSelection";
 import type { AuditLog } from "@/types";
 
 export default function NightAudit() {
     const { isAdmin } = useAuthStore();
     const [logs, setLogs] = useState<AuditLog[]>([]);
-    const [auditDate, setAuditDate] = useState(() => {
-        const d = new Date();
-        return d.toISOString().slice(0, 10);
-    });
+    // **Ngày mặc định là ngày địa phương hôm qua** — ngày đã kết thúc.
+    //
+    // Trước đây là `toISOString()`, tức ngày UTC: từ 00:00 đến 07:00 giờ Việt Nam
+    // nó ra hôm qua, còn lại ra hôm nay. Không ai chọn luật đó — nó là hệ quả của
+    // múi giờ, và nó lật lúc 07:00 mà không giải thích được với ai.
+    //
+    // Chọn "hôm qua" vì việc này đóng sổ một ngày đã xong, và vì audit là **một
+    // lần cho mỗi ngày**: `run_night_audit` chặn chạy lại và `mark_bookings_audited_tx`
+    // đóng dấu các booking. Audit một ngày còn đang chạy sẽ chốt vĩnh viễn ngày đó
+    // với doanh thu chưa đủ — không có chỗ nào chặn việc đó. Ô ngày vẫn sửa được
+    // nếu quy ước đóng ngày của khách sạn khác.
+    const [auditDate, setAuditDate] = useState(() =>
+        addDaysIso(localDateIso(new Date()), -1),
+    );
     const [notes, setNotes] = useState("");
     const [running, setRunning] = useState(false);
 
@@ -78,6 +89,11 @@ export default function NightAudit() {
                                 onChange={(e) => setAuditDate(e.target.value)}
                                 className="bg-white/20 border-white/30 text-white placeholder:text-white/50 w-44"
                             />
+                            {/* Mặc định là ngày đã kết thúc, và audit chỉ chạy được
+                                một lần cho mỗi ngày — nên nói rõ đang đóng ngày nào. */}
+                            <p className="text-[11px] text-white/60 mt-1" data-testid="audit-date-hint">
+                                Đóng sổ ngày đã kết thúc. Mỗi ngày chỉ audit được một lần.
+                            </p>
                         </div>
                         <div className="flex-1">
                             <label className="text-xs text-white/70 block mb-1">Ghi chú</label>


### PR DESCRIPTION
Independent of #190, #191 and #192 — verified by trial merge, no overlapping files.

## Why this one matters more than a display bug

`NightAudit` pre-filled its date from `new Date().toISOString().slice(0, 10)` — the
**UTC** day. In Vietnam that yields *yesterday* between 00:00 and 07:00 and *today*
the rest of the time. Nobody chose that rule. It is a timezone artifact that flips
at 07:00 for no reason anyone could state out loud.

What the audit does with that date:

- `run_night_audit` refuses a second run once a date has a log;
- `mark_bookings_audited_tx` stamps that date's bookings;
- **nothing prevents auditing a day that is still in progress.**

So the default date decides whether a date gets *permanently closed out with partial
revenue*. And the figures it summarises are bucketed by **local** date —
`local_date_sql` is `substr(created_at, 1, 10)` over `Local::now().to_rfc3339()`
stamps — so a UTC-derived date does not even line up with what it is closing.

## The decision

The default is now **the local day that has ended** (yesterday), stated rather than
inherited:

- it is what the accidental value produced during the hours a night audit is
  actually run;
- it is the safer reading in both windows — auditing a completed day cannot lock
  away revenue that has not landed yet, whereas defaulting to today can;
- the field stays editable, and the screen now says which day it is closing and
  that a day can only be audited once.

If the hotel's day-close convention differs, the default is one line. The point is
that it is now a decision with a reason attached instead of a byproduct of UTC+7.

## Also

`Dashboard`'s 30-day expense window had the same UTC derivation, plus
`- 30 * 24 * 60 * 60 * 1000` rather than walking the calendar. Both now go through
`localDateIso` / `addDaysIso`.

## Evidence

5 mutations, all caught:

| mutation | result |
|---|---|
| audit default back to `toISOString()` | caught |
| audit default to today | caught |
| audit default off-by-one the other way | caught |
| dashboard range back to `toISOString()` | caught |
| dashboard range span changed | caught |

`Dashboard` had no test file at all. It turns out to render in isolation, so the
range is now actually covered rather than asserted by comment.

442 frontend tests · `npm run verify:full` exit 0 against the real Tauri app.

## Not fixed here

**Nothing stops the audit closing a day still in progress.** That is a backend
guard and a product question — what the day-close cutoff is, and whether a
premature audit should be refused outright or merely warned about. This PR removes
the accidental default that made stumbling into it likely; it does not add the
guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
