### PR TITLE
fix(reservations): liệt kê phòng theo ngày đặt, không theo trạng thái hôm nay

### DIFF
--- a/mhm/src/components/ReservationSheet.test.tsx
+++ b/mhm/src/components/ReservationSheet.test.tsx
@@ -847,50 +847,78 @@ describe("ReservationSheet", () => {
     expect(checkInAfterRerender.value).toBe("2026-08-10");
   });
 
-  // Ô lịch tương lai của một phòng ĐANG CÓ KHÁCH vẫn kéo được (khách rời sau
-  // hai hôm), và cú kéo truyền thẳng roomId vào đây. Danh sách chỉ liệt kê
-  // vacant/booked, nên phòng đó không có option nào khớp: ô "Phòng" hiện
-  // trống trong khi state vẫn giữ id — và nút gửi vẫn sáng, vì nó gác trên
-  // `!roomId`, mà id vô hình kia là truthy.
-  it("bỏ chọn phòng khi phòng kéo từ lịch không nằm trong danh sách chọn được", async () => {
+  // Ca chủ khách sạn báo: phòng 5A đang có khách, khách trả ngày 3/8. Đặt
+  // trước cho 12–13/8 thì 5A không hề xuất hiện trong ô chọn phòng — nó là
+  // phòng duy nhất `occupied`, và cũng là phòng duy nhất biến mất.
+  //
+  // Trạng thái phòng nói về HÔM NAY; đặt phòng trước hỏi về một khoảng ngày
+  // khác hẳn. Cửa chặn đúng chiều thời gian là check_availability (theo
+  // khoảng ngày) và chốt chặn trong transaction ở create_reservation_tx —
+  // danh sách phòng không được đoán thay chúng.
+  it.each(["occupied", "cleaning"])(
+    "vẫn liệt kê phòng đang %s để đặt trước cho ngày phòng đó đã trống",
+    async (status) => {
+      rooms = [ORIGINAL_ROOMS[0], { ...ORIGINAL_ROOMS[1], status }];
+      render(<ReservationSheet open onOpenChange={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(fetchRooms).toHaveBeenCalledTimes(1);
+      });
+
+      expect(
+        Array.from(
+          (screen.getByLabelText(/^Phòng$/) as HTMLSelectElement).options,
+        ).map((o) => o.value),
+      ).toContain("R102");
+    },
+  );
+
+  // Ô lịch TƯƠNG LAI của một phòng đang có khách vẫn kéo được, và cú kéo
+  // truyền thẳng roomId đó vào đây. Phòng phải ở nguyên trong ô chọn: xoá đi
+  // là biến một cú kéo hợp lệ thành một form trống không rõ lý do.
+  it("giữ nguyên phòng kéo từ lịch dù phòng đó đang có khách", async () => {
     rooms = [
       ORIGINAL_ROOMS[0],
       { ...ORIGINAL_ROOMS[1], status: "occupied" },
     ];
-    const { rerender } = render(
-      <ReservationSheet open onOpenChange={vi.fn()} preSelectedRoomId="R102" />,
+    render(
+      <ReservationSheet
+        open
+        onOpenChange={vi.fn()}
+        preSelectedRoomId="R102"
+        prefillDates={{ checkIn: "2026-08-12", checkOut: "2026-08-13" }}
+      />,
     );
 
     const roomSelect = screen.getByLabelText(/^Phòng$/) as HTMLSelectElement;
     await waitFor(() => {
-      expect(roomSelect).toHaveValue("");
+      expect(roomSelect).toHaveValue("R102");
     });
-    // Điền tên khách trước — nút gửi cũng khoá bởi `!isEditMode && !guestName`
-    // (xem disabled expression trong ReservationSheet.tsx), nên nếu bỏ qua
-    // bước này, assertion dưới đúng bất kể roomId có bị xoá hay không và
-    // không chứng minh được gì cho chính bug đang test. Điền tên vào rồi thì
-    // việc phòng bị xoá mới là lý do DUY NHẤT còn giữ nút tắt.
+
+    // Nút gửi phải bật lên được: với phòng còn nguyên và tên khách đã điền,
+    // không còn gì chặn chủ khách sạn đặt phòng cho 12–13/8.
     fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
       target: { value: "Nguyễn Nhật Huy" },
     });
-    // Nút gửi phải tắt: bật lên với một phòng vô hình chỉ dẫn tới một cú từ
-    // chối ở backend.
-    expect(screen.getByRole("button", { name: /Đặt phòng/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Đặt phòng/ })).toBeEnabled();
+  });
 
-    // Ô trống chưa chứng minh gì — jsdom cũng hiện trống khi state còn giữ
-    // R102 mà option đã bị lọc mất. Cho R102 trở lại danh sách: state chưa bị
-    // xoá thật thì select tự nhảy về "R102" dù chủ chưa hề chọn lại.
-    rooms = ORIGINAL_ROOMS.map((r) => ({ ...r }));
-    rerender(<ReservationSheet open onOpenChange={vi.fn()} preSelectedRoomId="R102" />);
+  // Vế còn lại của cùng effect: một roomId KHÔNG phải phòng nào cả (phòng bị
+  // xoá trong Cài đặt khi sheet đang mở) vẫn phải bị bỏ chọn — ô select hiện
+  // trống trong khi state giữ một id truthy sẽ bật nút gửi, vì nút chỉ gác
+  // trên `!roomId`.
+  it("bỏ chọn roomId không còn tồn tại trong danh sách phòng", async () => {
+    render(
+      <ReservationSheet open onOpenChange={vi.fn()} preSelectedRoomId="R999" />,
+    );
 
     await waitFor(() => {
-      expect(
-        Array.from((screen.getByLabelText(/^Phòng$/) as HTMLSelectElement).options).map(
-          (o) => o.value,
-        ),
-      ).toContain("R102");
+      expect(screen.getByLabelText(/^Phòng$/)).toHaveValue("");
     });
-    expect(screen.getByLabelText(/^Phòng$/)).toHaveValue("");
+    fireEvent.change(screen.getByPlaceholderText(/họ và tên/i), {
+      target: { value: "Nguyễn Nhật Huy" },
+    });
+    expect(screen.getByRole("button", { name: /Đặt phòng/ })).toBeDisabled();
   });
 
   // Chế độ sửa: phòng lấy từ chính booking đang sửa, ô select bị disable, và

--- a/mhm/src/components/ReservationSheet.tsx
+++ b/mhm/src/components/ReservationSheet.tsx
@@ -154,27 +154,36 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
         if (room) setGuests(room.max_guests);
     }, [isEditMode, editBooking, rooms, guestsTouched]);
 
