### PR TITLE
fix(stays): gia hạn dời luôn scheduled_checkout, không để thanh timeline đứng yên

### DIFF
--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1072,14 +1072,24 @@ async fn extend_stay_tx(
         .ok_or_else(|| BookingError::validation("total_price overflowed".to_string()))?;
     let new_checkout = new_expected.to_rfc3339();
 
+    // `scheduled_checkout` phải đi theo `expected_checkout`: timeline vẽ thanh
+    // booking bằng `scheduled_checkout || expected_checkout`, nên bỏ quên cột này
+    // là khách đặt trước gia hạn bao nhiêu lần thanh vẫn đứng ở ngày trả cũ.
+    // CASE giữ NULL cho khách walk-in — họ không có ngày đặt trước để dời.
+    let new_scheduled_checkout = new_expected.date_naive().format("%Y-%m-%d").to_string();
+
     let result = sqlx::query(
         "UPDATE bookings
-         SET nights = ?, total_price = ?, expected_checkout = ?
+         SET nights = ?, total_price = ?, expected_checkout = ?,
+             scheduled_checkout = CASE
+                 WHEN scheduled_checkout IS NULL THEN NULL ELSE ?
+             END
          WHERE id = ? AND status = ? AND expected_checkout = ?",
     )
     .bind(current_nights + 1)
     .bind(new_total)
     .bind(&new_checkout)
+    .bind(&new_scheduled_checkout)
     .bind(booking_id)
     .bind(status::booking::ACTIVE)
     .bind(&old_expected_checkout)

--- a/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
@@ -83,6 +83,72 @@ async fn extend_stay_works_for_a_booking_confirmed_from_a_reservation() {
     assert_eq!(after, before + Duration::days(1));
 }
 
+/// Timeline vẽ thanh booking bằng `scheduled_checkout || expected_checkout`, nên
+/// gia hạn mà không dời `scheduled_checkout` thì thanh của khách đặt trước đứng
+/// yên ở ngày trả phòng cũ dù đã bấm gia hạn bao nhiêu lần.
+#[tokio::test]
+async fn extend_stay_moves_scheduled_checkout_for_a_reservation_booking() {
+    let pool = test_pool().await;
+    seed_booked_reservation_with_price(&pool, "B-RES-SCHED", "R-RES-SCHED", 500_000)
+        .await
+        .unwrap();
+    reservation_lifecycle::confirm_reservation(&pool, "B-RES-SCHED")
+        .await
+        .unwrap();
+
+    let before: Option<String> =
+        sqlx::query_scalar("SELECT scheduled_checkout FROM bookings WHERE id = ?")
+            .bind("B-RES-SCHED")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let extended = stay_lifecycle::extend_stay(&pool, "B-RES-SCHED")
+        .await
+        .unwrap();
+
+    let after: Option<String> =
+        sqlx::query_scalar("SELECT scheduled_checkout FROM bookings WHERE id = ?")
+            .bind("B-RES-SCHED")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let new_checkout_day = chrono::DateTime::parse_from_rfc3339(&extended.expected_checkout)
+        .unwrap()
+        .date_naive()
+        .format("%Y-%m-%d")
+        .to_string();
+    assert_ne!(
+        after, before,
+        "scheduled_checkout phải dời theo khi gia hạn"
+    );
+    assert_eq!(after, Some(new_checkout_day));
+}
+
+/// Khách walk-in không có `scheduled_checkout`; gia hạn không được tự đẻ ra giá
+/// trị cho cột đó, nếu không booking vãng lai sẽ bị nhầm thành đặt trước.
+#[tokio::test]
+async fn extend_stay_leaves_scheduled_checkout_null_for_a_walk_in() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-WALKIN-SCHED").await.unwrap();
+    seed_active_booking(&pool, "B-WALKIN-SCHED", "R-WALKIN-SCHED")
+        .await
+        .unwrap();
+
+    stay_lifecycle::extend_stay(&pool, "B-WALKIN-SCHED")
+        .await
+        .unwrap();
+
+    let after: Option<String> =
+        sqlx::query_scalar("SELECT scheduled_checkout FROM bookings WHERE id = ?")
+            .bind("B-WALKIN-SCHED")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(after, None);
+}
+
 #[tokio::test]
 async fn extend_stay_idempotent_retry_replays_without_extra_night_or_charge() {
     let pool = test_pool().await;


### PR DESCRIPTION
## Triệu chứng

Khách đặt trước bấm **Gia hạn** thành công, nhưng thanh booking trên timeline vẫn đứng ở ngày trả phòng cũ. Lễ tân tưởng lệnh không ăn nên bấm thêm nhiều lần — thực tế đã gia hạn **thừa 4 đêm** cho khách 5A.

Lệnh chạy đúng, ledger xác nhận 4 lệnh `extend_stay` **completed**. Sai là ở chỗ hiển thị.

## Root cause

[Reservations.tsx:234](../../blob/main/mhm/src/pages/Reservations.tsx#L234) dựng ngày kết thúc thanh như sau:

```js
: b.scheduled_checkout || b.expected_checkout
```

`scheduled_checkout` được ưu tiên. Mà `extend_stay_tx` chỉ cập nhật `expected_checkout` — `grep scheduled_checkout stay_lifecycle.rs` trả về **0 kết quả**.

Với booking sinh ra từ đặt phòng trước, `scheduled_checkout` giữ nguyên ngày đặt ban đầu nên thanh không bao giờ dài ra:

| Phòng | Loại | scheduled_checkout | expected_checkout |
|---|---|---|---|
| 5A | reservation | **2026-08-03** | 2026-08-11 |
| 2B | walk-in | *(NULL)* | 2026-08-08 |

Khách walk-in có `scheduled_checkout` NULL nên rơi xuống `expected_checkout` và hiển thị đúng — chỉ booking từ đặt phòng trước mới dính, cùng nhóm khách với #202.

## Cách sửa

Thêm `scheduled_checkout` vào `UPDATE`, bọc `CASE` để giữ NULL cho walk-in. Tự đẻ giá trị cho cột đó sẽ làm booking vãng lai bị nhầm thành đặt trước ở những chỗ khác đang phân biệt hai loại bằng chính cột này.

Sửa ở backend nên [BookingDetailPopup.tsx:69](../../blob/main/mhm/src/components/BookingDetailPopup.tsx#L69) và [ReservationSheet.tsx:86](../../blob/main/mhm/src/components/ReservationSheet.tsx#L86) — hai chỗ cùng đọc `scheduled_checkout` trước — cũng hết sai theo, không phải đụng vào frontend.

## Kiểm chứng

Test chính đỏ thật khi gỡ bản sửa ra (`git stash` phần production rồi chạy lại), đúng chữ ký của bug:

```
assertion `left != right` failed: scheduled_checkout phải dời theo khi gia hạn
  left: Some("2026-04-22")
 right: Some("2026-04-22")
```

Test walk-in thì xanh ở cả hai chiều — nó là **test canh**, chống bản sửa làm quá tay và ghi đè NULL, chứ không phải test đỏ.

Ba cổng CI xanh tại chỗ: `cargo fmt --check` (0), `cargo clippy --all-targets -- -D warnings` (0), `cargo test` **1017 passed, 0 failed**.

## Còn sót lại (không nằm trong PR này)

`confirm_reservation_tx` cũng không đồng bộ `scheduled_checkout`. Khách đặt trước đến muộn bị đẩy ngày trả phòng sang hôm sau, nhưng thanh vẫn đứng ở ngày đặt cũ — cùng loại bug, đường khác. Để riêng vì ngoài phạm vi được giao.

> Nhánh cắt thẳng từ `origin/main` (b0af36d) nên merge được linear — đừng bấm "Update branch".

🤖 Generated with [Claude Code](https://claude.com/claude-code)