### PR TITLE
fix(reservations): hiện lỗi đọc booking thay vì màn hình trống

### DIFF
--- a/mhm/src/pages/Reservations.test.tsx
+++ b/mhm/src/pages/Reservations.test.tsx
@@ -439,3 +439,70 @@ describe("Reservations checked-out bookings", () => {
     expect(await screen.findByText("invoice-dialog")).toBeTruthy();
   });
 });
+
+// Ca thật, ngày 31/07/2026: cột `bookings.guests` thiếu trên máy chủ khách sạn
+// (migration v22 bị bỏ qua vì schema_version đã là 23), nên `get_all_bookings`
+// đổ lỗi "no such column: b.guests". `.catch(() => setBookings([]))` nuốt trọn
+// nó và trang hiện "Chưa có booking nào" — chủ đọc ra là mất sạch dữ liệu, đi
+// tìm bản backup, trong khi 25 booking vẫn nằm nguyên trong database.
+describe("Reservations load errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetEventMocks();
+    invokeWriteCommand.mockResolvedValue(undefined);
+    createCorrelationId.mockReturnValue("COR-5E6F7A8B");
+  });
+
+  function failBookingsWith(message: string) {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_all_bookings") throw new Error(message);
+      return undefined;
+    });
+  }
+
+  it("hiện lỗi thật thay vì giả vờ là chưa có booking nào", async () => {
+    failBookingsWith("in prepare, no such column: b.guests");
+
+    render(<Reservations />);
+
+    expect(await screen.findByText(/no such column: b\.guests/i)).toBeTruthy();
+    // Câu này là thứ đã đánh lừa chủ khách sạn. Nó chỉ được phép xuất hiện khi
+    // đọc THÀNH CÔNG và kết quả rỗng thật.
+    expect(screen.queryByText(/Chưa có booking nào/i)).toBeNull();
+  });
+
+  it("giữ nguyên booking đang hiện khi một lần nạp lại thất bại", async () => {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_all_bookings") return [bookedReservation()];
+      return undefined;
+    });
+
+    render(<Reservations />);
+    expect(await screen.findByTestId("booking-bar-B101")).toBeTruthy();
+
+    // Lần nạp lại sau một lệnh ghi bị hỏng. Xoá sạch lịch vì một sự cố tạm
+    // thời là tự tay biến nó thành cảnh mất dữ liệu.
+    failBookingsWith("database is locked");
+    await emitTestEvent("db-updated", { entity: "bookings" });
+
+    expect(await screen.findByText(/database is locked/i)).toBeTruthy();
+    expect(screen.getByTestId("booking-bar-B101")).toBeTruthy();
+  });
+
+  it("cho thử lại, và gỡ thông báo lỗi khi đọc lại được", async () => {
+    const user = userEvent.setup();
+    failBookingsWith("database is locked");
+
+    render(<Reservations />);
+    expect(await screen.findByText(/database is locked/i)).toBeTruthy();
+
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_all_bookings") return [bookedReservation()];
+      return undefined;
+    });
+    await user.click(screen.getByRole("button", { name: /thử lại/i }));
+
+    expect(await screen.findByTestId("booking-bar-B101")).toBeTruthy();
+    expect(screen.queryByText(/database is locked/i)).toBeNull();
+  });
+});

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -112,9 +112,23 @@ function getStatusLabel(status: BookingStatus): string {
     return status;
 }
 
+// `get_all_bookings` là lệnh ĐỌC: chữ ký của nó là `Result<_, String>`, nên
+// thứ về tới đây là một chuỗi thô, không phải phong bì AppError.
+// `normalizeAppError` chỉ nhận diện phong bì và quy mọi thứ khác về một câu
+// chung chung, nên `formatAppError` dùng một mình ở đây sẽ nuốt mất dòng chẩn
+// đoán duy nhất — đúng thứ đã chỉ ra "no such column: b.guests" hôm 31/07/2026.
+// Phong bì thật thì vẫn để formatAppError lo, vì nó còn gắn mã hỗ trợ và mã
+// theo dõi.
+function describeLoadError(error: unknown): string {
+    if (typeof error === "string") return error;
+    if (error instanceof Error) return error.message;
+    return formatAppError(error);
+}
+
 export default function Reservations() {
     const { rooms, fetchRooms, setCheckinOpen } = useHotelStore();
     const [bookings, setBookings] = useState<BookingWithGuest[]>([]);
+    const [loadError, setLoadError] = useState<string | null>(null);
     const [searchQuery, setSearchQuery] = useState("");
     const [dateOffset, setDateOffset] = useState(0);
     const [sheetOpen, setSheetOpen] = useState(false);
@@ -131,10 +145,24 @@ export default function Reservations() {
 
     useEffect(() => { fetchRooms(); }, []);
 
+    // Lỗi đọc booking phải hiện ra, không được nuốt. Bản trước làm
+    // `.catch(() => setBookings([]))`, biến mọi thất bại thành đúng cái màn
+    // hình mà một khách sạn chưa có booking nào cũng thấy. Ngày 31/07/2026,
+    // cột `bookings.guests` thiếu trên máy chủ khách sạn (migration v22 bị bỏ
+    // qua vì schema_version đã là 23) nên query đổ lỗi "no such column:
+    // b.guests"; chủ khách sạn đọc màn hình trống ra là mất sạch dữ liệu và đi
+    // tìm bản backup, trong khi 25 booking vẫn nằm nguyên trong database.
+    //
+    // `setBookings` cũng không bị đụng tới ở nhánh lỗi: một lần nạp lại hỏng
+    // (ổ đĩa bận, database khoá) mà xoá sạch lịch là tự tay biến sự cố tạm
+    // thời thành cảnh mất dữ liệu.
     const loadBookings = () => {
         invoke<BookingWithGuest[]>("get_all_bookings", { filter: null })
-            .then(setBookings)
-            .catch(() => setBookings([]));
+            .then((rows) => {
+                setBookings(rows);
+                setLoadError(null);
+            })
+            .catch((e) => setLoadError(describeLoadError(e)));
     };
 
     useEffect(() => { loadBookings(); }, []);
@@ -464,7 +492,25 @@ export default function Reservations() {
                         </div>
                     ))}
 