-    const vacantRooms = rooms.filter((r) => r.status === "vacant" || r.status === "booked");
+    // Mọi phòng đều liệt kê được. Trạng thái phòng (`vacant`/`occupied`/
+    // `cleaning`/`booked`) mô tả HÔM NAY, còn đặt phòng trước hỏi về một
+    // khoảng ngày khác hẳn — lọc theo nó là trả lời sai câu hỏi. Một phòng
+    // đang có khách trả phòng ngày 3/8 vẫn trống nguyên từ 12/8, nhưng vẫn
+    // biến mất khỏi ô chọn, và chủ khách sạn không có cách nào đặt cho nó.
+    //
+    // Việc gác đúng chiều thời gian đã có sẵn hai lớp: useAvailability gọi
+    // `check_availability` theo đúng khoảng ngày đang chọn (hiện danh sách
+    // ngày vướng + số đêm tối đa ngay dưới ô ngày, và tắt nút gửi), còn
+    // `create_reservation_tx` đọc lại room_calendar trong chính transaction
+    // ghi nên hai người đặt cùng lúc vẫn không trùng phòng được. Lọc ở đây
+    // không thêm an toàn nào, chỉ giấu mất phòng.
 
-    // Kéo một ô lịch TƯƠNG LAI của phòng đang có khách (khách rời sau hai hôm)
-    // mở sheet này với đúng roomId đó, mà danh sách chỉ liệt kê vacant/booked —
-    // <select> không có option khớp nên hiện trống, còn state vẫn giữ id đó và
-    // nút gửi vẫn sáng vì nó gác trên `!roomId`, mà id vô hình kia là truthy.
-    // Cùng cách xử lý như BackfillSheet.tsx.
+    // roomId không ứng với phòng nào (phòng bị xoá trong Cài đặt khi sheet
+    // đang mở): <select> không có option khớp nên hiện trống, còn state vẫn
+    // giữ id đó và nút gửi vẫn sáng vì nó gác trên `!roomId`, mà id vô hình
+    // kia là truthy.
     //
     // Chế độ sửa được miễn: phòng ở đó lấy từ chính booking đang sửa và ô
