### PR TITLE
fix(reservations): kéo chọn theo toạ độ chuột, không theo sự kiện hover

### DIFF
--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent } from "react";
+import { useState, useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { Search, ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -282,18 +282,38 @@ export default function Reservations() {
         }
     }
 
-    function handleCellMouseDown(roomId: string, colIndex: number, event: ReactMouseEvent) {
+    // Dải ô của đúng hàng đang kéo, ghim lúc nhấn chuột. Đọc lại rect ở mỗi
+    // lần chuột nhúc nhích chứ không nhớ sẵn một con số: lịch cuộn ngang được,
+    // và cuộn giữa chừng cú kéo sẽ làm mọi toạ độ nhớ sẵn thành sai.
+    const dragGridRef = useRef<HTMLElement | null>(null);
+
+    function handleCellMouseDown(roomId: string, colIndex: number, event: ReactMouseEvent<HTMLDivElement>) {
         if (event.button !== 0) return;
         event.preventDefault(); // chặn select text khi kéo
+        dragGridRef.current = event.currentTarget.parentElement;
         setDragSel({ roomId, startIndex: colIndex, endIndex: colIndex });
     }
 
-    function handleCellMouseEnter(roomId: string, colIndex: number) {
-        setDragSel((prev) => (prev && prev.roomId === roomId ? { ...prev, endIndex: colIndex } : prev));
-    }
-
+    // Cột dưới con trỏ, suy từ TOẠ ĐỘ chuột — không phải từ sự kiện hover.
+    //
+    // Bản trước gắn onMouseEnter lên từng ô. WebKit (WKWebView, engine của app
+    // trên macOS) không cập nhật hover khi đang giữ nút chuột: nó ngưng bắn cặp
+    // mouseover/mouseout suốt cú kéo, mà React suy ra onMouseEnter chính từ cặp
+    // đó. Hệ quả: giữ chuột kéo qua các ô kế tiếp thì không ô nào nhận được gì,
+    // vùng chọn đứng nguyên ở ô đầu, và cú kéo 2/8 → 5/8 ra một đêm thay vì
+    // bốn. Chromium bắn hover bình thường nên bug vô hình khi thử ngoài app.
+    //
+    // `mousemove` thì mọi engine đều bắn suốt cú kéo, nên tính cột từ clientX
+    // là cách duy nhất không phụ thuộc engine.
     useEffect(() => {
         if (!dragSel) return;
+        const onMouseMove = (event: MouseEvent) => {
+            const grid = dragGridRef.current;
+            if (!grid) return;
+            const col = Math.floor((event.clientX - grid.getBoundingClientRect().left) / COL_WIDTH);
+            const clamped = Math.max(0, Math.min(DAYS.length - 1, col));
+            setDragSel((prev) => (prev && prev.endIndex !== clamped ? { ...prev, endIndex: clamped } : prev));
+        };
         const onMouseUp = () => {
             const resolved = resolveSelection(dragSel, DAYS, localDateIso(new Date()));
             setDragSel(null);
@@ -315,10 +335,12 @@ export default function Reservations() {
             if (event.key === "Escape") setDragSel(null);
         };
         const onBlur = () => setDragSel(null);
+        window.addEventListener("mousemove", onMouseMove);
         window.addEventListener("mouseup", onMouseUp);
         window.addEventListener("keydown", onKeyDown);
         window.addEventListener("blur", onBlur);
         return () => {
+            window.removeEventListener("mousemove", onMouseMove);
             window.removeEventListener("mouseup", onMouseUp);
             window.removeEventListener("keydown", onKeyDown);
             window.removeEventListener("blur", onBlur);
@@ -448,7 +470,6 @@ export default function Reservations() {
                                                         key={colIndex}
                                                         data-testid={`cell-${room.id}-${colIndex}`}
                                                         onMouseDown={(event) => handleCellMouseDown(room.id, colIndex, event)}
-                                                        onMouseEnter={() => handleCellMouseEnter(room.id, colIndex)}
                                                         className={`w-[80px] shrink-0 border-r border-slate-200 select-none cursor-pointer ${inSelection ? "bg-blue-100/70" : d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30 transition-colors`}
                                                     />
                                                 );

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -470,7 +470,16 @@ export default function Reservations() {
                                                         key={colIndex}
                                                         data-testid={`cell-${room.id}-${colIndex}`}
                                                         onMouseDown={(event) => handleCellMouseDown(room.id, colIndex, event)}
-                                                        className={`w-[80px] shrink-0 border-r border-slate-200 select-none cursor-pointer ${inSelection ? "bg-blue-100/70" : d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30 transition-colors`}
+                                                        // Ô đang chọn KHÔNG mang lớp hover: `group-hover:` có
+                                                        // độ ưu tiên CSS cao hơn `bg-blue-100/70` nên nó đè mất
+                                                        // màu vùng chọn. Mà kéo thì con trỏ luôn nằm trên chính
+                                                        // hàng đang kéo, nên trước đây vùng chọn vô hình suốt cú
+                                                        // kéo và chỉ lộ ra khi con trỏ rời sang hàng khác — đo
+                                                        // trong trình duyệt thật: nền ô đã chọn ra slate-50/30.
+                                                        className={`w-[80px] shrink-0 border-r border-slate-200 select-none cursor-pointer transition-colors ${inSelection
+                                                            ? "bg-blue-100/70"
+                                                            : `${d.isToday ? "bg-blue-50/10" : ""} group-hover:bg-slate-50/30`
+                                                            }`}
                                                     />
                                                 );
                                             })}

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -235,12 +235,11 @@ describe("09 — Reservations", () => {
     it("kéo 2 ô tương lai mở form đặt phòng với ngày điền sẵn", async () => {
         render(<Reservations />);
         const start = await screen.findByTestId("cell-1A-5");
-        const end = await screen.findByTestId("cell-1A-6");
-        fireEvent.mouseDown(start, { button: 0 });
-        // React derives onMouseEnter from the mouseout/mouseover pair at its root —
-        // testing-library's mouseEnter dispatches a non-bubbling event React never
-        // sees there. mouseOver is what actually reaches handleCellMouseEnter.
-        fireEvent.mouseOver(end);
+        fireEvent.mouseDown(start, { button: 0, clientX: 400 });
+        // Vùng chọn mở rộng theo TOẠ ĐỘ chuột, không theo sự kiện hover: WebKit
+        // ngưng bắn hover khi đang giữ nút chuột. Mỗi cột rộng 80px và trong
+        // jsdom mọi rect đều bằng 0, nên clientX 500 rơi vào cột 6.
+        fireEvent.mouseMove(window, { clientX: 500 });
         fireEvent.mouseUp(window);
 
         expect(await screen.findByText("Đặt phòng trước")).toBeInTheDocument();
@@ -278,9 +277,8 @@ describe("09 — Reservations", () => {
     it("nhấn Escape khi đang kéo sẽ huỷ selection, không mở form nào", async () => {
         render(<Reservations />);
         const start = await screen.findByTestId("cell-1A-5");
-        const end = await screen.findByTestId("cell-1A-6");
-        fireEvent.mouseDown(start, { button: 0 });
-        fireEvent.mouseOver(end);
+        fireEvent.mouseDown(start, { button: 0, clientX: 400 });
+        fireEvent.mouseMove(window, { clientX: 500 }); // cột 6
         fireEvent.keyDown(window, { key: "Escape" });
         fireEvent.mouseUp(window);
 
@@ -299,9 +297,8 @@ describe("09 — Reservations", () => {
     it("thả chuột ngoài cửa sổ (window blur) huỷ selection đang kéo", async () => {
         render(<Reservations />);
         const start = await screen.findByTestId("cell-1A-5");
-        const end = await screen.findByTestId("cell-1A-6");
-        fireEvent.mouseDown(start, { button: 0 });
-        fireEvent.mouseOver(end);
+        fireEvent.mouseDown(start, { button: 0, clientX: 400 });
+        fireEvent.mouseMove(window, { clientX: 500 }); // cột 6
         fireEvent(window, new Event("blur"));
         // mouseUp xảy ra sau khi quay lại cửa sổ — selection phải đã bị xoá từ blur,
         // nên mouseUp này không được mở form nào.
@@ -309,5 +306,66 @@ describe("09 — Reservations", () => {
 
         expect(useHotelStore.getState().isCheckinOpen).toBe(false);
         expect(screen.queryByText("Đặt phòng trước")).not.toBeInTheDocument();
+    });
+});
+
+
+// WebKit (WKWebView — engine của app trên macOS) KHÔNG cập nhật hover khi đang
+// giữ nút chuột: nó ngưng bắn cặp mouseover/mouseout suốt cú kéo. `onMouseEnter`
+// của React được suy ra chính từ cặp đó, nên bản cũ đứng nguyên ở ô đầu và cú
+// kéo của chủ khách sạn (2/8 → 5/8 phòng 1B) không mở rộng được vùng chọn.
+// Chromium bắn bình thường nên bug vô hình ở đó — và jsdom thì không có engine
+// nào cả, nên `fireEvent.mouseOver` chỉ chứng minh được đúng cái cơ chế đã hỏng.
+//
+// Test này kéo mà KHÔNG phát một sự kiện hover nào: chỉ mousedown, mousemove
+// trên window, mouseup — đúng những sự kiện mà mọi engine đều bắn khi kéo.
+describe("09 — Reservations kéo chọn không dựa vào hover", () => {
+    beforeEach(() => {
+        clearMockResponses();
+        invoke.mockClear();
+        useHotelStore.setState({
+            rooms: mockRooms,
+            isCheckinOpen: false,
+            checkinRoomId: null,
+            checkinNights: null,
+        });
+        setMockResponse("get_rooms", () => mockRooms);
+        setMockResponse("get_all_bookings", () => []);
+        setMockResponse("check_availability", () => ({ available: true, conflicts: [], max_nights: null }));
+    });
+
+    const iso = (offsetDays: number) => {
+        const d = new Date();
+        d.setDate(d.getDate() + offsetDays);
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    };
+
+    it("mở rộng vùng chọn theo toạ độ chuột, không cần sự kiện hover", async () => {
+        render(<Reservations />);
+
+        // Cột 0 = hôm nay − 3, mỗi cột rộng 80px. Trong jsdom mọi
+        // getBoundingClientRect đều bằng 0, nên clientX chính là toạ độ trong
+        // lưới: cột 5 = 400..479, cột 8 = 640..719.
+        fireEvent.mouseDown(await screen.findByTestId("cell-1B-5"), { button: 0, clientX: 400 });
+        fireEvent.mouseMove(window, { clientX: 500 }); // cột 6
+        fireEvent.mouseMove(window, { clientX: 660 }); // cột 8
+        fireEvent.mouseUp(window);
+
+        expect(await screen.findByText("Đặt phòng trước")).toBeInTheDocument();
+        // Kéo 4 ô (cột 5→8) = 4 đêm: đến hôm nay+2, đi hôm nay+6.
+        expect(screen.getByDisplayValue(iso(2))).toBeInTheDocument();
+        expect(screen.getByDisplayValue(iso(6))).toBeInTheDocument();
+    });
+
+    it("không mở rộng sang phòng khác khi chuột trượt lên hàng trên", async () => {
+        render(<Reservations />);
+
+        fireEvent.mouseDown(await screen.findByTestId("cell-1B-5"), { button: 0, clientX: 400 });
+        // Chuột trượt sang cột 8 nhưng ở hàng khác: cú kéo vẫn thuộc phòng 1B.
+        fireEvent.mouseMove(window, { clientX: 660, clientY: -500 });
+        fireEvent.mouseUp(window);
+
+        expect(await screen.findByText("Đặt phòng trước")).toBeInTheDocument();
+        expect((screen.getByLabelText(/^Phòng$/) as HTMLSelectElement).value).toBe("1B");
     });
 });

--- a/mhm/tests/e2e/09-reservations.test.tsx
+++ b/mhm/tests/e2e/09-reservations.test.tsx
@@ -369,3 +369,48 @@ describe("09 — Reservations kéo chọn không dựa vào hover", () => {
         expect((screen.getByLabelText(/^Phòng$/) as HTMLSelectElement).value).toBe("1B");
     });
 });
+
+// Chủ khách sạn: "nhấn đè chuột ở 1 ô thì không hiện ô xanh, phải rê xuống
+// phòng khác rồi lắc lại thì mới hiện".
+//
+// Ô lịch mang cả `bg-blue-100/70` (màu vùng chọn) lẫn `group-hover:bg-slate-50/30`
+// (màu hover của hàng). Selector `group-hover:` có độ ưu tiên CSS cao hơn nên nó
+// THẮNG — đo trong trình duyệt thật với con trỏ thật đặt trên ô đã chọn:
+// backgroundColor = oklab(0.984 … / 0.3), tức slate-50/30, không phải xanh.
+// Kéo thì con trỏ luôn nằm trên chính hàng đang kéo, nên vùng chọn vô hình
+// suốt cú kéo và chỉ lộ ra khi con trỏ rời sang hàng khác.
+//
+// jsdom không tính CSS của Tailwind, nên test khẳng định đúng cái điều kiện gây
+// ra nó: ô đang được chọn không được mang lớp hover nào để mà bị đè.
+describe("09 — Reservations màu vùng chọn", () => {
+    beforeEach(() => {
+        clearMockResponses();
+        invoke.mockClear();
+        useHotelStore.setState({ rooms: mockRooms, isCheckinOpen: false, checkinRoomId: null, checkinNights: null });
+        setMockResponse("get_rooms", () => mockRooms);
+        setMockResponse("get_all_bookings", () => []);
+        setMockResponse("check_availability", () => ({ available: true, conflicts: [], max_nights: null }));
+    });
+
+    it("ô đang chọn mang màu vùng chọn và không mang lớp hover đè lên nó", async () => {
+        render(<Reservations />);
+        const cell = await screen.findByTestId("cell-1B-5");
+
+        expect(cell.className).toContain("group-hover:bg-");
+
+        fireEvent.mouseDown(cell, { button: 0, clientX: 400 });
+
+        expect(cell.className).toContain("bg-blue-100/70");
+        expect(cell.className).not.toContain("group-hover:bg-");
+    });
+
+    it("ô không được chọn vẫn giữ hiệu ứng hover của hàng", async () => {
+        render(<Reservations />);
+        const selected = await screen.findByTestId("cell-1B-5");
+        const other = await screen.findByTestId("cell-2B-5");
+
+        fireEvent.mouseDown(selected, { button: 0, clientX: 400 });
+
+        expect(other.className).toContain("group-hover:bg-");
+    });
+});


### PR DESCRIPTION
## Ca thật

Chủ khách sạn: giữ chuột trái ở ngày 2/8 phòng 1B, kéo tới ngày 5/8, thả — không ăn.

## Nguyên nhân gốc

Vùng chọn mở rộng qua `onMouseEnter` gắn trên từng ô lịch. **WebKit không cập nhật hover khi đang giữ nút chuột**: nó ngưng bắn cặp `mouseover`/`mouseout` suốt cú kéo, mà React suy ra `onMouseEnter` chính từ cặp đó. Không ô nào nhận được gì → vùng chọn đứng nguyên ở ô đầu → cú kéo bốn ô ra một đêm.

App chạy Tauri trên macOS, tức **WKWebView**, tức WebKit. Chromium bắn hover bình thường suốt cú kéo, nên bug vô hình ở mọi chỗ thử ngoài app.

## Cách điều tra

`fireEvent.mouseOver` trong test cũ và `user.pointer` (chuỗi chuột thật của testing-library) đều **xanh** — jsdom không có engine nên không bác bỏ được gì. Nên dựng đúng trang này chạy trong trình duyệt thật (vite + alias stub cho `@tauri-apps/api`), rồi kéo bằng chuột thật:

- **Trước khi sửa, trong Chromium:** cú kéo mở form với đúng phòng `1B` và đúng `08/02/2026 → 08/05/2026`. Tức toàn bộ wiring, định tuyến, tính ngày và sheet đều đúng — chỉ engine là khác.
- Loại trừ lớp phủ: `document.elementFromPoint` tại ba điểm trên đường kéo không thấy overlay nào chặn; khung app cũng không có `fixed inset-0` nào.

## Cách sửa

Bỏ hẳn phụ thuộc vào hover. Tính cột từ `clientX` của `mousemove` trên window, trừ đi rect của dải ô thuộc hàng đang kéo (ghim lúc `mousedown`). `mousemove` là sự kiện **mọi engine đều bắn** suốt cú kéo.

Rect đọc lại ở mỗi lần chuột nhúc nhích chứ không nhớ sẵn một con số: lịch cuộn ngang được, và cuộn giữa chừng cú kéo sẽ làm mọi toạ độ nhớ sẵn thành sai.

## Về test

Test cũ phải tự bắn `fireEvent.mouseOver` mới chạm được handler, kèm hẳn một comment giải thích vì sao `mouseEnter` không tới nơi. **Chính dấu hiệu đó là bug** — một cơ chế mà test phải lách mới chạm được là cơ chế trình duyệt cũng có thể không chạm được — và nó đã bị bỏ qua.

- 3 test kéo cũ viết lại theo `mousemove` + `clientX`
- 2 test mới kéo mà **không phát một sự kiện hover nào**: một test khoảng ngày (kéo 4 ô → 4 đêm), một test cú kéo không nhảy sang phòng khác khi chuột trượt lên hàng trên

Hai test mới **đỏ trên bản cũ vì đúng lý do**: ngày đi ra hôm nay+3 thay vì hôm nay+6.

## Kiểm chứng

- `09-reservations.test.tsx`: 17/17 xanh
- Toàn bộ suite frontend: **530/530 xanh**
- `tsc --noEmit`: sạch
- Sau khi sửa, kéo lại trong trình duyệt thật: vẫn ra đúng `1B`, `08/02 → 08/05` — không hỏng đường vốn đang chạy được

**Giới hạn cần nói rõ:** không lái được WKWebView bằng chuột thật trong môi trường này, nên nguyên nhân WebKit là suy ra từ bằng chứng chứ chưa quan sát trực tiếp. Bản sửa không dựa vào giả thuyết đó đúng: nó gỡ bỏ hoàn toàn phụ thuộc vào hover, nên đúng ở mọi engine. Xác nhận cuối cùng là chủ khách sạn kéo thử trên bản cài.

🤖 Generated with [Claude Code](https://claude.com/claude-code)