### PR TITLE
test(reservations): phủ ca gia hạn-rồi-checkout với timestamp có offset

### DIFF
--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -178,6 +178,48 @@ describe("09 — Reservations", () => {
         expect(bar.style.width).toBe("160px");
     });
 
+    it("cắt bar khi khách bị gia hạn rồi trả phòng (dữ liệu thật, timestamp có offset)", async () => {
+        // Ca thật do chủ khách sạn báo: Su Huijan phòng 1B nhận 29/07 16:33, bị bấm
+        // gia hạn nên expected_checkout thành 31/07, rồi trả phòng 30/07 09:54.
+        // Backend ghi timestamp dạng RFC3339 kèm offset "+07:00" và micro-giây
+        // (chrono Local::now().to_rfc3339()) — khác định dạng "Z" mà test trên dùng,
+        // nên đường parse này cần được phủ riêng.
+        const atLocalOffset = (dayShift: number, hour: number, minute: number) => {
+            const d = new Date();
+            d.setDate(d.getDate() + dayShift);
+            d.setHours(hour, minute, 8, 0);
+            const offsetMinutes = -d.getTimezoneOffset();
+            const sign = offsetMinutes >= 0 ? "+" : "-";
+            const pad = (n: number) => String(Math.abs(n)).padStart(2, "0");
+            const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+                + `T${pad(d.getHours())}:${pad(d.getMinutes())}:08.752504`
+                + `${sign}${pad(Math.trunc(offsetMinutes / 60))}:${pad(offsetMinutes % 60)}`;
+            return stamp;
+        };
+
+        setMockResponse("get_all_bookings", () => [
+            createBookingWithGuest({
+                id: "b-su-huijan",
+                room_id: "1B",
+                guest_name: "Su Huijan",
+                status: "checked_out",
+                check_in_at: atLocalOffset(-1, 16, 33),
+                expected_checkout: atLocalOffset(1, 16, 33),
+                actual_checkout: atLocalOffset(0, 9, 54),
+            }),
+        ]);
+
+        render(<Reservations />);
+
+        const bar = await screen.findByTestId("booking-bar-b-su-huijan");
+        // Cột đầu = hôm nay − 3. Nhận phòng hôm qua → cột 2 → left (2 + 0.5) × 80 = 200px.
+        // Kết thúc tại actual_checkout (hôm nay, cột 3) → width (3.5 − 2.5) × 80 = 80px.
+        // Bản chưa vá vẽ tới expected_checkout (ngày mai, cột 4) → width 160px.
+        expect(bar.style.left).toBe("200px");
+        expect(bar.style.width).toBe("80px");
+        expect(bar.style.width).not.toBe("160px");
+    });
+
     it("bấm ô hôm nay mở check-in với phòng và số đêm", async () => {
         render(<Reservations />);
         const cell = await screen.findByTestId("cell-1A-3"); // cột 3 = hôm nay


### PR DESCRIPTION
Chủ khách sạn báo phòng 1B vẫn thừa 1 ngày cho khách Su Huijan — khách bị bấm gia hạn nhầm rồi trả phòng. Điều tra cho thấy **code trên `main` đã đúng**; máy đang chạy bản build từ 28/07, cũ hơn bản vá (PR #187, merge 29/07).

Nhưng ca thật này lộ ra một khoảng trống trong test.

## Khoảng trống

Test hồi quy hiện có (`cắt bar của booking đã trả tại ngày trả thực tế`) đi đúng nhánh logic này, nhưng dựng timestamp bằng `toISOString()` — ra dạng `Z` (UTC).

Backend thật ghi `chrono::Local::now().to_rfc3339()`, tức dạng có offset kèm micro-giây:

```
2026-07-30T09:54:08.752504+07:00
```

Đường parse đó chưa có test nào phủ.

## Test thêm vào

Dựng đúng theo bản ghi thật của Su Huijan:

| | |
|---|---|
| Nhận phòng | hôm qua 16:33 |
| `expected_checkout` | ngày mai 16:33 ← do bấm gia hạn nhầm |
| `actual_checkout` | hôm nay 09:54 |

Test tự tính offset theo múi giờ của máy chạy test nên không phụ thuộc `TZ`.

## Bằng chứng test có thể fail

Tạm gỡ điều kiện `status === "checked_out" && actual_checkout` trong `getBookingBars`:

```
AssertionError: expected '160px' to be '80px'
```

160px so với 80px chênh đúng một cột 80px — đúng bằng "thừa 1 ngày" mà chủ khách sạn nhìn thấy trên màn hình.

## Kiểm thử

`npx vitest run tests/e2e/09-reservations.test.tsx` → 15/15 pass trên `main` hiện tại.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