-                    {visibleBookings.length === 0 && (
+                    {/* Lỗi thắng ô trống: "Chưa có booking nào" chỉ đúng khi
+                        đọc THÀNH CÔNG và kết quả rỗng thật. */}
+                    {loadError && (
+                        <div className="mx-4 my-4 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                            <div className="font-semibold">Không đọc được danh sách booking</div>
+                            <div className="mt-1 whitespace-pre-line opacity-90">{loadError}</div>
+                            <div className="mt-2 text-xs opacity-80">
+                                Dữ liệu vẫn nằm trong máy — đây là lỗi lúc đọc, không phải mất booking.
+                            </div>
+                            <Button
+                                className="mt-3 h-9 rounded-lg text-sm font-semibold"
+                                onClick={loadBookings}
+                            >
+                                Thử lại
+                            </Button>
+                        </div>
+                    )}
+
+                    {!loadError && visibleBookings.length === 0 && (
                         <div className="flex items-center justify-center py-20 text-brand-muted">
                             {bookings.length === 0
                                 ? 'Chưa có booking nào — Nhấn "+ Đặt phòng" để tạo reservation'


### PR DESCRIPTION
## Chuyện đã xảy ra

`Reservations.tsx` nuốt trọn mọi lỗi khi đọc booking:

```ts
invoke<BookingWithGuest[]>("get_all_bookings", { filter: null })
    .then(setBookings)
    .catch(() => setBookings([]));   // <-- lỗi biến thành "chưa có booking nào"
```

Ngày 31/07/2026 nó gây một phen tưởng mất dữ liệu thật trên máy chủ khách sạn: cột `bookings.guests` không tồn tại (migration v22 gác trên `current < 22`, mà `schema_version` đã là 23 nên bị bỏ qua), query đổ lỗi `no such column: b.guests`. Trang Reservations hiện **"Chưa có booking nào"**, Dashboard vẫn chạy bình thường vì dùng query khác. Chủ khách sạn đọc ra là mất sạch dữ liệu và đi tìm bản backup — trong khi **25 booking vẫn nằm nguyên** trong database.

Màn hình trống là câu trả lời tệ nhất có thể: nó không chỉ giấu lỗi, nó **khẳng định một điều sai** và điều sai đó lại đúng bằng nỗi sợ lớn nhất của người dùng.

## Ba thay đổi

1. **Lỗi hiện ra.** Giữ trong state, render thành dải đỏ có nguyên văn thông báo + nút **Thử lại** + một dòng trấn an rằng dữ liệu vẫn nằm trong máy. `"Chưa có booking nào"` giờ chỉ hiện khi đọc **thành công** mà kết quả rỗng thật.

2. **Không xoá dữ liệu đang hiện.** Nhánh lỗi không đụng `setBookings`. Một lần nạp lại hỏng (database khoá, ổ đĩa bận) mà xoá sạch lịch là tự tay biến sự cố tạm thời thành cảnh mất dữ liệu.

3. **Giữ nguyên văn lỗi** (`describeLoadError`). Đây là chỗ dễ sai: `get_all_bookings` là lệnh **đọc**, chữ ký `Result<Vec<BookingWithGuest>, String>`, nên thứ về tới frontend là **chuỗi thô**, không phải phong bì `AppError`. `normalizeAppError` quy mọi thứ không-phải-phong-bì về `FALLBACK_SYSTEM_APP_ERROR`, nên `formatAppError` dùng một mình ở đây sẽ **luôn** ra một câu chung chung và nuốt mất đúng dòng `no such column: b.guests` — dòng duy nhất chẩn đoán được. Phong bì thật vẫn để `formatAppError` lo, vì nó còn gắn mã hỗ trợ và mã theo dõi.

## Test

Ba test mới, viết trước và **đỏ đúng 3 test** trước khi sửa:

- `hiện lỗi thật thay vì giả vờ là chưa có booking nào` — dựng lại đúng lỗi `no such column: b.guests`, khẳng định thông báo hiện ra **và** `"Chưa có booking nào"` biến mất
- `giữ nguyên booking đang hiện khi một lần nạp lại thất bại` — nạp thành công, rồi cho `db-updated` gặp lỗi; bar cũ phải còn nguyên
- `cho thử lại, và gỡ thông báo lỗi khi đọc lại được`

## Kiểm chứng

- `Reservations.test.tsx`: 3 đỏ → **17/17 xanh**
- Toàn bộ suite frontend: **527/527 xanh** (79 file)
- `tsc --noEmit`: sạch

🤖 Generated with [Claude Code](https://claude.com/claude-code)