-    // select bị disable — phòng đang có khách là chuyện bình thường, xoá đi sẽ
-    // chặn luôn việc lưu thay đổi.
+    // select bị disable, nên xoá đi chỉ chặn việc lưu thay đổi.
     useEffect(() => {
         if (isEditMode) return;
         // `rooms.length > 0`: các sheet này gọi fetchRooms() lúc mở, nên có một
         // khoảnh khắc danh sách còn rỗng. Không có vế này, một phòng hợp lệ
         // truyền vào bị xoá ngay trước khi rooms kịp về, và effect nạp
         // preSelected không chạy lại để đặt lại nó.
-        if (rooms.length > 0 && roomId && !vacantRooms.some((r) => r.id === roomId)) {
+        if (rooms.length > 0 && roomId && !rooms.some((r) => r.id === roomId)) {
             setRoomId("");
         }
-    }, [isEditMode, rooms, roomId, vacantRooms]);
+    }, [isEditMode, rooms, roomId]);
 
     async function handleSubmit() {
         if (!roomId || !checkInDate || !checkOutDate) {
@@ -301,7 +310,7 @@ export default function ReservationSheet({ open, onOpenChange, preSelectedRoomId
                             disabled={isEditMode}
                         >
                             <option value="">— Chọn phòng —</option>
-                            {vacantRooms.map((r) => (
+                            {rooms.map((r) => (
                                 <option key={r.id} value={r.id}>
                                     {/* Không kèm `base_price`: giá gắn với loại phòng,
                                         nên con số theo từng phòng đứng cạnh tổng do


### PR DESCRIPTION
## Ca thật

Chủ khách sạn báo: phòng 5A đang có khách, khách trả phòng 3/8. Vào "Đặt phòng trước" chọn 12→13/8 thì **5A không hề xuất hiện** trong ô chọn phòng.

## Nguyên nhân gốc

`ReservationSheet.tsx` lọc danh sách phòng theo trạng thái **hiện tại**:

```ts
const vacantRooms = rooms.filter((r) => r.status === "vacant" || r.status === "booked");
```

Trạng thái phòng mô tả *hôm nay*; đặt phòng trước hỏi về một khoảng ngày khác hẳn. Bộ lọc trả lời sai câu hỏi. Phòng `cleaning` cũng bị loại nhầm cùng lý do.

Kiểm chứng trên DB thật: 5A là phòng duy nhất `occupied` — và là phòng duy nhất vắng mặt. `room_calendar` của 5A chỉ kín 31/07–02/08; `SELECT COUNT(*) FROM room_calendar WHERE room_id='5A' AND date >= '2026-08-12' AND date < '2026-08-13'` trả về **0**.

## Cách sửa

Bỏ bộ lọc. Cửa chặn đúng chiều thời gian đã có sẵn hai lớp, và bộ lọc không thêm an toàn nào cho lớp nào:

1. `useAvailability` → `check_availability` → `check_room_availability` đọc `room_calendar` theo **đúng khoảng ngày đang chọn**, hiện ngày vướng + số đêm tối đa ngay trong sheet và tắt nút gửi.
2. `create_reservation_tx` (`reservation_lifecycle.rs:217-232`) đọc lại `room_calendar` **trong chính transaction ghi**, nên hai người đặt cùng lúc vẫn không trùng phòng được.

Effect bỏ chọn phòng nay gác trên `rooms` thay vì danh sách đã lọc.

## Về test bị thay

Test `"bỏ chọn phòng khi phòng kéo từ lịch không nằm trong danh sách chọn được"` mã hoá một bản vá triệu chứng của **chính bug này**: kéo ô lịch tương lai của phòng đang có khách thì phòng bị lọc mất, nên form xoá luôn lựa chọn. Với nguyên nhân đã sửa, cú kéo đó phải giữ nguyên phòng — nên test được thay bằng ba test:

- liệt kê được phòng `occupied` và `cleaning` (`it.each`)
- giữ nguyên phòng kéo từ lịch dù phòng đang có khách, nút gửi bật lên được
- **vẫn** bỏ chọn `roomId` không ứng với phòng nào (vế còn lại của effect — test này xanh trước cả khi sửa, và giữ nguyên)

## Kiểm chứng

- `ReservationSheet.test.tsx`: RED đúng 3 test trước khi sửa → 24/24 xanh sau khi sửa
- Toàn bộ suite frontend: **523/523 xanh** (79 file)
- `tsc --noEmit`: sạch
- `npm run verify:quick`: không test nào fail (frontend + cargo)

## Không đụng tới

`CheckinSheet`/`GroupCheckinSheet` cũng lọc `status === "vacant"`, nhưng nhận phòng là việc của hôm nay nên lọc theo trạng thái hiện tại ở đó là đúng. `BackfillSheet` chỉ lọc khi `stillStaying`, cũng đúng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)