### PR TITLE
fix(reservations): ghi expected_checkout dạng RFC3339 khi nhận phòng từ đặt trước

### DIFF
--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -620,6 +620,12 @@ pub async fn confirm_reservation_tx(
     let total_price = pricing.total;
     let actual_nights = (effective_checkout_date - today).num_days() as i32;
     let check_in_at = now.to_rfc3339();
+    // Cột `expected_checkout` của booking đang ở phải là RFC3339, giống hệt
+    // đường walk-in trong `stay_lifecycle::check_in_tx`: `extend_stay` đọc cột
+    // này bằng `DateTime::parse_from_rfc3339`, gặp chuỗi chỉ-có-ngày là chrono
+    // báo "premature end of input". `effective_checkout` dạng ngày vẫn giữ
+    // nguyên cho phần tính giá và ghi lịch phòng bên dưới.
+    let expected_checkout = (now + chrono::Duration::days(actual_nights as i64)).to_rfc3339();
 
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ?")
         .bind(booking_id)
@@ -643,7 +649,7 @@ pub async fn confirm_reservation_tx(
     )
     .bind(status::booking::ACTIVE)
     .bind(&check_in_at)
-    .bind(&effective_checkout)
+    .bind(&expected_checkout)
     .bind(actual_nights)
     .bind(total_price)
     .bind(reservation.paid_amount)

--- a/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
@@ -55,6 +55,34 @@ async fn extend_stay_uses_existing_expected_checkout() {
     assert_eq!(charge.get::<i64, _>("amount"), 250_000);
 }
 
+/// Booking đi vào `active` qua đường đặt phòng trước cũng phải gia hạn được.
+/// `confirm_reservation` từng ghi `expected_checkout` dạng chỉ-có-ngày, trong
+/// khi `extend_stay` đọc cột đó bằng RFC3339 — khách nhận phòng từ đặt trước
+/// bấm gia hạn là dính lỗi chrono "premature end of input".
+#[tokio::test]
+async fn extend_stay_works_for_a_booking_confirmed_from_a_reservation() {
+    let pool = test_pool().await;
+    seed_booked_reservation_with_price(&pool, "B-RES-EXT", "R-RES-EXT", 500_000)
+        .await
+        .unwrap();
+
+    let confirmed = reservation_lifecycle::confirm_reservation(&pool, "B-RES-EXT")
+        .await
+        .unwrap();
+
+    let extended = stay_lifecycle::extend_stay(&pool, "B-RES-EXT")
+        .await
+        .unwrap();
+
+    assert_eq!(extended.nights, confirmed.nights + 1);
+
+    let before = chrono::DateTime::parse_from_rfc3339(&confirmed.expected_checkout)
+        .expect("confirm_reservation phải ghi expected_checkout dạng RFC3339");
+    let after = chrono::DateTime::parse_from_rfc3339(&extended.expected_checkout)
+        .expect("extend_stay phải ghi expected_checkout dạng RFC3339");
+    assert_eq!(after, before + Duration::days(1));
+}
+
 #[tokio::test]
 async fn extend_stay_idempotent_retry_replays_without_extra_night_or_charge() {
     let pool = test_pool().await;

--- a/mhm/src-tauri/src/services/booking/tests/reservations.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservations.rs
@@ -436,7 +436,13 @@ async fn confirm_reservation_reprices_and_marks_room_occupied() {
 
     assert_eq!(booking.status, "active");
     assert_eq!(booking.paid_amount, 50_000);
-    assert_eq!(booking.expected_checkout, scheduled_checkout_str);
+    // Booking đang ở giữ `expected_checkout` dạng RFC3339 để `extend_stay` đọc được.
+    assert_eq!(
+        chrono::DateTime::parse_from_rfc3339(&booking.expected_checkout)
+            .unwrap()
+            .date_naive(),
+        scheduled_checkout
+    );
     assert_eq!(booking.nights, 5);
     assert_eq!(booking.total_price, 3_000_000);
     assert!(booking.check_in_at.contains('T'));
@@ -569,7 +575,15 @@ async fn confirm_reservation_late_arrival_persists_effective_checkout() {
 
     assert_eq!(booking.status, "active");
     assert_eq!(booking.nights, 1);
-    assert_eq!(booking.expected_checkout, effective_checkout_str);
+    // Booking đang ở giữ `expected_checkout` dạng RFC3339 để `extend_stay` đọc được.
+    assert_eq!(
+        chrono::DateTime::parse_from_rfc3339(&booking.expected_checkout)
+            .unwrap()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string(),
+        effective_checkout_str
+    );
     assert_eq!(booking.total_price, 600_000);
 
     let calendar_rows = sqlx::query(


### PR DESCRIPTION
## Triệu chứng

Khách nhận phòng từ một **đặt phòng trước** rồi bấm **Gia hạn** thì app báo lỗi `premature end of input`. Gặp thật trên phòng 5A (khách Andrei).

## Root cause

`premature end of input` là chuỗi Display của chrono `ParseErrorKind::TooShort` — không phải lỗi JSON/IPC như tên gọi gợi ý.

`confirm_reservation_tx` ghi `check_in_at` dạng RFC3339 nhưng lại ghi `expected_checkout` dạng `"%Y-%m-%d"`:

```rust
let effective_checkout = effective_checkout_date.format("%Y-%m-%d").to_string();
```

`extend_stay_tx` đọc đúng cột đó bằng `DateTime::parse_from_rfc3339` (qua `parse_booking_datetime`), gặp chuỗi 10 ký tự là hết input giữa chừng. `map_extend_stay_command_error` map thành `SYSTEM_INTERNAL_ERROR` và đẩy **nguyên văn message của chrono** lên UI.

Đường walk-in (`stay_lifecycle::check_in_tx`) ghi `.to_rfc3339()` nên không bao giờ dính — chỉ booking đi qua đường đặt phòng trước mới lỗi.

## Phạm vi

Chỉ đúng chức năng Gia hạn: `expected_checkout` chỉ được parse kiểu RFC3339 ở một chỗ duy nhất (`stay_lifecycle.rs:1027`). Trả phòng, tính tiền, lịch phòng đều dùng `check_in_at` nên không ảnh hưởng.

Phụ thêm: `booking_list_queries` lọc cột này qua `local_date_sql`, vốn được viết cho chuỗi RFC3339 có offset — nên chuỗi chỉ-có-ngày trước đây cũng đã cho kết quả lệch âm thầm ở đó.

## Cách sửa

Tách hai giá trị:
- `effective_checkout` (dạng ngày) giữ nguyên cho phần tính giá và ghi lịch phòng
- cột `expected_checkout` nhận RFC3339, dựng theo đúng quy ước của `check_in_tx` (ngày trả phòng ở giờ nhận phòng)

## Migration

Không cần. 5 đặt phòng đang chờ sẽ được ghi lại `expected_checkout` lúc nhận phòng; các booking cũ còn định dạng ngày đều đã trả phòng. Riêng booking 5A đang ở đã được sửa tay trực tiếp trên DB kèm gia hạn 4 đêm.

## Kiểm chứng

Test mới `extend_stay_works_for_a_booking_confirmed_from_a_reservation` — chạy trên bản chưa sửa thì đỏ đúng lỗi thật:

```
called `Result::unwrap()` on an `Err` value: DateTimeParse("premature end of input")
```

Hai test cũ của `confirm_reservation` từng khẳng định định dạng chỉ-có-ngày, nay đổi sang khẳng định RFC3339 (so sánh phần ngày, không so chuỗi thô).

Cả ba cổng CI đều xanh tại chỗ: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1015 passed, 0 failed).

> Nhánh cắt thẳng từ `origin/main` (beaac4d) nên merge được linear — đừng bấm "Update branch".

🤖 Generated with [Claude Code](https://claude.com/claude-code)