### PR TITLE
docs: describe the pricing engine and the reservation calendar that shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Temporary residence declaration workspace (khai báo tạm trú): its own declaration
+  module, extraction and validation, XLSX and XML writers generated from the official
+  template, a declaration page with a sidebar badge and reconcile loop, and a
+  `--check-resources` mode on the probe CLI
+- Reservation calendar timeline: click or drag across empty cells to open a check-in
+  or a reservation with those dates already prefilled
+- Backfill sheet for recording a stay that already happened, with the matching
+  `backfill_stay` service and Tauri command behind it
+- Read-only booking detail popup for checked-out guests, and a read-first
+  `viewInvoice` that shows an already-issued invoice without creating a new one
+- Peak seasons: declare one as a date range in Settings, delete it, and have
+  contiguous declared days group back into a single season
+- Extra-guest pricing: a flat per-guest, per-night charge above the room's included
+  headcount, with reservations storing a guest count and being priced with it
+- Room-keyed price preview so the reservation sheet quotes what the engine will
+  actually charge, with the breakdown in Vietnamese
+- Restore drill now asserts backup freshness, schema version, and a row baseline
+- Frontend experimental runtime profile
 - open-source repository metadata and community files
 - CI workflow and GitHub issue / PR templates
 
 ### Changed
 
+- Room cards show the room type's configured rate instead of `rooms.base_price`,
+  which the pricing model does not honour as a price
+- The reservation sheet takes a checkout date from a calendar instead of a nights box
+- Night audit and the sheets close the day by the local day rather than a
+  UTC-derived one
 - public repository cleanup for internal agent files and docs layout
 - README restructuring for public contributors and onboarding-based setup
+
+### Fixed
+
+- Peak-season uplift is charged per night inside the season, not once per check-in day
+- Vietnamese room type names no longer lose their configured price: room types are
+  matched case-insensitively with the same folding on both sides of the comparison
+- The guest charge survives extend-stay, early checkout, modify, and check-in
+- Previews fail visibly instead of quoting a default the front desk will not honour
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   module, extraction and validation, XLSX and XML writers generated from the official
   template, a declaration page with a sidebar badge and reconcile loop, and a
   `--check-resources` mode on the probe CLI
+- Mid-stay room change for a guest already in house, with the valid target rooms
+  listed for the booking and an option to keep the original price or charge the
+  difference between the two rooms
 - Reservation calendar timeline: click or drag across empty cells to open a check-in
   or a reservation with those dates already prefilled
 - Backfill sheet for recording a stay that already happened, with the matching

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ CapyInn is built for a narrow but practical use case: small hotels that need a s
 
 - Dashboard organized around the configured room layout
 - Check-in, check-out, extend-stay, and reservation flows in one desktop app
+- Mid-stay room change for an in-house guest, listing the valid target rooms for that booking and offering a choice between keeping the original price and charging the difference
 - Reservation calendar timeline: click or drag across empty cells to open a check-in or a reservation with those dates already filled in
 - Backfill sheet for recording a stay that already happened, opened from the same calendar
 - Read-only detail popup for a booking that has already checked out, including its issued invoice

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ CapyInn is built for a narrow but practical use case: small hotels that need a s
 
 - Dashboard organized around the configured room layout
 - Check-in, check-out, extend-stay, and reservation flows in one desktop app
+- Reservation calendar timeline: click or drag across empty cells to open a check-in or a reservation with those dates already filled in
+- Backfill sheet for recording a stay that already happened, opened from the same calendar
+- Read-only detail popup for a booking that has already checked out, including its issued invoice
 - Support for multiple guests on the same booking
 - Fast copy flow for guest registration details
 
@@ -125,9 +128,13 @@ CapyInn is built for a narrow but practical use case: small hotels that need a s
 - Watches `~/CapyInn/Scans/` for new scan files
 - Extracts guest name, national ID number, birth date, and address for check-in
 
-### Billing, payments, and reporting
+### Pricing, billing, and reporting
 
-- Night-based pricing by room type
+- Rates are a property of the room type, not of the individual room: hourly, overnight, and nightly/daily models, with an hourly total capped at the cheaper block
+- Weekend uplift, peak-season uplift, and early check-in / late check-out surcharges
+- Peak seasons are declared in Settings as date ranges; the uplift is charged only for the nights that fall inside one
+- Extra-person surcharge per guest per night above the room's included headcount — reservations carry a guest count and are quoted with it
+- Prices shown before a stay come from the backend preview that will charge it, never from arithmetic in the UI
 - Charge, payment, deposit, and balance tracking
 - Revenue analytics, expense tracking, and CSV export
 


### PR DESCRIPTION
## Problem

The last documentation pass merged as #181. Since `v0.1.6` (2026-05-09), **268 commits** have landed on `main`, 29 of them features. Two public docs drifted out of step with the code.

**README** described pricing in a single line — *"Night-based pricing by room type"* — for an engine that now charges:

- hourly / overnight / nightly-daily blocks, with the hourly total capped at the cheaper block (`mhm/src-tauri/src/pricing.rs`)
- a weekend uplift and early check-in / late check-out surcharges (`PricingRule`)
- a peak-season uplift declared as a date range in Settings (`SpecialDatesSection.tsx`), charged only for the nights inside the season
- an extra-person charge per guest per night above the room's included headcount (`domain/booking/pricing.rs`)

Front-desk operations also omitted the reservation calendar timeline, the backfill sheet, and the read-only popup for a closed booking — all shipped, all in the normal PMS profile.

**CHANGELOG** still had an `Unreleased` section listing only the open-source repository cleanup. Khai báo tạm trú, the reservation calendar, peak seasons, and extra-guest pricing were all missing from the file that opens by claiming every notable change is documented in it.

## Changes

- `README.md` — rewrote the pricing feature block, added the calendar timeline, backfill sheet, and closed-booking popup to front-desk operations
- `CHANGELOG.md` — filled in `Unreleased` with what actually landed since `v0.1.6`, split across Added / Changed / Fixed

## Verification

Markdown only — `git diff --name-only` returns nothing outside `*.md`, so no code path is touched.

Every claim added was checked against the source rather than against a commit message:

| Claim | Checked against |
| --- | --- |
| Hourly capped to the cheaper block | `pricing.rs:161`, `PricingResult.capped` |
| Weekend / early / late surcharges | `PricingRule` fields |
| Peak season is a declared date range, charged per night inside it | `SpecialDatesSection.tsx`; `special_uplift_covers_only_the_nights_inside_the_season` |
| Extra-person fee is per guest, per night, over `rooms.max_guests` | `domain/booking/pricing.rs:28-31` |
| Rate is keyed on room type, not room | `docs/architecture/core-pms-boundaries.md` |
| Preview is authoritative, no UI arithmetic | `usePricePreview` → `calculate_room_price_preview` |
| Calendar timeline, backfill, closed-booking popup | `pages/Reservations.tsx`, `BackfillSheet.tsx`, `BookingDetailPopup.tsx`, `commands/rooms.rs:154` |

All README relative links and every table-of-contents anchor still resolve (the renamed heading is an `###`, not referenced by the TOC).

## Scope note

Guest count is documented **for reservations only**. Walk-in check-in still passes `guests: null` on `main` (`CheckinSheet.tsx:182`) — the desk headcount prompt is #200 and is not merged, so it is deliberately absent from these docs.

Design specs and plans under `docs/superpowers/` were left alone: they are point-in-time records, not living documentation, and rewriting them to match today's code would destroy their value as history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)