### PR TITLE
chore: restructure Claude Code config for a large codebase

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./mhm/src-tauri/target/**)",
+      "Read(./mhm/Scans/**)",
+      "Read(./mhm/package-lock.json)",
+      "Read(./**/*.db)"
+    ]
+  },
+  "worktree": {
+    "sparsePaths": [".claude", "docs", "mhm"],
+    "symlinkDirectories": ["mhm/node_modules"]
+  }
+}

--- a/.claude/skills/pms-command-safety/SKILL.md
+++ b/.claude/skills/pms-command-safety/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: pms-command-safety
+description: Rules for writing or changing a PMS business write in mhm/src-tauri — commands, services, repositories, idempotency, outbox, locking, audit.
+paths:
+  - "mhm/src-tauri/src/commands/**"
+  - "mhm/src-tauri/src/services/**"
+  - "mhm/src-tauri/src/repositories/**"
+  - "mhm/src-tauri/src/command_idempotency/**"
+  - "mhm/src-tauri/src/command_ledger.rs"
+  - "mhm/src-tauri/src/command_recovery.rs"
+  - "mhm/src-tauri/src/outbox.rs"
+---
+
+# PMS command safety
+
+CapyInn runs real hotels offline. A lost or double-applied write is money or a room
+that does not exist. These rules are why the command layer looks heavier than the
+feature would suggest — do not simplify them away.
+
+## The command boundary
+
+Every PMS business write goes through an explicit command. UI, bots, agents, and
+integrations must never mutate PMS tables directly.
+
+Every command carries: actor, command name, idempotency key, canonical payload hash,
+timestamp, and request context. A command missing any of these is not a command.
+
+## Atomicity
+
+One business write is one unit:
+
+```
+validate → authorize → lock/serialize → mutate → audit → outbox → commit or rollback
+```
+
+All of it, or none of it. No partial commit, no "we'll fix it on the next run".
+
+## Idempotency
+
+Retryable commands must be idempotent:
+
+- same key + same canonical payload → replay the prior result, do not re-apply
+- same key + **different** payload → reject
+
+The canonical payload hash is what makes the second case detectable. Never hash a
+serialization whose field order or whitespace can vary.
+
+## Locking
+
+Serialize high-risk writes by stable lock keys: `booking_id`, `room_id`/date,
+`folio_id`, `invoice_id`, `ledger_id`, `audit_date`. Build keys through the shared
+lock-key builder rather than formatting strings at the call site.
+
+## Validation
+
+Validate before mutation, and fail closed. Unknown fields, invalid money, invalid
+dates, invalid statuses, illegal transitions, missing permissions, and ambiguity are
+all errors — never a best-effort guess.
+
+Booking, room, housekeeping, invoice, and group statuses move through explicit state
+machines. Never assign a raw status string.
+
+## Money
+
+Integer VND (`MoneyVnd = i64`). Never `f64` for an amount. Validate through
+`money.rs` before it crosses the IPC boundary. See `mhm/src-tauri/CLAUDE.md`.
+
+## Financial records
+
+Ledger and folio rows are append-only. A correction is a reversal or adjustment row,
+never an `UPDATE` over history.
+
+## External effects
+
+Anything leaving the process — OTA sync, notification, webhook, backup trigger,
+invoice delivery — is an outbox event written in the same transaction as the mutation.
+No direct side effect inside a business mutation, ever. The dispatcher owns delivery
+and retry.
+
+## Audit
+
+Every important mutation is reconstructable from actor, command, payload hash,
+timestamp, lock keys, and affected aggregate.
+
+## Agents and integrations
+
+Least privilege applies to AI agents and integration keys exactly as it does to staff.
+Agent memory is not PMS truth: an LLM may *suggest* a command, but state changes only
+through a validated, authorized, audited command. Booking, payment, and availability
+truth come from CapyInn read tools, never from memory.
+
+`mhm/tests/agentic-guardrails.test.ts` enforces the documented form of this and the
+loopback-only gateway binding.
+
+## Before you claim it is done
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml architecture_guard -- --nocapture
+npm run verify:money
+npm run verify:quick
+```

--- a/.claude/skills/verifying-a-build/SKILL.md
+++ b/.claude/skills/verifying-a-build/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verifying-a-build
+description: Use when installing, relaunching, or checking a CapyInn build in the GUI — which of the two builds is on screen, and whether the new binary actually took.
+---
+
+# Verifying a CapyInn build
+
+Two failure modes have each cost a full QA cycle. Both look like a broken feature and
+are actually a stale process. Rule out both before you believe anything you see on
+screen.
+
+## 1. The reinstall that did nothing
+
+The bundle is `CapyInn.app`; the executable inside is `Contents/MacOS/capyinn` —
+**lowercase**.
+
+`pkill -x CapyInn` matches nothing and exits `0`. The old process keeps running with
+the old binary held open by inode, so copying a new `.app` into `/Applications`
+appears to have no effect: `open -a` just reactivates the existing window, migrations
+never run, and the schema version stays put.
+
+```bash
+pkill -x capyinn
+ps aux | grep "[c]apyinn"     # expect no output before continuing
+open -a CapyInn
+```
+
+Then confirm the new binary is the one running, from the database rather than the window:
+
+```sql
+SELECT version FROM schema_version;
+```
+
+On 2026-07-28 the DB kept reporting schema 21 after installing a build containing
+migrations v22 and v23. It read as a broken migration. The app had simply never
+restarted.
+
+## 2. Two builds, one bundle id
+
+Both of these run as `io.capyinn.app`:
+
+- installed: `/Applications/CapyInn.app`
+- dev: the debug binary started by `npm run tauri dev`
+
+Screenshots and window titles cannot tell them apart, and launching "CapyInn" by name
+brings up the **installed** one. A single stray click can front the stale production
+window, after which every later screenshot silently shows old code.
+
+```bash
+ps aux | grep -E "debug/capyinn|CapyInn.app"
+```
+
+If both are up, **ask before quitting the installed one** — the owner may be running a
+real hotel in it right now.
+
+A decisive check for which build is on screen: change a visible string in the source
+and watch the window. Vite HMR reaches the dev build only.
+
+Merging to `main` does not update the installed app. That needs `npm run tauri build`
+and a reinstall.
+
+## 3. Before believing a green result
+
+A passing test can also mean the edit never landed. When mutation-testing, assert that
+the old string was actually found before you trust the outcome — `perl -pi` reports
+nothing when a pattern matches nothing, and has silently written NUL bytes into source
+here before.
+
+## Releases
+
+For release preflight, `docs/release-checklist.md` is the canonical list — version
+sanity, baseline validation, `npm run verify:full`, core-PMS profile, and signing.
+Follow it rather than reconstructing the steps.

--- a/.gitignore
+++ b/.gitignore
@@ -45,14 +45,17 @@ code2prompt-output.md
 # === Gemini agent internal ===
 .gemini/
 
-# === Claude agent internal ===
-.claude/
+# === Claude Code project config ===
+# Committed: settings.json and skills/ are shared project config.
+# Ignored: everything else under .claude/ is per-machine state
+# (settings.local.json, worktrees/, session data).
+.claude/*
+!.claude/settings.json
+!.claude/skills/
 
 # === Local agent/internal repo helpers ===
 .agent/
 **/.agent/
-AGENTS.md
-CLAUDE.md
 GEMINI.md
 docs/
 mhm/docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# CapyInn — agent instructions
+
+See [CLAUDE.md](CLAUDE.md). It is the single source of truth for this repository's
+conventions, guardrails, and commands, and it applies to any coding agent.
+
+Subsystem conventions live next to the code they govern:
+`mhm/src-tauri/CLAUDE.md` (Rust backend) and `mhm/src/CLAUDE.md` (React frontend).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CapyInn
+
+Offline-first PMS for mini hotels. Tauri v2 desktop app: Rust backend + React frontend, SQLite.
+
+- Git root is this directory. The app lives in `mhm/` — that name is **rename debt, not the product name**.
+- `mhm/src-tauri/` is the Rust backend (~71k lines). `mhm/src/` is the React frontend (~29k lines).
+- Each has its own `CLAUDE.md` with conventions for that side. Read it before editing there.
+
+## Dependency direction
+
+`mhm/src-tauri/src/architecture_guard.rs` enforces this as a test. Violating it is a red build, not a review comment.
+
+```
+write:  UI → command → service/lifecycle → repository/transaction → SQLite
+read:   UI → command → query → SQLite
+```
+
+`commands/` is the outermost boundary. Nothing further in may depend on it.
+
+## Core PMS vs experimental runtime
+
+- **Core PMS**: rooms, stays, reservations, guests, housekeeping, billing/folios/invoices, groups, night audit, settings, auth, schema/migrations.
+- **Experimental runtime**: gateway, MCP, agent runtime, observer streams, digest, Telegram, CEO, OpenAI.
+
+Normal PMS operation must never require experimental runtime to be configured. `docs/architecture/core-pms-boundaries.md` is the canonical guardrail.
+
+## Non-negotiables
+
+Each of these has an automated guard. Name the guard when you claim compliance.
+
+| Rule | Guard |
+| --- | --- |
+| Money is integer VND (`MoneyVnd = i64`). Never `f64` for an amount. | `npm run verify:money` — **manual only, not in CI** |
+| Layer dependency direction (above) | `cargo test architecture_guard` |
+| PMS writes go through the `invokeCommand` wrapper, not raw `invoke` | `mhm/tests/frontend-invoke-wrapper-guardrails.test.ts` |
+| Agent memory is not PMS truth; gateway stays loopback-only | `mhm/tests/agentic-guardrails.test.ts` |
+
+Beyond the guarded rules: every PMS business write goes through a command boundary with actor, command name, idempotency key, payload hash, and timestamp; validate before mutate and fail closed; serialize high-risk writes by stable lock keys; keep ledger and folio rows append-only; emit external effects via the outbox in the same transaction. The `pms-command-safety` skill has the full set — it loads on demand when you touch `commands/`, `services/`, or `repositories/`.
+
+## Commands
+
+Run from `mhm/` unless stated otherwise.
+
+```bash
+npm run tauri dev          # dev app
+npm test                   # frontend suite (vitest)
+npm run build              # tsc + vite build
+npm run verify:quick       # targeted frontend + cargo tests
+npm run verify:full        # verify:quick + full frontend + booking/backup + native smoke
+npm run verify:money       # money float scan — nothing else runs this, run it yourself
+```
+
+From `mhm/src-tauri/`:
+
+```bash
+cargo check
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt -- --check
+```
+
+CI (`.github/workflows/ci.yml`) runs `npm test`, `npm run build`, then the four cargo commands, then `verify:full` in a second job. It never runs `verify:money`.
+
+## Gotchas that have cost real time
+
+- **Never trust a GUI check without identifying the build first.** Two CapyInn builds share bundle id `io.capyinn.app`, and a reinstall silently does nothing if the old process is still up. Both traps have burned a full QA cycle. The `verifying-a-build` skill has the checks — use it before believing anything on screen.
+- **`rooms.type` stores the display name, not a slug.** Live values include `"Standard Room"` and `"Deluxe Balcony"` — they contain spaces. Never use a character delimiter for a list of room types; serialize with `JSON.stringify`. An unknown room type silently falls back to the house default instead of erroring, so corruption passes tests. Use real multi-word names as fixtures.
+- **The main checkout at `/Users/binhan/HotelManager` is shared with other sessions and changes branch mid-session.** For multi-step work, create a worktree off `main` first: `git worktree add .worktrees/<name> -b <branch> main`. Verify any path you read in the main checkout still exists on the branch you will actually build on.
+
+## Working approach
+
+- Read before writing. Prefer small targeted edits over rewriting files.
+- Test before declaring done. When mutation-testing, prove the edit landed before believing a green result.
+- Be concise in output, rigorous in reasoning.
+- No sycophantic openers or closing fluff.
+- Do not commit generated docs or specs unless asked.
+- Suggest `/cost` when a session runs long; suggest a new session when switching to an unrelated task.
+- User instructions override this file.

--- a/mhm/src-tauri/CLAUDE.md
+++ b/mhm/src-tauri/CLAUDE.md
@@ -1,0 +1,53 @@
+# Rust backend (`mhm/src-tauri`)
+
+Tauri v2 + SQLite. ~71k lines. `lib.rs` registers the command surface; `main.rs` is the native entrypoint.
+
+## Layer map
+
+Sizes are a rough guide to where the weight sits, measured 2026-08-01. They drift — do not treat them as current.
+
+| Directory | Size | Role |
+| --- | --- | --- |
+| `commands/` | ~6k | Outermost boundary — the `#[tauri::command]` surface. Nothing inner may depend on it. |
+| `services/` | ~19k | Business lifecycles (booking, stay, group, setup). The bulk of the domain logic. |
+| `queries/` | ~4k | Read path. UI → command → query → SQLite, bypassing services. |
+| `repositories/` | ~1k | Write path persistence + transactions. |
+| `domain/` | ~1k | Shared business rules and types. |
+| `db/` | ~2k | Connection, `migrations.rs`, `money.rs`, `outbox.rs`, row mapping. |
+| `agent/` | ~10k | Experimental runtime — agent loop, tools, memory. |
+| `gateway/` | ~3k | Experimental runtime — MCP gateway, loopback-only by default. |
+| `declaration/` | ~4k | Khai báo tạm trú (temporary residence declaration). |
+| `backup/` | ~2k | Backup, restore, and restore drills. |
+
+Cross-cutting files at `src/` root: `money.rs`, `money_migration.rs`, `outbox.rs`, `command_ledger.rs`, `command_idempotency.rs`, `command_recovery.rs`, `app_error.rs`, `architecture_guard.rs`.
+
+## Money
+
+`MoneyVnd = i64` in `money.rs`. Integer VND, always. Never `f64` for an amount.
+
+- Validate through `validate_transport_money_vnd` / `validate_non_negative_money_vnd` — values must stay inside the JS-safe integer range because they cross the Tauri IPC boundary as JSON numbers.
+- Percentages take `f64` (`percentage_money_line`), the resulting amount does not.
+- `npm run verify:money` (from `mhm/`) scans this tree for decimal literals on money-named fields. It matches by **field name** — a new money column whose name contains no money keyword slips through the net. When you add one, register it in `money_migration.rs` and in `scripts/verify/no-float-money.mjs`.
+- `bookings.guests` is a headcount, not money. Do not register it anywhere as a money column.
+
+## Command safety
+
+Every business write is one atomic unit: validate → authorize → lock → mutate → audit → outbox → commit. Retryable commands are idempotent by key + canonical payload hash (`command_idempotency/`). External effects go through `outbox.rs` inside the same transaction — never a direct HTTP call, webhook, or notification inside a mutation. Ledger and folio rows are append-only; correct with reversal rows.
+
+The `pms-command-safety` skill carries the full rule set and loads automatically when you edit here.
+
+## Tests
+
+```bash
+cargo test                                    # from this directory
+cargo clippy --all-targets -- -D warnings     # clippy is deny-warnings in CI
+cargo fmt -- --check
+```
+
+Targeted runs, from `mhm/`:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml services::booking::tests:: -- --nocapture
+```
+
+Tests are inline `mod tests` next to the code, not a separate tree. `architecture_guard.rs` holds the fitness tests for layer direction — if it goes red, the fix is the dependency, not the test.

--- a/mhm/src/CLAUDE.md
+++ b/mhm/src/CLAUDE.md
@@ -1,0 +1,41 @@
+# React frontend (`mhm/src`)
+
+React 19 + Vite 7 + TypeScript strict + Tailwind v4. UI primitives are shadcn-style on Base UI, in `components/ui/`. Icons are `lucide-react`, toasts are `sonner`, charts are `recharts`.
+
+## Layout
+
+- `App.tsx` owns the shell and routing; `main.tsx` mounts React.
+- `app/` — shell composition: `MainShell`, `AuthGate`, `BootstrapGate`, `RuntimeStateProvider`, `AppUpdateRuntime`.
+- `pages/` — one file per page; a page with sections becomes a folder with `index.tsx` (see `pages/settings/`).
+- `stores/` — zustand: `useHotelStore`, `useAuthStore`.
+- `hooks/`, `lib/`, `components/`, `contexts/`, `types/`.
+
+## Calling the backend
+
+Never call Tauri `invoke` directly for a PMS business write. Use the wrappers in `lib/command/`, re-exported from `lib/invokeCommand.ts`:
+
+```ts
+import { invokeCommand, invokeWriteCommand, createIdempotencyKey } from "@/lib/invokeCommand";
+```
+
+`invokeWriteCommand` attaches the idempotency key and canonical payload hash the backend requires. `tests/frontend-invoke-wrapper-guardrails.test.ts` parses this tree with the TypeScript compiler and fails the build on a raw `invoke` for a command that needs the wrapper. Read-only lookups (`get_*`, `check_availability`, `calculate_room_price_preview`) are on an explicit allow-list in that test — if you add a read command, add it there with a one-line reason.
+
+Errors come back as structured `AppError` (`lib/appError/`). Do not stringify and re-parse them; surface `code` and let `i18n.ts` resolve the message.
+
+## Pricing
+
+`usePricePreview` calls `calculate_room_price_preview`. It is a preview: the authoritative amount is whatever the backend returns at commit time. Never recompute a total in the frontend to display alongside it.
+
+Room types come from the backend as **display names containing spaces** (`"Standard Room"`, `"Deluxe Balcony"`). Never join or split a list of them on a character delimiter — use `JSON.stringify`. Use real multi-word names in fixtures; single-word placeholders hide the bug.
+
+## Tests
+
+Vitest + Testing Library + jsdom. Tests sit next to the code as `*.test.ts(x)`; cross-cutting suites and end-to-end flows live in `mhm/tests/` and `mhm/tests/e2e/`.
+
+```bash
+npm test                                    # whole suite
+npm test -- src/pages/NightAudit.test.tsx   # one file
+npm run test:watch
+```
+
+Prefer user-visible queries (`getByRole`, `getByText`) over test ids. Assert on what the operator sees, not on store internals.


### PR DESCRIPTION
## Problem

The repository's agent configuration had drifted from what it costs.

1. **Nothing was committed.** `CLAUDE.md`, `AGENTS.md`, and `.claude/` were all gitignored, so a fresh clone got no conventions and no change to them was ever reviewed.
2. **Two files, one content.** `CLAUDE.md` (4.6 KB) and `AGENTS.md` (5.0 KB) carried the same "Working Approach" block and an identical 43-line GitNexus block. Both loaded every session.
3. **The GitNexus block pointed at nothing.** Its index was last built 2026-05-27 against source last modified 2026-07-29, and no `gitnexus_*` MCP tool was connected. ~86 always-loaded MUST/NEVER lines named tools that did not exist — and an instruction file that is partly unfollowable loses weight everywhere, including its money-safety rules.
4. **No per-directory scoping.** 71k lines of Rust and 29k lines of TypeScript shared one generic root file, so a CSS edit loaded outbox and idempotency rules.
5. **The root file documented the discoverable and omitted the costly.** It listed `main.rs` as the native entrypoint — findable in one grep — while the layering contract, the money rule, and the install traps that had each burned a QA cycle appeared nowhere.

## Changes

| File | |
| --- | --- |
| `.gitignore` | Un-ignores `CLAUDE.md`, `AGENTS.md`, `.claude/settings.json`, `.claude/skills/`. `settings.local.json` and `.claude/worktrees/` stay local. |
| `CLAUDE.md` | Rewritten around the dependency direction enforced by `architecture_guard.rs`, which previously existed only as a Rust doc comment. |
| `AGENTS.md` | Reduced to a pointer. It was a second, drifting copy. |
| `mhm/src-tauri/CLAUDE.md` | New — layer map, money, command safety, cargo invocations. |
| `mhm/src/CLAUDE.md` | New — shell layout, `invokeCommand` wrapper rule, pricing, vitest. |
| `.claude/settings.json` | New — read denies for `target/`, `Scans/`, `package-lock.json`, `*.db`; worktree `sparsePaths`. |
| `.claude/skills/pms-command-safety/` | New — loads via `paths:` when editing the command layers. |
| `.claude/skills/verifying-a-build/` | New — the two-builds-one-bundle-id and stale-binary traps. |

Each non-negotiable is now stated with the guard that enforces it, so a compliance claim can name its evidence.

## Notable finding

`npm run verify:money` is defined in `package.json` but **invoked by nothing** — not CI, not `verify:quick`, not `verify:full`, not `CONTRIBUTING.md`. It is documented as manual-only rather than implied to be automatic. Wiring it into CI is deliberately left as a separate change, since it may go red on existing violations.

## Verification

| Check | Result |
| --- | --- |
| `git add --dry-run` | Exactly 8 files; `settings.local.json` and `.claude/worktrees/` correctly excluded |
| `cargo test architecture_guard` | 5 passed |
| `npm run verify:money` | Pass, exit 0 |
| Every path referenced in the new files | Confirmed to exist after rebase onto `origin/main` |

Always-loaded context per session: **9,675 → 4,762 bytes (−51%)**. Most of what went was duplication and dead references; the root file gained the layering contract and the field-tested traps it had been missing.

## Not in this PR

- `.agent/` (an unused third-party toolkit) and `.gitnexus/` (a stale 79 MB index) were removed from the local checkout only — both were gitignored, so neither appears in this diff.
- Language-server plugins replace GitNexus for symbol navigation; installing them is a local step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)