### PR TITLE
test(reservations): gỡ phụ thu cuối tuần khỏi test phụ thu thêm người

### DIFF
--- a/mhm/src-tauri/src/services/booking/tests/reservations.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservations.rs
@@ -888,6 +888,18 @@ async fn confirm_reservation_keeps_the_extra_guest_charge() {
     seed_room_with_guest_pricing(&pool, "R311", 500_000, 2, 50_000)
         .await
         .unwrap();
+    // `seed_room_with_guest_pricing` là helper seed DUY NHẤT không chèn dòng
+    // `pricing_rules` nào, nên phòng nó tạo rơi về `PricingRule::default()` —
+    // vốn mang phụ thu cuối tuần 20%. Kỳ ở dưới đây bắt đầu từ HÔM NAY thật và
+    // không đổi được: `confirm_reservation_tx` định giá lại từ lúc xác nhận đến
+    // ngày đi, nên đẩy ngày đến ra một mốc cố định chỉ kéo dài kỳ ở. Vậy nên
+    // chạy vào thứ Sáu/Bảy/Chủ nhật là có đêm cuối tuần lọt vào, cộng thêm
+    // 500.000 × 20% = 100.000 và kỳ vọng 1.200.000 dưới kia đỏ — 3 ngày trong 7.
+    //
+    // Bảng giá tường minh này khoá phụ thu cuối tuần về 0 đúng như mọi helper
+    // seed khác vẫn làm, giữ nguyên giá ngày 500.000. Test nói về phụ thu thêm
+    // người; cuối tuần là biến lạ, không phải thứ nó kiểm.
+    seed_pricing_rule(&pool, "standard", 500_000).await.unwrap();
 
     let today = Local::now().date_naive();
     let check_in = today.format("%Y-%m-%d").to_string();


### PR DESCRIPTION
## main đang đỏ

`confirm_reservation_keeps_the_extra_guest_charge` fail trên `main` sạch (đã dựng worktree ở `origin/main` để xác nhận, cùng y hệt con số): `left: 1300000, right: 1200000`. Nó fail **mọi thứ Sáu, thứ Bảy và Chủ nhật** — 3 ngày trong 7.

## Nguyên nhân

`seed_room_with_guest_pricing` là helper seed **duy nhất** không chèn dòng `pricing_rules` nào; `seed_pricing_rule`/`seed_pricing_rule_tx`/… đều chèn với `weekend_uplift_pct = 0`. Phòng nó tạo vì thế rơi về `PricingRule::default()` (`pricing.rs:46`), mang phụ thu cuối tuần **20%**.

Kỳ ở bắt đầu từ `Local::now()`, 2 đêm. Chạy vào thứ Sáu 31/07 → đêm Sáu + đêm **Bảy**:

```
500.000×2 + 2 khách phụ×50.000×2 + 500.000×1 đêm cuối tuần×20%
= 1.000.000 + 200.000 + 100.000 = 1.300.000
```

Test này nói về **phụ thu thêm người**; cuối tuần là biến lạ lọt vào.

## Vì sao không dời ngày

`confirm_reservation_tx` **định giá lại từ lúc xác nhận** đến ngày đi đã hẹn, nên đẩy ngày đến ra một mốc cố định chỉ kéo dài kỳ ở. Thử "thứ Hai kế tiếp" cho ra 5 đêm và **3.200.000** (`500k×5 + 2×50k×5 + 2 đêm cuối tuần×500k×20%`) — khớp chính xác, xác nhận cơ chế. Ngày bắt đầu buộc phải là hôm nay.

## Cách sửa

Seed một bảng giá tường minh với `weekend_uplift_pct = 0` — đúng như mọi helper seed khác vẫn làm — giữ nguyên giá ngày 500.000. Helper dùng chung **không** bị đổi: 11 test khác đang cố ý chạy qua đường bảng-giá-mặc-định, đổi helper là âm thầm đổi thứ chúng kiểm.

## Vì sao vẫn còn răng

- Kỳ vọng giữ nguyên **1.200.000**, không nới theo kết quả. Mất phụ thu thêm người thì còn 1.000.000 → vẫn đỏ.
- `calculate_weekend_uplift` (`pricing.rs:432`) return 0 ngay dòng đầu khi pct = 0, **bất kể ngày nào**. Hết phụ thuộc ngày chạy ở mức code, không phải may ngày.

## Kiểm chứng

`cargo test`: **1003 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)