### PR TITLE
feat(room-change): chuyển phòng giữa kỳ cho khách đang ở

### DIFF
--- a/mhm/src-tauri/src/commands/invoices.rs
+++ b/mhm/src-tauri/src/commands/invoices.rs
@@ -49,6 +49,7 @@ struct InvoiceDataWire {
     balance_due: crate::money::MoneyVnd,
     policy_text: Option<String>,
     notes: Option<String>,
+    settlement_note: Option<String>,
     status: String,
     created_at: String,
 }
@@ -76,6 +77,7 @@ impl From<InvoiceDataWire> for InvoiceData {
             balance_due: value.balance_due,
             policy_text: value.policy_text,
             notes: value.notes,
+            settlement_note: value.settlement_note,
             status: value.status,
             created_at: value.created_at,
         }

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -10,7 +10,7 @@ use crate::{
     queries::booking::{expense_queries, revenue_queries, room_queries, stay_info_queries},
     repositories::booking::expense_repository,
     services::{
-        booking::{backfill, stay_lifecycle},
+        booking::{backfill, room_change, stay_lifecycle},
         housekeeping::housekeeping_service,
     },
 };
@@ -73,6 +73,13 @@ fn extend_stay_failure_context(booking_id: &str) -> Value {
     json!({
         "booking_id": booking_id,
         "operation": "add_one_night",
+    })
+}
+
+fn change_room_failure_context(booking_id: &str, new_room_id: &str) -> Value {
+    json!({
+        "booking_id": booking_id,
+        "new_room_id": new_room_id,
     })
 }
 
@@ -352,6 +359,88 @@ pub async fn extend_stay(
 
     log::info!(
         "extend_stay success correlation_id={} source={:?} booking_id={} room_id={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        booking.id,
+        booking.room_id
+    );
+
+    emit_db_update(&app, "rooms");
+
+    Ok(booking)
+}
+
+// ─── Change Room ───
+
+#[tauri::command]
+pub async fn get_room_change_options(
+    state: State<'_, AppState>,
+    booking_id: String,
+) -> Result<RoomChangeOptions, String> {
+    room_change::load_options(&state.db, &booking_id, chrono::Local::now().date_naive())
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn change_room(
+    state: State<'_, AppState>,
+    booking_id: String,
+    new_room_id: String,
+    keep_price: bool,
+    reason: Option<String>,
+    app: tauri::AppHandle,
+    correlation_id: Option<String>,
+    idempotency_key: String,
+) -> CommandResult<Booking> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let error_context = change_room_failure_context(&booking_id, &new_room_id);
+    let actor_id = get_user_id(&state)
+        .ok_or_else(|| CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập"))?;
+    let mut write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "change_room",
+    )?;
+    write_command_context.actor_id = Some(actor_id);
+    log::info!(
+        "change_room start correlation_id={} source={:?} booking_id={} new_room_id={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        booking_id,
+        new_room_id
+    );
+
+    let result = room_change::change_room_idempotent(
+        &state.db,
+        &write_command_context,
+        &booking_id,
+        &new_room_id,
+        keep_price,
+        reason,
+    )
+    .await
+    .inspect_err(|command_error| {
+        record_command_failure_with_db_group(
+            "change_room",
+            command_error,
+            &effective_correlation_id.value,
+            None,
+            error_context.clone(),
+        );
+    })?;
+
+    let booking: Booking = serde_json::from_value(result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid change_room idempotent response: {error}"),
+        )
+        .with_request_id(write_command_context.request_id.clone())
+    })?;
+
+    log::info!(
+        "change_room success correlation_id={} source={:?} booking_id={} room_id={}",
         effective_correlation_id.value,
         effective_correlation_id.source,
         booking.id,

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -157,6 +157,18 @@ async fn ensure_setting_default(
 /// claiming the next number, survey every ref — `git for-each-ref` +
 /// `git show <ref>:mhm/src-tauri/src/db.rs | grep LATEST_SCHEMA_VERSION` — and
 /// read the live database, not the brief. Gaps are harmless; collisions are not.
+///
+/// **The same trap bites backwards, and that is the easier half to miss.** A
+/// branch written earlier and merged later is just as broken: once this build
+/// ships and the hotel's database reads 25, `feat/room-drawer-stay-edits` —
+/// still sitting at 24 — has a gate `current < 24` that can never fire again,
+/// so its `bookings.rate_overridden_at` would never be created. Picking a
+/// number higher than every *branch* is not enough; it must also be higher than
+/// whatever the live database has already reached by the time you merge. So the
+/// survey is not a one-off at the start of the work: re-run it immediately
+/// before merging, and if the shipped version has moved past yours, renumber
+/// above it. Nothing warns you — the app simply starts up and fails on the
+/// first query that touches the missing column.
 pub(crate) const LATEST_SCHEMA_VERSION: i32 = 25;
 
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -145,7 +145,7 @@ async fn ensure_setting_default(
 /// Schema version a database reaches after `run_migrations` finishes on this
 /// build. Bump this together with every new migration block below; the
 /// `migrations_run_to_latest_schema_version` test fails otherwise.
-pub(crate) const LATEST_SCHEMA_VERSION: i32 = 22;
+pub(crate) const LATEST_SCHEMA_VERSION: i32 = 23;
 
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {
     sqlx::query(
@@ -320,6 +320,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
     // -- V22: số khách trên booking, để tính phụ thu thêm người --
     if current < 22 {
         core_extensions::migrate_v22_booking_guest_count(pool).await?;
+    }
+
+    // -- V23: lời quyết toán in được cho khách, tách khỏi ghi chú nội bộ --
+    if current < 23 {
+        core_extensions::migrate_v23_invoice_settlement_note(pool).await?;
     }
     Ok(())
 }
@@ -814,6 +819,14 @@ mod tests {
             .await
             .expect("creates legacy bookings table");
 
+        // Same reason, for v23's ALTER: a real database sitting at v10 or v11
+        // went through v8, so it already has `invoices`. This fixture jumps
+        // straight past v8, so it has to stand the table up itself.
+        sqlx::query("CREATE TABLE invoices (id TEXT PRIMARY KEY)")
+            .execute(pool)
+            .await
+            .expect("creates legacy invoices table");
+
         sqlx::query(
             "CREATE TABLE transactions (
                 id          TEXT PRIMARY KEY,
@@ -872,7 +885,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -893,7 +906,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1181,7 +1194,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1248,7 +1261,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1328,7 +1341,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1368,7 +1381,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1386,7 +1399,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1416,7 +1429,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1429,7 +1442,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1438,6 +1451,38 @@ mod tests {
         run_migrations(&pool).await.expect("runs migrations");
 
         assert_agent_digest_runs_shape(&pool).await;
+    }
+
+    /// v23 is a bare `ALTER TABLE ... ADD COLUMN`, which SQLite rejects the
+    /// second time. `execute_compat_alter` is supposed to swallow exactly that
+    /// error, so rewinding the version and replaying must be a no-op rather
+    /// than an upgrade that dies halfway on a real hotel's database.
+    #[tokio::test]
+    async fn migration_v23_adds_invoice_settlement_note_idempotently() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("initial migrations run");
+
+        sqlx::query("UPDATE schema_version SET version = 22")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version");
+        run_migrations(&pool).await.expect("v23 migration reruns");
+        run_migrations(&pool)
+            .await
+            .expect("v23 migration is idempotent");
+
+        let settlement_note_columns: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('invoices') WHERE name = 'settlement_note'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("reads invoices columns");
+        assert_eq!(settlement_note_columns, 1);
+
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1462,7 +1507,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1486,7 +1531,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -1500,7 +1500,9 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("connects in-memory sqlite");
-        run_migrations(&pool).await.expect("runs migrations to latest");
+        run_migrations(&pool)
+            .await
+            .expect("runs migrations to latest");
 
         sqlx::query("ALTER TABLE invoices DROP COLUMN settlement_note")
             .execute(&pool)
@@ -1549,7 +1551,9 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("connects in-memory sqlite");
-        run_migrations(&pool).await.expect("runs migrations to latest");
+        run_migrations(&pool)
+            .await
+            .expect("runs migrations to latest");
 
         sqlx::query("ALTER TABLE invoices DROP COLUMN settlement_note")
             .execute(&pool)

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -145,7 +145,19 @@ async fn ensure_setting_default(
 /// Schema version a database reaches after `run_migrations` finishes on this
 /// build. Bump this together with every new migration block below; the
 /// `migrations_run_to_latest_schema_version` test fails otherwise.
-pub(crate) const LATEST_SCHEMA_VERSION: i32 = 23;
+///
+/// 23 and 24 are deliberately skipped, not free: 23 belongs to
+/// `design/kbtt-ux-simplify` (`migrate_v23_stay_snapshot`) and has already
+/// shipped to the hotel's machine, 24 belongs to
+/// `feat/room-drawer-stay-edits` (`migrate_v24_booking_rate_override`, see its
+/// commit 4c5c1c3, which renumbered away from this same collision). Reusing a
+/// number another branch already shipped is silent and fatal: the gate
+/// `current < N` is false on a database already at N, so the migration never
+/// runs and every query touching the new column dies at runtime. Before
+/// claiming the next number, survey every ref — `git for-each-ref` +
+/// `git show <ref>:mhm/src-tauri/src/db.rs | grep LATEST_SCHEMA_VERSION` — and
+/// read the live database, not the brief. Gaps are harmless; collisions are not.
+pub(crate) const LATEST_SCHEMA_VERSION: i32 = 25;
 
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {
     sqlx::query(
@@ -322,9 +334,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         core_extensions::migrate_v22_booking_guest_count(pool).await?;
     }
 
-    // -- V23: lời quyết toán in được cho khách, tách khỏi ghi chú nội bộ --
-    if current < 23 {
-        core_extensions::migrate_v23_invoice_settlement_note(pool).await?;
+    // -- V25: lời quyết toán in được cho khách, tách khỏi ghi chú nội bộ --
+    // (23 đã bị nhánh kbtt chiếm và đã chạy trên máy thật, 24 là của nhánh
+    //  room-drawer — xem chú thích ở LATEST_SCHEMA_VERSION)
+    if current < 25 {
+        core_extensions::migrate_v25_invoice_settlement_note(pool).await?;
     }
     Ok(())
 }
@@ -885,7 +899,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -906,7 +920,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1194,7 +1208,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1261,7 +1275,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1341,7 +1355,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1381,7 +1395,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1399,7 +1413,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1429,7 +1443,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1442,7 +1456,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1453,36 +1467,101 @@ mod tests {
         assert_agent_digest_runs_shape(&pool).await;
     }
 
-    /// v23 is a bare `ALTER TABLE ... ADD COLUMN`, which SQLite rejects the
-    /// second time. `execute_compat_alter` is supposed to swallow exactly that
-    /// error, so rewinding the version and replaying must be a no-op rather
-    /// than an upgrade that dies halfway on a real hotel's database.
+    /// The decisive migration test, modelled on
+    /// `migration_v24_alter_actually_runs_on_a_genuinely_pre_v24_database`
+    /// (commit 4c5c1c3, which renumbered away from this same collision).
+    ///
+    /// Rewinding `schema_version` while the column is still present proves
+    /// nothing: the replayed ALTER lands in `execute_compat_alter`'s
+    /// duplicate-column swallow and the assertion passes on the column the
+    /// FIRST run created. It stays green even when the gate never fires —
+    /// exactly the production failure this branch shipped, where the hotel's
+    /// database was already at 23 (claimed by another branch), `current < 23`
+    /// was false, `settlement_note` was never created, and the first
+    /// `generate_invoice` died on `no such column`.
+    ///
+    /// So: DROP the column to build a database that has genuinely never seen
+    /// this migration, rewind to the true predecessor, and require the real
+    /// ALTER path to put it back.
     #[tokio::test]
-    async fn migration_v23_adds_invoice_settlement_note_idempotently() {
+    async fn migration_v25_alter_actually_runs_on_a_genuinely_pre_v25_database() {
         let pool = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("connects in-memory sqlite");
-        run_migrations(&pool).await.expect("initial migrations run");
+        run_migrations(&pool).await.expect("runs migrations to latest");
 
-        sqlx::query("UPDATE schema_version SET version = 22")
+        sqlx::query("ALTER TABLE invoices DROP COLUMN settlement_note")
             .execute(&pool)
             .await
-            .expect("rewinds schema version");
-        run_migrations(&pool).await.expect("v23 migration reruns");
+            .expect("drops settlement_note to simulate a pre-v25 database");
+        assert_eq!(
+            invoices_settlement_note_column_count(&pool).await,
+            0,
+            "tiền đề của test: DB phải thật sự chưa có cột settlement_note"
+        );
+
+        // 24 is the true predecessor — the highest number claimed by any other
+        // branch. A database sitting at 23 or 24 must still be upgraded.
+        sqlx::query("UPDATE schema_version SET version = 24")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version to a genuinely pre-v25 state");
+
         run_migrations(&pool)
             .await
-            .expect("v23 migration is idempotent");
+            .expect("v25 migration adds the column back via a real ALTER TABLE");
 
-        let settlement_note_columns: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM pragma_table_info('invoices') WHERE name = 'settlement_note'",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("reads invoices columns");
-        assert_eq!(settlement_note_columns, 1);
+        assert_eq!(
+            invoices_settlement_note_column_count(&pool).await,
+            1,
+            "ALTER TABLE thật phải chạy và tạo lại cột settlement_note"
+        );
+
+        // Replaying must be a no-op, not a half-applied upgrade that dies on
+        // the hotel's database: `execute_compat_alter` swallows the
+        // duplicate-column error the second ALTER would raise.
+        run_migrations(&pool)
+            .await
+            .expect("v25 migration is idempotent");
+        assert_eq!(invoices_settlement_note_column_count(&pool).await, 1);
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
+    }
+
+    /// A database still sitting at kbtt's 23 — the version the hotel's machine
+    /// actually reports — must be carried all the way to 25, not stall because
+    /// some intermediate number was skipped.
+    #[tokio::test]
+    async fn migration_v25_upgrades_a_database_left_at_the_shipped_v23() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        run_migrations(&pool).await.expect("runs migrations to latest");
+
+        sqlx::query("ALTER TABLE invoices DROP COLUMN settlement_note")
+            .execute(&pool)
+            .await
+            .expect("drops settlement_note");
+        sqlx::query("UPDATE schema_version SET version = 23")
+            .execute(&pool)
+            .await
+            .expect("rewinds to the version the live database reports");
+
+        run_migrations(&pool).await.expect("v25 runs from v23");
+
+        assert_eq!(invoices_settlement_note_column_count(&pool).await, 1);
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 25);
+    }
+
+    async fn invoices_settlement_note_column_count(pool: &SqlitePool) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('invoices') WHERE name = 'settlement_note'",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("reads invoices columns")
     }
 
     #[tokio::test]
@@ -1507,7 +1586,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]
@@ -1531,7 +1610,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -160,7 +160,11 @@ pub(super) async fn migrate_v25_invoice_settlement_note(
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
-    execute_compat_alter(&mut tx, "ALTER TABLE invoices ADD COLUMN settlement_note TEXT").await?;
+    execute_compat_alter(
+        &mut tx,
+        "ALTER TABLE invoices ADD COLUMN settlement_note TEXT",
+    )
+    .await?;
 
     set_schema_version(&mut tx, 25).await?;
     tx.commit().await?;

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -155,14 +155,14 @@ pub(super) async fn migrate_v22_booking_guest_count(
 ///
 /// Cho phép NULL: hoá đơn không tách phòng không có gì để nói thêm, và hoá đơn
 /// phát hành trước phiên bản này cũng vậy.
-pub(super) async fn migrate_v23_invoice_settlement_note(
+pub(super) async fn migrate_v25_invoice_settlement_note(
     pool: &Pool<Sqlite>,
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
     execute_compat_alter(&mut tx, "ALTER TABLE invoices ADD COLUMN settlement_note TEXT").await?;
 
-    set_schema_version(&mut tx, 23).await?;
+    set_schema_version(&mut tx, 25).await?;
     tx.commit().await?;
     Ok(())
 }

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -145,3 +145,24 @@ pub(super) async fn migrate_v22_booking_guest_count(
     tx.commit().await?;
     Ok(())
 }
+
+/// Lời quyết toán in cho khách trên hoá đơn tách theo phòng.
+///
+/// Cố ý KHÔNG dùng lại `invoices.notes`: cột đó chép nguyên `bookings.notes`,
+/// tức là ghi chú nội bộ của lễ tân ("cọc 600k", "Agoda thanh toan"), thứ không
+/// bao giờ được in cho khách đọc. Tách riêng một cột thì thứ hiển thị được và
+/// thứ nội bộ không thể lẫn vào nhau.
+///
+/// Cho phép NULL: hoá đơn không tách phòng không có gì để nói thêm, và hoá đơn
+/// phát hành trước phiên bản này cũng vậy.
+pub(super) async fn migrate_v23_invoice_settlement_note(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    execute_compat_alter(&mut tx, "ALTER TABLE invoices ADD COLUMN settlement_note TEXT").await?;
+
+    set_schema_version(&mut tx, 23).await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -429,7 +429,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .expect("reads schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     /// Khách tới trước khi có booking: phải khai báo được ngay, không phải chờ

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -429,7 +429,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .expect("reads schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 25);
     }
 
     /// Khách tới trước khi có booking: phải khai báo được ngay, không phải chờ

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -325,6 +325,8 @@ pub fn run() {
             commands::rooms::check_out,
             commands::rooms::preview_checkout_settlement,
             commands::rooms::extend_stay,
+            commands::rooms::change_room,
+            commands::rooms::get_room_change_options,
             commands::rooms::get_housekeeping_tasks,
             commands::rooms::update_housekeeping,
             commands::rooms::create_expense,

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -596,7 +596,14 @@ pub struct InvoiceData {
     pub total: MoneyVnd,
     pub balance_due: MoneyVnd,
     pub policy_text: Option<String>,
+    /// The booking's own notes, copied verbatim — front-desk shorthand, NOT
+    /// guest-facing. Neither invoice renderer prints this; see
+    /// `settlement_note` for the text that is meant to be read by the guest.
     pub notes: Option<String>,
+    /// Guest-facing explanation of how the total was reached, set only when
+    /// the breakdown splits per room (`invoice_generation.rs`). `None` on a
+    /// single-line invoice, where the breakdown line already says it.
+    pub settlement_note: Option<String>,
     pub status: String,
     pub created_at: String,
 }

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -733,6 +733,38 @@ pub struct GroupInvoiceRoomLine {
     pub guest_name: String,
 }
 
+// ── Room Change DTOs ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomChangeOption {
+    pub room_id: String,
+    pub name: String,
+    pub room_type: String,
+    pub floor: i32,
+    pub base_price: MoneyVnd,
+    pub max_guests: i32,
+    /// Chênh lệch cho toàn bộ dải ngày còn lại: giá phòng này trừ giá phòng hiện tại.
+    /// Âm khi chuyển xuống hạng thấp hơn.
+    pub price_difference: MoneyVnd,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomChangeOptions {
+    pub booking_id: String,
+    pub current_room_id: String,
+    pub current_room_name: String,
+    /// Đêm đầu tiên được chuyển, dạng `YYYY-MM-DD`.
+    pub from_date: String,
+    /// Đêm cuối cùng được chuyển, dạng `YYYY-MM-DD`. Bao gồm chính nó.
+    pub to_date: String,
+    pub nights_remaining: i32,
+    pub nights_stayed: i32,
+    pub guest_count: i32,
+    pub rooms: Vec<RoomChangeOption>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::Booking;

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -742,10 +742,16 @@ pub struct RoomChangeOption {
     pub name: String,
     pub room_type: String,
     pub floor: i32,
-    pub base_price: MoneyVnd,
     pub max_guests: i32,
     /// Chênh lệch cho toàn bộ dải ngày còn lại: giá phòng này trừ giá phòng hiện tại.
     /// Âm khi chuyển xuống hạng thấp hơn.
+    ///
+    /// Đây là số duy nhất DTO này trả về để hiển thị giá — không có
+    /// `base_price`. `rooms.base_price` không phải giá hệ thống tính tiền
+    /// (xem `pricing_queries.rs`): tiền tính theo `room_type` qua
+    /// `pricing_rules`, `base_price` chỉ là dự phòng khi loại phòng chưa có
+    /// luật giá. Đưa `base_price` ra giao diện dễ khiến lễ tân đọc một số mà
+    /// hệ thống tính tiền khách một số khác.
     pub price_difference: MoneyVnd,
 }
 

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -24,7 +24,8 @@ use super::{
     pricing_service::calculate_stay_price_tx,
     support::{
         begin_immediate_tx, ensure_one_row_affected, ensure_rows_affected,
-        insert_room_calendar_rows, invalid_state_transition, validate_non_negative_booking_money,
+        insert_room_calendar_rows, invalid_state_transition, merge_pricing_snapshot,
+        room_calendar_stays_tx, room_stays_to_json, validate_non_negative_booking_money,
     },
 };
 
@@ -997,6 +998,45 @@ pub(crate) async fn group_checkout_tx(
             .push_bind(&now);
     });
     qb.build().execute(&mut **tx).await?;
+
+    // Snapshot `room_stays` before the DELETE below wipes `room_calendar` —
+    // the same move `check_out_tx` (stay_lifecycle.rs) makes on the
+    // single-booking path, and for the same reason: after checkout the
+    // snapshot is the only place the invoice can learn that a booking slept in
+    // more than one room. `change_room_tx` did write a snapshot at move time,
+    // but nothing has refreshed it since — an `extend_stay_tx` after the move
+    // added `room_calendar` rows and left it behind — so skipping this leaves
+    // a group booking's invoice splitting its money over the wrong nights.
+    //
+    // No truncation here, unlike `check_out_tx`: group checkout never settles
+    // fewer nights than booked — it leaves `bookings.nights` and `total_price`
+    // untouched (see the status UPDATE above), so `room_calendar` already
+    // holds exactly the nights being charged. A group is at most ~10 bookings,
+    // so a per-booking UPDATE is cheap.
+    for booking_id in &unique_booking_ids {
+        let room_stays = room_calendar_stays_tx(tx, booking_id).await?;
+        if room_stays.is_empty() {
+            continue;
+        }
+
+        let existing_snapshot: Option<String> =
+            sqlx::query_scalar("SELECT pricing_snapshot FROM bookings WHERE id = ?")
+                .bind(booking_id)
+                .fetch_optional(&mut **tx)
+                .await?
+                .flatten();
+        let merged_snapshot = merge_pricing_snapshot(
+            existing_snapshot.as_deref(),
+            "room_stays",
+            room_stays_to_json(&room_stays),
+        );
+
+        sqlx::query("UPDATE bookings SET pricing_snapshot = ? WHERE id = ?")
+            .bind(&merged_snapshot)
+            .bind(booking_id)
+            .execute(&mut **tx)
+            .await?;
+    }
 
     let mut qb = sqlx::QueryBuilder::new("DELETE FROM room_calendar WHERE booking_id IN (");
     let mut sep = qb.separated(", ");

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -116,13 +116,60 @@ pub async fn generate_invoice_tx(
     } else {
         total_price
     };
-    let breakdown: Vec<crate::pricing::PricingLine> = vec![crate::pricing::PricingLine {
+    let mut breakdown: Vec<crate::pricing::PricingLine> = vec![crate::pricing::PricingLine {
         label: settlement_label.unwrap_or_else(|| format!("{} night(s) x {}d", nights, per_night)),
         amount: total_price,
     }];
 
     let subtotal = total_price;
     let balance_due = (total_price - paid_amount).max(0);
+
+    // If the booking moved rooms mid-stay, replace the single combined room
+    // line with one line per room actually occupied, grouped by the night the
+    // guest first slept there. Nights slept before a move stay on the old
+    // room in `room_calendar` (see room_change service), so this query is the
+    // source of truth for "which rooms, how many nights each, in what order".
+    let room_nights = sqlx::query(
+        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights
+         FROM room_calendar rc
+         JOIN rooms r ON r.id = rc.room_id
+         WHERE rc.booking_id = ?
+         GROUP BY rc.room_id, r.name
+         ORDER BY MIN(rc.date)",
+    )
+    .bind(booking_id)
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if room_nights.len() > 1 {
+        let total_nights: i64 = room_nights.iter().map(|r| r.get::<i64, _>("nights")).sum();
+        if total_nights > 0 {
+            let mut allocated: crate::money::MoneyVnd = 0;
+            let mut room_lines = Vec::with_capacity(room_nights.len());
+            for (index, row) in room_nights.iter().enumerate() {
+                let room_name: String = row.get("room_name");
+                let nights_here: i64 = row.get("nights");
+                let amount = if index == room_nights.len() - 1 {
+                    subtotal - allocated
+                } else {
+                    let share = subtotal * nights_here / total_nights;
+                    allocated += share;
+                    share
+                };
+                room_lines.push(crate::pricing::PricingLine {
+                    label: format!("Phòng {room_name} × {nights_here} đêm"),
+                    amount,
+                });
+            }
+            // Preserve any non-room lines already present (surcharges, etc.):
+            // only the original single combined room line is being replaced.
+            let extra_lines: Vec<crate::pricing::PricingLine> =
+                breakdown.into_iter().skip(1).collect();
+            breakdown = room_lines;
+            breakdown.extend(extra_lines);
+        }
+    }
 
     // Generate invoice number: INV-YYYYMMDD-XXX
     let today = chrono::Local::now().format("%Y%m%d").to_string();

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -63,10 +63,12 @@ pub async fn generate_invoice_tx(
     let deposit_amount = get_optional_money_vnd(&b, "deposit_amount").unwrap_or(0);
     let notes: Option<String> = b.get("notes");
     let pricing_snapshot: Option<String> = b.get("pricing_snapshot");
-
-    let checkout_settlement = pricing_snapshot
+    let snapshot_value: Option<serde_json::Value> = pricing_snapshot
         .as_deref()
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
+
+    let checkout_settlement = snapshot_value
+        .as_ref()
         .and_then(|value| value.get("checkout_settlement").cloned());
 
     let settlement_label = checkout_settlement
@@ -126,31 +128,68 @@ pub async fn generate_invoice_tx(
 
     // If the booking moved rooms mid-stay, replace the single combined room
     // line with one line per room actually occupied, grouped by the night the
-    // guest first slept there. Nights slept before a move stay on the old
-    // room in `room_calendar` (see room_change service), so this query is the
-    // source of truth for "which rooms, how many nights each, in what order".
-    let room_nights = sqlx::query(
-        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights
-         FROM room_calendar rc
-         JOIN rooms r ON r.id = rc.room_id
-         WHERE rc.booking_id = ?
-         GROUP BY rc.room_id, r.name
-         ORDER BY MIN(rc.date)",
-    )
-    .bind(booking_id)
-    .fetch_all(&mut **tx)
-    .await
-    .map_err(|e| e.to_string())?;
+    // guest first slept there, in occupancy order.
+    //
+    // Resolution order for the (room name, nights) pairs:
+    //  1. `pricing_snapshot.room_stays`, written by `change_room_tx`
+    //     (room_change.rs) at move time — authoritative once present and
+    //     non-empty, and the ONLY source left once the guest has checked out:
+    //     `check_out_tx` (stay_lifecycle.rs) deletes every `room_calendar`
+    //     row for the booking, so a booking invoiced after checkout has
+    //     nothing left in `room_calendar` to group.
+    //  2. `room_calendar`, grouped by room — still correct for a booking
+    //     invoiced while the guest is in-house (checkout hasn't run yet).
+    //  3. Neither present ⇒ the pre-existing single line built above.
+    let room_stays_from_snapshot: Vec<(String, i64)> = snapshot_value
+        .as_ref()
+        .and_then(|value| value.get("room_stays"))
+        .and_then(|value| value.as_array())
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| {
+                    let room_name = entry.get("room_name")?.as_str()?.to_string();
+                    let nights = entry.get("nights")?.as_i64()?;
+                    Some((room_name, nights))
+                })
+                .collect::<Vec<(String, i64)>>()
+        })
+        .unwrap_or_default();
 
-    if room_nights.len() > 1 {
-        let total_nights: i64 = room_nights.iter().map(|r| r.get::<i64, _>("nights")).sum();
+    let room_entries: Vec<(String, i64)> = if !room_stays_from_snapshot.is_empty() {
+        room_stays_from_snapshot
+    } else {
+        let room_nights = sqlx::query(
+            "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights
+             FROM room_calendar rc
+             JOIN rooms r ON r.id = rc.room_id
+             WHERE rc.booking_id = ?
+             GROUP BY rc.room_id, r.name
+             ORDER BY MIN(rc.date)",
+        )
+        .bind(booking_id)
+        .fetch_all(&mut **tx)
+        .await
+        .map_err(|e| e.to_string())?;
+
+        room_nights
+            .into_iter()
+            .map(|row| {
+                let room_name: String = row.get("room_name");
+                let nights: i64 = row.get("nights");
+                (room_name, nights)
+            })
+            .collect()
+    };
+
+    if room_entries.len() > 1 {
+        let total_nights: i64 = room_entries.iter().map(|(_, nights)| nights).sum();
         if total_nights > 0 {
             let mut allocated: crate::money::MoneyVnd = 0;
-            let mut room_lines = Vec::with_capacity(room_nights.len());
-            for (index, row) in room_nights.iter().enumerate() {
-                let room_name: String = row.get("room_name");
-                let nights_here: i64 = row.get("nights");
-                let amount = if index == room_nights.len() - 1 {
+            let last_index = room_entries.len() - 1;
+            let mut room_lines = Vec::with_capacity(room_entries.len());
+            for (index, (room_name, nights_here)) in room_entries.into_iter().enumerate() {
+                let amount = if index == last_index {
                     subtotal - allocated
                 } else {
                     let share = subtotal * nights_here / total_nights;

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -61,7 +61,7 @@ pub async fn generate_invoice_tx(
     let total_price = get_money_vnd(&b, "total_price");
     let paid_amount = get_money_vnd(&b, "paid_amount");
     let deposit_amount = get_optional_money_vnd(&b, "deposit_amount").unwrap_or(0);
-    let mut notes: Option<String> = b.get("notes");
+    let notes: Option<String> = b.get("notes");
     let pricing_snapshot: Option<String> = b.get("pricing_snapshot");
     let snapshot_value: Option<serde_json::Value> = pricing_snapshot
         .as_deref()
@@ -124,6 +124,10 @@ pub async fn generate_invoice_tx(
         label: settlement_line_label.clone(),
         amount: total_price,
     }];
+    // Only set when the split below fires: on a single-line invoice the
+    // settlement wording IS the breakdown line, so repeating it below the
+    // table would say the same thing twice.
+    let mut settlement_note: Option<String> = None;
 
     let subtotal = total_price;
     let balance_due = (total_price - paid_amount).max(0);
@@ -211,20 +215,17 @@ pub async fn generate_invoice_tx(
 
             // The settlement wording still has to reach the guest: a moved,
             // possibly early-checked-out booking is precisely the one whose
-            // total is hardest to read. It moves to `notes`, which both
-            // renderers show as a "GHI CHÚ" block under the breakdown — text,
-            // not money, so it cannot be mistaken for another charge. The
-            // booking's own notes (which already carry the "Chuyển phòng ..."
-            // line written by `change_room_tx`) stay first.
-            let existing_notes = notes
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string);
-            notes = Some(match existing_notes {
-                Some(existing) => format!("{existing}\n{settlement_line_label}"),
-                None => settlement_line_label.clone(),
-            });
+            // total is hardest to read. It goes to `settlement_note`, which
+            // both renderers print as a "GHI CHÚ" block under the breakdown —
+            // text, not money, so it cannot be mistaken for another charge.
+            //
+            // Deliberately NOT merged into `notes`: that column copies
+            // `bookings.notes` verbatim, i.e. internal front-desk shorthand
+            // ("cọc 600k", "Agoda thanh toan"), which must never be printed on
+            // a guest's invoice. Keeping the printable text in its own column
+            // is what makes "render this" impossible to confuse with "render
+            // whatever the receptionist typed".
+            settlement_note = Some(settlement_line_label.clone());
         }
     }
 
@@ -257,8 +258,8 @@ pub async fn generate_invoice_tx(
         "INSERT INTO invoices (id, invoice_number, booking_id, hotel_name, hotel_address, hotel_phone,
          guest_name, guest_phone, room_name, room_type, check_in, check_out, nights,
          pricing_breakdown, subtotal, deposit_amount, total, balance_due, policy_text, notes,
-         status, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'issued', ?)"
+         settlement_note, status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'issued', ?)"
     )
     .bind(&id).bind(&invoice_number).bind(booking_id)
     .bind(&hotel_name).bind(&hotel_address).bind(&hotel_phone)
@@ -267,7 +268,7 @@ pub async fn generate_invoice_tx(
     .bind(&check_in).bind(&check_out).bind(nights)
     .bind(&breakdown_json)
     .bind(subtotal).bind(deposit_amount).bind(total_price).bind(balance_due)
-    .bind(DEFAULT_POLICY_TEXT).bind(&notes)
+    .bind(DEFAULT_POLICY_TEXT).bind(&notes).bind(&settlement_note)
     .bind(&now)
     .execute(&mut **tx).await.map_err(|e| e.to_string())?;
 
@@ -292,6 +293,7 @@ pub async fn generate_invoice_tx(
         balance_due,
         policy_text: Some(DEFAULT_POLICY_TEXT.to_string()),
         notes,
+        settlement_note,
         status: "issued".to_string(),
         created_at: now,
     })
@@ -316,7 +318,7 @@ pub async fn get_invoice(
         "SELECT id, invoice_number, booking_id, hotel_name, hotel_address, hotel_phone,
                 guest_name, guest_phone, room_name, room_type, check_in, check_out, nights,
                 pricing_breakdown, subtotal, deposit_amount, total, balance_due,
-                policy_text, notes, status, created_at
+                policy_text, notes, settlement_note, status, created_at
          FROM invoices WHERE booking_id = ? ORDER BY created_at DESC LIMIT 1",
     )
     .bind(booking_id)
@@ -351,6 +353,7 @@ pub async fn get_invoice(
                 balance_due: get_money_vnd(&r, "balance_due"),
                 policy_text: r.get("policy_text"),
                 notes: r.get("notes"),
+                settlement_note: r.get("settlement_note"),
                 status: r.get("status"),
                 created_at: r.get("created_at"),
             }))

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -118,10 +118,17 @@ pub async fn generate_invoice_tx(
     } else {
         total_price
     };
-    let settlement_line_label =
-        settlement_label.unwrap_or_else(|| format!("{} night(s) x {}d", nights, per_night));
+    // `settlement_label` is `None` until checkout writes `checkout_settlement`,
+    // so an invoice printed for an in-house guest (RoomDetailPanel and
+    // RoomDrawer both offer that) falls back to a developer-shaped English
+    // string. It is tolerable as a breakdown line, which is where it has always
+    // been, but it must never reach `settlement_note` — see below.
+    let settlement_line_label = match &settlement_label {
+        Some(label) => label.clone(),
+        None => format!("{} night(s) x {}d", nights, per_night),
+    };
     let mut breakdown: Vec<crate::pricing::PricingLine> = vec![crate::pricing::PricingLine {
-        label: settlement_line_label.clone(),
+        label: settlement_line_label,
         amount: total_price,
     }];
     // Only set when the split below fires: on a single-line invoice the
@@ -225,7 +232,13 @@ pub async fn generate_invoice_tx(
             // a guest's invoice. Keeping the printable text in its own column
             // is what makes "render this" impossible to confuse with "render
             // whatever the receptionist typed".
-            settlement_note = Some(settlement_line_label.clone());
+            //
+            // `settlement_label`, not `settlement_line_label`: before checkout
+            // there is no settlement metadata and the fallback is the English
+            // developer string "3 night(s) x 250000d". Printing that under a
+            // Vietnamese "GHI CHÚ" heading is worse than printing nothing, and
+            // nothing is lost — the room lines below already state the nights.
+            settlement_note = settlement_label.clone();
         }
     }
 

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -126,60 +126,64 @@ pub async fn generate_invoice_tx(
     let subtotal = total_price;
     let balance_due = (total_price - paid_amount).max(0);
 
-    // If the booking moved rooms mid-stay, replace the single combined room
-    // line with one line per room actually occupied, grouped by the night the
-    // guest first slept there, in occupancy order.
+    // If the booking moved rooms mid-stay, append one line per room actually
+    // occupied to the settlement line already in `breakdown`, grouped by the
+    // night the guest first slept there, in occupancy order.
     //
     // Resolution order for the (room name, nights) pairs:
-    //  1. `pricing_snapshot.room_stays`, written by `change_room_tx`
-    //     (room_change.rs) at move time — authoritative once present and
-    //     non-empty, and the ONLY source left once the guest has checked out:
-    //     `check_out_tx` (stay_lifecycle.rs) deletes every `room_calendar`
-    //     row for the booking, so a booking invoiced after checkout has
-    //     nothing left in `room_calendar` to group.
-    //  2. `room_calendar`, grouped by room — still correct for a booking
-    //     invoiced while the guest is in-house (checkout hasn't run yet).
+    //  1. `room_calendar`, grouped by room — the LIVE truth whenever this
+    //     booking still has rows there, i.e. checkout has not run yet.
+    //     `pricing_snapshot.room_stays` is a snapshot taken at move time and
+    //     nothing refreshes it afterwards: `extend_stay_tx`
+    //     (stay_lifecycle.rs) inserts new `room_calendar` rows on the
+    //     guest's current room without touching the snapshot, so after a
+    //     move-then-extend the snapshot undercounts the current room while
+    //     `room_calendar` has the real count. Preferring the calendar here
+    //     fixes that.
+    //  2. `pricing_snapshot.room_stays`, written by `change_room_tx`
+    //     (room_change.rs) at move time and re-derived (then truncated to
+    //     the settled night count) by `check_out_tx` (stay_lifecycle.rs)
+    //     immediately before it deletes the booking's `room_calendar` rows
+    //     — the ONLY source left once the guest has checked out.
     //  3. Neither present ⇒ the pre-existing single line built above.
-    let room_stays_from_snapshot: Vec<(String, i64)> = snapshot_value
-        .as_ref()
-        .and_then(|value| value.get("room_stays"))
-        .and_then(|value| value.as_array())
-        .map(|entries| {
-            entries
-                .iter()
-                .filter_map(|entry| {
-                    let room_name = entry.get("room_name")?.as_str()?.to_string();
-                    let nights = entry.get("nights")?.as_i64()?;
-                    Some((room_name, nights))
-                })
-                .collect::<Vec<(String, i64)>>()
-        })
-        .unwrap_or_default();
+    let room_entries_from_calendar: Vec<(String, i64)> = sqlx::query(
+        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights
+         FROM room_calendar rc
+         JOIN rooms r ON r.id = rc.room_id
+         WHERE rc.booking_id = ?
+         GROUP BY rc.room_id, r.name
+         ORDER BY MIN(rc.date)",
+    )
+    .bind(booking_id)
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(|e| e.to_string())?
+    .into_iter()
+    .map(|row| {
+        let room_name: String = row.get("room_name");
+        let nights: i64 = row.get("nights");
+        (room_name, nights)
+    })
+    .collect();
 
-    let room_entries: Vec<(String, i64)> = if !room_stays_from_snapshot.is_empty() {
-        room_stays_from_snapshot
+    let room_entries: Vec<(String, i64)> = if !room_entries_from_calendar.is_empty() {
+        room_entries_from_calendar
     } else {
-        let room_nights = sqlx::query(
-            "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights
-             FROM room_calendar rc
-             JOIN rooms r ON r.id = rc.room_id
-             WHERE rc.booking_id = ?
-             GROUP BY rc.room_id, r.name
-             ORDER BY MIN(rc.date)",
-        )
-        .bind(booking_id)
-        .fetch_all(&mut **tx)
-        .await
-        .map_err(|e| e.to_string())?;
-
-        room_nights
-            .into_iter()
-            .map(|row| {
-                let room_name: String = row.get("room_name");
-                let nights: i64 = row.get("nights");
-                (room_name, nights)
+        snapshot_value
+            .as_ref()
+            .and_then(|value| value.get("room_stays"))
+            .and_then(|value| value.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| {
+                        let room_name = entry.get("room_name")?.as_str()?.to_string();
+                        let nights = entry.get("nights")?.as_i64()?;
+                        Some((room_name, nights))
+                    })
+                    .collect::<Vec<(String, i64)>>()
             })
-            .collect()
+            .unwrap_or_default()
     };
 
     if room_entries.len() > 1 {
@@ -201,12 +205,11 @@ pub async fn generate_invoice_tx(
                     amount,
                 });
             }
-            // Preserve any non-room lines already present (surcharges, etc.):
-            // only the original single combined room line is being replaced.
-            let extra_lines: Vec<crate::pricing::PricingLine> =
-                breakdown.into_iter().skip(1).collect();
-            breakdown = room_lines;
-            breakdown.extend(extra_lines);
+            // Keep the settlement line (breakdown[0]) — it explains how the
+            // total was reached, and that explanation matters most exactly
+            // for a moved (possibly early-checked-out) booking, whose total
+            // is the least obvious to read at a glance. Room lines follow it.
+            breakdown.extend(room_lines);
         }
     }
 

--- a/mhm/src-tauri/src/services/booking/invoice_generation.rs
+++ b/mhm/src-tauri/src/services/booking/invoice_generation.rs
@@ -61,7 +61,7 @@ pub async fn generate_invoice_tx(
     let total_price = get_money_vnd(&b, "total_price");
     let paid_amount = get_money_vnd(&b, "paid_amount");
     let deposit_amount = get_optional_money_vnd(&b, "deposit_amount").unwrap_or(0);
-    let notes: Option<String> = b.get("notes");
+    let mut notes: Option<String> = b.get("notes");
     let pricing_snapshot: Option<String> = b.get("pricing_snapshot");
     let snapshot_value: Option<serde_json::Value> = pricing_snapshot
         .as_deref()
@@ -118,21 +118,23 @@ pub async fn generate_invoice_tx(
     } else {
         total_price
     };
+    let settlement_line_label =
+        settlement_label.unwrap_or_else(|| format!("{} night(s) x {}d", nights, per_night));
     let mut breakdown: Vec<crate::pricing::PricingLine> = vec![crate::pricing::PricingLine {
-        label: settlement_label.unwrap_or_else(|| format!("{} night(s) x {}d", nights, per_night)),
+        label: settlement_line_label.clone(),
         amount: total_price,
     }];
 
     let subtotal = total_price;
     let balance_due = (total_price - paid_amount).max(0);
 
-    // If the booking moved rooms mid-stay, append one line per room actually
-    // occupied to the settlement line already in `breakdown`, grouped by the
-    // night the guest first slept there, in occupancy order.
+    // If the booking moved rooms mid-stay, replace the settlement line with
+    // one line per occupancy segment (a run of consecutive nights in one
+    // room), in date order.
     //
     // Resolution order for the (room name, nights) pairs:
-    //  1. `room_calendar`, grouped by room — the LIVE truth whenever this
-    //     booking still has rows there, i.e. checkout has not run yet.
+    //  1. `room_calendar` — the LIVE truth whenever this booking still has
+    //     rows there, i.e. checkout has not run yet.
     //     `pricing_snapshot.room_stays` is a snapshot taken at move time and
     //     nothing refreshes it afterwards: `extend_stay_tx`
     //     (stay_lifecycle.rs) inserts new `room_calendar` rows on the
@@ -143,28 +145,22 @@ pub async fn generate_invoice_tx(
     //  2. `pricing_snapshot.room_stays`, written by `change_room_tx`
     //     (room_change.rs) at move time and re-derived (then truncated to
     //     the settled night count) by `check_out_tx` (stay_lifecycle.rs)
-    //     immediately before it deletes the booking's `room_calendar` rows
-    //     — the ONLY source left once the guest has checked out.
+    //     and `group_checkout_tx` (group_lifecycle.rs) immediately before
+    //     they delete the booking's `room_calendar` rows — the ONLY source
+    //     left once the guest has checked out.
     //  3. Neither present ⇒ the pre-existing single line built above.
-    let room_entries_from_calendar: Vec<(String, i64)> = sqlx::query(
-        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights
-         FROM room_calendar rc
-         JOIN rooms r ON r.id = rc.room_id
-         WHERE rc.booking_id = ?
-         GROUP BY rc.room_id, r.name
-         ORDER BY MIN(rc.date)",
-    )
-    .bind(booking_id)
-    .fetch_all(&mut **tx)
-    .await
-    .map_err(|e| e.to_string())?
-    .into_iter()
-    .map(|row| {
-        let room_name: String = row.get("room_name");
-        let nights: i64 = row.get("nights");
-        (room_name, nights)
-    })
-    .collect();
+    //
+    // Case 1 goes through `room_calendar_stays_tx` rather than a local query:
+    // that helper is what writes case 2's snapshot, so sharing it is what
+    // makes an invoice generated before checkout and one generated after tell
+    // the same story.
+    let room_entries_from_calendar: Vec<(String, i64)> =
+        super::support::room_calendar_stays_tx(tx, booking_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .map(|stay| (stay.room_name, stay.nights))
+            .collect();
 
     let room_entries: Vec<(String, i64)> = if !room_entries_from_calendar.is_empty() {
         room_entries_from_calendar
@@ -205,11 +201,30 @@ pub async fn generate_invoice_tx(
                     amount,
                 });
             }
-            // Keep the settlement line (breakdown[0]) — it explains how the
-            // total was reached, and that explanation matters most exactly
-            // for a moved (possibly early-checked-out) booking, whose total
-            // is the least obvious to read at a glance. Room lines follow it.
-            breakdown.extend(room_lines);
+            // REPLACE the settlement line, never append to it. Both renderers
+            // print every breakdown line with its amount and then print
+            // "Subtotal" from `total` right underneath — and the room lines
+            // already sum to exactly that subtotal. Keeping the settlement
+            // line too would hand the guest a document whose printed lines add
+            // up to twice its own stated subtotal.
+            breakdown = room_lines;
+
+            // The settlement wording still has to reach the guest: a moved,
+            // possibly early-checked-out booking is precisely the one whose
+            // total is hardest to read. It moves to `notes`, which both
+            // renderers show as a "GHI CHÚ" block under the breakdown — text,
+            // not money, so it cannot be mistaken for another charge. The
+            // booking's own notes (which already carry the "Chuyển phòng ..."
+            // line written by `change_room_tx`) stay first.
+            let existing_notes = notes
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+            notes = Some(match existing_notes {
+                Some(existing) => format!("{existing}\n{settlement_line_label}"),
+                None => settlement_line_label.clone(),
+            });
         }
     }
 

--- a/mhm/src-tauri/src/services/booking/mod.rs
+++ b/mhm/src-tauri/src/services/booking/mod.rs
@@ -7,6 +7,7 @@ pub mod guest_service;
 pub mod invoice_generation;
 pub mod pricing_service;
 pub mod reservation_lifecycle;
+pub mod room_change;
 pub mod stay_lifecycle;
 pub mod support;
 

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -78,13 +78,12 @@ async fn remaining_nights(
         ));
     }
 
-    let stayed: i32 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date < ?",
-    )
-    .bind(booking_id)
-    .bind(&today_str)
-    .fetch_one(pool)
-    .await?;
+    let stayed: i32 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date < ?")
+            .bind(booking_id)
+            .bind(&today_str)
+            .fetch_one(pool)
+            .await?;
 
     Ok(RemainingNights {
         from_date: row.get("from_date"),
@@ -95,11 +94,10 @@ async fn remaining_nights(
 }
 
 async fn guest_count(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<i32> {
-    let count: i32 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
-            .bind(booking_id)
-            .fetch_one(pool)
-            .await?;
+    let count: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
+        .bind(booking_id)
+        .fetch_one(pool)
+        .await?;
     Ok(count.max(1))
 }
 
@@ -342,10 +340,11 @@ pub(super) async fn change_room_tx(
         )));
     }
 
-    let guests: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
-        .bind(booking_id)
-        .fetch_one(&mut **tx)
-        .await?;
+    let guests: i32 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
+            .bind(booking_id)
+            .fetch_one(&mut **tx)
+            .await?;
     let max_guests: Option<i32> = sqlx::query_scalar("SELECT max_guests FROM rooms WHERE id = ?")
         .bind(new_room_id)
         .fetch_optional(&mut **tx)
@@ -412,8 +411,7 @@ pub(super) async fn change_room_tx(
                 format!("booking {booking_id} changed before room-change repricing"),
             )?;
 
-            let note =
-                format!("Chuyển phòng {old_room_id} → {new_room_id}: chênh {remaining} đêm");
+            let note = format!("Chuyển phòng {old_room_id} → {new_room_id}: chênh {remaining} đêm");
             let created_at = Local::now().to_rfc3339();
             match &origin_key {
                 Some(key) => {
@@ -495,10 +493,7 @@ pub(super) async fn change_room_tx(
             .bind(status::room::OCCUPIED)
             .execute(&mut **tx)
             .await?;
-        ensure_one_row_affected(
-            result,
-            format!("room {old_room_id} is no longer occupied"),
-        )?;
+        ensure_one_row_affected(result, format!("room {old_room_id} is no longer occupied"))?;
 
         let now = Local::now().to_rfc3339();
         sqlx::query(
@@ -519,10 +514,7 @@ pub(super) async fn change_room_tx(
             .bind(status::room::VACANT)
             .execute(&mut **tx)
             .await?;
-        ensure_one_row_affected(
-            result,
-            format!("room {new_room_id} is no longer vacant"),
-        )?;
+        ensure_one_row_affected(result, format!("room {new_room_id} is no longer vacant"))?;
     }
 
     Ok(())
@@ -624,10 +616,9 @@ pub async fn change_room_idempotent(
             ctx,
             request,
             move || async move {
-                let old_room_id =
-                    lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
-                        .await
-                        .map_err(map_change_room_command_error)?;
+                let old_room_id = lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
+                    .await
+                    .map_err(map_change_room_command_error)?;
                 let lock_keys = vec![
                     crate::aggregate_locks::booking_key(&booking_id_for_lookup)?,
                     crate::aggregate_locks::room_key(&old_room_id)?,

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -8,8 +8,8 @@
 //! with `date >= today` — not from "today until checkout" — which matters for
 //! future reservations that start days from now.
 
-use chrono::NaiveDate;
-use sqlx::{Pool, Row, Sqlite};
+use chrono::{Local, NaiveDate};
+use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::{
     domain::booking::{BookingError, BookingResult},
@@ -18,8 +18,16 @@ use crate::{
 
 use super::{
     pricing_service::calculate_stay_price_tx,
-    support::{begin_tx, read_money_vnd_or_zero},
+    support::{begin_tx, ensure_one_row_affected, invalid_state_transition, read_money_vnd_or_zero},
 };
+
+// `change_room` (the test-only pool-level wrapper below) is the only caller of
+// these two; production code will call `change_room_tx` directly once
+// `commands/rooms.rs` wires up the Tauri command in a later task.
+#[cfg(test)]
+use super::support::{begin_immediate_tx, fetch_booking};
+#[cfg(test)]
+use crate::models::Booking;
 
 /// Dải đêm sẽ được chuyển: các dòng `room_calendar` của booking có ngày >= `today`.
 ///
@@ -203,4 +211,197 @@ fn pricing_range(nights: &RemainingNights) -> (String, String) {
         format!("{}T14:00:00+07:00", nights.from_date),
         format!("{}T12:00:00+07:00", checkout.format("%Y-%m-%d")),
     )
+}
+
+/// Chuyển các đêm còn lại (từ `today` trở đi) của `booking_id` sang `new_room_id`,
+/// đổi `bookings.room_id`, và cập nhật trạng thái hai phòng.
+///
+/// Đêm đã ở giữ nguyên trên phòng cũ — chỉ những dòng `room_calendar` có
+/// `date >= today` mới chuyển. Việc này giữ báo cáo công suất và hóa đơn đúng
+/// sự thật.
+///
+/// Task này chưa đụng tới tiền: không nhận `keep_price`, không ghi `transactions`,
+/// không sửa `total_price`. Task 3 sẽ thêm.
+#[allow(dead_code)]
+pub(super) async fn change_room_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    new_room_id: &str,
+    reason: Option<&str>,
+    today: NaiveDate,
+) -> BookingResult<()> {
+    let today_str = today.format("%Y-%m-%d").to_string();
+
+    let booking = sqlx::query("SELECT room_id, status, notes FROM bookings WHERE id = ?")
+        .bind(booking_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {booking_id}")))?;
+
+    let booking_status: String = booking.get("status");
+    if booking_status != status::booking::ACTIVE && booking_status != status::booking::BOOKED {
+        return Err(invalid_state_transition(format!(
+            "booking {booking_id} is not movable (status: {booking_status})"
+        )));
+    }
+
+    let old_room_id: String = booking.get("room_id");
+    if old_room_id == new_room_id {
+        return Err(BookingError::validation(
+            "Phòng mới trùng phòng hiện tại".to_string(),
+        ));
+    }
+
+    // Dải đêm sẽ chuyển.
+    let range = sqlx::query(
+        "SELECT MIN(date) AS from_date, MAX(date) AS to_date, COUNT(*) AS remaining
+         FROM room_calendar WHERE booking_id = ? AND date >= ?",
+    )
+    .bind(booking_id)
+    .bind(&today_str)
+    .fetch_one(&mut **tx)
+    .await?;
+    let remaining: i32 = range.get("remaining");
+    if remaining == 0 {
+        return Err(BookingError::validation(
+            "Không còn đêm nào để chuyển phòng".to_string(),
+        ));
+    }
+    let from_date: String = range.get("from_date");
+    let to_date: String = range.get("to_date");
+
+    // Kiểm lại trong transaction, không tin danh sách giao diện gửi lên.
+    let conflict: Option<String> = sqlx::query_scalar(
+        "SELECT date FROM room_calendar
+         WHERE room_id = ? AND date >= ? AND date <= ? AND booking_id != ?
+         ORDER BY date LIMIT 1",
+    )
+    .bind(new_room_id)
+    .bind(&from_date)
+    .bind(&to_date)
+    .bind(booking_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if let Some(date) = conflict {
+        return Err(BookingError::conflict(format!(
+            "Phòng {new_room_id} đã có lịch cho ngày {date}"
+        )));
+    }
+
+    let guests: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
+        .bind(booking_id)
+        .fetch_one(&mut **tx)
+        .await?;
+    let max_guests: Option<i32> = sqlx::query_scalar("SELECT max_guests FROM rooms WHERE id = ?")
+        .bind(new_room_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+    let max_guests = max_guests
+        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy phòng {new_room_id}")))?;
+    if guests.max(1) > max_guests {
+        return Err(BookingError::validation(format!(
+            "Phòng {new_room_id} chỉ chứa tối đa {max_guests} khách"
+        )));
+    }
+
+    // Chuyển đêm từ hôm nay trở đi.
+    sqlx::query("UPDATE room_calendar SET room_id = ? WHERE booking_id = ? AND date >= ?")
+        .bind(new_room_id)
+        .bind(booking_id)
+        .bind(&today_str)
+        .execute(&mut **tx)
+        .await?;
+
+    let mut note_line = format!(
+        "Chuyển phòng {old_room_id} → {new_room_id} ngày {}",
+        today.format("%d/%m/%Y")
+    );
+    if let Some(reason) = reason.map(str::trim).filter(|value| !value.is_empty()) {
+        note_line.push_str(&format!(" ({reason})"));
+    }
+    let existing_notes: Option<String> = booking.get("notes");
+    let merged_notes = match existing_notes.as_deref().map(str::trim) {
+        Some(existing) if !existing.is_empty() => format!("{existing} | {note_line}"),
+        _ => note_line,
+    };
+
+    let result = sqlx::query(
+        "UPDATE bookings SET room_id = ?, notes = ? WHERE id = ? AND status = ? AND room_id = ?",
+    )
+    .bind(new_room_id)
+    .bind(&merged_notes)
+    .bind(booking_id)
+    .bind(&booking_status)
+    .bind(&old_room_id)
+    .execute(&mut **tx)
+    .await?;
+    ensure_one_row_affected(
+        result,
+        format!("booking {booking_id} changed before room-change"),
+    )?;
+
+    // Trạng thái phòng chỉ đổi khi khách đang ở thật. Mirrors the check-out /
+    // check-in room-status transitions (stay_lifecycle.rs): every UPDATE
+    // carries the old-state condition and is checked with
+    // ensure_one_row_affected, so a room that already changed status under us
+    // fails loudly instead of silently overwriting it.
+    if booking_status == status::booking::ACTIVE {
+        let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status = ?")
+            .bind(status::room::CLEANING)
+            .bind(&old_room_id)
+            .bind(status::room::OCCUPIED)
+            .execute(&mut **tx)
+            .await?;
+        ensure_one_row_affected(
+            result,
+            format!("room {old_room_id} is no longer occupied"),
+        )?;
+
+        let now = Local::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO housekeeping (id, room_id, status, note, triggered_at, cleaned_at, created_at)
+             VALUES (?, ?, 'needs_cleaning', ?, ?, NULL, ?)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(&old_room_id)
+        .bind(format!("Khách chuyển sang phòng {new_room_id}"))
+        .bind(&now)
+        .bind(&now)
+        .execute(&mut **tx)
+        .await?;
+
+        let result = sqlx::query("UPDATE rooms SET status = ? WHERE id = ? AND status = ?")
+            .bind(status::room::OCCUPIED)
+            .bind(new_room_id)
+            .bind(status::room::VACANT)
+            .execute(&mut **tx)
+            .await?;
+        ensure_one_row_affected(
+            result,
+            format!("room {new_room_id} is no longer vacant"),
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub async fn change_room(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    new_room_id: &str,
+    reason: Option<&str>,
+    today: NaiveDate,
+) -> BookingResult<Booking> {
+    let mut tx = begin_immediate_tx(pool).await?;
+    change_room_tx(&mut tx, booking_id, new_room_id, reason, today).await?;
+    tx.commit().await.map_err(BookingError::from)?;
+
+    fetch_booking(
+        pool,
+        booking_id,
+        format!("Không tìm thấy booking {booking_id}"),
+        read_money_vnd_or_zero,
+    )
+    .await
 }

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -1,0 +1,206 @@
+//! Room change read-side: which rooms a booking could move to, and the price
+//! difference for each.
+//!
+//! `bookings.room_id` holds the guest's CURRENT room; `room_calendar` (one row
+//! per room per night) holds the real history. When a guest moves mid-stay,
+//! nights already slept stay on the old room and only nights from today
+//! forward move. So "remaining nights" is derived from `room_calendar` rows
+//! with `date >= today` — not from "today until checkout" — which matters for
+//! future reservations that start days from now.
+
+use chrono::NaiveDate;
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::{
+    domain::booking::{BookingError, BookingResult},
+    models::{status, RoomChangeOption, RoomChangeOptions},
+};
+
+use super::{
+    pricing_service::calculate_stay_price_tx,
+    support::{begin_tx, read_money_vnd_or_zero},
+};
+
+/// Dải đêm sẽ được chuyển: các dòng `room_calendar` của booking có ngày >= `today`.
+///
+/// Không lấy "từ hôm nay tới hết kỳ": đặt trước nhận phòng tuần sau thì dải phải
+/// bắt đầu từ ngày nhận phòng, nếu không sẽ tính tiền cho những đêm không tồn tại.
+struct RemainingNights {
+    from_date: String,
+    to_date: String,
+    remaining: i32,
+    stayed: i32,
+}
+
+async fn remaining_nights(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    today: NaiveDate,
+) -> BookingResult<RemainingNights> {
+    let today_str = today.format("%Y-%m-%d").to_string();
+
+    let row = sqlx::query(
+        "SELECT MIN(date) AS from_date, MAX(date) AS to_date, COUNT(*) AS remaining
+         FROM room_calendar
+         WHERE booking_id = ? AND date >= ?",
+    )
+    .bind(booking_id)
+    .bind(&today_str)
+    .fetch_one(pool)
+    .await?;
+
+    let remaining: i32 = row.get("remaining");
+    if remaining == 0 {
+        return Err(BookingError::validation(
+            "Không còn đêm nào để chuyển phòng".to_string(),
+        ));
+    }
+
+    let stayed: i32 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date < ?",
+    )
+    .bind(booking_id)
+    .bind(&today_str)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(RemainingNights {
+        from_date: row.get("from_date"),
+        to_date: row.get("to_date"),
+        remaining,
+        stayed,
+    })
+}
+
+async fn guest_count(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<i32> {
+    let count: i32 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM booking_guests WHERE booking_id = ?")
+            .bind(booking_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count.max(1))
+}
+
+#[allow(dead_code)]
+pub async fn load_options(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    today: NaiveDate,
+) -> BookingResult<RoomChangeOptions> {
+    let booking = sqlx::query(
+        "SELECT b.room_id, b.status, b.pricing_type, r.name AS room_name
+         FROM bookings b JOIN rooms r ON r.id = b.room_id
+         WHERE b.id = ?",
+    )
+    .bind(booking_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {booking_id}")))?;
+
+    let booking_status: String = booking.get("status");
+    if booking_status != status::booking::ACTIVE && booking_status != status::booking::BOOKED {
+        return Err(BookingError::validation(format!(
+            "Booking {booking_id} không ở trạng thái chuyển phòng được (đang: {booking_status})"
+        )));
+    }
+
+    let current_room_id: String = booking.get("room_id");
+    let current_room_name: String = booking.get("room_name");
+    let pricing_type = booking
+        .get::<Option<String>, _>("pricing_type")
+        .unwrap_or_else(|| "nightly".to_string());
+
+    let nights = remaining_nights(pool, booking_id, today).await?;
+    let guests = guest_count(pool, booking_id).await?;
+
+    // Phòng trống suốt dải đêm còn lại. Dòng của chính booking này không tính là vướng.
+    // Phòng đang dọn chỉ bị loại khi khách vào ngay tối nay. Với đặt trước tuần
+    // sau, tình trạng dọn dẹp hôm nay không nói lên điều gì về tuần sau.
+    let moving_in_today = nights.from_date == today.format("%Y-%m-%d").to_string();
+
+    let candidates = sqlx::query(
+        "SELECT r.id, r.name, r.type, r.floor, r.base_price, r.max_guests
+         FROM rooms r
+         WHERE r.id != ?
+           AND r.max_guests >= ?
+           AND (? = 0 OR r.status = 'vacant')
+           AND NOT EXISTS (
+             SELECT 1 FROM room_calendar rc
+             WHERE rc.room_id = r.id
+               AND rc.date >= ? AND rc.date <= ?
+               AND (rc.booking_id IS NULL OR rc.booking_id != ?)
+           )
+         ORDER BY r.floor, r.id",
+    )
+    .bind(&current_room_id)
+    .bind(guests)
+    .bind(i32::from(moving_in_today))
+    .bind(&nights.from_date)
+    .bind(&nights.to_date)
+    .bind(booking_id)
+    .fetch_all(pool)
+    .await?;
+
+    let (range_start, range_end) = pricing_range(&nights);
+    let mut tx = begin_tx(pool).await?;
+    let current_price = calculate_stay_price_tx(
+        &mut tx,
+        &current_room_id,
+        &range_start,
+        &range_end,
+        &pricing_type,
+        Some(guests),
+    )
+    .await?
+    .total;
+
+    let mut rooms = Vec::with_capacity(candidates.len());
+    for row in candidates {
+        let room_id: String = row.get("id");
+        let candidate_price = calculate_stay_price_tx(
+            &mut tx,
+            &room_id,
+            &range_start,
+            &range_end,
+            &pricing_type,
+            Some(guests),
+        )
+        .await?
+        .total;
+
+        rooms.push(RoomChangeOption {
+            room_id,
+            name: row.get("name"),
+            room_type: row.get("type"),
+            floor: row.get("floor"),
+            base_price: read_money_vnd_or_zero(&row, "base_price"),
+            max_guests: row.get("max_guests"),
+            price_difference: candidate_price - current_price,
+        });
+    }
+    tx.rollback().await.map_err(BookingError::from)?;
+
+    Ok(RoomChangeOptions {
+        booking_id: booking_id.to_string(),
+        current_room_id,
+        current_room_name,
+        from_date: nights.from_date,
+        to_date: nights.to_date,
+        nights_remaining: nights.remaining,
+        nights_stayed: nights.stayed,
+        guest_count: guests,
+        rooms,
+    })
+}
+
+/// `calculate_stay_price_tx` nhận mốc nhận phòng và trả phòng, không nhận đêm đầu/cuối.
+/// Đêm cuối là `to_date` nên mốc trả phòng là ngày kế tiếp.
+fn pricing_range(nights: &RemainingNights) -> (String, String) {
+    let last_night = NaiveDate::parse_from_str(&nights.to_date, "%Y-%m-%d")
+        .expect("to_date lấy từ room_calendar nên luôn đúng dạng");
+    let checkout = last_night + chrono::Duration::days(1);
+    (
+        format!("{}T14:00:00+07:00", nights.from_date),
+        format!("{}T12:00:00+07:00", checkout.format("%Y-%m-%d")),
+    )
+}

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -12,11 +12,12 @@ use chrono::{Local, NaiveDate};
 use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::{
-    domain::booking::{BookingError, BookingResult},
+    domain::booking::{BookingError, BookingResult, OriginSideEffect},
     models::{status, RoomChangeOption, RoomChangeOptions},
 };
 
 use super::{
+    billing_service::{record_charge_tx, record_charge_with_origin_tx},
     pricing_service::calculate_stay_price_tx,
     support::{begin_tx, ensure_one_row_affected, invalid_state_transition, read_money_vnd_or_zero},
 };
@@ -204,11 +205,17 @@ pub async fn load_options(
 /// `calculate_stay_price_tx` nhận mốc nhận phòng và trả phòng, không nhận đêm đầu/cuối.
 /// Đêm cuối là `to_date` nên mốc trả phòng là ngày kế tiếp.
 fn pricing_range(nights: &RemainingNights) -> (String, String) {
-    let last_night = NaiveDate::parse_from_str(&nights.to_date, "%Y-%m-%d")
+    date_range_for_pricing(&nights.from_date, &nights.to_date)
+}
+
+/// Như `pricing_range`, nhưng nhận thẳng cặp ngày thay vì `RemainingNights` —
+/// dùng ở nơi đã có sẵn `from_date`/`to_date` mà không cần dựng cả struct.
+fn date_range_for_pricing(from_date: &str, to_date: &str) -> (String, String) {
+    let last_night = NaiveDate::parse_from_str(to_date, "%Y-%m-%d")
         .expect("to_date lấy từ room_calendar nên luôn đúng dạng");
     let checkout = last_night + chrono::Duration::days(1);
     (
-        format!("{}T14:00:00+07:00", nights.from_date),
+        format!("{from_date}T14:00:00+07:00"),
         format!("{}T12:00:00+07:00", checkout.format("%Y-%m-%d")),
     )
 }
@@ -220,23 +227,32 @@ fn pricing_range(nights: &RemainingNights) -> (String, String) {
 /// `date >= today` mới chuyển. Việc này giữ báo cáo công suất và hóa đơn đúng
 /// sự thật.
 ///
-/// Task này chưa đụng tới tiền: không nhận `keep_price`, không ghi `transactions`,
-/// không sửa `total_price`. Task 3 sẽ thêm.
+/// Khi `keep_price == false`, khoản chênh lệch giữa giá phòng mới và phòng cũ
+/// cho các đêm còn lại (cùng khoảng ngày nên các hệ số cuối tuần/lễ tự triệt
+/// tiêu, chỉ còn lại phần chênh theo hạng phòng) được cộng vào `total_price` và
+/// ghi một dòng `transactions`. Đây KHÔNG phải định giá lại toàn bộ kỳ ở: nó
+/// cộng thêm phần chênh lên trên mức giá khách đang trả, nên khách đang có giá
+/// ưu đãi vẫn giữ nguyên ưu đãi đó.
 #[allow(dead_code)]
 pub(super) async fn change_room_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,
     new_room_id: &str,
+    keep_price: bool,
     reason: Option<&str>,
     today: NaiveDate,
+    origin_key: Option<String>,
 ) -> BookingResult<()> {
     let today_str = today.format("%Y-%m-%d").to_string();
 
-    let booking = sqlx::query("SELECT room_id, status, notes FROM bookings WHERE id = ?")
-        .bind(booking_id)
-        .fetch_optional(&mut **tx)
-        .await?
-        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {booking_id}")))?;
+    let booking =
+        sqlx::query("SELECT room_id, status, notes, total_price FROM bookings WHERE id = ?")
+            .bind(booking_id)
+            .fetch_optional(&mut **tx)
+            .await?
+            .ok_or_else(|| {
+                BookingError::not_found(format!("Không tìm thấy booking {booking_id}"))
+            })?;
 
     let booking_status: String = booking.get("status");
     if booking_status != status::booking::ACTIVE && booking_status != status::booking::BOOKED {
@@ -302,6 +318,74 @@ pub(super) async fn change_room_tx(
         return Err(BookingError::validation(format!(
             "Phòng {new_room_id} chỉ chứa tối đa {max_guests} khách"
         )));
+    }
+
+    // Tiền chênh lệch phải tính trước khi đổi room_id: cần old_room_id và
+    // total_price đọc lúc mở hàm.
+    if !keep_price {
+        let pricing_type: String = sqlx::query_scalar(
+            "SELECT COALESCE(pricing_type, 'nightly') FROM bookings WHERE id = ?",
+        )
+        .bind(booking_id)
+        .fetch_one(&mut **tx)
+        .await?;
+
+        let (range_start, range_end) = date_range_for_pricing(&from_date, &to_date);
+
+        let old_price = calculate_stay_price_tx(
+            tx,
+            &old_room_id,
+            &range_start,
+            &range_end,
+            &pricing_type,
+            Some(guests.max(1)),
+        )
+        .await?
+        .total;
+        let new_price = calculate_stay_price_tx(
+            tx,
+            new_room_id,
+            &range_start,
+            &range_end,
+            &pricing_type,
+            Some(guests.max(1)),
+        )
+        .await?
+        .total;
+
+        let difference = new_price - old_price;
+        if difference != 0 {
+            let current_total = read_money_vnd_or_zero(&booking, "total_price");
+            let new_total = current_total
+                .checked_add(difference)
+                .ok_or_else(|| BookingError::validation("total_price overflowed".to_string()))?;
+
+            let result = sqlx::query("UPDATE bookings SET total_price = ? WHERE id = ?")
+                .bind(new_total)
+                .bind(booking_id)
+                .execute(&mut **tx)
+                .await?;
+            ensure_one_row_affected(
+                result,
+                format!("booking {booking_id} changed before room-change repricing"),
+            )?;
+
+            let note =
+                format!("Chuyển phòng {old_room_id} → {new_room_id}: chênh {remaining} đêm");
+            let created_at = Local::now().to_rfc3339();
+            match &origin_key {
+                Some(key) => {
+                    let origin = OriginSideEffect::new(key.clone(), 0)?;
+                    record_charge_with_origin_tx(
+                        tx, booking_id, difference, note, created_at, &origin,
+                    )
+                    .await?;
+                }
+                None => {
+                    record_charge_tx(tx, booking_id, difference, note, created_at).await?;
+                }
+            }
+        }
     }
 
     // Chuyển đêm từ hôm nay trở đi.
@@ -390,11 +474,21 @@ pub async fn change_room(
     pool: &Pool<Sqlite>,
     booking_id: &str,
     new_room_id: &str,
+    keep_price: bool,
     reason: Option<&str>,
     today: NaiveDate,
 ) -> BookingResult<Booking> {
     let mut tx = begin_immediate_tx(pool).await?;
-    change_room_tx(&mut tx, booking_id, new_room_id, reason, today).await?;
+    change_room_tx(
+        &mut tx,
+        booking_id,
+        new_room_id,
+        keep_price,
+        reason,
+        today,
+        None,
+    )
+    .await?;
     tx.commit().await.map_err(BookingError::from)?;
 
     fetch_booking(

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -360,11 +360,15 @@ pub(super) async fn change_room_tx(
                 .checked_add(difference)
                 .ok_or_else(|| BookingError::validation("total_price overflowed".to_string()))?;
 
-            let result = sqlx::query("UPDATE bookings SET total_price = ? WHERE id = ?")
-                .bind(new_total)
-                .bind(booking_id)
-                .execute(&mut **tx)
-                .await?;
+            let result = sqlx::query(
+                "UPDATE bookings SET total_price = ? WHERE id = ? AND status = ? AND total_price = ?",
+            )
+            .bind(new_total)
+            .bind(booking_id)
+            .bind(&booking_status)
+            .bind(current_total)
+            .execute(&mut **tx)
+            .await?;
             ensure_one_row_affected(
                 result,
                 format!("booking {booking_id} changed before room-change repricing"),

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -31,7 +31,7 @@ use super::{
     stay_lifecycle::fetch_booking_tx,
     support::{
         begin_tx, ensure_one_row_affected, invalid_state_transition, lookup_booking_room_id,
-        read_money_vnd_or_zero,
+        merge_pricing_snapshot, read_money_vnd_or_zero,
     },
 };
 
@@ -239,6 +239,12 @@ fn date_range_for_pricing(from_date: &str, to_date: &str) -> (String, String) {
 /// `date >= today` mới chuyển. Việc này giữ báo cáo công suất và hóa đơn đúng
 /// sự thật.
 ///
+/// Sau khi chuyển, hàm còn nhóm lại toàn bộ `room_calendar` của booking theo
+/// phòng và ghi mảng đó vào `bookings.pricing_snapshot.room_stays` (merge,
+/// không ghi đè các khoá khác). `check_out_tx` (stay_lifecycle.rs) xoá sạch
+/// `room_calendar` khi trả phòng, nên đây là nguồn sự thật duy nhất còn lại
+/// để hóa đơn tách dòng theo phòng sau khi khách đã check-out.
+///
 /// Khi `keep_price == false`, khoản chênh lệch giữa giá phòng mới và phòng cũ
 /// cho các đêm còn lại (cùng khoảng ngày nên các hệ số cuối tuần/lễ tự triệt
 /// tiêu, chỉ còn lại phần chênh theo hạng phòng) được cộng vào `total_price` và
@@ -256,14 +262,13 @@ pub(super) async fn change_room_tx(
 ) -> BookingResult<()> {
     let today_str = today.format("%Y-%m-%d").to_string();
 
-    let booking =
-        sqlx::query("SELECT room_id, status, notes, total_price FROM bookings WHERE id = ?")
-            .bind(booking_id)
-            .fetch_optional(&mut **tx)
-            .await?
-            .ok_or_else(|| {
-                BookingError::not_found(format!("Không tìm thấy booking {booking_id}"))
-            })?;
+    let booking = sqlx::query(
+        "SELECT room_id, status, notes, total_price, pricing_snapshot FROM bookings WHERE id = ?",
+    )
+    .bind(booking_id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {booking_id}")))?;
 
     let booking_status: String = booking.get("status");
     if booking_status != status::booking::ACTIVE && booking_status != status::booking::BOOKED {
@@ -424,11 +429,54 @@ pub(super) async fn change_room_tx(
         _ => note_line,
     };
 
+    // Snapshot which rooms this booking actually occupied, in occupancy
+    // order, so the invoice can split its lines correctly even after
+    // check-out deletes `room_calendar` (stay_lifecycle::check_out_tx).
+    // room_calendar was just updated above, so this reflects the post-move
+    // truth. Recomputed from scratch (not appended) so a guest who moves
+    // twice ends up with three correct entries, not an append-only mess.
+    let room_stay_rows = sqlx::query(
+        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights, MIN(rc.date) AS first_night
+         FROM room_calendar rc
+         JOIN rooms r ON r.id = rc.room_id
+         WHERE rc.booking_id = ?
+         GROUP BY rc.room_id, r.name
+         ORDER BY MIN(rc.date)",
+    )
+    .bind(booking_id)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let room_stays: Vec<serde_json::Value> = room_stay_rows
+        .iter()
+        .map(|row| {
+            let room_id: String = row.get("room_id");
+            let room_name: String = row.get("room_name");
+            let nights: i64 = row.get("nights");
+            let first_night: String = row.get("first_night");
+            json!({
+                "room_id": room_id,
+                "room_name": room_name,
+                "nights": nights,
+                "first_night": first_night,
+            })
+        })
+        .collect();
+
+    let existing_snapshot: Option<String> = booking.get("pricing_snapshot");
+    let merged_snapshot = merge_pricing_snapshot(
+        existing_snapshot.as_deref(),
+        "room_stays",
+        serde_json::Value::Array(room_stays),
+    );
+
     let result = sqlx::query(
-        "UPDATE bookings SET room_id = ?, notes = ? WHERE id = ? AND status = ? AND room_id = ?",
+        "UPDATE bookings SET room_id = ?, notes = ?, pricing_snapshot = ?
+         WHERE id = ? AND status = ? AND room_id = ?",
     )
     .bind(new_room_id)
     .bind(&merged_notes)
+    .bind(&merged_snapshot)
     .bind(booking_id)
     .bind(&booking_status)
     .bind(&old_room_id)

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -31,7 +31,7 @@ use super::{
     stay_lifecycle::fetch_booking_tx,
     support::{
         begin_tx, ensure_one_row_affected, invalid_state_transition, lookup_booking_room_id,
-        merge_pricing_snapshot, read_money_vnd_or_zero,
+        merge_pricing_snapshot, read_money_vnd_or_zero, room_calendar_stays_tx, room_stays_to_json,
     },
 };
 
@@ -137,10 +137,17 @@ pub async fn load_options(
     // Phòng trống suốt dải đêm còn lại. Dòng của chính booking này không tính là vướng.
     // Phòng đang dọn chỉ bị loại khi khách vào ngay tối nay. Với đặt trước tuần
     // sau, tình trạng dọn dẹp hôm nay không nói lên điều gì về tuần sau.
+    //
+    // Nhưng một booking đang ACTIVE thì luôn bắt buộc phòng mới phải `vacant`,
+    // bất kể đêm chuyển đầu tiên có phải tối nay hay không — `change_room_tx`
+    // đòi hỏi điều đó vô điều kiện cho booking active (UPDATE rooms ... WHERE
+    // status = 'vacant' ở cuối hàm). Bỏ sót vế active thì danh sách gợi ý một
+    // phòng mà thao tác ghi sẽ từ chối.
     let moving_in_today = nights.from_date == today.format("%Y-%m-%d").to_string();
+    let requires_vacant_room = moving_in_today || booking_status == status::booking::ACTIVE;
 
     let candidates = sqlx::query(
-        "SELECT r.id, r.name, r.type, r.floor, r.base_price, r.max_guests
+        "SELECT r.id, r.name, r.type, r.floor, r.max_guests
          FROM rooms r
          WHERE r.id != ?
            AND r.max_guests >= ?
@@ -155,7 +162,7 @@ pub async fn load_options(
     )
     .bind(&current_room_id)
     .bind(guests)
-    .bind(i32::from(moving_in_today))
+    .bind(i32::from(requires_vacant_room))
     .bind(&nights.from_date)
     .bind(&nights.to_date)
     .bind(booking_id)
@@ -194,7 +201,6 @@ pub async fn load_options(
             name: row.get("name"),
             room_type: row.get("type"),
             floor: row.get("floor"),
-            base_price: read_money_vnd_or_zero(&row, "base_price"),
             max_guests: row.get("max_guests"),
             price_difference: candidate_price - current_price,
         });
@@ -435,39 +441,13 @@ pub(super) async fn change_room_tx(
     // room_calendar was just updated above, so this reflects the post-move
     // truth. Recomputed from scratch (not appended) so a guest who moves
     // twice ends up with three correct entries, not an append-only mess.
-    let room_stay_rows = sqlx::query(
-        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights, MIN(rc.date) AS first_night
-         FROM room_calendar rc
-         JOIN rooms r ON r.id = rc.room_id
-         WHERE rc.booking_id = ?
-         GROUP BY rc.room_id, r.name
-         ORDER BY MIN(rc.date)",
-    )
-    .bind(booking_id)
-    .fetch_all(&mut **tx)
-    .await?;
-
-    let room_stays: Vec<serde_json::Value> = room_stay_rows
-        .iter()
-        .map(|row| {
-            let room_id: String = row.get("room_id");
-            let room_name: String = row.get("room_name");
-            let nights: i64 = row.get("nights");
-            let first_night: String = row.get("first_night");
-            json!({
-                "room_id": room_id,
-                "room_name": room_name,
-                "nights": nights,
-                "first_night": first_night,
-            })
-        })
-        .collect();
+    let room_stay_rows = room_calendar_stays_tx(tx, booking_id).await?;
 
     let existing_snapshot: Option<String> = booking.get("pricing_snapshot");
     let merged_snapshot = merge_pricing_snapshot(
         existing_snapshot.as_deref(),
         "room_stays",
-        serde_json::Value::Array(room_stays),
+        room_stays_to_json(&room_stay_rows),
     );
 
     let result = sqlx::query(

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -245,11 +245,19 @@ fn date_range_for_pricing(from_date: &str, to_date: &str) -> (String, String) {
 /// `date >= today` mới chuyển. Việc này giữ báo cáo công suất và hóa đơn đúng
 /// sự thật.
 ///
-/// Sau khi chuyển, hàm còn nhóm lại toàn bộ `room_calendar` của booking theo
-/// phòng và ghi mảng đó vào `bookings.pricing_snapshot.room_stays` (merge,
-/// không ghi đè các khoá khác). `check_out_tx` (stay_lifecycle.rs) xoá sạch
-/// `room_calendar` khi trả phòng, nên đây là nguồn sự thật duy nhất còn lại
-/// để hóa đơn tách dòng theo phòng sau khi khách đã check-out.
+/// Sau khi chuyển, hàm còn dựng lại toàn bộ `room_calendar` của booking thành
+/// các **đoạn lưu trú liên tiếp theo ngày** — không phải gộp theo phòng — rồi
+/// ghi mảng đó vào `bookings.pricing_snapshot.room_stays` (merge, không ghi đè
+/// các khoá khác). Khách đi A → B → A ra ba đoạn chứ không phải hai dòng; gộp
+/// theo phòng chính là lỗi tính tiền mà `support.rs` mô tả ở `RoomStayRow`.
+///
+/// Ảnh chụp này là bản ghi lúc chuyển phòng, KHÔNG phải nguồn sự thật cuối
+/// cùng: `check_out_tx` (stay_lifecycle.rs) và `group_checkout_tx`
+/// (group_lifecycle.rs) đều dựng lại `room_stays` từ `room_calendar` ngay
+/// trước khi xoá bảng đó, và `check_out_tx` còn cắt bớt theo số đêm thực sự
+/// quyết toán. Nó chỉ là nguồn duy nhất còn lại nếu không đường check-out nào
+/// chạy — và ngay cả trước khi trả phòng, `invoice_generation.rs` vẫn ưu tiên
+/// `room_calendar` vì `extend_stay_tx` thêm đêm mà không đụng vào ảnh chụp.
 ///
 /// Khi `keep_price == false`, khoản chênh lệch giữa giá phòng mới và phòng cũ
 /// cho các đêm còn lại (cùng khoảng ngày nên các hệ số cuối tuần/lễ tự triệt
@@ -309,9 +317,17 @@ pub(super) async fn change_room_tx(
     let to_date: String = range.get("to_date");
 
     // Kiểm lại trong transaction, không tin danh sách giao diện gửi lên.
+    //
+    // `booking_id IS NULL OR ...`: SQL ba trị làm `NULL != ?` ra NULL, tức là
+    // dòng giữ chỗ không có booking (block bảo trì) sẽ tàng hình với phép kiểm
+    // này. `load_options` ở trên đã viết đúng dạng đó; nếu ở đây viết thiếu thì
+    // `PRIMARY KEY (room_id, date)` vẫn chặn được UPDATE nên không bao giờ
+    // trùng phòng thật, nhưng lễ tân nhận SYSTEM_INTERNAL_ERROR thay vì câu
+    // "phòng đã có lịch" đọc được.
     let conflict: Option<String> = sqlx::query_scalar(
         "SELECT date FROM room_calendar
-         WHERE room_id = ? AND date >= ? AND date <= ? AND booking_id != ?
+         WHERE room_id = ? AND date >= ? AND date <= ?
+           AND (booking_id IS NULL OR booking_id != ?)
          ORDER BY date LIMIT 1",
     )
     .bind(new_room_id)

--- a/mhm/src-tauri/src/services/booking/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/room_change.rs
@@ -9,22 +9,35 @@
 //! future reservations that start days from now.
 
 use chrono::{Local, NaiveDate};
+use serde_json::json;
 use sqlx::{Pool, Row, Sqlite, Transaction};
 
 use crate::{
+    app_error::{codes, CommandError, CommandResult},
+    command_idempotency::{
+        system_error, CommandLedgerResultSummary, CommandLedgerSummary, IdempotentCommandResult,
+        ResolvedWriteCommandGuard, SanitizedLedgerIntent, WriteCommandContext,
+        WriteCommandExecutor, WriteCommandRequest,
+    },
+    db_error_monitoring::{classify_db_error_code, is_room_unavailable_conflict_message},
     domain::booking::{BookingError, BookingResult, OriginSideEffect},
     models::{status, RoomChangeOption, RoomChangeOptions},
+    outbox::{OutboxAggregateKeySource, OutboxEventSpec},
 };
 
 use super::{
     billing_service::{record_charge_tx, record_charge_with_origin_tx},
     pricing_service::calculate_stay_price_tx,
-    support::{begin_tx, ensure_one_row_affected, invalid_state_transition, read_money_vnd_or_zero},
+    stay_lifecycle::fetch_booking_tx,
+    support::{
+        begin_tx, ensure_one_row_affected, invalid_state_transition, lookup_booking_room_id,
+        read_money_vnd_or_zero,
+    },
 };
 
-// `change_room` (the test-only pool-level wrapper below) is the only caller of
-// these two; production code will call `change_room_tx` directly once
-// `commands/rooms.rs` wires up the Tauri command in a later task.
+// `change_room` (the test-only pool-level wrapper below) is the only other
+// caller of `change_room_tx`; production code goes through
+// `change_room_idempotent` below, which `commands/rooms.rs` wires up.
 #[cfg(test)]
 use super::support::{begin_immediate_tx, fetch_booking};
 #[cfg(test)]
@@ -90,7 +103,6 @@ async fn guest_count(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<i32
     Ok(count.max(1))
 }
 
-#[allow(dead_code)]
 pub async fn load_options(
     pool: &Pool<Sqlite>,
     booking_id: &str,
@@ -233,7 +245,6 @@ fn date_range_for_pricing(from_date: &str, to_date: &str) -> (String, String) {
 /// ghi một dòng `transactions`. Đây KHÔNG phải định giá lại toàn bộ kỳ ở: nó
 /// cộng thêm phần chênh lên trên mức giá khách đang trả, nên khách đang có giá
 /// ưu đãi vẫn giữ nguyên ưu đãi đó.
-#[allow(dead_code)]
 pub(super) async fn change_room_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,
@@ -471,6 +482,141 @@ pub(super) async fn change_room_tx(
     }
 
     Ok(())
+}
+
+pub(super) fn map_change_room_command_error(error: BookingError) -> CommandError {
+    match error {
+        BookingError::Conflict(message) => {
+            if is_room_unavailable_conflict_message(&message) {
+                return CommandError::user(codes::CONFLICT_ROOM_UNAVAILABLE, message);
+            }
+            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+        }
+        BookingError::Validation(message) => {
+            CommandError::user(codes::BOOKING_INVALID_STATE, message)
+        }
+        BookingError::NotFound(message) if message.starts_with("Không tìm thấy phòng ") => {
+            CommandError::user(codes::ROOM_NOT_FOUND, message)
+        }
+        BookingError::NotFound(message) => CommandError::user(codes::BOOKING_NOT_FOUND, message),
+        BookingError::DatabaseWrite(message) | BookingError::Database(message) => {
+            if classify_db_error_code(&message) == Some(codes::DB_LOCKED_RETRYABLE) {
+                return CommandError::system(codes::DB_LOCKED_RETRYABLE, message).retryable(true);
+            }
+            CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
+        }
+        BookingError::DateTimeParse(message) => {
+            CommandError::system(codes::SYSTEM_INTERNAL_ERROR, message)
+        }
+    }
+}
+
+fn change_room_initial_lock_keys_from_payload(
+    payload: &serde_json::Value,
+) -> CommandResult<Vec<String>> {
+    let booking_id = payload
+        .get("booking_id")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| system_error("change-room lock payload missing booking_id"))?;
+    Ok(vec![crate::aggregate_locks::booking_key(booking_id)?])
+}
+
+/// Idempotent wrapper around `change_room_tx`, wired into the same
+/// idempotency key → aggregate lock → command ledger → recovery queue →
+/// outbox event pipeline as `extend_stay_idempotent` (`stay_lifecycle.rs`).
+///
+/// The lock set is four keys — booking, old room, new room, folio — resolved
+/// only once the booking's current room is known (the old room is not part of
+/// the request payload). `aggregate_locks::canonicalize_lock_keys` sorts and
+/// dedupes the resolved set, so two opposing room-change commands (A→B and
+/// B→A running concurrently) naturally acquire their locks in the same order
+/// and cannot deadlock each other.
+pub async fn change_room_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    booking_id: &str,
+    new_room_id: &str,
+    keep_price: bool,
+    reason: Option<String>,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let hash_payload = json!({
+        "schema": "stay.change_room.v1",
+        "booking_id": booking_id,
+        "new_room_id": new_room_id,
+        "keep_price": keep_price,
+        "reason": reason,
+    });
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("stay.change_room.v1")),
+        ("booking_present", json!(true)),
+        ("operation", json!("change_room")),
+        ("keep_price", json!(keep_price)),
+        ("reason_present", json!(reason.is_some())),
+    ])?;
+    let summary = CommandLedgerSummary::new("Change room")?.with_aggregate_ref(
+        "booking",
+        "booking",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload.clone(), ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{booking_id}"))
+        .with_lock_key_deriver(change_room_initial_lock_keys_from_payload)
+        .with_success_summary(CommandLedgerResultSummary::success("Room changed")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.room_changed",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms", "folio"],
+        )?);
+
+    let pool_for_lookup = pool.clone();
+    let booking_id_for_lookup = booking_id.to_string();
+    let booking_id_for_service = booking_id.to_string();
+    let new_room_for_lookup = new_room_id.to_string();
+    let new_room_for_service = new_room_id.to_string();
+    let origin_key = format!("{}:{}", ctx.command_name, ctx.idempotency_key);
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || async move {
+                let old_room_id =
+                    lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
+                        .await
+                        .map_err(map_change_room_command_error)?;
+                let lock_keys = vec![
+                    crate::aggregate_locks::booking_key(&booking_id_for_lookup)?,
+                    crate::aggregate_locks::room_key(&old_room_id)?,
+                    crate::aggregate_locks::room_key(&new_room_for_lookup)?,
+                    crate::aggregate_locks::folio_key(&booking_id_for_lookup)?,
+                ];
+                let guard = crate::aggregate_locks::global_manager()
+                    .acquire(lock_keys.clone())
+                    .await?;
+                Ok(ResolvedWriteCommandGuard::new(guard, lock_keys))
+            },
+            move |tx, _resolved| {
+                Box::pin(async move {
+                    change_room_tx(
+                        tx,
+                        &booking_id_for_service,
+                        &new_room_for_service,
+                        keep_price,
+                        reason.as_deref(),
+                        Local::now().date_naive(),
+                        Some(origin_key),
+                    )
+                    .await
+                    .map_err(map_change_room_command_error)?;
+
+                    let booking = fetch_booking_tx(tx, &booking_id_for_service)
+                        .await
+                        .map_err(map_change_room_command_error)?;
+                    serde_json::to_value(&booking).map_err(system_error)
+                })
+            },
+        )
+        .await
 }
 
 #[cfg(test)]

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -29,7 +29,8 @@ use super::{
     support::{
         begin_tx, ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
         lookup_booking_room_id, map_room_calendar_insert_error, merge_pricing_snapshot,
-        parse_booking_datetime, read_money_vnd_or_zero, validate_non_negative_booking_money,
+        parse_booking_datetime, read_money_vnd_or_zero, room_calendar_stays_tx, room_stays_to_json,
+        validate_non_negative_booking_money, RoomStayRow,
     },
 };
 
@@ -627,6 +628,37 @@ fn checkout_settlement_value(
     })
 }
 
+/// Caps the cumulative night count in `rows` (already ordered by occupancy —
+/// `room_calendar_stays_tx` orders by `MIN(date)`) to `settled_nights`,
+/// walking rooms in that order. A room's own night count can only shrink,
+/// never grow: the first room keeps up to its full count, the next room gets
+/// whatever budget is left, and any room past the point the budget hits zero
+/// is dropped entirely — the guest never reached it under the nights actually
+/// being settled.
+fn truncate_room_stays_to_settled_nights(
+    rows: &[RoomStayRow],
+    settled_nights: i32,
+) -> Vec<RoomStayRow> {
+    let mut remaining = i64::from(settled_nights.max(0));
+    let mut truncated = Vec::new();
+
+    for row in rows {
+        if remaining <= 0 {
+            break;
+        }
+        let nights_here = row.nights.min(remaining);
+        truncated.push(RoomStayRow {
+            room_id: row.room_id.clone(),
+            room_name: row.room_name.clone(),
+            nights: nights_here,
+            first_night: row.first_night.clone(),
+        });
+        remaining -= nights_here;
+    }
+
+    truncated
+}
+
 async fn preview_checkout_settlement_tx(
     tx: &mut Transaction<'_, Sqlite>,
     req: &CheckoutSettlementPreviewRequest,
@@ -871,6 +903,23 @@ async fn check_out_tx(
         settlement.pricing_snapshot.as_deref(),
         "checkout_settlement",
         settlement_value,
+    );
+
+    // Re-derive `room_stays` from `room_calendar` — the live truth — before
+    // the DELETE below wipes it. The snapshot `change_room_tx` wrote at move
+    // time assumed the guest would stay every remaining *booked* night;
+    // settlement may charge fewer than that (early checkout), so truncate
+    // the per-room split down to `settled_nights`, walking rooms in
+    // occupancy order and capping the running total. Reuses the same
+    // `merge_pricing_snapshot` helper as `checkout_settlement` above — no
+    // second snapshot writer.
+    let room_stays_from_calendar = room_calendar_stays_tx(tx, &req.booking_id).await?;
+    let truncated_room_stays =
+        truncate_room_stays_to_settled_nights(&room_stays_from_calendar, settlement.settled_nights);
+    let pricing_snapshot = merge_pricing_snapshot(
+        Some(&pricing_snapshot),
+        "room_stays",
+        room_stays_to_json(&truncated_room_stays),
     );
 
     let result = sqlx::query(

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -628,13 +628,17 @@ fn checkout_settlement_value(
     })
 }
 
-/// Caps the cumulative night count in `rows` (already ordered by occupancy —
-/// `room_calendar_stays_tx` orders by `MIN(date)`) to `settled_nights`,
-/// walking rooms in that order. A room's own night count can only shrink,
-/// never grow: the first room keeps up to its full count, the next room gets
-/// whatever budget is left, and any room past the point the budget hits zero
-/// is dropped entirely — the guest never reached it under the nights actually
-/// being settled.
+/// Caps the cumulative night count in `rows` to `settled_nights`, walking the
+/// segments in the date order `room_calendar_stays_tx` returns them: each
+/// segment keeps up to its own count, the next one gets whatever budget is
+/// left, and any segment past the point the budget hits zero is dropped
+/// entirely — the guest never reached it under the nights actually settled.
+///
+/// This is only correct because `rows` are *occupancy segments in date order*,
+/// not one row per room: a guest who moves A → B → A gets three segments, so
+/// the budget is spent on the nights actually slept first. Group by room
+/// instead and the earliest-dated A row swallows the whole budget while B
+/// silently disappears from the invoice.
 fn truncate_room_stays_to_settled_nights(
     rows: &[RoomStayRow],
     settled_nights: i32,

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -28,8 +28,8 @@ use super::{
     pricing_service::calculate_stay_price_tx,
     support::{
         begin_tx, ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
-        lookup_booking_room_id, map_room_calendar_insert_error, parse_booking_datetime,
-        read_money_vnd_or_zero, validate_non_negative_booking_money,
+        lookup_booking_room_id, map_room_calendar_insert_error, merge_pricing_snapshot,
+        parse_booking_datetime, read_money_vnd_or_zero, validate_non_negative_booking_money,
     },
 };
 
@@ -515,6 +515,11 @@ struct CheckoutSettlementComputation {
     already_paid: MoneyVnd,
     explanation: String,
     reporting_checkout: String,
+    /// The booking's `pricing_snapshot` column as it stood before checkout —
+    /// carried through so `check_out_tx` can merge `checkout_settlement`
+    /// into it instead of overwriting keys a room change already wrote
+    /// (`room_stays`).
+    pricing_snapshot: Option<String>,
 }
 
 fn settlement_mode_label(mode: CheckoutSettlementMode) -> &'static str {
@@ -592,8 +597,14 @@ fn settlement_explanation(
     }
 }
 
+/// Builds the *inner* `checkout_settlement` object — the shape
+/// `revenue_queries.rs` reads via `json_extract(pricing_snapshot,
+/// '$.checkout_settlement.mode')` and `'...reporting_checkout')`. Callers
+/// merge this under the `checkout_settlement` key with `merge_pricing_snapshot`
+/// rather than writing it as the whole `pricing_snapshot` column, so a
+/// `room_stays` key written earlier by a room change survives checkout.
 #[allow(clippy::too_many_arguments)]
-fn checkout_settlement_snapshot(
+fn checkout_settlement_value(
     settlement_mode: CheckoutSettlementMode,
     original_nights: i32,
     actual_nights: i32,
@@ -602,21 +613,18 @@ fn checkout_settlement_snapshot(
     original_total: MoneyVnd,
     settled_total: MoneyVnd,
     manual_override: bool,
-) -> String {
+) -> serde_json::Value {
     serde_json::json!({
-        "checkout_settlement": {
-            "mode": settlement_mode,
-            "label": settlement_mode_label(settlement_mode),
-            "reporting_checkout": reporting_checkout,
-            "original_nights": original_nights,
-            "actual_nights": actual_nights,
-            "settled_nights": settled_nights,
-            "original_total": original_total,
-            "settled_total": settled_total,
-            "manual_override": manual_override,
-        }
+        "mode": settlement_mode,
+        "label": settlement_mode_label(settlement_mode),
+        "reporting_checkout": reporting_checkout,
+        "original_nights": original_nights,
+        "actual_nights": actual_nights,
+        "settled_nights": settled_nights,
+        "original_total": original_total,
+        "settled_total": settled_total,
+        "manual_override": manual_override,
     })
-    .to_string()
 }
 
 async fn preview_checkout_settlement_tx(
@@ -626,7 +634,8 @@ async fn preview_checkout_settlement_tx(
 ) -> BookingResult<CheckoutSettlementComputation> {
     let booking = sqlx::query(
         "SELECT room_id, check_in_at, nights, total_price, paid_amount,
-                COALESCE(pricing_type, 'nightly') AS pricing_type, guests, status
+                COALESCE(pricing_type, 'nightly') AS pricing_type, guests, status,
+                pricing_snapshot
          FROM bookings WHERE id = ?",
     )
     .bind(&req.booking_id)
@@ -654,6 +663,7 @@ async fn preview_checkout_settlement_tx(
     let original_total = read_money_vnd_or_zero(&booking, "total_price");
     let guests: Option<i32> = booking.get("guests");
     let already_paid = read_money_vnd_or_zero(&booking, "paid_amount");
+    let pricing_snapshot: Option<String> = booking.get("pricing_snapshot");
     let actual_nights = actual_nights_for_checkout(&check_in_at, now)?;
 
     let (settled_nights, recommended_total) = match req.settlement_mode {
@@ -690,6 +700,7 @@ async fn preview_checkout_settlement_tx(
         already_paid,
         explanation,
         reporting_checkout,
+        pricing_snapshot,
     })
 }
 
@@ -843,7 +854,7 @@ async fn check_out_tx(
     }
 
     let manual_override = final_total != settlement.recommended_total;
-    let pricing_snapshot = checkout_settlement_snapshot(
+    let settlement_value = checkout_settlement_value(
         req.settlement_mode,
         settlement.original_nights,
         settlement.actual_nights,
@@ -852,6 +863,14 @@ async fn check_out_tx(
         settlement.original_total,
         final_total,
         manual_override,
+    );
+    // Merge, don't overwrite: a room change earlier in the stay may have
+    // already written `room_stays` into this same column
+    // (room_change.rs::change_room_tx), and checkout must not erase it.
+    let pricing_snapshot = merge_pricing_snapshot(
+        settlement.pricing_snapshot.as_deref(),
+        "checkout_settlement",
+        settlement_value,
     );
 
     let result = sqlx::query(

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -109,12 +109,18 @@ pub(crate) fn map_room_calendar_insert_error(error: sqlx::Error, date: NaiveDate
     BookingError::from(error)
 }
 
-/// One room a booking has occupied, derived by grouping `room_calendar` rows
-/// for that booking by room and taking the earliest night as occupancy
-/// order. Feeds `pricing_snapshot.room_stays`: written wholesale by
-/// `room_change::change_room_tx` at move time, and re-derived (then
-/// truncated to the settled night count) by `stay_lifecycle::check_out_tx`
-/// right before it deletes the booking's `room_calendar` rows.
+/// One **occupancy segment**: a run of consecutive nights the booking spent in
+/// one room, in date order. Feeds `pricing_snapshot.room_stays`: written
+/// wholesale by `room_change::change_room_tx` at move time, and re-derived by
+/// `stay_lifecycle::check_out_tx` (then truncated to the settled night count)
+/// and `group_lifecycle::group_checkout_tx` right before they delete the
+/// booking's `room_calendar` rows.
+///
+/// A segment, not a room: a guest who moves A → B → A produces three rows, not
+/// two. Grouping by room instead would collapse the two A stays into one row
+/// carrying the *earliest* `first_night`, and every consumer that walks the
+/// list in stay order (`truncate_room_stays_to_settled_nights`, the invoice
+/// split) would then hand B's nights to A.
 pub struct RoomStayRow {
     pub room_id: String,
     pub room_name: String,
@@ -126,27 +132,37 @@ pub async fn room_calendar_stays_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,
 ) -> BookingResult<Vec<RoomStayRow>> {
+    // One row per night, in date order, then run-length encoded below. The
+    // `room_id` tiebreak only matters for the pathological case of two rooms
+    // holding the same booking on the same date; it keeps the output stable.
     let rows = sqlx::query(
-        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights, MIN(rc.date) AS first_night
+        "SELECT rc.room_id, r.name AS room_name, rc.date
          FROM room_calendar rc
          JOIN rooms r ON r.id = rc.room_id
          WHERE rc.booking_id = ?
-         GROUP BY rc.room_id, r.name
-         ORDER BY MIN(rc.date)",
+         ORDER BY rc.date, rc.room_id",
     )
     .bind(booking_id)
     .fetch_all(&mut **tx)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|row| RoomStayRow {
-            room_id: row.get("room_id"),
-            room_name: row.get("room_name"),
-            nights: row.get("nights"),
-            first_night: row.get("first_night"),
-        })
-        .collect())
+    let mut segments: Vec<RoomStayRow> = Vec::new();
+    for row in rows {
+        let room_id: String = row.get("room_id");
+        let room_name: String = row.get("room_name");
+        let date: String = row.get("date");
+        match segments.last_mut() {
+            Some(last) if last.room_id == room_id => last.nights += 1,
+            _ => segments.push(RoomStayRow {
+                room_id,
+                room_name,
+                nights: 1,
+                first_night: date,
+            }),
+        }
+    }
+
+    Ok(segments)
 }
 
 /// Serializes `RoomStayRow`s into the JSON shape stored under

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -186,9 +186,32 @@ pub fn validate_non_negative_booking_money(
         .map_err(|error| BookingError::validation(error.message))
 }
 
+/// Merge `value` under `key` into the JSON object held by a booking's
+/// `pricing_snapshot` column, preserving every other key already present.
+///
+/// `pricing_snapshot` is a shared scratch space (`checkout_settlement`,
+/// `room_stays`, ...); callers that write one key must never clobber the
+/// others. A booking with no prior snapshot (`existing == None`) or a
+/// snapshot that failed to parse as a JSON object starts from `{}`.
+pub fn merge_pricing_snapshot(
+    existing: Option<&str>,
+    key: &str,
+    value: serde_json::Value,
+) -> String {
+    let mut map = existing
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|parsed| match parsed {
+            serde_json::Value::Object(map) => Some(map),
+            _ => None,
+        })
+        .unwrap_or_default();
+    map.insert(key.to_string(), value);
+    serde_json::Value::Object(map).to_string()
+}
+
 #[cfg(test)]
 pub mod tests {
-    use super::{begin_immediate_tx, invalid_state_transition};
+    use super::{begin_immediate_tx, invalid_state_transition, merge_pricing_snapshot};
     use sqlx::{sqlite::SqlitePoolOptions, Row};
 
     #[test]
@@ -197,6 +220,41 @@ pub mod tests {
         assert!(error
             .to_string()
             .contains(crate::app_error::codes::CONFLICT_INVALID_STATE_TRANSITION));
+    }
+
+    #[test]
+    fn merge_pricing_snapshot_starts_from_empty_object_when_none() {
+        let result = merge_pricing_snapshot(None, "room_stays", serde_json::json!([1, 2]));
+        let value: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(value, serde_json::json!({"room_stays": [1, 2]}));
+    }
+
+    #[test]
+    fn merge_pricing_snapshot_preserves_other_keys() {
+        let existing = r#"{"checkout_settlement":{"mode":"hourly"}}"#;
+        let result = merge_pricing_snapshot(Some(existing), "room_stays", serde_json::json!([3]));
+        let value: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "checkout_settlement": {"mode": "hourly"},
+                "room_stays": [3],
+            })
+        );
+    }
+
+    #[test]
+    fn merge_pricing_snapshot_overwrites_only_the_targeted_key() {
+        let existing = r#"{"room_stays":[1],"checkout_settlement":{"mode":"hourly"}}"#;
+        let result = merge_pricing_snapshot(Some(existing), "room_stays", serde_json::json!([2]));
+        let value: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "checkout_settlement": {"mode": "hourly"},
+                "room_stays": [2],
+            })
+        );
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -109,6 +109,63 @@ pub(crate) fn map_room_calendar_insert_error(error: sqlx::Error, date: NaiveDate
     BookingError::from(error)
 }
 
+/// One room a booking has occupied, derived by grouping `room_calendar` rows
+/// for that booking by room and taking the earliest night as occupancy
+/// order. Feeds `pricing_snapshot.room_stays`: written wholesale by
+/// `room_change::change_room_tx` at move time, and re-derived (then
+/// truncated to the settled night count) by `stay_lifecycle::check_out_tx`
+/// right before it deletes the booking's `room_calendar` rows.
+pub struct RoomStayRow {
+    pub room_id: String,
+    pub room_name: String,
+    pub nights: i64,
+    pub first_night: String,
+}
+
+pub async fn room_calendar_stays_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+) -> BookingResult<Vec<RoomStayRow>> {
+    let rows = sqlx::query(
+        "SELECT rc.room_id, r.name AS room_name, COUNT(*) AS nights, MIN(rc.date) AS first_night
+         FROM room_calendar rc
+         JOIN rooms r ON r.id = rc.room_id
+         WHERE rc.booking_id = ?
+         GROUP BY rc.room_id, r.name
+         ORDER BY MIN(rc.date)",
+    )
+    .bind(booking_id)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| RoomStayRow {
+            room_id: row.get("room_id"),
+            room_name: row.get("room_name"),
+            nights: row.get("nights"),
+            first_night: row.get("first_night"),
+        })
+        .collect())
+}
+
+/// Serializes `RoomStayRow`s into the JSON shape stored under
+/// `pricing_snapshot.room_stays` and read back by `invoice_generation.rs`.
+pub fn room_stays_to_json(rows: &[RoomStayRow]) -> serde_json::Value {
+    serde_json::Value::Array(
+        rows.iter()
+            .map(|row| {
+                serde_json::json!({
+                    "room_id": row.room_id,
+                    "room_name": row.room_name,
+                    "nights": row.nights,
+                    "first_night": row.first_night,
+                })
+            })
+            .collect(),
+    )
+}
+
 #[allow(dead_code)]
 pub async fn fetch_booking<F>(
     pool: &Pool<Sqlite>,

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -38,7 +38,7 @@ mod prelude {
         },
         group_lifecycle, group_service_management, guest_service, pricing_service,
         pricing_service::calculate_stay_price_tx,
-        reservation_lifecycle, stay_lifecycle,
+        reservation_lifecycle, room_change, stay_lifecycle,
     };
 }
 
@@ -57,5 +57,6 @@ mod pricing;
 mod reporting;
 mod reservation_idempotency;
 mod reservations;
+mod room_change;
 mod stay_error_mapping;
 mod stays;

--- a/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
+++ b/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
@@ -559,16 +559,31 @@ async fn the_migrated_special_dates_table_matches_what_the_code_assumes() {
     db.close().await;
 }
 
-/// Tính năng mùa cao điểm không cần migration nào của riêng nó: nó chỉ ghi vào
-/// `special_dates`, bảng đã có sẵn từ v3.
+/// Dây bẫy số hiệu schema. Con số dưới đây cố ý viết cứng chứ không đọc
+/// `LATEST_SCHEMA_VERSION` — đọc hằng số thì test luôn xanh và chẳng canh gì cả.
 ///
-/// Con số dưới đây cố ý viết cứng chứ không đọc `LATEST_SCHEMA_VERSION` — nó là
-/// dây bẫy: bất kỳ nhánh nào thêm migration đều làm test này đỏ, buộc người sửa
-/// phải nhìn lại xem migration đó có thật sự cần không rồi mới nâng số. Lần
-/// nâng gần nhất: 22 → 23, thêm cột `invoices.settlement_note` để lời quyết
-/// toán in cho khách không phải mượn cột ghi chú nội bộ.
+/// Hợp đồng nó canh: **số hiệu này đã được dời có chủ đích, hiện là 25.** Bản
+/// thân tính năng mùa cao điểm không cần migration riêng (nó chỉ ghi vào
+/// `special_dates`, có từ v3); con số ở đây phản ánh migration mới nhất của cả
+/// repo, hiện là `migrate_v25_invoice_settlement_note`.
+///
+/// Nếu test này đỏ, nghĩa là ai đó vừa thêm migration. **Đừng tăng số này lên
+/// một rồi đi tiếp.** Số hiệu bị trùng là lỗi im lặng và chết người: gate
+/// `current < N` sai ngay trên DB đã ở N, migration không chạy, và mọi truy vấn
+/// chạm cột mới chết lúc runtime. Nhánh này từng ship đúng lỗi đó với v23 —
+/// máy khách sạn đã ở 23 do nhánh kbtt, nên cột `invoices.settlement_note`
+/// không bao giờ được tạo và toàn bộ đường hoá đơn/check-out chết ngay lần mở
+/// app đầu tiên. Nhánh `feat/room-drawer-stay-edits` cũng đã vấp y hệt (commit
+/// 4c5c1c3).
+///
+/// Việc phải làm trước khi nâng: quét MỌI ref, không chỉ `main` —
+/// `git for-each-ref --format='%(refname:short)' | xargs -I{} git show
+/// {}:mhm/src-tauri/src/db.rs | grep LATEST_SCHEMA_VERSION` — và đọc thẳng DB
+/// thật (`sqlite3 "file:…/capyinn.db?immutable=1" "SELECT MAX(version) FROM
+/// schema_version"`), đừng tin con số ai đó nói miệng. Chọn số cao hơn tất cả;
+/// bỏ trống vài số là vô hại, trùng số thì không.
 #[tokio::test]
-async fn the_branch_does_not_move_the_schema_version() {
+async fn the_schema_version_is_the_one_this_branch_deliberately_claimed() {
     let db = migrated_db("schema-version").await;
 
     let version: i64 = sqlx::query_scalar("SELECT version FROM schema_version LIMIT 1")
@@ -577,8 +592,9 @@ async fn the_branch_does_not_move_the_schema_version() {
         .expect("đọc schema_version");
 
     assert_eq!(
-        version, 23,
-        "một migration mới vừa xuất hiện — kiểm tra lại nó trước khi nâng số này"
+        version, 25,
+        "một migration mới vừa xuất hiện — quét mọi ref và đọc DB thật để chắc \
+         số hiệu chưa bị nhánh nào chiếm, rồi mới nâng con số này"
     );
 
     db.close().await;

--- a/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
+++ b/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
@@ -559,8 +559,14 @@ async fn the_migrated_special_dates_table_matches_what_the_code_assumes() {
     db.close().await;
 }
 
-/// Nhánh này không được thêm hay sửa migration nào: phiên bản schema phải đứng
-/// yên ở 22, đúng như trên `main`.
+/// Tính năng mùa cao điểm không cần migration nào của riêng nó: nó chỉ ghi vào
+/// `special_dates`, bảng đã có sẵn từ v3.
+///
+/// Con số dưới đây cố ý viết cứng chứ không đọc `LATEST_SCHEMA_VERSION` — nó là
+/// dây bẫy: bất kỳ nhánh nào thêm migration đều làm test này đỏ, buộc người sửa
+/// phải nhìn lại xem migration đó có thật sự cần không rồi mới nâng số. Lần
+/// nâng gần nhất: 22 → 23, thêm cột `invoices.settlement_note` để lời quyết
+/// toán in cho khách không phải mượn cột ghi chú nội bộ.
 #[tokio::test]
 async fn the_branch_does_not_move_the_schema_version() {
     let db = migrated_db("schema-version").await;
@@ -570,7 +576,10 @@ async fn the_branch_does_not_move_the_schema_version() {
         .await
         .expect("đọc schema_version");
 
-    assert_eq!(version, 22, "nhánh mùa cao điểm không đụng vào migration");
+    assert_eq!(
+        version, 23,
+        "một migration mới vừa xuất hiện — kiểm tra lại nó trước khi nâng số này"
+    );
 
     db.close().await;
 }

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -132,3 +132,97 @@ async fn load_options_hides_a_dirty_room_when_the_guest_moves_in_tonight() {
     let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
     assert!(!ids.contains(&"R-NEW"), "không đưa khách vào phòng chưa dọn");
 }
+
+#[tokio::test]
+async fn change_room_keeps_past_nights_on_the_old_room() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let old_nights: Vec<String> = sqlx::query_scalar(
+        "SELECT date FROM room_calendar WHERE booking_id = 'B-OPT' AND room_id = 'R-OLD' ORDER BY date",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(old_nights, vec!["2026-04-15".to_string()]);
+
+    let new_nights: Vec<String> = sqlx::query_scalar(
+        "SELECT date FROM room_calendar WHERE booking_id = 'B-OPT' AND room_id = 'R-NEW' ORDER BY date",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        new_nights,
+        vec!["2026-04-16".to_string(), "2026-04-17".to_string()]
+    );
+
+    let room_id: String = sqlx::query_scalar("SELECT room_id FROM bookings WHERE id = 'B-OPT'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(room_id, "R-NEW");
+}
+
+#[tokio::test]
+async fn change_room_sends_the_old_room_to_cleaning() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let old_status: String = sqlx::query_scalar("SELECT status FROM rooms WHERE id = 'R-OLD'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(old_status, "cleaning");
+
+    let new_status: String = sqlx::query_scalar("SELECT status FROM rooms WHERE id = 'R-NEW'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(new_status, "occupied");
+
+    let task_count: i32 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM housekeeping WHERE room_id = 'R-OLD' AND status = 'needs_cleaning'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(task_count, 1, "phòng cũ phải sinh đúng một phiếu dọn");
+}
+
+#[tokio::test]
+async fn change_room_rejects_the_same_room() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    let result = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-OLD",
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(BookingError::Validation(_))));
+}

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -1,6 +1,32 @@
 use super::prelude::*;
 use crate::services::booking::invoice_generation;
 
+/// Both invoice renderers (`InvoicePDF.tsx`, `InvoiceDialog.tsx`) print
+/// **every** breakdown line with its amount under a "PRICE BREAKDOWN" header
+/// and then print "Subtotal" from `invoice.total` right underneath. A guest
+/// therefore reads the lines as an itemisation of the subtotal: if they do not
+/// add up to it, the printed document contradicts itself.
+///
+/// Deliberately sums *all* lines, not a `starts_with("Phòng ")` subset — a
+/// filtered assertion cannot see a duplicated charge, which is exactly the
+/// defect this guards against.
+fn assert_breakdown_sums_to_subtotal(invoice: &crate::models::InvoiceData) {
+    let lines: Vec<String> = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| format!("{} = {:?}", line.label, line.amount))
+        .collect();
+    let sum: i64 = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| line.amount)
+        .sum();
+    assert_eq!(
+        sum, invoice.subtotal,
+        "mọi dòng in ra phải cộng đúng bằng subtotal, không được thừa dòng nào: {lines:?}"
+    );
+}
+
 /// Khách đã ở 1 đêm (15/04), còn 2 đêm (16/04, 17/04). Hôm nay là 16/04.
 ///
 /// R-OLD hạng `standard` 250.000/đêm, R-NEW hạng `deluxe` 350.000/đêm.
@@ -721,19 +747,7 @@ async fn invoice_splits_lines_per_room_after_a_move() {
     assert!(labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")));
     assert!(labels.iter().any(|l| l.contains("R-NEW") && l.contains("2 đêm")));
 
-    // breakdown[0] is the settlement line (Finding 2 keeps it alongside the
-    // room lines, not replaced by them) — only the "Phòng " lines need to sum
-    // to subtotal.
-    let room_lines_sum: i64 = invoice
-        .pricing_breakdown
-        .iter()
-        .filter(|l| l.label.starts_with("Phòng "))
-        .map(|l| l.amount)
-        .sum();
-    assert_eq!(
-        room_lines_sum, invoice.subtotal,
-        "tổng các dòng phòng phải khớp subtotal"
-    );
+    assert_breakdown_sums_to_subtotal(&invoice);
 }
 
 #[tokio::test]
@@ -752,6 +766,7 @@ async fn invoice_keeps_one_line_when_no_move_happened() {
         1,
         "chưa đổi phòng thì hoá đơn chỉ có một dòng, đúng như trước đây"
     );
+    assert_breakdown_sums_to_subtotal(&invoice);
 }
 
 /// The decisive regression test: `check_out_tx` deletes every `room_calendar`
@@ -819,25 +834,28 @@ async fn move_then_real_checkout_still_splits_invoice_lines() {
         "labels: {labels:?}"
     );
 
-    let room_lines_sum: i64 = invoice
-        .pricing_breakdown
-        .iter()
-        .filter(|l| l.label.starts_with("Phòng "))
-        .map(|l| l.amount)
-        .sum();
-    assert_eq!(
-        room_lines_sum, invoice.subtotal,
-        "tổng các dòng phòng phải khớp subtotal"
-    );
+    assert_breakdown_sums_to_subtotal(&invoice);
 
-    // Finding 2: the settlement line ("Thanh toán theo số đêm đã đặt") must
-    // survive the split, not get silently dropped when the invoice also
-    // breaks down by room — this is exactly the booking whose settlement is
-    // least obvious (moved mid-stay), so losing the line that explains the
-    // total is worst here.
-    assert_eq!(
-        invoice.pricing_breakdown[0].label, "Thanh toán theo số đêm đã đặt",
-        "dòng quyết toán không được biến mất khi hoá đơn tách theo phòng: {labels:?}"
+    // The settlement wording ("Thanh toán theo số đêm đã đặt") must survive
+    // the split — this is exactly the booking whose settlement is least
+    // obvious (moved mid-stay), so losing the wording that explains the total
+    // is worst here. It lands in `notes`, NOT in `pricing_breakdown`: as a
+    // money line it would be printed alongside the room lines that already
+    // sum to subtotal, and the guest would read a document adding up to twice
+    // its own stated subtotal.
+    assert!(
+        invoice
+            .notes
+            .as_deref()
+            .is_some_and(|notes| notes.contains("Thanh toán theo số đêm đã đặt")),
+        "ghi chú phải giữ lại lời quyết toán: {:?}",
+        invoice.notes
+    );
+    assert!(
+        !labels
+            .iter()
+            .any(|l| l.contains("Thanh toán theo số đêm đã đặt")),
+        "lời quyết toán không được ở lại danh sách dòng tiền: {labels:?}"
     );
 
     // checkout_settlement must survive the pricing_snapshot merge alongside
@@ -929,16 +947,7 @@ async fn move_then_extend_reflects_the_real_split_not_the_stale_snapshot() {
          không dừng lại ở snapshot 2 đêm chụp lúc chuyển phòng: {labels:?}"
     );
 
-    let room_lines_sum: i64 = invoice
-        .pricing_breakdown
-        .iter()
-        .filter(|l| l.label.starts_with("Phòng "))
-        .map(|l| l.amount)
-        .sum();
-    assert_eq!(
-        room_lines_sum, invoice.subtotal,
-        "tổng các dòng phòng phải khớp subtotal"
-    );
+    assert_breakdown_sums_to_subtotal(&invoice);
 }
 
 /// Finding 1(b): the snapshot written at move time assumes the guest stays
@@ -1025,16 +1034,7 @@ async fn move_then_early_checkout_truncates_room_stays_to_settled_nights() {
         "labels: {labels:?}"
     );
 
-    let room_lines_sum: i64 = invoice
-        .pricing_breakdown
-        .iter()
-        .filter(|l| l.label.starts_with("Phòng "))
-        .map(|l| l.amount)
-        .sum();
-    assert_eq!(
-        room_lines_sum, invoice.subtotal,
-        "tổng các dòng phòng phải khớp subtotal"
-    );
+    assert_breakdown_sums_to_subtotal(&invoice);
 
     // The checkout_settlement key must still be intact and still readable by
     // revenue_queries.rs — the room_stays truncation must merge, not clobber.
@@ -1080,20 +1080,358 @@ async fn invoice_split_remainder_lands_on_last_line_for_non_divisible_subtotal()
         .unwrap();
     tx.commit().await.unwrap();
 
-    // breakdown[0] is the settlement line (Finding 2 keeps it, not replaced
-    // by the room split); the two room lines follow it.
-    assert_eq!(invoice.pricing_breakdown.len(), 3);
-    assert_eq!(invoice.pricing_breakdown[1].amount, 33_333);
-    assert_eq!(invoice.pricing_breakdown[2].amount, 66_667);
+    // The split replaces the settlement line, so the breakdown is exactly the
+    // two room lines — nothing else may carry an amount.
+    assert_eq!(invoice.pricing_breakdown.len(), 2);
+    assert_eq!(invoice.pricing_breakdown[0].amount, 33_333);
+    assert_eq!(invoice.pricing_breakdown[1].amount, 66_667);
 
-    let room_lines_sum: i64 = invoice
+    assert_breakdown_sums_to_subtotal(&invoice);
+}
+
+/// Finding A: the settlement wording is not allowed to just vanish when the
+/// split takes over the money lines — it moves to `notes`, which both
+/// renderers now print as a "GHI CHÚ" block. With no guest notes on the
+/// booking it must stand alone, with no stray separator or blank first line.
+#[tokio::test]
+async fn split_invoice_carries_the_settlement_wording_in_notes() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    stay_lifecycle::check_out(
+        &pool,
+        checkout_req("B-OPT", CheckoutSettlementMode::BookedNights, 750_000),
+    )
+    .await
+    .unwrap();
+
+    // `change_room_tx` appends its own "Chuyển phòng ..." line to
+    // `bookings.notes`; clear the column afterwards so this test sees the
+    // no-guest-notes branch instead of the merge branch.
+    sqlx::query("UPDATE bookings SET notes = NULL WHERE id = 'B-OPT'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        invoice.notes.as_deref(),
+        Some("Thanh toán theo số đêm đã đặt"),
+        "không có ghi chú của khách thì lời quyết toán phải đứng một mình, \
+         không kèm dấu phân cách hay dòng trống"
+    );
+    assert_breakdown_sums_to_subtotal(&invoice);
+
+    // Regenerating must not stack a second copy of the wording: the invoice
+    // reads `bookings.notes`, which this path never writes back to.
+    let mut tx = pool.begin().await.unwrap();
+    let again = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(again.notes, invoice.notes);
+}
+
+/// The guest's own notes are the reason `notes` is rendered at all — the
+/// settlement wording is appended to them, never on top of them.
+#[tokio::test]
+async fn split_invoice_keeps_guest_notes_above_the_settlement_wording() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    sqlx::query("UPDATE bookings SET notes = 'Khách xin hoá đơn công ty' WHERE id = 'B-OPT'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    stay_lifecycle::check_out(
+        &pool,
+        checkout_req("B-OPT", CheckoutSettlementMode::BookedNights, 750_000),
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let notes = invoice.notes.clone().unwrap_or_default();
+    assert!(
+        notes.starts_with("Khách xin hoá đơn công ty"),
+        "ghi chú của khách phải đứng trước: {notes:?}"
+    );
+    assert!(
+        notes.contains("Chuyển phòng R-OLD → R-NEW"),
+        "dòng chuyển phòng do change_room_tx ghi phải còn nguyên: {notes:?}"
+    );
+    assert_eq!(
+        notes.lines().last(),
+        Some("Thanh toán theo số đêm đã đặt"),
+        "lời quyết toán là một dòng riêng ở cuối: {notes:?}"
+    );
+    assert_breakdown_sums_to_subtotal(&invoice);
+}
+
+/// Finding B: a guest who moves A → B and later back to A.
+///
+/// `room_calendar_stays_tx` used to `GROUP BY rc.room_id`, which collapsed the
+/// two A stays into one row carrying A's *earliest* night. Walking that list,
+/// `truncate_room_stays_to_settled_nights` handed the whole settled-night
+/// budget to A and dropped B entirely — an early-checkout invoice then billed
+/// two nights to a room the guest slept in once, and never mentioned the room
+/// they actually slept in on the second night.
+///
+/// Nights 15/04 (R-OLD), 16/04 (R-NEW), 17/04 (R-OLD). The guest leaves on the
+/// morning of 17/04 ⇒ 2 settled nights ⇒ R-OLD × 1 + R-NEW × 1.
+#[tokio::test]
+async fn move_out_and_back_bills_each_stay_separately_on_early_checkout() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    // Buồng phòng dọn xong R-OLD trước khi khách quay lại — `change_room_tx`
+    // chỉ nhận phòng mới ở trạng thái `vacant`, đúng như check-in.
+    sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = 'R-OLD'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-OLD",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 17).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let checkout_at = Local
+        .with_ymd_and_hms(2026, 4, 17, 9, 0, 0)
+        .single()
+        .unwrap();
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B-OPT".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+        checkout_at,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        preview.settled_nights, 2,
+        "tiền đề của test: khách rời sau đúng 2 đêm thật"
+    );
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        checkout_req(
+            "B-OPT",
+            CheckoutSettlementMode::ActualNights,
+            preview.recommended_total,
+        ),
+        checkout_at,
+    )
+    .await
+    .unwrap();
+
+    let snapshot: String =
+        sqlx::query_scalar("SELECT pricing_snapshot FROM bookings WHERE id = 'B-OPT'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let stays = serde_json::from_str::<serde_json::Value>(&snapshot).unwrap()["room_stays"].clone();
+    let stay_pairs: Vec<(String, i64)> = stays
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| {
+            (
+                entry["room_id"].as_str().unwrap().to_string(),
+                entry["nights"].as_i64().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        stay_pairs,
+        vec![("R-OLD".to_string(), 1), ("R-NEW".to_string(), 1)],
+        "hai đêm đã quyết toán là 15/04 ở R-OLD và 16/04 ở R-NEW, \
+         không phải 2 đêm dồn hết cho R-OLD: {stays}"
+    );
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let labels: Vec<String> = invoice
         .pricing_breakdown
         .iter()
-        .filter(|l| l.label.starts_with("Phòng "))
-        .map(|l| l.amount)
-        .sum();
-    assert_eq!(
-        room_lines_sum, 100_000,
-        "lines phải cộng đúng bằng subtotal dù chia không chẵn"
+        .map(|line| line.label.clone())
+        .collect();
+    assert!(
+        labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        "labels: {labels:?}"
     );
+    assert!(
+        labels.iter().any(|l| l.contains("R-NEW") && l.contains("1 đêm")),
+        "R-NEW phải còn trên hoá đơn — khách ngủ ở đó đúng đêm 16/04: {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|l| l.contains("R-OLD") && l.contains("2 đêm")),
+        "R-OLD không được nuốt cả ngân sách 2 đêm: {labels:?}"
+    );
+    assert_breakdown_sums_to_subtotal(&invoice);
+}
+
+/// Finding C: `group_checkout_tx` bulk-deletes `room_calendar` for every
+/// booking in the group without re-deriving `room_stays` into
+/// `pricing_snapshot` first — the move `check_out_tx` already makes on the
+/// single-booking path.
+///
+/// The move-time snapshot alone is not enough, for the same reason
+/// `move_then_extend_reflects_the_real_split_not_the_stale_snapshot` documents
+/// above: `extend_stay_tx` adds `room_calendar` rows on the guest's current
+/// room without touching `pricing_snapshot`. So this test moves *and* extends.
+/// With the calendar deleted and the snapshot never refreshed, the invoice
+/// bills the extended night to the wrong room — it splits 750.000 over the two
+/// nights the stale snapshot remembers instead of the three actually charged.
+#[tokio::test]
+async fn group_checkout_keeps_the_room_split_for_a_booking_that_moved() {
+    let pool = test_pool().await;
+    seed_rooms_with_price(&pool, &["G-A", "G-B", "G-C"], 250_000)
+        .await
+        .unwrap();
+
+    let group = group_lifecycle::group_checkin(
+        &pool,
+        Some("seed-user".to_string()),
+        minimal_group_checkin_request(&["G-A", "G-B"]),
+    )
+    .await
+    .unwrap();
+
+    let moved_booking_id: String =
+        sqlx::query_scalar("SELECT id FROM bookings WHERE group_id = ? AND room_id = 'G-A'")
+            .bind(&group.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let other_booking_id: String =
+        sqlx::query_scalar("SELECT id FROM bookings WHERE group_id = ? AND room_id = 'G-B'")
+            .bind(&group.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    // group_checkin books 2 nights from today; moving "tomorrow" leaves the
+    // first night on G-A and puts the second on G-C — the only shape that
+    // makes a per-room split meaningful.
+    let tomorrow = Local::now().date_naive() + Duration::days(1);
+    room_change::change_room(&pool, &moved_booking_id, "G-C", true, None, tomorrow)
+        .await
+        .unwrap();
+
+    // The extra night lands on G-C and is invisible to the snapshot
+    // `change_room_tx` took at move time — only `room_calendar` knows about
+    // it, and group checkout is about to delete that.
+    stay_lifecycle::extend_stay(&pool, &moved_booking_id)
+        .await
+        .unwrap();
+
+    group_lifecycle::group_checkout(
+        &pool,
+        GroupCheckoutRequest {
+            group_id: group.id.clone(),
+            booking_ids: vec![moved_booking_id.clone(), other_booking_id.clone()],
+            final_paid: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let calendar_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
+            .bind(&moved_booking_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        calendar_rows, 0,
+        "group checkout phải xoá room_calendar — nếu còn thì test này không đại diện cho path thật"
+    );
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, &moved_booking_id)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let labels: Vec<String> = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| line.label.clone())
+        .collect();
+    assert!(
+        labels.iter().any(|l| l.contains("G-A") && l.contains("1 đêm")),
+        "labels: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l.contains("G-C") && l.contains("2 đêm")),
+        "G-C phải cộng cả đêm gia hạn — group checkout phải chốt lại room_stays \
+         từ room_calendar trước khi xoá, đúng như check_out_tx: {labels:?}"
+    );
+    assert_breakdown_sums_to_subtotal(&invoice);
+
+    // The booking that never moved keeps its single line — the loop must not
+    // invent a split where there was no move.
+    let mut tx = pool.begin().await.unwrap();
+    let other_invoice = invoice_generation::generate_invoice_tx(&mut tx, &other_booking_id)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(other_invoice.pricing_breakdown.len(), 1);
+    assert_breakdown_sums_to_subtotal(&other_invoice);
 }

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -1,4 +1,5 @@
 use super::prelude::*;
+use crate::services::booking::invoice_generation;
 
 /// Khách đã ở 1 đêm (15/04), còn 2 đêm (16/04, 17/04). Hôm nay là 16/04.
 ///
@@ -647,4 +648,56 @@ async fn change_room_idempotent_retry_does_not_charge_twice() {
     assert_eq!(total, 950_000);
 
     assert_single_outbox_event(&pool, &ctx, "booking.room_changed").await;
+}
+
+#[tokio::test]
+async fn invoice_splits_lines_per_room_after_a_move() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let labels: Vec<String> = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| line.label.clone())
+        .collect();
+    assert!(labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")));
+    assert!(labels.iter().any(|l| l.contains("R-NEW") && l.contains("2 đêm")));
+
+    let sum: i64 = invoice.pricing_breakdown.iter().map(|l| l.amount).sum();
+    assert_eq!(sum, invoice.subtotal, "tổng các dòng phải khớp subtotal");
+}
+
+#[tokio::test]
+async fn invoice_keeps_one_line_when_no_move_happened() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        invoice.pricing_breakdown.len(),
+        1,
+        "chưa đổi phòng thì hoá đơn chỉ có một dòng, đúng như trước đây"
+    );
 }

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -1204,6 +1204,49 @@ async fn settlement_note_never_carries_the_bookings_internal_notes() {
         "notes vẫn giữ nguyên ghi chú của booking: {:?}",
         invoice.notes
     );
+
+    assert_breakdown_sums_to_subtotal(&invoice);
+}
+
+/// An in-house guest can be handed an invoice — `RoomDetailPanel.tsx` and
+/// `RoomDrawer.tsx` both offer it — and before checkout there is no
+/// `checkout_settlement`, so the settlement label falls back to the English
+/// developer string "3 night(s) x 250000d". That is tolerable as a breakdown
+/// line (it has always been one) but not under a Vietnamese "GHI CHÚ" heading,
+/// so `settlement_note` must stay empty until checkout gives it real wording.
+#[tokio::test]
+async fn a_pre_checkout_split_invoice_has_no_settlement_note() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    // No check_out call: the guest is still in the room.
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert!(
+        invoice.pricing_breakdown.len() > 1,
+        "tiền đề của test: hoá đơn này phải là loại tách theo phòng"
+    );
+    assert_eq!(
+        invoice.settlement_note, None,
+        "chưa check-out thì không có lời quyết toán tiếng Việt nào để in — \
+         thà bỏ trống còn hơn in chuỗi tiếng Anh của lập trình viên"
+    );
+    assert_breakdown_sums_to_subtotal(&invoice);
 }
 
 /// Finding B: a guest who moves A → B and later back to A.

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -555,3 +555,96 @@ async fn change_room_keeps_the_group_link_intact() {
             .unwrap();
     assert_eq!(master, "B-OPT");
 }
+
+/// Same shape as `seed_stay_in_progress` (one night already stayed, two nights
+/// remaining, R-OLD standard vs. R-NEW deluxe at a 100.000/night difference),
+/// but with dates computed from the real wall clock instead of hard-coded to
+/// April 2026.
+///
+/// `change_room_idempotent` — unlike the pool-level `change_room` test helper
+/// above, which takes `today` as an explicit argument — resolves `today` from
+/// `Local::now()` (mirroring `extend_stay_idempotent`/`check_out_idempotent`),
+/// because the Tauri command has no `today` input either. A fixture pinned to
+/// a fixed past date would leave zero `room_calendar` rows with
+/// `date >= today` once the real date moves past it, and
+/// `change_room_tx` would reject the move outright.
+async fn seed_stay_in_progress_around_today(pool: &sqlx::Pool<sqlx::Sqlite>) {
+    let today = Local::now().date_naive();
+    let yesterday = today - Duration::days(1);
+    let tomorrow = today + Duration::days(1);
+
+    seed_room(pool, "R-OLD").await.unwrap();
+    seed_room(pool, "R-NEW").await.unwrap();
+    sqlx::query("UPDATE rooms SET type = 'deluxe' WHERE id = 'R-NEW'")
+        .execute(pool)
+        .await
+        .unwrap();
+    seed_pricing_rule(pool, "standard", 250_000).await.unwrap();
+    seed_pricing_rule(pool, "deluxe", 350_000).await.unwrap();
+
+    seed_active_booking_with_terms(
+        pool,
+        "B-OPT",
+        "R-OLD",
+        &format!("{}T10:00:00+07:00", yesterday.format("%Y-%m-%d")),
+        &format!(
+            "{}T10:00:00+07:00",
+            (tomorrow + Duration::days(1)).format("%Y-%m-%d")
+        ),
+        3,
+        750_000,
+        Some(0),
+    )
+    .await
+    .unwrap();
+
+    // `seed_active_booking` hard-codes a single 2026-04-15 calendar row;
+    // replace it with the three real nights of this stay.
+    sqlx::query("DELETE FROM room_calendar WHERE booking_id = 'B-OPT'")
+        .execute(pool)
+        .await
+        .unwrap();
+    for date in [yesterday, today, tomorrow] {
+        sqlx::query(
+            "INSERT INTO room_calendar (room_id, date, booking_id, status)
+             VALUES ('R-OLD', ?, 'B-OPT', 'occupied')",
+        )
+        .bind(date.format("%Y-%m-%d").to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn change_room_idempotent_retry_does_not_charge_twice() {
+    let pool = test_pool().await;
+    seed_stay_in_progress_around_today(&pool).await;
+
+    let ctx = cmd_with_request("change_room", "req-change-room-idem", "idem-room-change-1");
+
+    let first = room_change::change_room_idempotent(&pool, &ctx, "B-OPT", "R-NEW", false, None)
+        .await
+        .unwrap();
+    let second = room_change::change_room_idempotent(&pool, &ctx, "B-OPT", "R-NEW", false, None)
+        .await
+        .unwrap();
+
+    assert_replayed_pair(&first, &second);
+
+    let charges: i32 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = 'B-OPT' AND type = 'charge'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 1, "gọi lại cùng khoá không được tính tiền lần hai");
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = 'B-OPT'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 950_000);
+
+    assert_single_outbox_event(&pool, &ctx, "booking.room_changed").await;
+}

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -142,6 +142,7 @@ async fn change_room_keeps_past_nights_on_the_old_room() {
         &pool,
         "B-OPT",
         "R-NEW",
+        true,
         None,
         NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
     )
@@ -183,6 +184,7 @@ async fn change_room_sends_the_old_room_to_cleaning() {
         &pool,
         "B-OPT",
         "R-NEW",
+        true,
         None,
         NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
     )
@@ -219,10 +221,124 @@ async fn change_room_rejects_the_same_room() {
         &pool,
         "B-OPT",
         "R-OLD",
+        true,
         None,
         NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
     )
     .await;
 
     assert!(matches!(result, Err(BookingError::Validation(_))));
+}
+
+#[tokio::test]
+async fn change_room_charges_only_the_difference_for_remaining_nights() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    // R-NEW hạng deluxe, đắt hơn 100.000/đêm. Còn 2 đêm ⇒ chênh 200.000.
+
+    let booking = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        false,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(booking.total_price, 750_000 + 200_000);
+
+    let charge: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = 'B-OPT' AND type = 'charge'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charge, 200_000);
+}
+
+#[tokio::test]
+async fn change_room_with_keep_price_records_no_money_at_all() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    let booking = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(booking.total_price, 750_000, "giữ giá cũ thì tổng không đổi");
+
+    let count: i32 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = 'B-OPT' AND type = 'charge'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn change_room_to_a_cheaper_room_records_a_negative_charge() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    // Hạ giá hạng deluxe xuống dưới standard: 150.000 so với 250.000.
+    // Sửa `pricing_rules`, không sửa `rooms.base_price` — engine đọc bảng này.
+    sqlx::query("UPDATE pricing_rules SET daily_rate = 150000 WHERE room_type = 'deluxe'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let booking = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        false,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(booking.total_price, 750_000 - 200_000);
+
+    let charge: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = 'B-OPT' AND type = 'charge'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charge, -200_000);
+}
+
+#[tokio::test]
+async fn change_room_appends_the_move_to_booking_notes() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        Some("máy lạnh hỏng"),
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let notes: String = sqlx::query_scalar("SELECT notes FROM bookings WHERE id = 'B-OPT'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(notes.starts_with("seed booking |"), "ghi chú cũ phải còn");
+    assert!(notes.contains("Chuyển phòng R-OLD → R-NEW ngày 16/04/2026"));
+    assert!(notes.contains("máy lạnh hỏng"));
 }

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -701,3 +701,153 @@ async fn invoice_keeps_one_line_when_no_move_happened() {
         "chưa đổi phòng thì hoá đơn chỉ có một dòng, đúng như trước đây"
     );
 }
+
+/// The decisive regression test: `check_out_tx` deletes every `room_calendar`
+/// row for the booking (stay_lifecycle.rs), and in the real production
+/// database invoices are always generated *after* checkout — so by the time
+/// `generate_invoice_tx` runs, `room_calendar` has nothing left to group.
+/// The split must come from `bookings.pricing_snapshot.room_stays`, written
+/// by `change_room_tx` at move time, not from `room_calendar`.
+#[tokio::test]
+async fn move_then_real_checkout_still_splits_invoice_lines() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    // Real checkout path, not a direct SQL fixture — this is what production
+    // actually runs, and it wipes room_calendar as a side effect.
+    stay_lifecycle::check_out(
+        &pool,
+        checkout_req("B-OPT", CheckoutSettlementMode::BookedNights, 750_000),
+    )
+    .await
+    .unwrap();
+
+    let calendar_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = 'B-OPT'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        calendar_rows, 0,
+        "checkout phải xoá hết room_calendar — nếu còn dòng thì test này không còn đại diện cho path thật"
+    );
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let labels: Vec<String> = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| line.label.clone())
+        .collect();
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        "labels: {labels:?}"
+    );
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.contains("R-NEW") && l.contains("2 đêm")),
+        "labels: {labels:?}"
+    );
+
+    let sum: i64 = invoice.pricing_breakdown.iter().map(|l| l.amount).sum();
+    assert_eq!(sum, invoice.subtotal, "tổng các dòng phải khớp subtotal");
+
+    // checkout_settlement must survive the pricing_snapshot merge alongside
+    // room_stays — revenue_queries.rs reads it via json_extract and those
+    // paths must keep resolving.
+    let snapshot: String =
+        sqlx::query_scalar("SELECT pricing_snapshot FROM bookings WHERE id = 'B-OPT'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let value: serde_json::Value = serde_json::from_str(&snapshot).unwrap();
+    assert!(
+        value.get("room_stays").is_some(),
+        "room_stays phải sống sót qua checkout: {value}"
+    );
+    assert!(
+        value.get("checkout_settlement").is_some(),
+        "checkout_settlement phải còn nguyên: {value}"
+    );
+
+    let mode: Option<String> = sqlx::query_scalar(
+        "SELECT json_extract(pricing_snapshot, '$.checkout_settlement.mode') FROM bookings WHERE id = 'B-OPT'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(mode.as_deref(), Some("booked_nights"));
+
+    let reporting_checkout: Option<String> = sqlx::query_scalar(
+        "SELECT json_extract(pricing_snapshot, '$.checkout_settlement.reporting_checkout') FROM bookings WHERE id = 'B-OPT'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        reporting_checkout.is_some(),
+        "revenue_queries.rs đọc path này qua json_extract, phải còn resolve được"
+    );
+}
+
+/// The existing split test (750.000 / 3 nights = 250.000 exactly) never
+/// exercises the remainder-on-last-line branch. Pick a subtotal that does
+/// not divide evenly across the split nights so integer truncation would
+/// silently drop money if the remainder handling were wrong.
+#[tokio::test]
+async fn invoice_split_remainder_lands_on_last_line_for_non_divisible_subtotal() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    // 1 night on R-OLD, 2 nights on R-NEW ⇒ 3 nights total. 100.000 / 3 does
+    // not divide evenly (33.333,33...).
+    sqlx::query("UPDATE bookings SET total_price = 100000 WHERE id = 'B-OPT'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(invoice.pricing_breakdown.len(), 2);
+    assert_eq!(invoice.pricing_breakdown[0].amount, 33_333);
+    assert_eq!(invoice.pricing_breakdown[1].amount, 66_667);
+
+    let sum: i64 = invoice.pricing_breakdown.iter().map(|l| l.amount).sum();
+    assert_eq!(
+        sum, 100_000,
+        "lines phải cộng đúng bằng subtotal dù chia không chẵn"
+    );
+}

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -106,7 +106,10 @@ async fn load_options_excludes_current_room_and_lists_free_ones() {
     .unwrap();
 
     let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
-    assert!(!ids.contains(&"R-OLD"), "phòng hiện tại không được là phương án");
+    assert!(
+        !ids.contains(&"R-OLD"),
+        "phòng hiện tại không được là phương án"
+    );
     assert!(ids.contains(&"R-NEW"));
 }
 
@@ -157,7 +160,10 @@ async fn load_options_hides_a_dirty_room_when_the_guest_moves_in_tonight() {
     .unwrap();
 
     let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
-    assert!(!ids.contains(&"R-NEW"), "không đưa khách vào phòng chưa dọn");
+    assert!(
+        !ids.contains(&"R-NEW"),
+        "không đưa khách vào phòng chưa dọn"
+    );
 }
 
 /// `load_options` only applied the vacancy filter when `moving_in_today`. But
@@ -342,7 +348,10 @@ async fn change_room_with_keep_price_records_no_money_at_all() {
     .await
     .unwrap();
 
-    assert_eq!(booking.total_price, 750_000, "giữ giá cũ thì tổng không đổi");
+    assert_eq!(
+        booking.total_price, 750_000,
+        "giữ giá cũ thì tổng không đổi"
+    );
 
     let count: i32 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM transactions WHERE booking_id = 'B-OPT' AND type = 'charge'",
@@ -744,8 +753,12 @@ async fn invoice_splits_lines_per_room_after_a_move() {
         .iter()
         .map(|line| line.label.clone())
         .collect();
-    assert!(labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")));
-    assert!(labels.iter().any(|l| l.contains("R-NEW") && l.contains("2 đêm")));
+    assert!(labels
+        .iter()
+        .any(|l| l.contains("R-OLD") && l.contains("1 đêm")));
+    assert!(labels
+        .iter()
+        .any(|l| l.contains("R-NEW") && l.contains("2 đêm")));
 
     assert_breakdown_sums_to_subtotal(&invoice);
 }
@@ -939,11 +952,15 @@ async fn move_then_extend_reflects_the_real_split_not_the_stale_snapshot() {
         .map(|line| line.label.clone())
         .collect();
     assert!(
-        labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
         "labels: {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("R-NEW") && l.contains("4 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("R-NEW") && l.contains("4 đêm")),
         "phòng hiện tại phải cộng dồn cả 2 đêm gia hạn (2 gốc + 2 gia hạn = 4), \
          không dừng lại ở snapshot 2 đêm chụp lúc chuyển phòng: {labels:?}"
     );
@@ -1022,16 +1039,22 @@ async fn move_then_early_checkout_truncates_room_stays_to_settled_nights() {
         .map(|line| line.label.clone())
         .collect();
     assert!(
-        labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
         "labels: {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("R-NEW") && l.contains("1 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("R-NEW") && l.contains("1 đêm")),
         "R-NEW phải bị cắt xuống 1 đêm (ngân sách 2 đêm settled trừ 1 đêm R-OLD đã dùng), \
          không phải 2 đêm như snapshot lúc chuyển phòng còn nhớ: {labels:?}"
     );
     assert!(
-        !labels.iter().any(|l| l.contains("R-NEW") && l.contains("2 đêm")),
+        !labels
+            .iter()
+            .any(|l| l.contains("R-NEW") && l.contains("2 đêm")),
         "labels: {labels:?}"
     );
 
@@ -1361,15 +1384,21 @@ async fn move_out_and_back_bills_each_stay_separately_on_early_checkout() {
         .map(|line| line.label.clone())
         .collect();
     assert!(
-        labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
         "labels: {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("R-NEW") && l.contains("1 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("R-NEW") && l.contains("1 đêm")),
         "R-NEW phải còn trên hoá đơn — khách ngủ ở đó đúng đêm 16/04: {labels:?}"
     );
     assert!(
-        !labels.iter().any(|l| l.contains("R-OLD") && l.contains("2 đêm")),
+        !labels
+            .iter()
+            .any(|l| l.contains("R-OLD") && l.contains("2 đêm")),
         "R-OLD không được nuốt cả ngân sách 2 đêm: {labels:?}"
     );
     assert_breakdown_sums_to_subtotal(&invoice);
@@ -1464,11 +1493,15 @@ async fn group_checkout_keeps_the_room_split_for_a_booking_that_moved() {
         .map(|line| line.label.clone())
         .collect();
     assert!(
-        labels.iter().any(|l| l.contains("G-A") && l.contains("1 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("G-A") && l.contains("1 đêm")),
         "labels: {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("G-C") && l.contains("2 đêm")),
+        labels
+            .iter()
+            .any(|l| l.contains("G-C") && l.contains("2 đêm")),
         "G-C phải cộng cả đêm gia hạn — group checkout phải chốt lại room_stays \
          từ room_calendar trước khi xoá, đúng như check_out_tx: {labels:?}"
     );

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -1484,3 +1484,138 @@ async fn group_checkout_keeps_the_room_split_for_a_booking_that_moved() {
     assert_eq!(other_invoice.pricing_breakdown.len(), 1);
     assert_breakdown_sums_to_subtotal(&other_invoice);
 }
+
+/// H4: the split must fire only on a genuine move (`len() > 1`), not on any
+/// non-empty result.
+///
+/// `invoice_keeps_one_line_when_no_move_happened` above cannot see the
+/// difference: its booking never checked out, so there is no
+/// `checkout_settlement`, the single breakdown line is the English fallback
+/// either way, and `settlement_note` is `None` in both worlds. Running the
+/// same scenario THROUGH checkout gives the settlement label something to say,
+/// and then the two behaviours diverge — relaxing the threshold rewrites the
+/// line as "Phòng … × 3 đêm" and adds a GHI CHÚ block to an invoice that never
+/// needed one.
+#[tokio::test]
+async fn a_checked_out_booking_that_never_moved_keeps_its_settlement_line() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    stay_lifecycle::check_out(
+        &pool,
+        checkout_req("B-OPT", CheckoutSettlementMode::BookedNights, 750_000),
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        invoice.pricing_breakdown.len(),
+        1,
+        "khách không đổi phòng thì không có gì để tách: {:?}",
+        invoice.pricing_breakdown
+    );
+    assert_eq!(
+        invoice.pricing_breakdown[0].label, "Thanh toán theo số đêm đã đặt",
+        "dòng duy nhất phải là lời quyết toán, không phải một dòng 'Phòng …' tự dựng"
+    );
+    assert_eq!(
+        invoice.settlement_note, None,
+        "một dòng thì không cần khối GHI CHÚ lặp lại đúng câu đó"
+    );
+    assert_breakdown_sums_to_subtotal(&invoice);
+}
+
+/// H3: pins the optimistic guard added by commit 0736d14 — the repricing
+/// `UPDATE` must stay conditioned on the `status` and `total_price` read
+/// before the change, so `ensure_one_row_affected` can actually detect a
+/// stale-state write instead of matching any existing row.
+///
+/// Deliberately a source-level assertion, which is unusual here and needs the
+/// reason stated: inside one `BEGIN IMMEDIATE` transaction nothing can change
+/// the row between the `SELECT` at the top of `change_room_tx` and this
+/// `UPDATE`, and a second writer is blocked by SQLite's write lock. The guard
+/// is therefore unreachable at runtime by construction, so no behavioural test
+/// can turn it red and a tautology mutation survives the whole suite unseen.
+/// What is testable is the property the guard exists for: that the write names
+/// the pre-read values in its `WHERE`.
+#[test]
+fn the_repricing_update_stays_guarded_on_pre_read_state() {
+    const SOURCE: &str = include_str!("../room_change.rs");
+
+    let start = SOURCE
+        .find("UPDATE bookings SET total_price = ?")
+        .expect("câu UPDATE định giá lại phải còn trong room_change.rs");
+    let statement = &SOURCE[start..start + SOURCE[start..].find('"').expect("hết chuỗi SQL")];
+
+    assert!(
+        statement.contains("WHERE id = ?"),
+        "câu UPDATE phải khoá theo booking: {statement}"
+    );
+    assert!(
+        statement.contains("status = ?"),
+        "thiếu điều kiện status đọc trước khi đổi — ensure_one_row_affected sẽ \
+         khớp mọi dòng còn tồn tại và không phát hiện được ghi đè lên state cũ: {statement}"
+    );
+    assert!(
+        statement.contains("total_price = ?"),
+        "thiếu điều kiện total_price đọc trước khi đổi: {statement}"
+    );
+}
+
+/// C2: a `room_calendar` row with a NULL `booking_id` — a maintenance block,
+/// which the schema allows since `booking_id` is nullable — must be reported
+/// as "phòng đã có lịch", not leak out as an internal error.
+///
+/// The in-transaction re-check used a bare `booking_id != ?`, and SQL
+/// three-valued logic makes `NULL != 'B-OPT'` evaluate to NULL, so the row was
+/// invisible to it. No double booking ever resulted — `PRIMARY KEY (room_id,
+/// date)` rejects the UPDATE and the transaction rolls back — but the
+/// receptionist got a `SYSTEM_INTERNAL_ERROR` for an ordinary "that room is
+/// taken", with no idea what to do next.
+#[tokio::test]
+async fn a_maintenance_block_without_a_booking_reads_as_a_room_conflict() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    // Phòng khoá để bảo trì: giữ chỗ trong lịch nhưng không thuộc booking nào.
+    sqlx::query(
+        "INSERT INTO room_calendar (room_id, date, booking_id, status)
+         VALUES ('R-NEW', '2026-04-17', NULL, 'blocked')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let error = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        matches!(error, BookingError::Conflict(_)),
+        "phải là xung đột lịch phòng đọc được, không phải lỗi hệ thống: {error:?}"
+    );
+    assert!(
+        error.to_string().contains("đã có lịch"),
+        "thông báo phải nói rõ phòng đã có lịch: {error}"
+    );
+
+    // Và khách vẫn ở nguyên phòng cũ: giao dịch phải rollback trọn vẹn.
+    let room_id: String = sqlx::query_scalar("SELECT room_id FROM bookings WHERE id = 'B-OPT'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(room_id, "R-OLD");
+}

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -767,6 +767,10 @@ async fn invoice_keeps_one_line_when_no_move_happened() {
         "chưa đổi phòng thì hoá đơn chỉ có một dòng, đúng như trước đây"
     );
     assert_breakdown_sums_to_subtotal(&invoice);
+    assert_eq!(
+        invoice.settlement_note, None,
+        "hoá đơn một dòng không cần khối GHI CHÚ: dòng tiền duy nhất đã nói đúng điều đó"
+    );
 }
 
 /// The decisive regression test: `check_out_tx` deletes every `room_calendar`
@@ -839,17 +843,14 @@ async fn move_then_real_checkout_still_splits_invoice_lines() {
     // The settlement wording ("Thanh toán theo số đêm đã đặt") must survive
     // the split — this is exactly the booking whose settlement is least
     // obvious (moved mid-stay), so losing the wording that explains the total
-    // is worst here. It lands in `notes`, NOT in `pricing_breakdown`: as a
-    // money line it would be printed alongside the room lines that already
-    // sum to subtotal, and the guest would read a document adding up to twice
-    // its own stated subtotal.
-    assert!(
-        invoice
-            .notes
-            .as_deref()
-            .is_some_and(|notes| notes.contains("Thanh toán theo số đêm đã đặt")),
-        "ghi chú phải giữ lại lời quyết toán: {:?}",
-        invoice.notes
+    // is worst here. It lands in `settlement_note`, NOT in
+    // `pricing_breakdown`: as a money line it would be printed alongside the
+    // room lines that already sum to subtotal, and the guest would read a
+    // document adding up to twice its own stated subtotal.
+    assert_eq!(
+        invoice.settlement_note.as_deref(),
+        Some("Thanh toán theo số đêm đã đặt"),
+        "hoá đơn tách phòng phải giữ lời quyết toán ở settlement_note"
     );
     assert!(
         !labels
@@ -1090,11 +1091,11 @@ async fn invoice_split_remainder_lands_on_last_line_for_non_divisible_subtotal()
 }
 
 /// Finding A: the settlement wording is not allowed to just vanish when the
-/// split takes over the money lines — it moves to `notes`, which both
-/// renderers now print as a "GHI CHÚ" block. With no guest notes on the
-/// booking it must stand alone, with no stray separator or blank first line.
+/// split takes over the money lines — it moves to `settlement_note`, which
+/// both renderers print as a "GHI CHÚ" block. It must survive a re-read too:
+/// `get_invoice` is what the UI calls for an already-issued invoice.
 #[tokio::test]
-async fn split_invoice_carries_the_settlement_wording_in_notes() {
+async fn split_invoice_carries_the_settlement_wording_in_a_settlement_note() {
     let pool = test_pool().await;
     seed_stay_in_progress(&pool).await;
 
@@ -1116,14 +1117,6 @@ async fn split_invoice_carries_the_settlement_wording_in_notes() {
     .await
     .unwrap();
 
-    // `change_room_tx` appends its own "Chuyển phòng ..." line to
-    // `bookings.notes`; clear the column afterwards so this test sees the
-    // no-guest-notes branch instead of the merge branch.
-    sqlx::query("UPDATE bookings SET notes = NULL WHERE id = 'B-OPT'")
-        .execute(&pool)
-        .await
-        .unwrap();
-
     let mut tx = pool.begin().await.unwrap();
     let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
         .await
@@ -1131,30 +1124,36 @@ async fn split_invoice_carries_the_settlement_wording_in_notes() {
     tx.commit().await.unwrap();
 
     assert_eq!(
-        invoice.notes.as_deref(),
+        invoice.settlement_note.as_deref(),
         Some("Thanh toán theo số đêm đã đặt"),
-        "không có ghi chú của khách thì lời quyết toán phải đứng một mình, \
-         không kèm dấu phân cách hay dòng trống"
+        "lời quyết toán phải đứng một mình trong settlement_note"
     );
     assert_breakdown_sums_to_subtotal(&invoice);
 
-    // Regenerating must not stack a second copy of the wording: the invoice
-    // reads `bookings.notes`, which this path never writes back to.
-    let mut tx = pool.begin().await.unwrap();
-    let again = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+    let reread = invoice_generation::get_invoice(&pool, "B-OPT")
         .await
-        .unwrap();
-    tx.commit().await.unwrap();
-    assert_eq!(again.notes, invoice.notes);
+        .unwrap()
+        .expect("hoá đơn vừa phát hành phải đọc lại được");
+    assert_eq!(
+        reread.settlement_note, invoice.settlement_note,
+        "settlement_note phải sống sót qua vòng ghi/đọc lại — UI mở hoá đơn cũ bằng get_invoice"
+    );
 }
 
-/// The guest's own notes are the reason `notes` is rendered at all — the
-/// settlement wording is appended to them, never on top of them.
+/// `invoices.notes` copies `bookings.notes` verbatim, and in the live database
+/// that column holds internal front-desk shorthand: "Agoda thanh toan",
+/// "cọc 600k", scribbles about who is paying. The renderers print
+/// `settlement_note` and nothing else, so the guard has to be that no scrap of
+/// the booking's own notes can ever reach that field — not merely that the
+/// renderers currently happen to read the right one.
 #[tokio::test]
-async fn split_invoice_keeps_guest_notes_above_the_settlement_wording() {
+async fn settlement_note_never_carries_the_bookings_internal_notes() {
     let pool = test_pool().await;
     seed_stay_in_progress(&pool).await;
-    sqlx::query("UPDATE bookings SET notes = 'Khách xin hoá đơn công ty' WHERE id = 'B-OPT'")
+    // Shaped after real rows in the production database.
+    let internal_note = "Agoda thanh toan | cọc 600k, chị Hằng thu";
+    sqlx::query("UPDATE bookings SET notes = ? WHERE id = 'B-OPT'")
+        .bind(internal_note)
         .execute(&pool)
         .await
         .unwrap();
@@ -1183,21 +1182,28 @@ async fn split_invoice_keeps_guest_notes_above_the_settlement_wording() {
         .unwrap();
     tx.commit().await.unwrap();
 
-    let notes = invoice.notes.clone().unwrap_or_default();
-    assert!(
-        notes.starts_with("Khách xin hoá đơn công ty"),
-        "ghi chú của khách phải đứng trước: {notes:?}"
-    );
-    assert!(
-        notes.contains("Chuyển phòng R-OLD → R-NEW"),
-        "dòng chuyển phòng do change_room_tx ghi phải còn nguyên: {notes:?}"
-    );
+    let settlement_note = invoice.settlement_note.clone().unwrap_or_default();
+    for fragment in ["Agoda", "cọc 600k", "chị Hằng", "Chuyển phòng"] {
+        assert!(
+            !settlement_note.contains(fragment),
+            "ghi chú nội bộ ({fragment:?}) không được lọt vào phần in cho khách: {settlement_note:?}"
+        );
+    }
     assert_eq!(
-        notes.lines().last(),
-        Some("Thanh toán theo số đêm đã đặt"),
-        "lời quyết toán là một dòng riêng ở cuối: {notes:?}"
+        settlement_note, "Thanh toán theo số đêm đã đặt",
+        "phần in cho khách chỉ chứa đúng lời quyết toán"
     );
-    assert_breakdown_sums_to_subtotal(&invoice);
+
+    // `notes` itself is still carried on the invoice row — it is data the back
+    // office may want; it is simply never rendered.
+    assert!(
+        invoice
+            .notes
+            .as_deref()
+            .is_some_and(|notes| notes.starts_with(internal_note)),
+        "notes vẫn giữ nguyên ghi chú của booking: {:?}",
+        invoice.notes
+    );
 }
 
 /// Finding B: a guest who moves A → B and later back to A.

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -342,3 +342,216 @@ async fn change_room_appends_the_move_to_booking_notes() {
     assert!(notes.contains("Chuyển phòng R-OLD → R-NEW ngày 16/04/2026"));
     assert!(notes.contains("máy lạnh hỏng"));
 }
+
+/// Đặt trước nhận phòng 20/04, hôm nay 16/04. Chưa đêm nào trôi qua.
+async fn seed_future_reservation(pool: &sqlx::Pool<sqlx::Sqlite>) {
+    seed_room(pool, "R-RES-OLD").await.unwrap();
+    seed_room(pool, "R-RES-NEW").await.unwrap();
+    // Khác loại phòng thì mới có chênh lệch — xem ghi chú ở `seed_stay_in_progress`.
+    sqlx::query("UPDATE rooms SET type = 'deluxe' WHERE id = 'R-RES-NEW'")
+        .execute(pool)
+        .await
+        .unwrap();
+    seed_pricing_rule(pool, "standard", 250_000).await.unwrap();
+    seed_pricing_rule(pool, "deluxe", 350_000).await.unwrap();
+
+    seed_active_booking_with_terms(
+        pool,
+        "B-RES",
+        "R-RES-OLD",
+        "2026-04-20T14:00:00+07:00",
+        "2026-04-22T12:00:00+07:00",
+        2,
+        500_000,
+        Some(0),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'booked' WHERE id = 'B-RES'")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = 'R-RES-OLD'")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM room_calendar WHERE booking_id = 'B-RES'")
+        .execute(pool)
+        .await
+        .unwrap();
+    for date in ["2026-04-20", "2026-04-21"] {
+        sqlx::query(
+            "INSERT INTO room_calendar (room_id, date, booking_id, status)
+             VALUES ('R-RES-OLD', ?, 'B-RES', 'booked')",
+        )
+        .bind(date)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn changing_a_reservation_leaves_both_rooms_alone() {
+    let pool = test_pool().await;
+    seed_future_reservation(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-RES",
+        "R-RES-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    for room_id in ["R-RES-OLD", "R-RES-NEW"] {
+        let status: String = sqlx::query_scalar("SELECT status FROM rooms WHERE id = ?")
+            .bind(room_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "vacant", "{room_id} không được đổi trạng thái");
+    }
+
+    let tasks: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM housekeeping")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(tasks, 0, "đặt trước không sinh phiếu dọn");
+}
+
+#[tokio::test]
+async fn reservation_prices_the_real_stay_not_from_today() {
+    let pool = test_pool().await;
+    seed_future_reservation(&pool).await;
+    // R-RES-NEW hạng deluxe, đắt hơn 100.000/đêm. Kỳ ở thật 2 đêm ⇒ chênh 200.000.
+
+    let booking = room_change::change_room(
+        &pool,
+        "B-RES",
+        "R-RES-NEW",
+        false,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    // Chênh 100.000 × 2 đêm thật, không phải 6 đêm tính từ 16/04.
+    assert_eq!(booking.total_price, 500_000 + 200_000);
+}
+
+#[tokio::test]
+async fn change_room_rejects_a_room_that_is_too_small() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    sqlx::query("UPDATE rooms SET max_guests = 1 WHERE id = 'R-NEW'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    // Thêm khách thứ hai vào booking.
+    sqlx::query(
+        "INSERT INTO guests (id, guest_type, full_name, doc_number, created_at)
+         VALUES ('g2', 'domestic', 'Khách 2', 'DOC-g2', '2026-04-15T10:00:00+07:00')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO booking_guests (booking_id, guest_id) VALUES ('B-OPT', 'g2')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let result = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(BookingError::Validation(_))));
+}
+
+#[tokio::test]
+async fn change_room_rejects_a_room_taken_mid_transaction() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    seed_active_booking_with_room(&pool, "B-RIVAL", "R-RIVAL")
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO room_calendar (room_id, date, booking_id, status)
+         VALUES ('R-NEW', '2026-04-17', 'B-RIVAL', 'booked')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let result = room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(BookingError::Conflict(_))));
+
+    // Không được đổi gì cả.
+    let room_id: String = sqlx::query_scalar("SELECT room_id FROM bookings WHERE id = 'B-OPT'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(room_id, "R-OLD");
+}
+
+#[tokio::test]
+async fn change_room_keeps_the_group_link_intact() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    sqlx::query(
+        "INSERT INTO booking_groups (id, group_name, master_booking_id, organizer_name,
+                                     total_rooms, status, created_at)
+         VALUES ('G1', 'Đoàn thử', 'B-OPT', 'Trưởng đoàn', 1, 'active', '2026-04-15T10:00:00+07:00')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("UPDATE bookings SET group_id = 'G1' WHERE id = 'B-OPT'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let group_id: String = sqlx::query_scalar("SELECT group_id FROM bookings WHERE id = 'B-OPT'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(group_id, "G1");
+
+    let master: String =
+        sqlx::query_scalar("SELECT master_booking_id FROM booking_groups WHERE id = 'G1'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(master, "B-OPT");
+}

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -1553,18 +1553,26 @@ fn the_repricing_update_stays_guarded_on_pre_read_state() {
         .expect("câu UPDATE định giá lại phải còn trong room_change.rs");
     let statement = &SOURCE[start..start + SOURCE[start..].find('"').expect("hết chuỗi SQL")];
 
+    // Chỉ soi phần sau WHERE. Soi cả câu thì `contains("total_price = ?")` đã
+    // được chính mệnh đề SET thoả mãn, và assert cuối trở thành vô nghĩa: xoá
+    // `AND total_price = ?` khỏi WHERE mà cả bộ test vẫn xanh.
+    let where_clause = statement
+        .split_once("WHERE")
+        .map(|(_, rest)| rest)
+        .expect("câu UPDATE định giá lại phải có mệnh đề WHERE");
+
     assert!(
-        statement.contains("WHERE id = ?"),
+        where_clause.contains("id = ?"),
         "câu UPDATE phải khoá theo booking: {statement}"
     );
     assert!(
-        statement.contains("status = ?"),
+        where_clause.contains("status = ?"),
         "thiếu điều kiện status đọc trước khi đổi — ensure_one_row_affected sẽ \
          khớp mọi dòng còn tồn tại và không phát hiện được ghi đè lên state cũ: {statement}"
     );
     assert!(
-        statement.contains("total_price = ?"),
-        "thiếu điều kiện total_price đọc trước khi đổi: {statement}"
+        where_clause.contains("total_price = ?"),
+        "thiếu điều kiện total_price đọc trước khi đổi trong WHERE: {statement}"
     );
 }
 

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -1,0 +1,134 @@
+use super::prelude::*;
+
+/// Khách đã ở 1 đêm (15/04), còn 2 đêm (16/04, 17/04). Hôm nay là 16/04.
+///
+/// R-OLD hạng `standard` 250.000/đêm, R-NEW hạng `deluxe` 350.000/đêm.
+///
+/// Hai phòng **bắt buộc khác loại**: pricing engine lấy giá theo `room_type`
+/// (`load_stay_pricing_inputs_tx` → `load_fallback_base_price_tx(room_type)`),
+/// không theo `rooms.base_price` của từng phòng. `seed_room` tạo mọi phòng cùng
+/// `type = 'standard'`, nên nếu chỉ sửa `base_price` của một phòng thì chênh
+/// lệch luôn ra 0 và test sẽ xanh giả.
+async fn seed_stay_in_progress(pool: &sqlx::Pool<sqlx::Sqlite>) {
+    seed_room(pool, "R-OLD").await.unwrap();
+    seed_room(pool, "R-NEW").await.unwrap();
+    sqlx::query("UPDATE rooms SET type = 'deluxe' WHERE id = 'R-NEW'")
+        .execute(pool)
+        .await
+        .unwrap();
+    seed_pricing_rule(pool, "standard", 250_000).await.unwrap();
+    seed_pricing_rule(pool, "deluxe", 350_000).await.unwrap();
+
+    seed_active_booking_with_terms(
+        pool,
+        "B-OPT",
+        "R-OLD",
+        "2026-04-15T10:00:00+07:00",
+        "2026-04-18T10:00:00+07:00",
+        3,
+        750_000,
+        Some(0),
+    )
+    .await
+    .unwrap();
+
+    // seed_active_booking chỉ tạo dòng 15/04; thêm hai đêm còn lại.
+    for date in ["2026-04-16", "2026-04-17"] {
+        sqlx::query(
+            "INSERT INTO room_calendar (room_id, date, booking_id, status)
+             VALUES ('R-OLD', ?, 'B-OPT', 'occupied')",
+        )
+        .bind(date)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn load_options_splits_nights_at_today() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    let options = room_change::load_options(
+        &pool,
+        "B-OPT",
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(options.nights_stayed, 1);
+    assert_eq!(options.nights_remaining, 2);
+    assert_eq!(options.from_date, "2026-04-16");
+    assert_eq!(options.to_date, "2026-04-17");
+    assert_eq!(options.current_room_id, "R-OLD");
+}
+
+#[tokio::test]
+async fn load_options_excludes_current_room_and_lists_free_ones() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    let options = room_change::load_options(
+        &pool,
+        "B-OPT",
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
+    assert!(!ids.contains(&"R-OLD"), "phòng hiện tại không được là phương án");
+    assert!(ids.contains(&"R-NEW"));
+}
+
+#[tokio::test]
+async fn load_options_hides_room_taken_on_any_remaining_night() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    // R-NEW bị khách khác giữ đúng một đêm trong dải còn lại.
+    seed_active_booking_with_room(&pool, "B-OTHER", "R-BUSY")
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO room_calendar (room_id, date, booking_id, status)
+         VALUES ('R-NEW', '2026-04-17', 'B-OTHER', 'booked')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let options = room_change::load_options(
+        &pool,
+        "B-OPT",
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
+    assert!(!ids.contains(&"R-NEW"), "vướng một đêm là đủ để loại");
+}
+
+#[tokio::test]
+async fn load_options_hides_a_dirty_room_when_the_guest_moves_in_tonight() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    sqlx::query("UPDATE rooms SET status = 'cleaning' WHERE id = 'R-NEW'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let options = room_change::load_options(
+        &pool,
+        "B-OPT",
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
+    assert!(!ids.contains(&"R-NEW"), "không đưa khách vào phòng chưa dọn");
+}

--- a/mhm/src-tauri/src/services/booking/tests/room_change.rs
+++ b/mhm/src-tauri/src/services/booking/tests/room_change.rs
@@ -134,6 +134,47 @@ async fn load_options_hides_a_dirty_room_when_the_guest_moves_in_tonight() {
     assert!(!ids.contains(&"R-NEW"), "không đưa khách vào phòng chưa dọn");
 }
 
+/// `load_options` only applied the vacancy filter when `moving_in_today`. But
+/// `change_room_tx` requires the new room to be `vacant` whenever the booking
+/// is ACTIVE (see the final `UPDATE rooms ... WHERE status = 'vacant'` guard),
+/// regardless of whether the first remaining night is tonight or later. An
+/// active guest whose earliest movable night is tomorrow (not tonight) could
+/// otherwise be offered an occupied room that the write then rejects.
+///
+/// Drop the 16/04 row so the only remaining night is 17/04 — `moving_in_today`
+/// is false — while the booking stays ACTIVE.
+#[tokio::test]
+async fn load_options_requires_vacant_room_for_an_active_booking_moving_later() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+    sqlx::query("DELETE FROM room_calendar WHERE booking_id = 'B-OPT' AND date = '2026-04-16'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'occupied' WHERE id = 'R-NEW'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let options = room_change::load_options(
+        &pool,
+        "B-OPT",
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        options.from_date, "2026-04-17",
+        "đêm chuyển đầu tiên phải là 17/04, không phải hôm nay — tiền đề của test"
+    );
+    let ids: Vec<&str> = options.rooms.iter().map(|r| r.room_id.as_str()).collect();
+    assert!(
+        !ids.contains(&"R-NEW"),
+        "booking đang active thì phòng mới phải trống, dù đêm chuyển đầu tiên không phải tối nay"
+    );
+}
+
 #[tokio::test]
 async fn change_room_keeps_past_nights_on_the_old_room() {
     let pool = test_pool().await;
@@ -680,8 +721,19 @@ async fn invoice_splits_lines_per_room_after_a_move() {
     assert!(labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")));
     assert!(labels.iter().any(|l| l.contains("R-NEW") && l.contains("2 đêm")));
 
-    let sum: i64 = invoice.pricing_breakdown.iter().map(|l| l.amount).sum();
-    assert_eq!(sum, invoice.subtotal, "tổng các dòng phải khớp subtotal");
+    // breakdown[0] is the settlement line (Finding 2 keeps it alongside the
+    // room lines, not replaced by them) — only the "Phòng " lines need to sum
+    // to subtotal.
+    let room_lines_sum: i64 = invoice
+        .pricing_breakdown
+        .iter()
+        .filter(|l| l.label.starts_with("Phòng "))
+        .map(|l| l.amount)
+        .sum();
+    assert_eq!(
+        room_lines_sum, invoice.subtotal,
+        "tổng các dòng phòng phải khớp subtotal"
+    );
 }
 
 #[tokio::test]
@@ -767,8 +819,26 @@ async fn move_then_real_checkout_still_splits_invoice_lines() {
         "labels: {labels:?}"
     );
 
-    let sum: i64 = invoice.pricing_breakdown.iter().map(|l| l.amount).sum();
-    assert_eq!(sum, invoice.subtotal, "tổng các dòng phải khớp subtotal");
+    let room_lines_sum: i64 = invoice
+        .pricing_breakdown
+        .iter()
+        .filter(|l| l.label.starts_with("Phòng "))
+        .map(|l| l.amount)
+        .sum();
+    assert_eq!(
+        room_lines_sum, invoice.subtotal,
+        "tổng các dòng phòng phải khớp subtotal"
+    );
+
+    // Finding 2: the settlement line ("Thanh toán theo số đêm đã đặt") must
+    // survive the split, not get silently dropped when the invoice also
+    // breaks down by room — this is exactly the booking whose settlement is
+    // least obvious (moved mid-stay), so losing the line that explains the
+    // total is worst here.
+    assert_eq!(
+        invoice.pricing_breakdown[0].label, "Thanh toán theo số đêm đã đặt",
+        "dòng quyết toán không được biến mất khi hoá đơn tách theo phòng: {labels:?}"
+    );
 
     // checkout_settlement must survive the pricing_snapshot merge alongside
     // room_stays — revenue_queries.rs reads it via json_extract and those
@@ -808,6 +878,175 @@ async fn move_then_real_checkout_still_splits_invoice_lines() {
     );
 }
 
+/// Finding 1(a): `change_room_tx` snapshots `room_stays` at move time, but
+/// nothing refreshes it afterwards. `extend_stay_tx` inserts new
+/// `room_calendar` rows on the guest's *current* room without touching
+/// `pricing_snapshot` — so a guest who moves and then extends ends up with a
+/// snapshot that undercounts the current room's nights while `room_calendar`
+/// (still intact — checkout has not run) holds the true split. The invoice
+/// must prefer `room_calendar` over the stale snapshot whenever the calendar
+/// still has rows for this booking.
+#[tokio::test]
+async fn move_then_extend_reflects_the_real_split_not_the_stale_snapshot() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+    // Snapshot right after the move: R-OLD × 1, R-NEW × 2 (3 nights total).
+
+    // Extend twice — both extra nights land on R-NEW, the current room.
+    // change_room_tx has no way to know about these; only room_calendar does.
+    stay_lifecycle::extend_stay(&pool, "B-OPT").await.unwrap();
+    stay_lifecycle::extend_stay(&pool, "B-OPT").await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let labels: Vec<String> = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| line.label.clone())
+        .collect();
+    assert!(
+        labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        "labels: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l.contains("R-NEW") && l.contains("4 đêm")),
+        "phòng hiện tại phải cộng dồn cả 2 đêm gia hạn (2 gốc + 2 gia hạn = 4), \
+         không dừng lại ở snapshot 2 đêm chụp lúc chuyển phòng: {labels:?}"
+    );
+
+    let room_lines_sum: i64 = invoice
+        .pricing_breakdown
+        .iter()
+        .filter(|l| l.label.starts_with("Phòng "))
+        .map(|l| l.amount)
+        .sum();
+    assert_eq!(
+        room_lines_sum, invoice.subtotal,
+        "tổng các dòng phòng phải khớp subtotal"
+    );
+}
+
+/// Finding 1(b): the snapshot written at move time assumes the guest stays
+/// every remaining booked night. An early checkout settles fewer nights than
+/// that — `check_out_tx` must truncate `room_stays` to `settled_nights`,
+/// walking rooms in occupancy order, not leave the move-time snapshot
+/// (which oversells the new room) as the post-checkout source of truth.
+///
+/// 1 night stayed on R-OLD, 2 remaining nights moved to R-NEW (snapshot:
+/// R-OLD × 1, R-NEW × 2 ⇒ 3). Guest actually leaves after 2 real nights
+/// (ActualNights settlement, checkout 2 days after check-in) ⇒ settled_nights
+/// = 2. Truncated: R-OLD keeps its 1 (fits under the 2-night budget), R-NEW
+/// is capped to the 1 night left in the budget — not the 2 nights the stale
+/// snapshot would still claim.
+#[tokio::test]
+async fn move_then_early_checkout_truncates_room_stays_to_settled_nights() {
+    let pool = test_pool().await;
+    seed_stay_in_progress(&pool).await;
+
+    room_change::change_room(
+        &pool,
+        "B-OPT",
+        "R-NEW",
+        true,
+        None,
+        NaiveDate::from_ymd_opt(2026, 4, 16).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let checkout_at = Local
+        .with_ymd_and_hms(2026, 4, 17, 9, 0, 0)
+        .single()
+        .unwrap();
+    let preview = stay_lifecycle::preview_checkout_settlement_at(
+        &pool,
+        CheckoutSettlementPreviewRequest {
+            booking_id: "B-OPT".to_string(),
+            settlement_mode: CheckoutSettlementMode::ActualNights,
+        },
+        checkout_at,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        preview.settled_nights, 2,
+        "tiền đề của test: khách rời sau đúng 2 đêm thật"
+    );
+
+    stay_lifecycle::check_out_at(
+        &pool,
+        checkout_req(
+            "B-OPT",
+            CheckoutSettlementMode::ActualNights,
+            preview.recommended_total,
+        ),
+        checkout_at,
+    )
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let invoice = invoice_generation::generate_invoice_tx(&mut tx, "B-OPT")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let labels: Vec<String> = invoice
+        .pricing_breakdown
+        .iter()
+        .map(|line| line.label.clone())
+        .collect();
+    assert!(
+        labels.iter().any(|l| l.contains("R-OLD") && l.contains("1 đêm")),
+        "labels: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l.contains("R-NEW") && l.contains("1 đêm")),
+        "R-NEW phải bị cắt xuống 1 đêm (ngân sách 2 đêm settled trừ 1 đêm R-OLD đã dùng), \
+         không phải 2 đêm như snapshot lúc chuyển phòng còn nhớ: {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|l| l.contains("R-NEW") && l.contains("2 đêm")),
+        "labels: {labels:?}"
+    );
+
+    let room_lines_sum: i64 = invoice
+        .pricing_breakdown
+        .iter()
+        .filter(|l| l.label.starts_with("Phòng "))
+        .map(|l| l.amount)
+        .sum();
+    assert_eq!(
+        room_lines_sum, invoice.subtotal,
+        "tổng các dòng phòng phải khớp subtotal"
+    );
+
+    // The checkout_settlement key must still be intact and still readable by
+    // revenue_queries.rs — the room_stays truncation must merge, not clobber.
+    let mode: Option<String> = sqlx::query_scalar(
+        "SELECT json_extract(pricing_snapshot, '$.checkout_settlement.mode') FROM bookings WHERE id = 'B-OPT'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(mode.as_deref(), Some("actual_nights"));
+}
+
 /// The existing split test (750.000 / 3 nights = 250.000 exactly) never
 /// exercises the remainder-on-last-line branch. Pick a subtotal that does
 /// not divide evenly across the split nights so integer truncation would
@@ -841,13 +1080,20 @@ async fn invoice_split_remainder_lands_on_last_line_for_non_divisible_subtotal()
         .unwrap();
     tx.commit().await.unwrap();
 
-    assert_eq!(invoice.pricing_breakdown.len(), 2);
-    assert_eq!(invoice.pricing_breakdown[0].amount, 33_333);
-    assert_eq!(invoice.pricing_breakdown[1].amount, 66_667);
+    // breakdown[0] is the settlement line (Finding 2 keeps it, not replaced
+    // by the room split); the two room lines follow it.
+    assert_eq!(invoice.pricing_breakdown.len(), 3);
+    assert_eq!(invoice.pricing_breakdown[1].amount, 33_333);
+    assert_eq!(invoice.pricing_breakdown[2].amount, 66_667);
 
-    let sum: i64 = invoice.pricing_breakdown.iter().map(|l| l.amount).sum();
+    let room_lines_sum: i64 = invoice
+        .pricing_breakdown
+        .iter()
+        .filter(|l| l.label.starts_with("Phòng "))
+        .map(|l| l.amount)
+        .sum();
     assert_eq!(
-        sum, 100_000,
+        room_lines_sum, 100_000,
         "lines phải cộng đúng bằng subtotal dù chia không chẵn"
     );
 }

--- a/mhm/src-tauri/src/services/booking/tests/support/db.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/db.rs
@@ -372,6 +372,51 @@ pub async fn test_pool() -> Pool<Sqlite> {
     .await
     .expect("failed to create outbox origin command index");
 
+    sqlx::query(
+        "CREATE TABLE invoices (
+            id                TEXT PRIMARY KEY,
+            invoice_number    TEXT NOT NULL UNIQUE,
+            booking_id        TEXT NOT NULL REFERENCES bookings(id),
+            hotel_name        TEXT NOT NULL,
+            hotel_address     TEXT NOT NULL,
+            hotel_phone       TEXT NOT NULL,
+            guest_name        TEXT NOT NULL,
+            guest_phone       TEXT,
+            room_name         TEXT NOT NULL,
+            room_type         TEXT NOT NULL,
+            check_in          TEXT NOT NULL,
+            check_out         TEXT NOT NULL,
+            nights            INTEGER NOT NULL,
+            pricing_breakdown TEXT NOT NULL,
+            subtotal          INTEGER NOT NULL,
+            deposit_amount    INTEGER NOT NULL DEFAULT 0,
+            total             INTEGER NOT NULL,
+            balance_due       INTEGER NOT NULL,
+            policy_text       TEXT,
+            notes             TEXT,
+            status            TEXT NOT NULL DEFAULT 'issued',
+            created_at        TEXT NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to create invoices table");
+
+    sqlx::query("CREATE INDEX idx_invoices_booking ON invoices(booking_id)")
+        .execute(&pool)
+        .await
+        .expect("failed to create invoices booking index");
+
+    sqlx::query(
+        "CREATE TABLE settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to create settings table");
+
     pool
 }
 

--- a/mhm/src-tauri/src/services/booking/tests/support/db.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/db.rs
@@ -394,6 +394,7 @@ pub async fn test_pool() -> Pool<Sqlite> {
             balance_due       INTEGER NOT NULL,
             policy_text       TEXT,
             notes             TEXT,
+            settlement_note   TEXT,
             status            TEXT NOT NULL DEFAULT 'issued',
             created_at        TEXT NOT NULL
         )",

--- a/mhm/src-tauri/src/write_manifest.rs
+++ b/mhm/src-tauri/src/write_manifest.rs
@@ -49,6 +49,11 @@ pub const WRITE_COMMAND_MANIFEST: &[WriteCommandMeta] = &[
         enforced_in_foundation: true,
     },
     WriteCommandMeta {
+        command_name: "change_room",
+        lock_deriver: LockDeriverId::BookingAndRoomFromBooking,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
         command_name: "group_checkin",
         lock_deriver: LockDeriverId::GroupCheckinRooms,
         enforced_in_foundation: true,
@@ -116,6 +121,7 @@ mod tests {
             "check_in",
             "check_out",
             "extend_stay",
+            "change_room",
             "group_checkin",
             "group_checkout",
             "confirm_reservation",

--- a/mhm/src/app/MainShell.tsx
+++ b/mhm/src/app/MainShell.tsx
@@ -26,6 +26,7 @@ import { BackupStatusIndicator } from "@/components/BackupStatusIndicator";
 import CheckinSheet from "@/components/CheckinSheet";
 import CrashReportPrompt from "@/components/CrashReportPrompt";
 import GroupCheckinSheet from "@/components/GroupCheckinSheet";
+import { RoomChangeSheet } from "@/components/RoomChangeSheet";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useAppUpdate } from "@/contexts/AppUpdateContext";
@@ -350,6 +351,10 @@ export function MainShell() {
 
       <CheckinSheet preSelectedRoomId={checkinRoomId ?? undefined} preSelectedNights={checkinNights ?? undefined} />
       <GroupCheckinSheet />
+      {/* Sheet dùng chung cho mọi lối vào chuyển phòng (Task 9) — render một lần
+          duy nhất ở gốc, không lặp trong từng màn hình, để tránh nhiều bản sao
+          cùng đọc một store và cùng mở một lúc. */}
+      <RoomChangeSheet />
       <AppToaster />
     </div>
   );

--- a/mhm/src/components/BookingDetailPopup.test.tsx
+++ b/mhm/src/components/BookingDetailPopup.test.tsx
@@ -69,6 +69,37 @@ describe("BookingDetailPopup", () => {
     expect(screen.queryByRole("button", { name: /xem hóa đơn/i })).toBeNull();
   });
 
+  it("opens the room change sheet for a booked reservation", async () => {
+    const user = userEvent.setup();
+    const onRoomChange = vi.fn();
+
+    render(
+      <BookingDetailPopup
+        booking={booking({ status: "booked", actual_checkout: null })}
+        mode="reservation"
+        onClose={vi.fn()}
+        onRoomChange={onRoomChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /chuyển phòng/i }));
+    expect(onRoomChange).toHaveBeenCalledWith("B-1");
+  });
+
+  it("hides the room change action for a read-only (checked-out) booking", () => {
+    render(
+      <BookingDetailPopup
+        booking={booking({ status: "checked_out" })}
+        mode="readonly"
+        onClose={vi.fn()}
+        onViewInvoice={vi.fn()}
+        onRoomChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /chuyển phòng/i })).toBeNull();
+  });
+
   it("shows a read-only view with the actual checkout time for closed bookings", async () => {
     const user = userEvent.setup();
     const onViewInvoice = vi.fn();

--- a/mhm/src/components/BookingDetailPopup.tsx
+++ b/mhm/src/components/BookingDetailPopup.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, XCircle, Pencil, FileText } from "lucide-react";
+import { CheckCircle2, XCircle, Pencil, FileText, ArrowRightLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { fmtDate, fmtDateShort, fmtNumber } from "@/lib/format";
@@ -12,6 +12,7 @@ interface BookingDetailPopupProps {
     onEdit?: (booking: BookingWithGuest) => void;
     onCancel?: (bookingId: string) => void;
     onViewInvoice?: (bookingId: string) => void;
+    onRoomChange?: (bookingId: string) => void;
     invoiceLoading?: boolean;
 }
 
@@ -55,6 +56,7 @@ export default function BookingDetailPopup({
     onEdit,
     onCancel,
     onViewInvoice,
+    onRoomChange,
     invoiceLoading,
 }: BookingDetailPopupProps) {
     const isReadonly = mode === "readonly";
@@ -115,27 +117,39 @@ export default function BookingDetailPopup({
                         </Button>
                     </div>
                 ) : (
-                    <div className="flex gap-2 pt-2">
-                        <Button
-                            className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl h-10 gap-1.5 cursor-pointer"
-                            onClick={() => onConfirm?.(booking.id)}
-                        >
-                            <CheckCircle2 size={14} /> Check-in
-                        </Button>
-                        <Button
-                            variant="outline"
-                            className="flex-1 border-blue-200 text-blue-600 hover:bg-blue-50 rounded-xl h-10 gap-1.5 cursor-pointer"
-                            onClick={() => onEdit?.(booking)}
-                        >
-                            <Pencil size={14} /> Chỉnh sửa
-                        </Button>
-                        <Button
-                            variant="outline"
-                            className="flex-1 border-red-200 text-red-600 hover:bg-red-50 rounded-xl h-10 gap-1.5 cursor-pointer"
-                            onClick={() => onCancel?.(booking.id)}
-                        >
-                            <XCircle size={14} /> Hủy
-                        </Button>
+                    <div className="space-y-2 pt-2">
+                        <div className="flex gap-2">
+                            <Button
+                                className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl h-10 gap-1.5 cursor-pointer"
+                                onClick={() => onConfirm?.(booking.id)}
+                            >
+                                <CheckCircle2 size={14} /> Check-in
+                            </Button>
+                            <Button
+                                variant="outline"
+                                className="flex-1 border-blue-200 text-blue-600 hover:bg-blue-50 rounded-xl h-10 gap-1.5 cursor-pointer"
+                                onClick={() => onEdit?.(booking)}
+                            >
+                                <Pencil size={14} /> Chỉnh sửa
+                            </Button>
+                            <Button
+                                variant="outline"
+                                className="flex-1 border-red-200 text-red-600 hover:bg-red-50 rounded-xl h-10 gap-1.5 cursor-pointer"
+                                onClick={() => onCancel?.(booking.id)}
+                            >
+                                <XCircle size={14} /> Hủy
+                            </Button>
+                        </div>
+                        {/* Chỉ hiện khi còn đổi được phòng — không cho với booking đã trả. */}
+                        {(booking.status === "active" || booking.status === "booked") && (
+                            <Button
+                                variant="outline"
+                                className="w-full border-indigo-200 text-indigo-600 hover:bg-indigo-50 rounded-xl h-10 gap-1.5 cursor-pointer"
+                                onClick={() => onRoomChange?.(booking.id)}
+                            >
+                                <ArrowRightLeft size={14} /> Chuyển phòng
+                            </Button>
+                        )}
                     </div>
                 )}
             </div>

--- a/mhm/src/components/InvoiceDialog.tsx
+++ b/mhm/src/components/InvoiceDialog.tsx
@@ -226,17 +226,18 @@ export default function InvoiceDialog({ open, onOpenChange, data, groupData }: P
                                 </div>
                             </div>
 
-                            {/* Notes — for a booking that changed rooms this is
-                                where the checkout settlement wording lives
-                                (invoice_generation.rs moves it out of the
-                                money lines so they still sum to Subtotal). */}
-                            {(data!.notes ?? "").trim() !== "" && (
+                            {/* Settlement note — how the total was reached when
+                                the breakdown splits per room (invoice_generation.rs
+                                keeps it out of the money lines so they still sum
+                                to Subtotal). Never `notes`: that column holds the
+                                booking's internal front-desk shorthand. */}
+                            {(data!.settlement_note ?? "").trim() !== "" && (
                                 <div className="mx-4 mb-4 p-3 bg-muted/50 rounded-md border-l-2 border-[#2D4373]">
                                     <div className="text-[10px] uppercase tracking-wider text-[#1B2A4A] font-bold mb-2">
                                         Ghi chú
                                     </div>
                                     <div className="text-xs text-muted-foreground whitespace-pre-line leading-relaxed">
-                                        {data!.notes}
+                                        {data!.settlement_note}
                                     </div>
                                 </div>
                             )}

--- a/mhm/src/components/InvoiceDialog.tsx
+++ b/mhm/src/components/InvoiceDialog.tsx
@@ -226,6 +226,21 @@ export default function InvoiceDialog({ open, onOpenChange, data, groupData }: P
                                 </div>
                             </div>
 
+                            {/* Notes — for a booking that changed rooms this is
+                                where the checkout settlement wording lives
+                                (invoice_generation.rs moves it out of the
+                                money lines so they still sum to Subtotal). */}
+                            {(data!.notes ?? "").trim() !== "" && (
+                                <div className="mx-4 mb-4 p-3 bg-muted/50 rounded-md border-l-2 border-[#2D4373]">
+                                    <div className="text-[10px] uppercase tracking-wider text-[#1B2A4A] font-bold mb-2">
+                                        Ghi chú
+                                    </div>
+                                    <div className="text-xs text-muted-foreground whitespace-pre-line leading-relaxed">
+                                        {data!.notes}
+                                    </div>
+                                </div>
+                            )}
+
                             {/* Policy */}
                             {data!.policy_text && (
                                 <div className="mx-4 mb-4 p-3 bg-muted/50 rounded-md border-l-2 border-[#C5A55A]">

--- a/mhm/src/components/InvoicePDF.tsx
+++ b/mhm/src/components/InvoicePDF.tsx
@@ -252,6 +252,25 @@ const s = StyleSheet.create({
         color: gray600,
         lineHeight: 1.6,
     },
+    notesBox: {
+        marginTop: 16,
+        padding: 12,
+        backgroundColor: gray100,
+        borderRadius: 4,
+        borderLeft: `3px solid ${navyLight}`,
+    },
+    notesTitle: {
+        fontSize: 9,
+        fontWeight: 700,
+        color: navy,
+        marginBottom: 6,
+        letterSpacing: 0.5,
+    },
+    notesText: {
+        fontSize: 8,
+        color: gray600,
+        lineHeight: 1.6,
+    },
     footer: {
         position: "absolute",
         bottom: 30,
@@ -335,6 +354,11 @@ export default function InvoicePDF({ data, groupData }: InvoicePDFProps) {
     const hotelName = isGroup ? groupData.hotel_name : data!.hotel_name;
     const hotelAddress = isGroup ? groupData.hotel_address : data!.hotel_address;
     const hotelPhone = isGroup ? groupData.hotel_phone : data!.hotel_phone;
+    // Trimmed up front so a blank-but-not-null `notes` renders nothing rather
+    // than an empty "GHI CHÚ" box. For a booking that changed rooms this is
+    // where the settlement wording lives (`invoice_generation.rs`), so it has
+    // to be printed, not just stored.
+    const notes = isGroup ? "" : (data!.notes ?? "").trim();
 
     return (
         <Document>
@@ -541,6 +565,15 @@ export default function InvoicePDF({ data, groupData }: InvoicePDFProps) {
                                 </Text>
                             </View>
                         </View>
+
+                        {/* Notes — carries the checkout settlement wording for
+                            a booking that changed rooms */}
+                        {notes !== "" && (
+                            <View style={s.notesBox}>
+                                <Text style={s.notesTitle}>GHI CHÚ</Text>
+                                <Text style={s.notesText}>{notes}</Text>
+                            </View>
+                        )}
 
                         {/* Policy */}
                         {data!.policy_text && (

--- a/mhm/src/components/InvoicePDF.tsx
+++ b/mhm/src/components/InvoicePDF.tsx
@@ -45,7 +45,10 @@ export interface InvoiceData {
     total: number;
     balance_due: number;
     policy_text: string | null;
+    /** The booking's own notes — internal front-desk shorthand. NOT rendered. */
     notes: string | null;
+    /** Guest-facing settlement wording, set only on a per-room split invoice. */
+    settlement_note: string | null;
     status: string;
     created_at: string;
 }
@@ -354,11 +357,11 @@ export default function InvoicePDF({ data, groupData }: InvoicePDFProps) {
     const hotelName = isGroup ? groupData.hotel_name : data!.hotel_name;
     const hotelAddress = isGroup ? groupData.hotel_address : data!.hotel_address;
     const hotelPhone = isGroup ? groupData.hotel_phone : data!.hotel_phone;
-    // Trimmed up front so a blank-but-not-null `notes` renders nothing rather
-    // than an empty "GHI CHÚ" box. For a booking that changed rooms this is
-    // where the settlement wording lives (`invoice_generation.rs`), so it has
-    // to be printed, not just stored.
-    const notes = isGroup ? "" : (data!.notes ?? "").trim();
+    // Trimmed up front so a blank-but-not-null value renders nothing rather
+    // than an empty "GHI CHÚ" box. Deliberately `settlement_note`, never
+    // `notes`: `notes` copies the booking's internal front-desk shorthand
+    // ("cọc 600k", "Agoda thanh toan") and must not be printed for a guest.
+    const settlementNote = isGroup ? "" : (data!.settlement_note ?? "").trim();
 
     return (
         <Document>
@@ -566,12 +569,12 @@ export default function InvoicePDF({ data, groupData }: InvoicePDFProps) {
                             </View>
                         </View>
 
-                        {/* Notes — carries the checkout settlement wording for
-                            a booking that changed rooms */}
-                        {notes !== "" && (
+                        {/* Settlement note — how the total was reached, for a
+                            booking whose breakdown splits per room */}
+                        {settlementNote !== "" && (
                             <View style={s.notesBox}>
                                 <Text style={s.notesTitle}>GHI CHÚ</Text>
-                                <Text style={s.notesText}>{notes}</Text>
+                                <Text style={s.notesText}>{settlementNote}</Text>
                             </View>
                         )}
 

--- a/mhm/src/components/RoomChangeSheet.test.tsx
+++ b/mhm/src/components/RoomChangeSheet.test.tsx
@@ -328,6 +328,80 @@ describe("RoomChangeSheet", () => {
     ).toHaveLength(1);
   });
 
+  // Cùng vết đứt, nhánh thành công: `saving`, câu báo và lệnh đóng sheet đều là
+  // state của MỘT sheet dùng chung. Lệnh của khách A về muộn không được khoá nút
+  // của khách B, không được gọi tên phòng của B, và không được đóng sheet của B
+  // — làm mất phòng B vừa chọn.
+  it("lệnh của khách cũ về muộn không đụng vào sheet của khách mới", async () => {
+    // Mỗi lần gọi giữ resolve riêng — dùng chung một biến thì lệnh sau ghi đè
+    // lệnh trước và bài test lại hoá ra đang giải quyết đúng lệnh của khách mới.
+    const resolvers: Array<() => void> = [];
+    const requestedBookingIds: string[] = [];
+    const changeRoom = vi.fn(
+      (bookingId: string) =>
+        new Promise<void>((resolve) => {
+          requestedBookingIds.push(bookingId);
+          resolvers.push(resolve);
+        }),
+    );
+    // Khách mới được mời phòng khác, để câu báo thành công của khách cũ mà gọi
+    // nhầm tên phòng là lộ ra ngay.
+    const fetchRoomChangeOptions = vi
+      .fn()
+      .mockImplementation(async (bookingId: string) => ({
+        ...baseOptions,
+        bookingId,
+        rooms:
+          bookingId === "B2"
+            ? [
+                {
+                  roomId: "3C",
+                  name: "Phòng 3C",
+                  roomType: "standard",
+                  floor: 3,
+                  maxGuests: 2,
+                  priceDifference: -50000,
+                },
+              ]
+            : baseOptions.rooms,
+      }));
+
+    renderSheet(baseOptions, { changeRoom, fetchRoomChangeOptions });
+
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    await userEvent.click(screen.getByRole("button", { name: /chuyển sang/i }));
+    await waitFor(() => expect(changeRoom).toHaveBeenCalled());
+
+    await act(async () => {
+      useHotelStore.setState({ roomChangeBookingId: "B2" });
+    });
+    await waitFor(() =>
+      expect(fetchRoomChangeOptions).toHaveBeenCalledWith("B2"),
+    );
+
+    // Nút của khách mới phải mở ngay, không chờ lệnh của khách cũ.
+    await userEvent.click(await screen.findByText("Phòng 3C"));
+    const confirm = screen.getByRole("button", { name: /chuyển sang/i });
+    expect(confirm).toBeEnabled();
+    await userEvent.click(confirm);
+    await waitFor(() => expect(changeRoom).toHaveBeenCalledTimes(2));
+    expect(requestedBookingIds).toEqual(["B1", "B2"]);
+
+    // Giờ mới cho lệnh của khách cũ trả về.
+    await act(async () => {
+      resolvers[0]?.();
+      await Promise.resolve();
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("Đã chuyển sang Phòng 2A");
+    // Không được đóng sheet — sheet lúc này là của khách mới, đóng đi là mất
+    // phòng họ vừa chọn. `setRoomChangeOpen` bị mock nên phải soi lời gọi chứ
+    // soi `isRoomChangeOpen` thì lúc nào cũng xanh.
+    expect(useHotelStore.getState().setRoomChangeOpen).not.toHaveBeenCalled();
+    // Và vẫn đang khoá cho lệnh của chính khách mới.
+    expect(screen.getByRole("button", { name: /đang xử lý/i })).toBeDisabled();
+  });
+
   it("khi đổi phòng thất bại: báo lỗi dễ đọc, nạp lại danh sách, bỏ chọn cũ", async () => {
     const fetchRoomChangeOptions = vi
       .fn()

--- a/mhm/src/components/RoomChangeSheet.test.tsx
+++ b/mhm/src/components/RoomChangeSheet.test.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -127,6 +127,30 @@ describe("RoomChangeSheet", () => {
     expect(screen.queryByText(/500\.000đ\/đêm/)).not.toBeInTheDocument();
   });
 
+  // Đoạn tóm tắt "Cách tính tiền" tồn tại để nói ra con số, nên nó phải nói
+  // đúng cả chiều âm: hard-code dấu "+" ở đây sẽ in "+50.000đ" cho một lần hạ
+  // hạng mà khách đang được trả lại tiền.
+  it("bảng tóm tắt hiện dấu trừ khi phòng chọn rẻ hơn", async () => {
+    renderSheet({
+      ...baseOptions,
+      rooms: [
+        {
+          roomId: "3C",
+          name: "Phòng 3C",
+          roomType: "standard",
+          floor: 3,
+          maxGuests: 2,
+          priceDifference: -50000,
+        },
+      ],
+    });
+    await userEvent.click(await screen.findByText("Phòng 3C"));
+    expect(
+      screen.getByText(/−50\.000đ cho cả kỳ so với phòng cũ/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/\+50\.000đ cho cả kỳ so với phòng cũ/)).toBeNull();
+  });
+
   it("dòng phòng hiện dấu trừ khi phòng rẻ hơn phòng hiện tại", async () => {
     renderSheet({
       ...baseOptions,
@@ -215,6 +239,26 @@ describe("RoomChangeSheet", () => {
     );
   });
 
+  // Chỉ kiểm tham số gửi xuống backend là chưa đủ: nếu phần hiển thị quên
+  // nhánh keepPrice thì màn hình vẫn ghi "+500.000đ cho cả kỳ" trong khi
+  // backend không tính đồng nào — lễ tân thu thừa nửa triệu.
+  it("giữ nguyên giá cũ thì màn hình cũng phải về không đồng", async () => {
+    renderSheet(baseOptions);
+
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    expect(
+      screen.getByText(/\+500\.000đ cho cả kỳ so với phòng cũ/),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText(/giữ nguyên giá cũ/i));
+
+    expect(screen.getByText(/^Không đổi tiền$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/so với phòng cũ/)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /chuyển sang phòng 2a/i }),
+    ).toHaveTextContent(/không đổi tiền/i);
+  });
+
   it("nút xác nhận nêu rõ phòng và tiền, không phải chỉ 'Xác nhận'", async () => {
     renderSheet(baseOptions);
     await userEvent.click(await screen.findByText("Phòng 2A"));
@@ -228,6 +272,60 @@ describe("RoomChangeSheet", () => {
     expect(
       await screen.findByText(/Không phòng nào trống suốt 5 đêm còn lại/i),
     ).toBeInTheDocument();
+  });
+
+  // Sheet dùng chung: lễ tân bấm xác nhận cho khách A, đóng lại, mở cho khách
+  // B, rồi lệnh ghi của A mới rơi lỗi. Nhánh catch nạp lại danh sách phòng —
+  // nếu không kiểm booking hiện tại thì danh sách của A đắp lên tiêu đề của B.
+  // Effect nạp ở trên đã có cờ `cancelled` cho đúng tình huống này; nhánh
+  // catch phải đối xứng.
+  it("không đắp danh sách của booking cũ khi sheet đã chuyển sang booking khác", async () => {
+    let rejectChange: ((err: unknown) => void) | undefined;
+    const changeRoom = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectChange = reject;
+        }),
+    );
+    const fetchRoomChangeOptions = vi
+      .fn()
+      .mockImplementation(async (bookingId: string) => ({
+        ...baseOptions,
+        bookingId,
+      }));
+
+    renderSheet(baseOptions, { changeRoom, fetchRoomChangeOptions });
+
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    await userEvent.click(screen.getByRole("button", { name: /chuyển sang/i }));
+    await waitFor(() => expect(changeRoom).toHaveBeenCalled());
+
+    // Lễ tân đóng sheet và mở lại cho khách khác trong lúc lệnh của B1 còn bay.
+    await act(async () => {
+      useHotelStore.setState({ roomChangeBookingId: "B2" });
+    });
+    await waitFor(() =>
+      expect(fetchRoomChangeOptions).toHaveBeenCalledWith("B2"),
+    );
+    const callsBeforeRejection = fetchRoomChangeOptions.mock.calls.length;
+
+    await act(async () => {
+      rejectChange?.(
+        createAppErrorException({
+          code: "BOOKING_INVALID_STATE",
+          message: "Phòng 2A vừa được người khác chọn.",
+          kind: "user",
+          support_id: null,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(fetchRoomChangeOptions).toHaveBeenCalledTimes(callsBeforeRejection);
+    expect(
+      fetchRoomChangeOptions.mock.calls.filter(([id]) => id === "B1"),
+    ).toHaveLength(1);
   });
 
   it("khi đổi phòng thất bại: báo lỗi dễ đọc, nạp lại danh sách, bỏ chọn cũ", async () => {

--- a/mhm/src/components/RoomChangeSheet.test.tsx
+++ b/mhm/src/components/RoomChangeSheet.test.tsx
@@ -107,13 +107,22 @@ describe("RoomChangeSheet", () => {
     renderSheet(baseOptions);
     await userEvent.click(await screen.findByText("Phòng 2A"));
     // Chọn dòng có hậu tố "so với phòng cũ" — dòng phòng trong danh sách cũng
-    // hiện chênh lệch (không hậu tố) nên chỉ khớp regex trần sẽ khớp cả hai.
+    // hiện chênh lệch (hậu tố "cả kỳ") nên chỉ khớp regex trần sẽ khớp cả hai.
     expect(screen.getByText(/\+500\.000đ so với phòng cũ/)).toBeInTheDocument();
   });
 
   it("dòng phòng hiện chênh lệch giá, không phải basePrice", async () => {
     renderSheet(baseOptions);
     expect(await screen.findByText(/\+500\.000đ/)).toBeInTheDocument();
+  });
+
+  // `priceDifference` là chênh lệch cho TOÀN BỘ số đêm còn lại. Dòng này trước
+  // đây đọc là "…đ/đêm", nên một con số trần rất dễ bị đọc thành giá mỗi đêm và
+  // báo sai cho khách.
+  it("dòng phòng nói rõ chênh lệch là cho cả kỳ, không phải mỗi đêm", async () => {
+    renderSheet(baseOptions);
+    expect(await screen.findByText(/\+500\.000đ cả kỳ/)).toBeInTheDocument();
+    expect(screen.queryByText(/500\.000đ\/đêm/)).not.toBeInTheDocument();
   });
 
   it("dòng phòng hiện dấu trừ khi phòng rẻ hơn phòng hiện tại", async () => {
@@ -130,7 +139,7 @@ describe("RoomChangeSheet", () => {
         },
       ],
     });
-    expect(await screen.findByText(/−50\.000đ/)).toBeInTheDocument();
+    expect(await screen.findByText(/−50\.000đ cả kỳ/)).toBeInTheDocument();
   });
 
   it("dòng phòng hiện 'không đổi tiền' khi chênh lệch bằng 0", async () => {

--- a/mhm/src/components/RoomChangeSheet.test.tsx
+++ b/mhm/src/components/RoomChangeSheet.test.tsx
@@ -1,0 +1,182 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { useHotelStore } from "@/stores/useHotelStore";
+import { createAppErrorException } from "@/lib/appError";
+import type { RoomChangeOptions } from "@/types";
+import { toast } from "sonner";
+import { RoomChangeSheet } from "./RoomChangeSheet";
+
+const baseOptions: RoomChangeOptions = {
+  bookingId: "B1",
+  currentRoomId: "5B",
+  currentRoomName: "Phòng 5B",
+  fromDate: "2026-08-03",
+  toDate: "2026-08-07",
+  nightsRemaining: 5,
+  nightsStayed: 3,
+  guestCount: 2,
+  rooms: [
+    {
+      roomId: "2A",
+      name: "Phòng 2A",
+      roomType: "deluxe",
+      floor: 2,
+      basePrice: 500000,
+      maxGuests: 4,
+      priceDifference: 500000,
+    },
+  ],
+};
+
+type FetchRoomChangeOptions = (bookingId: string) => Promise<RoomChangeOptions>;
+type ChangeRoom = (
+  bookingId: string,
+  newRoomId: string,
+  keepPrice: boolean,
+  reason?: string,
+) => Promise<void>;
+
+function renderSheet(
+  options: RoomChangeOptions,
+  overrides: Partial<{
+    fetchRoomChangeOptions: FetchRoomChangeOptions;
+    changeRoom: ChangeRoom;
+  }> = {},
+) {
+  const fetchRoomChangeOptions: FetchRoomChangeOptions =
+    overrides.fetchRoomChangeOptions ?? vi.fn().mockResolvedValue(options);
+  const changeRoom: ChangeRoom =
+    overrides.changeRoom ?? vi.fn().mockResolvedValue(undefined);
+
+  useHotelStore.setState({
+    isRoomChangeOpen: true,
+    roomChangeBookingId: options.bookingId,
+    setRoomChangeOpen: vi.fn(),
+    fetchRoomChangeOptions,
+    changeRoom,
+  });
+
+  render(<RoomChangeSheet />);
+
+  return { fetchRoomChangeOptions, changeRoom };
+}
+
+describe("RoomChangeSheet", () => {
+  beforeEach(() => {
+    useHotelStore.setState({ isRoomChangeOpen: false, roomChangeBookingId: null });
+    vi.clearAllMocks();
+  });
+
+  it("nói rõ những đêm đã ở vẫn thuộc phòng cũ", async () => {
+    renderSheet(baseOptions);
+    expect(
+      await screen.findByText(/3 đêm trước vẫn tính phòng 5B/i),
+    ).toBeInTheDocument();
+  });
+
+  it("không hiện dòng đêm cũ khi đặt phòng chưa bắt đầu (nightsStayed = 0)", async () => {
+    renderSheet({ ...baseOptions, nightsStayed: 0 });
+    await screen.findByText("Phòng 2A");
+    expect(screen.queryByText(/vẫn tính phòng/i)).not.toBeInTheDocument();
+  });
+
+  it("hiện chênh lệch sau khi chọn phòng", async () => {
+    renderSheet(baseOptions);
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    expect(screen.getByText(/\+500\.000/)).toBeInTheDocument();
+  });
+
+  it("gửi keepPrice true khi chọn giữ nguyên giá cũ", async () => {
+    const changeRoom = vi.fn().mockResolvedValue(undefined);
+    renderSheet(baseOptions, { changeRoom });
+
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    await userEvent.click(screen.getByLabelText(/giữ nguyên giá cũ/i));
+    await userEvent.click(screen.getByRole("button", { name: /chuyển sang/i }));
+
+    await waitFor(() =>
+      expect(changeRoom).toHaveBeenCalledWith("B1", "2A", true, undefined),
+    );
+  });
+
+  it("nút xác nhận nêu rõ phòng và tiền, không phải chỉ 'Xác nhận'", async () => {
+    renderSheet(baseOptions);
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    const confirmButton = screen.getByRole("button", { name: /chuyển sang phòng 2a/i });
+    expect(confirmButton).toHaveTextContent(/500\.000/);
+    expect(confirmButton.textContent?.trim().toLowerCase()).not.toBe("xác nhận");
+  });
+
+  it("báo hết phòng thay vì hiện danh sách rỗng", async () => {
+    renderSheet({ ...baseOptions, rooms: [] });
+    expect(
+      await screen.findByText(/Không phòng nào trống suốt 5 đêm còn lại/i),
+    ).toBeInTheDocument();
+  });
+
+  it("khi đổi phòng thất bại: báo lỗi dễ đọc, nạp lại danh sách, bỏ chọn cũ", async () => {
+    const fetchRoomChangeOptions = vi
+      .fn()
+      .mockResolvedValueOnce(baseOptions)
+      .mockResolvedValueOnce({
+        ...baseOptions,
+        rooms: [
+          {
+            roomId: "3C",
+            name: "Phòng 3C",
+            roomType: "standard",
+            floor: 3,
+            basePrice: 300000,
+            maxGuests: 2,
+            priceDifference: -100000,
+          },
+        ],
+      });
+    const changeRoom = vi.fn().mockRejectedValue(
+      createAppErrorException({
+        code: "BOOKING_INVALID_STATE",
+        message: "Phòng 2A vừa được người khác chọn.",
+        kind: "user",
+        support_id: null,
+      }),
+    );
+
+    renderSheet(baseOptions, { fetchRoomChangeOptions, changeRoom });
+
+    await userEvent.click(await screen.findByText("Phòng 2A"));
+    await userEvent.click(screen.getByRole("button", { name: /chuyển sang/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    const [message] = (toast.error as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(message).toContain("Phòng 2A vừa được người khác chọn.");
+    expect(message).not.toMatch(/\[object Object\]/);
+
+    expect(fetchRoomChangeOptions).toHaveBeenCalledTimes(2);
+    await screen.findByText("Phòng 3C");
+    expect(screen.queryByText("Phòng 2A")).not.toBeInTheDocument();
+  });
+});

--- a/mhm/src/components/RoomChangeSheet.test.tsx
+++ b/mhm/src/components/RoomChangeSheet.test.tsx
@@ -108,7 +108,9 @@ describe("RoomChangeSheet", () => {
     await userEvent.click(await screen.findByText("Phòng 2A"));
     // Chọn dòng có hậu tố "so với phòng cũ" — dòng phòng trong danh sách cũng
     // hiện chênh lệch (hậu tố "cả kỳ") nên chỉ khớp regex trần sẽ khớp cả hai.
-    expect(screen.getByText(/\+500\.000đ so với phòng cũ/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/\+500\.000đ cho cả kỳ so với phòng cũ/),
+    ).toBeInTheDocument();
   });
 
   it("dòng phòng hiện chênh lệch giá, không phải basePrice", async () => {
@@ -176,8 +178,9 @@ describe("RoomChangeSheet", () => {
     });
     await userEvent.click(await screen.findByText("Phòng 3C"));
     const confirmButton = screen.getByRole("button", { name: /chuyển sang phòng 3c/i });
-    expect(confirmButton).toHaveTextContent(/50\.000/);
-    expect(confirmButton).toHaveTextContent(/trừ/);
+    // Nút này là dòng chữ cuối cùng lễ tân đọc trước khi chốt tiền, nên nó phải
+    // nói rõ 50.000đ là cho cả kỳ chứ không phải mỗi đêm.
+    expect(confirmButton).toHaveTextContent(/trừ 50\.000đ cho cả kỳ/);
   });
 
   it("nút xác nhận hiện 'không đổi tiền' khi phòng chọn không chênh lệch", async () => {
@@ -216,7 +219,7 @@ describe("RoomChangeSheet", () => {
     renderSheet(baseOptions);
     await userEvent.click(await screen.findByText("Phòng 2A"));
     const confirmButton = screen.getByRole("button", { name: /chuyển sang phòng 2a/i });
-    expect(confirmButton).toHaveTextContent(/500\.000/);
+    expect(confirmButton).toHaveTextContent(/cộng 500\.000đ cho cả kỳ/);
     expect(confirmButton.textContent?.trim().toLowerCase()).not.toBe("xác nhận");
   });
 

--- a/mhm/src/components/RoomChangeSheet.test.tsx
+++ b/mhm/src/components/RoomChangeSheet.test.tsx
@@ -45,7 +45,6 @@ const baseOptions: RoomChangeOptions = {
       name: "Phòng 2A",
       roomType: "deluxe",
       floor: 2,
-      basePrice: 500000,
       maxGuests: 4,
       priceDifference: 500000,
     },
@@ -107,7 +106,88 @@ describe("RoomChangeSheet", () => {
   it("hiện chênh lệch sau khi chọn phòng", async () => {
     renderSheet(baseOptions);
     await userEvent.click(await screen.findByText("Phòng 2A"));
-    expect(screen.getByText(/\+500\.000/)).toBeInTheDocument();
+    // Chọn dòng có hậu tố "so với phòng cũ" — dòng phòng trong danh sách cũng
+    // hiện chênh lệch (không hậu tố) nên chỉ khớp regex trần sẽ khớp cả hai.
+    expect(screen.getByText(/\+500\.000đ so với phòng cũ/)).toBeInTheDocument();
+  });
+
+  it("dòng phòng hiện chênh lệch giá, không phải basePrice", async () => {
+    renderSheet(baseOptions);
+    expect(await screen.findByText(/\+500\.000đ/)).toBeInTheDocument();
+  });
+
+  it("dòng phòng hiện dấu trừ khi phòng rẻ hơn phòng hiện tại", async () => {
+    renderSheet({
+      ...baseOptions,
+      rooms: [
+        {
+          roomId: "3C",
+          name: "Phòng 3C",
+          roomType: "standard",
+          floor: 3,
+          maxGuests: 2,
+          priceDifference: -50000,
+        },
+      ],
+    });
+    expect(await screen.findByText(/−50\.000đ/)).toBeInTheDocument();
+  });
+
+  it("dòng phòng hiện 'không đổi tiền' khi chênh lệch bằng 0", async () => {
+    renderSheet({
+      ...baseOptions,
+      rooms: [
+        {
+          roomId: "4D",
+          name: "Phòng 4D",
+          roomType: "deluxe",
+          floor: 4,
+          maxGuests: 2,
+          priceDifference: 0,
+        },
+      ],
+    });
+    await screen.findByText("Phòng 4D");
+    expect(screen.getByText(/không đổi tiền/i)).toBeInTheDocument();
+  });
+
+  it("nút xác nhận hiện dấu trừ khi chọn phòng rẻ hơn", async () => {
+    renderSheet({
+      ...baseOptions,
+      rooms: [
+        {
+          roomId: "3C",
+          name: "Phòng 3C",
+          roomType: "standard",
+          floor: 3,
+          maxGuests: 2,
+          priceDifference: -50000,
+        },
+      ],
+    });
+    await userEvent.click(await screen.findByText("Phòng 3C"));
+    const confirmButton = screen.getByRole("button", { name: /chuyển sang phòng 3c/i });
+    expect(confirmButton).toHaveTextContent(/50\.000/);
+    expect(confirmButton).toHaveTextContent(/trừ/);
+  });
+
+  it("nút xác nhận hiện 'không đổi tiền' khi phòng chọn không chênh lệch", async () => {
+    renderSheet({
+      ...baseOptions,
+      rooms: [
+        {
+          roomId: "4D",
+          name: "Phòng 4D",
+          roomType: "deluxe",
+          floor: 4,
+          maxGuests: 2,
+          priceDifference: 0,
+        },
+      ],
+    });
+    await userEvent.click(await screen.findByText("Phòng 4D"));
+    const confirmButton = screen.getByRole("button", { name: /chuyển sang phòng 4d/i });
+    expect(confirmButton).toHaveTextContent(/không đổi tiền/i);
   });
 
   it("gửi keepPrice true khi chọn giữ nguyên giá cũ", async () => {
@@ -150,7 +230,6 @@ describe("RoomChangeSheet", () => {
             name: "Phòng 3C",
             roomType: "standard",
             floor: 3,
-            basePrice: 300000,
             maxGuests: 2,
             priceDifference: -100000,
           },

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { useHotelStore } from "@/stores/useHotelStore";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
-import { fmtMoney, fmtNumber } from "@/lib/format";
+import { fmtDateShort, fmtMoney, fmtNumber } from "@/lib/format";
 import { toast } from "sonner";
 import type { RoomChangeOptions } from "@/types";
 
@@ -114,7 +114,7 @@ export function RoomChangeSheet() {
               <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 space-y-1.5">
                 <p className="text-sm text-slate-700">
                   Còn <span className="font-semibold">{options.nightsRemaining} đêm</span> sẽ chuyển:{" "}
-                  {options.fromDate} → {options.toDate}
+                  {fmtDateShort(options.fromDate)} → {fmtDateShort(options.toDate)}
                 </p>
                 {options.nightsStayed > 0 && (
                   <p className="text-sm font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-2.5 py-1.5">

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ArrowRightLeft } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
@@ -51,7 +51,15 @@ export function RoomChangeSheet() {
   const [reason, setReason] = useState("");
   const [saving, setSaving] = useState(false);
 
+  // Sheet này dùng chung cho mọi booking, nên `bookingId` đổi ngay khi lễ tân
+  // đóng rồi mở lại cho khách khác. Một `changeRoom` của khách trước vẫn đang
+  // bay lúc đó, và nhánh catch của nó vẫn còn quyền ghi state. Closure giữ giá
+  // trị cũ nên chỉ ref mới trả lời được "sheet đang nói về booking nào" tại
+  // thời điểm promise trả về — cùng vai trò với cờ `cancelled` ngay dưới đây.
+  const activeBookingIdRef = useRef<string | null>(bookingId);
+
   useEffect(() => {
+    activeBookingIdRef.current = isOpen ? bookingId : null;
     if (!isOpen || !bookingId) return;
     let cancelled = false;
     setOptions(null);
@@ -80,9 +88,10 @@ export function RoomChangeSheet() {
 
   async function handleConfirm() {
     if (!options || !selected || saving) return;
+    const requestBookingId = options.bookingId;
     setSaving(true);
     try {
-      await changeRoom(options.bookingId, selected.roomId, keepPrice, reason.trim() || undefined);
+      await changeRoom(requestBookingId, selected.roomId, keepPrice, reason.trim() || undefined);
       toast.success(`Đã chuyển sang ${selected.name}`);
       closeAndReset(false);
     } catch (err) {
@@ -90,14 +99,18 @@ export function RoomChangeSheet() {
       // đang mở — báo lỗi rồi nạp lại danh sách để lễ tân chọn tiếp, thay vì
       // để lại một lựa chọn đã chết trên màn hình.
       toast.error(formatAppError(err));
+      // ...nhưng chỉ khi sheet còn đang nói về đúng booking đó. Nếu lễ tân đã
+      // đóng và mở lại cho khách khác, danh sách phòng nạp lại ở đây là của
+      // khách cũ và sẽ nằm dưới tiêu đề của khách mới.
+      if (activeBookingIdRef.current !== requestBookingId) return;
       setSelectedRoomId(null);
-      if (bookingId) {
-        try {
-          const refreshed = await fetchRoomChangeOptions(bookingId);
-          setOptions(refreshed);
-        } catch (refreshErr) {
-          setLoadError(formatAppError(refreshErr));
-        }
+      try {
+        const refreshed = await fetchRoomChangeOptions(requestBookingId);
+        if (activeBookingIdRef.current !== requestBookingId) return;
+        setOptions(refreshed);
+      } catch (refreshErr) {
+        if (activeBookingIdRef.current !== requestBookingId) return;
+        setLoadError(formatAppError(refreshErr));
       }
     } finally {
       setSaving(false);

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -21,7 +21,9 @@ import type { RoomChangeOptions } from "@/types";
  *
  * "cả kỳ" is not decoration: `priceDifference` covers ALL remaining nights,
  * while this row used to read "…đ/đêm", so a returning receptionist reads a
- * bare "+500.000đ" as per-night and quotes the guest the wrong number.
+ * bare "+500.000đ" as per-night and quotes the guest the wrong number. The
+ * summary panel and the confirm button carry the same qualifier as "cho cả
+ * kỳ" — they read as sentences, this dense middot-separated row does not.
  */
 function formatPriceDifference(value: number): string {
   if (value === 0) return "không đổi tiền";
@@ -210,7 +212,7 @@ export function RoomChangeSheet() {
                   <p className="text-sm font-semibold text-slate-800">
                     {difference === 0
                       ? "Không đổi tiền"
-                      : `${difference > 0 ? "+" : "−"}${fmtNumber(Math.abs(difference))}đ so với phòng cũ`}
+                      : `${difference > 0 ? "+" : "−"}${fmtNumber(Math.abs(difference))}đ cho cả kỳ so với phòng cũ`}
                   </p>
                 </div>
               )}
@@ -238,7 +240,7 @@ export function RoomChangeSheet() {
                   : selected
                     ? `Chuyển sang ${selected.name}${
                         difference !== 0
-                          ? `, ${difference > 0 ? "cộng" : "trừ"} ${fmtNumber(Math.abs(difference))}đ`
+                          ? `, ${difference > 0 ? "cộng" : "trừ"} ${fmtNumber(Math.abs(difference))}đ cho cả kỳ`
                           : ", không đổi tiền"
                       }`
                     : "Chọn một phòng để chuyển"}

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -18,10 +18,14 @@ import type { RoomChangeOptions } from "@/types";
  * that actually matches what `change_room` will charge, so that is what the
  * row shows instead — same "+X" / "−X" / "không đổi tiền" vocabulary already
  * used below once a room is selected.
+ *
+ * "cả kỳ" is not decoration: `priceDifference` covers ALL remaining nights,
+ * while this row used to read "…đ/đêm", so a returning receptionist reads a
+ * bare "+500.000đ" as per-night and quotes the guest the wrong number.
  */
 function formatPriceDifference(value: number): string {
   if (value === 0) return "không đổi tiền";
-  return `${value > 0 ? "+" : "−"}${fmtNumber(Math.abs(value))}đ`;
+  return `${value > 0 ? "+" : "−"}${fmtNumber(Math.abs(value))}đ cả kỳ`;
 }
 
 /**

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -67,6 +67,10 @@ export function RoomChangeSheet() {
     setSelectedRoomId(null);
     setKeepPrice(false);
     setReason("");
+    // Kể cả `saving`: sheet chỉ mount một lần ở MainShell, nên nếu lễ tân đóng
+    // giữa chừng rồi mở cho khách khác, nút xác nhận của khách mới vẫn kẹt ở
+    // "Đang xử lý..." cho tới khi lệnh của khách cũ trả về.
+    setSaving(false);
     fetchRoomChangeOptions(bookingId)
       .then((result) => {
         if (!cancelled) setOptions(result);
@@ -92,7 +96,12 @@ export function RoomChangeSheet() {
     setSaving(true);
     try {
       await changeRoom(requestBookingId, selected.roomId, keepPrice, reason.trim() || undefined);
+      // `selected` là biến của lần render đã bấm nút nên câu báo luôn gọi đúng
+      // tên phòng của khách đó, kể cả khi sheet đã chuyển sang khách khác.
       toast.success(`Đã chuyển sang ${selected.name}`);
+      // Nhưng đóng sheet thì không: lúc này sheet có thể đang là của khách khác,
+      // đóng đi là mất luôn phòng họ vừa chọn.
+      if (activeBookingIdRef.current !== requestBookingId) return;
       closeAndReset(false);
     } catch (err) {
       // Phòng vừa được chọn có thể đã bị người khác lấy mất trong lúc sheet
@@ -113,7 +122,10 @@ export function RoomChangeSheet() {
         setLoadError(formatAppError(refreshErr));
       }
     } finally {
-      setSaving(false);
+      // Chỉ nhả khoá nếu sheet còn đang nói về đúng booking này. Lệnh của khách
+      // cũ trả về muộn mà nhả khoá vô điều kiện thì nó mở khoá cho lệnh của
+      // khách mới đang bay — đúng cái double-submit mà `saving` sinh ra để chặn.
+      if (activeBookingIdRef.current === requestBookingId) setSaving(false);
     }
   }
 

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from "react";
+import { ArrowRightLeft } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { useHotelStore } from "@/stores/useHotelStore";
+import { formatAppError } from "@/lib/appError";
+import { getRoomTypeLabel } from "@/lib/constants";
+import { fmtMoney, fmtNumber } from "@/lib/format";
+import { toast } from "sonner";
+import type { RoomChangeOptions } from "@/types";
+
+/**
+ * Sheet dùng chung cho mọi lối vào chuyển phòng (Task 9). Một booking có thể
+ * đã ở vài đêm trước khi chuyển — những đêm đó KHÔNG được gán lại cho phòng
+ * mới, chỉ những đêm từ hôm nay trở đi mới chuyển. Đây là điều dễ hiểu lầm
+ * nhất của tính năng này nên phải nói thẳng ra, không chỉ ngụ ý qua con số
+ * "còn X đêm".
+ */
+export function RoomChangeSheet() {
+  const isOpen = useHotelStore((s) => s.isRoomChangeOpen);
+  const bookingId = useHotelStore((s) => s.roomChangeBookingId);
+  const setRoomChangeOpen = useHotelStore((s) => s.setRoomChangeOpen);
+  const fetchRoomChangeOptions = useHotelStore((s) => s.fetchRoomChangeOptions);
+  const changeRoom = useHotelStore((s) => s.changeRoom);
+
+  const [options, setOptions] = useState<RoomChangeOptions | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+  const [keepPrice, setKeepPrice] = useState(false);
+  const [reason, setReason] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !bookingId) return;
+    let cancelled = false;
+    setOptions(null);
+    setLoadError(null);
+    setSelectedRoomId(null);
+    setKeepPrice(false);
+    setReason("");
+    fetchRoomChangeOptions(bookingId)
+      .then((result) => {
+        if (!cancelled) setOptions(result);
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(formatAppError(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, bookingId, fetchRoomChangeOptions]);
+
+  const selected = options?.rooms.find((r) => r.roomId === selectedRoomId) ?? null;
+  const difference = selected ? (keepPrice ? 0 : selected.priceDifference) : 0;
+
+  function closeAndReset(open: boolean) {
+    setRoomChangeOpen(open, bookingId);
+  }
+
+  async function handleConfirm() {
+    if (!options || !selected || saving) return;
+    setSaving(true);
+    try {
+      await changeRoom(options.bookingId, selected.roomId, keepPrice, reason.trim() || undefined);
+      toast.success(`Đã chuyển sang ${selected.name}`);
+      closeAndReset(false);
+    } catch (err) {
+      // Phòng vừa được chọn có thể đã bị người khác lấy mất trong lúc sheet
+      // đang mở — báo lỗi rồi nạp lại danh sách để lễ tân chọn tiếp, thay vì
+      // để lại một lựa chọn đã chết trên màn hình.
+      toast.error(formatAppError(err));
+      setSelectedRoomId(null);
+      if (bookingId) {
+        try {
+          const refreshed = await fetchRoomChangeOptions(bookingId);
+          setOptions(refreshed);
+        } catch (refreshErr) {
+          setLoadError(formatAppError(refreshErr));
+        }
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Sheet open={isOpen} onOpenChange={closeAndReset}>
+      <SheetContent side="right" className="w-[480px] sm:w-[520px] overflow-y-auto p-0">
+        <SheetHeader className="p-6 pb-4 border-b border-slate-100">
+          <SheetTitle className="flex items-center gap-2 text-lg">
+            <ArrowRightLeft size={20} className="text-brand-primary" />
+            Chuyển phòng
+          </SheetTitle>
+          {options && (
+            <p className="text-sm text-slate-500">
+              Đang ở <span className="font-semibold text-slate-700">{options.currentRoomName}</span>
+            </p>
+          )}
+        </SheetHeader>
+
+        <div className="p-6 space-y-5">
+          {loadError && (
+            <div className="rounded-xl p-3 text-sm bg-red-50 text-red-700 border border-red-200">
+              {loadError}
+            </div>
+          )}
+
+          {!options && !loadError && (
+            <p className="text-sm text-slate-400 py-6 text-center">Đang tải...</p>
+          )}
+
+          {options && (
+            <>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 space-y-1.5">
+                <p className="text-sm text-slate-700">
+                  Còn <span className="font-semibold">{options.nightsRemaining} đêm</span> sẽ chuyển:{" "}
+                  {options.fromDate} → {options.toDate}
+                </p>
+                {options.nightsStayed > 0 && (
+                  <p className="text-sm font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-2.5 py-1.5">
+                    {options.nightsStayed} đêm trước vẫn tính {options.currentRoomName} — chỉ những
+                    đêm còn lại mới chuyển sang phòng mới.
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                  Chọn phòng mới
+                </h3>
+
+                {options.rooms.length === 0 ? (
+                  <div className="rounded-xl p-3 text-sm bg-red-50 text-red-700 border border-red-200">
+                    Không phòng nào trống suốt {options.nightsRemaining} đêm còn lại.
+                  </div>
+                ) : (
+                  <ul className="space-y-2">
+                    {options.rooms.map((room) => {
+                      const isSelected = room.roomId === selectedRoomId;
+                      return (
+                        <li key={room.roomId}>
+                          <button
+                            type="button"
+                            onClick={() => setSelectedRoomId(room.roomId)}
+                            aria-pressed={isSelected}
+                            className={`w-full text-left rounded-xl border p-3 transition-colors cursor-pointer ${
+                              isSelected
+                                ? "border-brand-primary bg-brand-primary/5 ring-2 ring-brand-primary/20"
+                                : "border-slate-200 bg-white hover:border-slate-300"
+                            }`}
+                          >
+                            <span className="font-semibold text-sm text-slate-800">{room.name}</span>
+                            <p className="text-xs text-slate-500 mt-0.5">
+                              {getRoomTypeLabel(room.roomType)} · Tầng {room.floor} ·{" "}
+                              {fmtMoney(room.basePrice)}/đêm · tối đa {room.maxGuests} khách
+                            </p>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+
+              {selected && (
+                <div className="space-y-3 rounded-xl border border-slate-200 p-3">
+                  <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                    Cách tính tiền
+                  </h3>
+                  <label className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="room-change-pricing"
+                      checked={!keepPrice}
+                      onChange={() => setKeepPrice(false)}
+                    />
+                    Tính lại theo phòng mới
+                  </label>
+                  <label className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="room-change-pricing"
+                      aria-label="Giữ nguyên giá cũ"
+                      checked={keepPrice}
+                      onChange={() => setKeepPrice(true)}
+                    />
+                    Giữ nguyên giá cũ{" "}
+                    <span className="text-xs text-slate-400">(lỗi của khách sạn hoặc nâng hạng miễn phí)</span>
+                  </label>
+                  <p className="text-sm font-semibold text-slate-800">
+                    {difference === 0
+                      ? "Không đổi tiền"
+                      : `${difference > 0 ? "+" : "−"}${fmtNumber(Math.abs(difference))}đ so với phòng cũ`}
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-1.5">
+                <label htmlFor="room-change-reason" className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                  Lý do (không bắt buộc)
+                </label>
+                <input
+                  id="room-change-reason"
+                  className="w-full h-10 px-3 rounded-xl border border-slate-200 bg-slate-50 text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="Vd: khách phàn nàn tiếng ồn, nâng hạng miễn phí..."
+                />
+              </div>
+
+              <Button
+                className="w-full h-12 rounded-xl bg-brand-primary hover:bg-brand-primary/90 text-white font-semibold text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleConfirm}
+                disabled={!selected || saving}
+              >
+                {saving
+                  ? "Đang xử lý..."
+                  : selected
+                    ? `Chuyển sang ${selected.name}${
+                        difference !== 0
+                          ? `, ${difference > 0 ? "cộng" : "trừ"} ${fmtNumber(Math.abs(difference))}đ`
+                          : ", không đổi tiền"
+                      }`
+                    : "Chọn một phòng để chuyển"}
+              </Button>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/mhm/src/components/RoomChangeSheet.tsx
+++ b/mhm/src/components/RoomChangeSheet.tsx
@@ -5,9 +5,24 @@ import { Button } from "@/components/ui/button";
 import { useHotelStore } from "@/stores/useHotelStore";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
-import { fmtDateShort, fmtMoney, fmtNumber } from "@/lib/format";
+import { fmtDateShort, fmtNumber } from "@/lib/format";
 import { toast } from "sonner";
 import type { RoomChangeOptions } from "@/types";
+
+/**
+ * `rooms.base_price` is not a price the system charges (see
+ * `pricing_queries.rs`): the charge resolves by `room_type` through
+ * `pricing_rules`, and `base_price` is only a per-room fallback for a type
+ * with no rule. Showing it in the picker risks the front desk reading one
+ * number while the guest is charged another. `priceDifference` is the number
+ * that actually matches what `change_room` will charge, so that is what the
+ * row shows instead — same "+X" / "−X" / "không đổi tiền" vocabulary already
+ * used below once a room is selected.
+ */
+function formatPriceDifference(value: number): string {
+  if (value === 0) return "không đổi tiền";
+  return `${value > 0 ? "+" : "−"}${fmtNumber(Math.abs(value))}đ`;
+}
 
 /**
  * Sheet dùng chung cho mọi lối vào chuyển phòng (Task 9). Một booking có thể
@@ -152,7 +167,8 @@ export function RoomChangeSheet() {
                             <span className="font-semibold text-sm text-slate-800">{room.name}</span>
                             <p className="text-xs text-slate-500 mt-0.5">
                               {getRoomTypeLabel(room.roomType)} · Tầng {room.floor} ·{" "}
-                              {fmtMoney(room.basePrice)}/đêm · tối đa {room.maxGuests} khách
+                              {formatPriceDifference(room.priceDifference)} · tối đa{" "}
+                              {room.maxGuests} khách
                             </p>
                           </button>
                         </li>

--- a/mhm/src/components/RoomDetailPanel.test.tsx
+++ b/mhm/src/components/RoomDetailPanel.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import RoomDetailPanel from "./RoomDetailPanel";
 
 const checkOut = vi.fn();
+const setRoomChangeOpen = vi.fn();
 let roomTypeRates: Record<string, { room_type: string; nightly_rate: number; configured: boolean }> | null =
     null;
 
@@ -20,6 +21,7 @@ vi.mock("@/stores/useHotelStore", () => ({
         getStayInfoText: vi.fn(),
         setTab: vi.fn(),
         setCheckinOpen: vi.fn(),
+        setRoomChangeOpen,
         loading: false,
         roomTypeRates,
     }),
@@ -38,6 +40,7 @@ vi.mock("@/hooks/useInvoiceDialog", () => ({
 describe("RoomDetailPanel checkout settlement", () => {
     beforeEach(() => {
         checkOut.mockReset();
+        setRoomChangeOpen.mockReset();
     });
 
     it("opens the shared checkout settlement modal from the detail page", async () => {
@@ -78,6 +81,46 @@ describe("RoomDetailPanel checkout settlement", () => {
         await user.click(screen.getByRole("button", { name: /check-out/i }));
 
         expect(screen.getByTestId("checkout-settlement-modal")).toBeInTheDocument();
+    });
+
+    it("opens the room change sheet for the current booking", async () => {
+        const user = userEvent.setup();
+
+        render(
+            <RoomDetailPanel
+                mode="page"
+                roomDetail={{
+                    room: {
+                        id: "101",
+                        name: "101",
+                        type: "standard",
+                        floor: 1,
+                        has_balcony: false,
+                        base_price: 500000,
+                        max_guests: 2,
+                        extra_person_fee: 0,
+                        status: "occupied",
+                    },
+                    booking: {
+                        id: "B600",
+                        room_id: "101",
+                        primary_guest_id: "G1",
+                        check_in_at: "2026-04-20T08:00:00+07:00",
+                        expected_checkout: "2026-04-25T12:00:00+07:00",
+                        nights: 5,
+                        total_price: 2500000,
+                        paid_amount: 0,
+                        status: "active",
+                        created_at: "2026-04-20T08:00:00+07:00",
+                    },
+                    guests: [],
+                }}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: /chuyển phòng/i }));
+
+        expect(setRoomChangeOpen).toHaveBeenCalledWith(true, "B600");
     });
 });
 

--- a/mhm/src/components/RoomDetailPanel.tsx
+++ b/mhm/src/components/RoomDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   ArrowLeft,
+  ArrowRightLeft,
   Building2,
   CalendarDays,
   CalendarPlus,
@@ -50,6 +51,7 @@ export default function RoomDetailPanel({
     getStayInfoText,
     setTab,
     setCheckinOpen,
+    setRoomChangeOpen,
     loading,
     roomTypeRates,
   } = useHotelStore();
@@ -208,6 +210,12 @@ export default function RoomDetailPanel({
                 variant="ghost"
               />
               <ActionBtn icon={CalendarPlus} label="Extend +1 đêm" onClick={handleExtend} variant="blue" />
+              <ActionBtn
+                icon={ArrowRightLeft}
+                label="Chuyển phòng"
+                onClick={() => booking && setRoomChangeOpen(true, booking.id)}
+                variant="ghost"
+              />
               <Button
                 variant="outline"
                 className="rounded-xl gap-2 text-sm font-semibold cursor-pointer"
@@ -217,9 +225,11 @@ export default function RoomDetailPanel({
                 <FileText className="w-4 h-4" />
                 {invoiceLoading ? "Đang tạo..." : "📄 Invoice"}
               </Button>
+              {/* 5 nút trong lưới 2 cột — nút cuối trải hết chiều ngang thay vì
+                  bị bỏ mồ côi một cột khi số nút lẻ. */}
               <button
                 onClick={() => setShowCheckout(true)}
-                className="flex items-center justify-center gap-2 py-3 bg-red-600 hover:bg-red-700 text-white rounded-xl font-semibold text-[13px] transition-colors cursor-pointer"
+                className="col-span-2 flex items-center justify-center gap-2 py-3 bg-red-600 hover:bg-red-700 text-white rounded-xl font-semibold text-[13px] transition-colors cursor-pointer"
               >
                 <LogOut size={15} /> Check-out
               </button>

--- a/mhm/src/components/RoomDrawer.test.tsx
+++ b/mhm/src/components/RoomDrawer.test.tsx
@@ -16,12 +16,15 @@ vi.mock("@/components/CheckoutSettlementModal", () => ({
     default: ({ open }: { open: boolean }) =>
         open ? <div data-testid="checkout-settlement-modal" /> : null,
 }));
+const setRoomChangeOpen = vi.fn();
+
 vi.mock("@/stores/useHotelStore", () => ({
     useHotelStore: () => ({
         checkOut: vi.fn(),
         extendStay: vi.fn(),
         getStayInfoText: vi.fn(),
         setCheckinOpen: vi.fn(),
+        setRoomChangeOpen,
         fetchRooms: vi.fn(),
         updateHousekeeping: vi.fn(),
         roomTypeRates,
@@ -40,6 +43,7 @@ vi.mock("@/hooks/useInvoiceDialog", () => ({
 describe("RoomDrawer checkout settlement", () => {
     beforeEach(() => {
         invoke.mockReset();
+        setRoomChangeOpen.mockReset();
     });
 
     it("opens the shared checkout settlement modal from the drawer", async () => {
@@ -79,6 +83,45 @@ describe("RoomDrawer checkout settlement", () => {
         await user.click(screen.getByRole("button", { name: /check-out/i }));
 
         expect(screen.getByTestId("checkout-settlement-modal")).toBeInTheDocument();
+    });
+
+    it("opens the room change sheet for the current booking", async () => {
+        const user = userEvent.setup();
+        invoke
+            .mockResolvedValueOnce({
+                room: {
+                    id: "101",
+                    name: "101",
+                    type: "standard",
+                    floor: 1,
+                    has_balcony: false,
+                    base_price: 500000,
+                    status: "occupied",
+                },
+                booking: {
+                    id: "B601",
+                    room_id: "101",
+                    primary_guest_id: "G1",
+                    check_in_at: "2026-04-20T08:00:00+07:00",
+                    expected_checkout: "2026-04-25T12:00:00+07:00",
+                    nights: 5,
+                    total_price: 2500000,
+                    paid_amount: 0,
+                    status: "active",
+                    created_at: "2026-04-20T08:00:00+07:00",
+                },
+                guests: [],
+            })
+            .mockResolvedValueOnce([]);
+
+        render(<RoomDrawer open onClose={vi.fn()} roomId="101" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /chuyển phòng/i })).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole("button", { name: /chuyển phòng/i }));
+
+        expect(setRoomChangeOpen).toHaveBeenCalledWith(true, "B601");
     });
 });
 

--- a/mhm/src/components/RoomDrawer.test.tsx
+++ b/mhm/src/components/RoomDrawer.test.tsx
@@ -123,6 +123,52 @@ describe("RoomDrawer checkout settlement", () => {
 
         expect(setRoomChangeOpen).toHaveBeenCalledWith(true, "B601");
     });
+
+    // `roomDetail` là state cục bộ, effect nạp nó chỉ phụ thuộc [open, roomId]
+    // — không cái nào đổi khi khách chuyển phòng — và listener "db-updated"
+    // toàn cục chỉ làm mới rooms/stats của store. Nếu drawer không đóng thì nó
+    // đứng nguyên với phòng cũ và tổng tiền cũ, kèm nút Check-out mở
+    // CheckoutSettlementModal ghi đúng cái `roomId` cũ đó.
+    it("đóng lại sau khi bàn giao cho sheet chuyển phòng, không đứng lại với phòng cũ", async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        invoke
+            .mockResolvedValueOnce({
+                room: {
+                    id: "101",
+                    name: "101",
+                    type: "standard",
+                    floor: 1,
+                    has_balcony: false,
+                    base_price: 500000,
+                    status: "occupied",
+                },
+                booking: {
+                    id: "B601",
+                    room_id: "101",
+                    primary_guest_id: "G1",
+                    check_in_at: "2026-04-20T08:00:00+07:00",
+                    expected_checkout: "2026-04-25T12:00:00+07:00",
+                    nights: 5,
+                    total_price: 2500000,
+                    paid_amount: 0,
+                    status: "active",
+                    created_at: "2026-04-20T08:00:00+07:00",
+                },
+                guests: [],
+            })
+            .mockResolvedValueOnce([]);
+
+        render(<RoomDrawer open onClose={onClose} roomId="101" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /chuyển phòng/i })).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole("button", { name: /chuyển phòng/i }));
+
+        expect(setRoomChangeOpen).toHaveBeenCalledWith(true, "B601");
+        expect(onClose).toHaveBeenCalled();
+    });
 });
 
 describe("RoomDrawer nightly rate", () => {

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -275,7 +275,20 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
                 <ActionBtn
                     icon={ArrowRightLeft}
                     label="Chuyển phòng"
-                    onClick={() => booking && setRoomChangeOpen(true, booking.id)}
+                    onClick={() => {
+                        if (!booking) return;
+                        setRoomChangeOpen(true, booking.id);
+                        // Bàn giao hẳn cho RoomChangeSheet rồi đóng, giống hệt
+                        // nút check-in bên dưới. `roomDetail` là state cục bộ
+                        // và effect nạp nó chỉ phụ thuộc [open, roomId] — cả
+                        // hai đều không đổi khi khách chuyển phòng, còn
+                        // listener "db-updated" toàn cục chỉ làm mới
+                        // rooms/stats của store. Để drawer mở là nó vẫn khoe
+                        // phòng cũ, tổng tiền trước khi cộng chênh, và một nút
+                        // Check-out mở modal ghi "Phòng 101" cho khách đã sang
+                        // 202 — sai ngay lúc xác nhận tiền.
+                        handleClose();
+                    }}
                     variant="ghost"
                     className="col-span-2"
                 />

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
+    ArrowRightLeft,
     CalendarDays,
     CalendarPlus,
     Check,
@@ -43,6 +44,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         extendStay,
         getStayInfoText,
         setCheckinOpen,
+        setRoomChangeOpen,
         fetchRooms,
         updateHousekeeping,
         roomTypeRates,
@@ -268,6 +270,15 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
                     variant="ghost"
                 />
                 <ActionBtn icon={CalendarPlus} label="Extend +1 đêm" onClick={handleExtend} variant="blue" />
+                {/* 3 nút trong lưới 2 cột — nút cuối trải hết chiều ngang thay
+                    vì bị bỏ mồ côi một cột khi số nút lẻ. */}
+                <ActionBtn
+                    icon={ArrowRightLeft}
+                    label="Chuyển phòng"
+                    onClick={() => booking && setRoomChangeOpen(true, booking.id)}
+                    variant="ghost"
+                    className="col-span-2"
+                />
             </div>
             <button
                 onClick={() => setShowCheckout(true)}

--- a/mhm/src/components/invoiceGuestFacingNotes.test.tsx
+++ b/mhm/src/components/invoiceGuestFacingNotes.test.tsx
@@ -1,0 +1,125 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Both invoice renderers must print `settlement_note` and never `notes`.
+ *
+ * `invoices.notes` copies `bookings.notes` verbatim, and in the live database
+ * that column is internal front-desk shorthand — "Agoda thanh toan",
+ * "cọc 600k", scribbles about who is collecting the money. Flipping either
+ * renderer from `settlement_note` back to `notes` is a one-token edit that
+ * type-checks cleanly and puts all of that on a guest's PDF.
+ *
+ * These are real render tests rather than a source-level grep: what matters is
+ * what the guest ends up reading, not which identifier the file mentions. The
+ * react-pdf primitives are mocked down to plain DOM nodes so `InvoicePDF` —
+ * which otherwise only ever produces a binary — can be asserted on the same
+ * way as the on-screen dialog.
+ */
+vi.mock("@react-pdf/renderer", () => {
+    const passthrough =
+        (Tag: "div" | "span") =>
+        ({ children }: { children?: ReactNode }) => <Tag>{children}</Tag>;
+    return {
+        Document: passthrough("div"),
+        Page: passthrough("div"),
+        View: passthrough("div"),
+        Text: passthrough("span"),
+        StyleSheet: { create: <T,>(styles: T) => styles },
+        Font: { register: () => {} },
+        pdf: () => ({ toBlob: async () => new Blob() }),
+    };
+});
+
+vi.mock("@/components/ui/sheet", () => ({
+    Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+    Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+    ),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import InvoicePDF, { type InvoiceData } from "./InvoicePDF";
+import InvoiceDialog from "./InvoiceDialog";
+
+/** Shaped after real rows in the hotel's database. */
+const INTERNAL_NOTE = "Agoda thanh toan | cọc 600k, chị Hằng thu";
+const SETTLEMENT_NOTE = "Thanh toán theo số đêm đã đặt";
+
+function invoice(overrides: Partial<InvoiceData> = {}): InvoiceData {
+    return {
+        id: "invoice-1",
+        invoice_number: "INV-20260802-001",
+        booking_id: "booking-1",
+        hotel_name: "CapyInn",
+        hotel_address: "",
+        hotel_phone: "",
+        guest_name: "Nguyen Van A",
+        guest_phone: null,
+        room_name: "5B",
+        room_type: "standard",
+        check_in: "2026-04-15",
+        check_out: "2026-04-18",
+        nights: 3,
+        pricing_breakdown: [
+            { label: "Phòng 5B × 1 đêm", amount: 250000 },
+            { label: "Phòng 2B × 2 đêm", amount: 500000 },
+        ],
+        subtotal: 750000,
+        deposit_amount: 0,
+        total: 750000,
+        balance_due: 750000,
+        policy_text: null,
+        notes: INTERNAL_NOTE,
+        settlement_note: SETTLEMENT_NOTE,
+        status: "issued",
+        created_at: "2026-04-18T09:00:00+07:00",
+        ...overrides,
+    };
+}
+
+const renderers = [
+    {
+        name: "InvoicePDF",
+        render: (data: InvoiceData) => render(<InvoicePDF data={data} />),
+    },
+    {
+        name: "InvoiceDialog",
+        render: (data: InvoiceData) =>
+            render(<InvoiceDialog open onOpenChange={() => {}} data={data} />),
+    },
+] as const;
+
+describe.each(renderers)("$name", ({ render: renderInvoice }) => {
+    it("in lời quyết toán trong khối GHI CHÚ", () => {
+        const { container } = renderInvoice(invoice());
+        expect(container.textContent).toContain(SETTLEMENT_NOTE);
+        expect(container.textContent?.toUpperCase()).toContain("GHI CHÚ");
+    });
+
+    it("không bao giờ in ghi chú nội bộ của lễ tân cho khách", () => {
+        const { container } = renderInvoice(invoice());
+        for (const fragment of ["Agoda", "cọc 600k", "chị Hằng"]) {
+            expect(container.textContent).not.toContain(fragment);
+        }
+    });
+
+    it("không in khối GHI CHÚ rỗng khi không có lời quyết toán", () => {
+        const { container } = renderInvoice(invoice({ settlement_note: null }));
+        expect(container.textContent?.toUpperCase()).not.toContain("GHI CHÚ");
+        expect(container.textContent).not.toContain("Agoda");
+    });
+
+    it("khoảng trắng thuần cũng không dựng khối GHI CHÚ", () => {
+        const { container } = renderInvoice(invoice({ settlement_note: "   " }));
+        expect(container.textContent?.toUpperCase()).not.toContain("GHI CHÚ");
+    });
+});

--- a/mhm/src/components/shared/ActionBtn.tsx
+++ b/mhm/src/components/shared/ActionBtn.tsx
@@ -5,9 +5,11 @@ interface ActionBtnProps {
     label: string;
     onClick: () => void;
     variant: "ghost" | "blue";
+    /** Lớp CSS phụ, ví dụ `col-span-2` cho nút đứng lẻ trong lưới 2 cột. */
+    className?: string;
 }
 
-export default function ActionBtn({ icon: Icon, label, onClick, variant }: ActionBtnProps) {
+export default function ActionBtn({ icon: Icon, label, onClick, variant, className: extraClassName }: ActionBtnProps) {
     const className =
         variant === "blue"
             ? "bg-blue-50 text-blue-600 border border-blue-200 hover:bg-blue-100"
@@ -16,7 +18,7 @@ export default function ActionBtn({ icon: Icon, label, onClick, variant }: Actio
     return (
         <button
             onClick={onClick}
-            className={`flex items-center justify-center gap-1.5 py-2.5 rounded-xl text-[12px] font-medium transition-colors cursor-pointer ${className}`}
+            className={`flex items-center justify-center gap-1.5 py-2.5 rounded-xl text-[12px] font-medium transition-colors cursor-pointer ${className} ${extraClassName ?? ""}`}
         >
             <Icon size={14} /> {label}
         </button>

--- a/mhm/src/hooks/useInvoiceDialog.test.ts
+++ b/mhm/src/hooks/useInvoiceDialog.test.ts
@@ -49,6 +49,7 @@ describe("useInvoiceDialog", () => {
       balance_due: 0,
       policy_text: null,
       notes: null,
+      settlement_note: null,
       status: "issued",
       created_at: "2026-05-01T09:00:00+07:00",
     } satisfies InvoiceData;
@@ -104,6 +105,7 @@ describe("useInvoiceDialog", () => {
     balance_due: 0,
     policy_text: null,
     notes: null,
+    settlement_note: null,
     status: "issued",
     created_at: "2026-07-25T09:12:00+07:00",
   } satisfies InvoiceData;

--- a/mhm/src/lib/crashReporting/commandFailure.ts
+++ b/mhm/src/lib/crashReporting/commandFailure.ts
@@ -20,6 +20,9 @@ export type MonitoringContext =
       operation: "add_one_night";
     }
   | {
+      operation: "change_room";
+    }
+  | {
       nights: number;
       deposit_present: boolean;
       source: string | null;
@@ -30,6 +33,7 @@ export type MonitoringContext =
     };
 
 const MONITORED_COMMANDS = new Set([
+  "change_room",
   "check_in",
   "check_out",
   "create_reservation",

--- a/mhm/src/pages/GroupManagement.test.tsx
+++ b/mhm/src/pages/GroupManagement.test.tsx
@@ -102,6 +102,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
+import { emitTestEvent, resetEventMocks } from "@test-mocks/tauri-event";
 import GroupManagement from "./GroupManagement";
 
 const checkoutUserError: AppError = {
@@ -114,6 +115,7 @@ const checkoutUserError: AppError = {
 describe("GroupManagement", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetEventMocks();
     fetchGroups.mockResolvedValue(undefined);
     getGroupDetail.mockResolvedValue({
       group: {
@@ -259,5 +261,77 @@ describe("GroupManagement room change gating", () => {
     await screen.findByText("Trần Thị B");
 
     expect(screen.queryByRole("button", { name: /chuyển phòng/i })).toBeNull();
+  });
+});
+
+describe("GroupManagement refresh after a room change", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetEventMocks();
+    fetchGroups.mockResolvedValue(undefined);
+    groupCheckout.mockResolvedValue(undefined);
+  });
+
+  function groupDetailWith(roomName: string, totalPrice: number) {
+    return {
+      group: {
+        id: "group-1",
+        group_name: "Đoàn A",
+        organizer_name: "Trưởng đoàn",
+        organizer_phone: "0123456789",
+        total_rooms: 1,
+        status: "active",
+        created_at: "2026-04-22T00:00:00Z",
+      },
+      bookings: [
+        {
+          id: "booking-1",
+          room_id: roomName,
+          room_name: roomName,
+          guest_name: "Nguyễn Văn A",
+          check_in_at: "2026-04-22T00:00:00Z",
+          expected_checkout: "2026-04-23T00:00:00Z",
+          actual_checkout: null,
+          nights: 1,
+          total_price: totalPrice,
+          paid_amount: 0,
+          status: "active",
+          source: "walk-in",
+          booking_type: "group",
+          deposit_amount: null,
+          scheduled_checkin: null,
+          scheduled_checkout: null,
+          guest_phone: null,
+        },
+      ],
+      services: [],
+      total_room_cost: totalPrice,
+      total_service_cost: 0,
+      grand_total: totalPrice,
+      paid_amount: 0,
+    };
+  }
+
+  // `detail` là state cục bộ và RoomChangeSheet không có callback quay về đây,
+  // nên nếu trang không nghe "db-updated" thì sau khi chuyển R102 → R105
+  // (+500.000đ) dòng vẫn ghi R102 với giá cũ và `grand_total` vẫn thiếu khoản
+  // chênh — lễ tân đọc con số đó lên là báo sai tiền cho khách.
+  it("cập nhật phòng và tổng tiền sau khi backend báo dữ liệu đổi", async () => {
+    const user = userEvent.setup();
+    getGroupDetail.mockResolvedValue(groupDetailWith("R102", 500000));
+
+    render(<GroupManagement />);
+    await user.click(screen.getByText("Đoàn A"));
+    await screen.findByText("R102");
+
+    // Khách vừa được chuyển sang R105 và bị tính thêm 500.000đ.
+    getGroupDetail.mockResolvedValue(groupDetailWith("R105", 1000000));
+    await emitTestEvent("db-updated", { entity: "bookings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("R105")).toBeTruthy();
+    });
+    expect(screen.queryByText("R102")).toBeNull();
+    expect(getGroupDetail).toHaveBeenCalledTimes(2);
   });
 });

--- a/mhm/src/pages/GroupManagement.test.tsx
+++ b/mhm/src/pages/GroupManagement.test.tsx
@@ -20,6 +20,7 @@ const groupCheckout = vi.hoisted(() => vi.fn());
 const addGroupService = vi.hoisted(() => vi.fn());
 const removeGroupService = vi.hoisted(() => vi.fn());
 const generateGroupInvoice = vi.hoisted(() => vi.fn());
+const setRoomChangeOpen = vi.hoisted(() => vi.fn());
 const toastError = vi.hoisted(() => vi.fn());
 const toastSuccess = vi.hoisted(() => vi.fn());
 
@@ -42,6 +43,7 @@ vi.mock("@/stores/useHotelStore", () => ({
     addGroupService,
     removeGroupService,
     generateGroupInvoice,
+    setRoomChangeOpen,
   }),
 }));
 
@@ -189,5 +191,73 @@ describe("GroupManagement", () => {
         correlation_id: correlationId,
       }),
     );
+  });
+
+  it("opens the room change sheet for an active booking in the group", async () => {
+    const user = userEvent.setup();
+
+    render(<GroupManagement />);
+
+    await user.click(screen.getByText("Đoàn A"));
+    await screen.findByText("Nguyễn Văn A");
+
+    await user.click(screen.getByRole("button", { name: /chuyển phòng/i }));
+
+    expect(setRoomChangeOpen).toHaveBeenCalledWith(true, "booking-1");
+  });
+});
+
+describe("GroupManagement room change gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchGroups.mockResolvedValue(undefined);
+    getGroupDetail.mockResolvedValue({
+      group: {
+        id: "group-1",
+        group_name: "Đoàn A",
+        organizer_name: "Trưởng đoàn",
+        organizer_phone: "0123456789",
+        total_rooms: 1,
+        status: "completed",
+        created_at: "2026-04-22T00:00:00Z",
+      },
+      bookings: [
+        {
+          id: "booking-2",
+          room_id: "R102",
+          room_name: "R102",
+          guest_name: "Trần Thị B",
+          check_in_at: "2026-04-20T00:00:00Z",
+          expected_checkout: "2026-04-22T00:00:00Z",
+          actual_checkout: "2026-04-22T08:00:00Z",
+          nights: 2,
+          total_price: 800000,
+          paid_amount: 800000,
+          status: "checked_out",
+          source: "walk-in",
+          booking_type: "group",
+          deposit_amount: null,
+          scheduled_checkin: null,
+          scheduled_checkout: null,
+          guest_phone: null,
+        },
+      ],
+      services: [],
+      total_room_cost: 800000,
+      total_service_cost: 0,
+      grand_total: 800000,
+      paid_amount: 800000,
+    });
+  });
+
+  it("hides the room change action for a checked-out booking", async () => {
+    const user = userEvent.setup();
+
+    render(<GroupManagement />);
+
+    await user.click(screen.getByText("Đoàn A"));
+    await screen.findByText("Trần Thị B");
+
+    expect(screen.queryByRole("button", { name: /chuyển phòng/i })).toBeNull();
   });
 });

--- a/mhm/src/pages/GroupManagement.test.tsx
+++ b/mhm/src/pages/GroupManagement.test.tsx
@@ -334,4 +334,23 @@ describe("GroupManagement refresh after a room change", () => {
     expect(screen.queryByText("R102")).toBeNull();
     expect(getGroupDetail).toHaveBeenCalledTimes(2);
   });
+
+  // Nuốt lỗi ở chỗ nghe này là quay lại đúng triệu chứng nó sinh ra để chống:
+  // bảng đứng yên với phòng cũ và tổng cũ mà lễ tân không biết là đã hỏng.
+  it("báo lỗi khi nạp lại thất bại thay vì im lặng để bảng cũ trên màn hình", async () => {
+    const user = userEvent.setup();
+    getGroupDetail.mockResolvedValue(groupDetailWith("R102", 500000));
+
+    render(<GroupManagement />);
+    await user.click(screen.getByText("Đoàn A"));
+    await screen.findByText("R102");
+
+    getGroupDetail.mockRejectedValue(new Error("mất kết nối cơ sở dữ liệu"));
+    await emitTestEvent("db-updated", { entity: "bookings" });
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled();
+    });
+    expect(screen.getByText("R102")).toBeTruthy();
+  });
 });

--- a/mhm/src/pages/GroupManagement.tsx
+++ b/mhm/src/pages/GroupManagement.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { useHotelStore } from "../stores/useHotelStore";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
@@ -7,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import EmptyState from "@/components/shared/EmptyState";
 import SlideDrawer from "@/components/shared/SlideDrawer";
 import { formatAppError } from "@/lib/appError";
+import { createDeferredCleanup } from "@/lib/deferredCleanup";
 import { BALANCE_TONE_CLASS, balanceDisplay } from "@/lib/bookingBalance";
 import { fmtMoney, fmtDateShort } from "@/lib/format";
 import { toast } from "sonner";
@@ -79,6 +81,28 @@ export default function GroupManagement() {
             fetchGroups(filter || undefined);
         }
     };
+
+    // `detail` là state cục bộ của trang này. Nút "Chuyển phòng" ở danh sách
+    // phòng trong đoàn bàn giao hẳn cho RoomChangeSheet ở MainShell, nên không
+    // có callback nào quay về đây; `useHotelStore.changeRoom` chỉ làm mới
+    // rooms/stats chứ không đụng tới `groups`, và listener toàn cục ở
+    // RuntimeStateProvider cũng vậy. Không có chỗ nghe này thì chuyển xong
+    // dòng vẫn ghi phòng cũ với `total_price` cũ, còn `grand_total` dưới chân
+    // bảng thì thiếu khoản chênh — lễ tân đọc lên là báo sai tiền cho khách.
+    // Backend phát "db-updated" sau MỌI lệnh ghi
+    // (commands/mod.rs::emit_db_update), giống hệt cách Reservations.tsx làm
+    // mới lịch của nó.
+    useEffect(() => {
+        const cleanup = createDeferredCleanup(
+            listen<{ entity: string }>("db-updated", () => {
+                void refreshDetail();
+            }),
+        );
+        return cleanup;
+        // `refreshDetail` đọc hai state này; đăng ký lại khi chúng đổi để
+        // closure không giữ mãi `selectedGroupId` của lần render đầu (null).
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedGroupId, filter]);
 
     const handleAddService = async () => {
         if (!selectedGroupId || !svcName.trim()) return;

--- a/mhm/src/pages/GroupManagement.tsx
+++ b/mhm/src/pages/GroupManagement.tsx
@@ -10,7 +10,7 @@ import { formatAppError } from "@/lib/appError";
 import { BALANCE_TONE_CLASS, balanceDisplay } from "@/lib/bookingBalance";
 import { fmtMoney, fmtDateShort } from "@/lib/format";
 import { toast } from "sonner";
-import { Users, Plus, Trash2, FileText, LogOut, ChevronRight } from "lucide-react";
+import { Users, Plus, Trash2, FileText, LogOut, ChevronRight, ArrowRightLeft } from "lucide-react";
 import type { GroupDetailResponse, GroupService, BookingWithGuest, GroupInvoiceData } from "@/types";
 import InvoiceDialog from "@/components/InvoiceDialog";
 
@@ -37,7 +37,7 @@ function getLegacyErrorMessage(error: unknown): string {
 }
 
 export default function GroupManagement() {
-    const { groups, fetchGroups, getGroupDetail, groupCheckout, addGroupService, removeGroupService, generateGroupInvoice } = useHotelStore();
+    const { groups, fetchGroups, getGroupDetail, groupCheckout, addGroupService, removeGroupService, generateGroupInvoice, setRoomChangeOpen } = useHotelStore();
     const [filter, setFilter] = useState<string>("");
     const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
     const [detail, setDetail] = useState<GroupDetailResponse | null>(null);
@@ -275,6 +275,17 @@ export default function GroupManagement() {
                                                 {b.status === "active" ? "Active" : "Checked out"}
                                             </Badge>
                                         </div>
+                                        {/* Đã trả thì hết đổi được phòng — nút chỉ hiện khi còn đang ở hoặc chưa nhận phòng. */}
+                                        {(b.status === "active" || b.status === "booked") && (
+                                            <button
+                                                onClick={() => setRoomChangeOpen(true, b.id)}
+                                                title="Chuyển phòng"
+                                                aria-label="Chuyển phòng"
+                                                className="text-slate-400 hover:text-brand-primary cursor-pointer p-1"
+                                            >
+                                                <ArrowRightLeft size={14} />
+                                            </button>
+                                        )}
                                     </div>
                                 ))}
                             </div>

--- a/mhm/src/pages/GroupManagement.tsx
+++ b/mhm/src/pages/GroupManagement.tsx
@@ -95,7 +95,12 @@ export default function GroupManagement() {
     useEffect(() => {
         const cleanup = createDeferredCleanup(
             listen<{ entity: string }>("db-updated", () => {
-                void refreshDetail();
+                // Nuốt lỗi ở đây là quay lại đúng triệu chứng chỗ nghe này sinh
+                // ra để chống: bảng đứng yên với phòng cũ và tổng cũ mà không ai
+                // biết. Báo lên như `loadDetail` vẫn làm.
+                refreshDetail().catch((err) => {
+                    toast.error(formatAppError(err));
+                });
             }),
         );
         return cleanup;

--- a/mhm/src/pages/Reservations.test.tsx
+++ b/mhm/src/pages/Reservations.test.tsx
@@ -8,6 +8,7 @@ const invokeWriteCommand = vi.hoisted(() => vi.fn());
 const createCorrelationId = vi.hoisted(() => vi.fn());
 const toastSuccess = vi.hoisted(() => vi.fn());
 const fetchRooms = vi.hoisted(() => vi.fn());
+const setRoomChangeOpen = vi.hoisted(() => vi.fn());
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke,
@@ -32,6 +33,7 @@ vi.mock("@/stores/useHotelStore", () => ({
       },
     ],
     fetchRooms,
+    setRoomChangeOpen,
   }),
 }));
 
@@ -179,6 +181,15 @@ describe("Reservations", () => {
     await user.click(screen.getByRole("button", { name: /chỉnh sửa/i }));
 
     expect(screen.queryByText(/Reservation — Nguyen Van A/)).toBeNull();
+  });
+
+  it("opens the room change sheet for a booked reservation", async () => {
+    const user = userEvent.setup();
+    await openBookedReservationActions(user);
+
+    await user.click(screen.getByRole("button", { name: /chuyển phòng/i }));
+
+    expect(setRoomChangeOpen).toHaveBeenCalledWith(true, "B101");
   });
 });
 
@@ -420,6 +431,7 @@ describe("Reservations checked-out bookings", () => {
     expect(screen.getByText(/Đã trả — Hoseo Kim/)).toBeTruthy();
     expect(screen.getByText("Trả phòng lúc")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^hủy$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /chuyển phòng/i })).toBeNull();
   });
 
   it("reads the existing invoice instead of generating a new one", async () => {

--- a/mhm/src/pages/Reservations.tsx
+++ b/mhm/src/pages/Reservations.tsx
@@ -126,7 +126,7 @@ function describeLoadError(error: unknown): string {
 }
 
 export default function Reservations() {
-    const { rooms, fetchRooms, setCheckinOpen } = useHotelStore();
+    const { rooms, fetchRooms, setCheckinOpen, setRoomChangeOpen } = useHotelStore();
     const [bookings, setBookings] = useState<BookingWithGuest[]>([]);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [searchQuery, setSearchQuery] = useState("");
@@ -560,6 +560,7 @@ export default function Reservations() {
                     onEdit={(booking) => { setEditBooking(booking); setSelectedBooking(null); }}
                     onCancel={handleCancelReservation}
                     onViewInvoice={viewInvoice}
+                    onRoomChange={(bookingId) => setRoomChangeOpen(true, bookingId)}
                     invoiceLoading={invoiceLoading}
                 />
             )}

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -556,7 +556,6 @@ describe("useHotelStore room change", () => {
           name: "Phòng 2B",
           roomType: "Standard",
           floor: 2,
-          basePrice: 400000,
           maxGuests: 2,
           priceDifference: -150000,
         },

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -530,6 +530,15 @@ describe("useHotelStore room change", () => {
     expect(invoke).toHaveBeenCalledWith("get_rooms");
   });
 
+  // Cùng lý do với check-in / check-out ở trên: Dashboard chỉ nạp lại khi
+  // `dashboardRefreshVersion` nhích lên, mà chuyển phòng vừa đổi công suất
+  // từng phòng vừa đổi `total_price` — hai thứ Dashboard đang hiển thị.
+  it("chuyển phòng cũng phải nhích dashboardRefreshVersion", async () => {
+    await useHotelStore.getState().changeRoom("B1", "2B", false, undefined);
+
+    expect(useHotelStore.getState().dashboardRefreshVersion).toBe(1);
+  });
+
   it("setRoomChangeOpen mở sheet cho đúng booking", () => {
     useHotelStore.getState().setRoomChangeOpen(true, "B1");
     expect(useHotelStore.getState().isRoomChangeOpen).toBe(true);

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -484,3 +484,93 @@ describe("useHotelStore room type rates", () => {
     expect(useHotelStore.getState().roomTypeRates).toBeNull();
   });
 });
+
+describe("useHotelStore room change", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    createCorrelationId.mockReturnValue("COR-1A2B3C4D");
+    invokeWriteCommand.mockResolvedValue(undefined);
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_rooms") return [];
+      if (command === "get_dashboard_stats") {
+        return { total_rooms: 10, occupied: 2, vacant: 8, cleaning: 0, revenue_today: 0 };
+      }
+      throw new Error(`Unhandled invoke ${command}`);
+    });
+    useHotelStore.setState({
+      rooms: [],
+      stats: null,
+      dashboardRefreshVersion: 0,
+      loading: false,
+      isRoomChangeOpen: false,
+      roomChangeBookingId: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("gửi change_room kèm đủ tham số rồi nạp lại phòng", async () => {
+    await useHotelStore.getState().changeRoom("B1", "2B", false, "máy lạnh hỏng");
+
+    expect(invokeWriteCommand).toHaveBeenCalledWith(
+      "change_room",
+      expect.objectContaining({
+        bookingId: "B1",
+        newRoomId: "2B",
+        keepPrice: false,
+        reason: "máy lạnh hỏng",
+      }),
+      expect.objectContaining({
+        correlationId: "COR-1A2B3C4D",
+      }),
+    );
+    expect(invoke).toHaveBeenCalledWith("get_rooms");
+  });
+
+  it("setRoomChangeOpen mở sheet cho đúng booking", () => {
+    useHotelStore.getState().setRoomChangeOpen(true, "B1");
+    expect(useHotelStore.getState().isRoomChangeOpen).toBe(true);
+    expect(useHotelStore.getState().roomChangeBookingId).toBe("B1");
+
+    useHotelStore.getState().setRoomChangeOpen(false);
+    expect(useHotelStore.getState().isRoomChangeOpen).toBe(false);
+    expect(useHotelStore.getState().roomChangeBookingId).toBeNull();
+  });
+
+  it("fetchRoomChangeOptions đọc get_room_change_options và giữ nguyên priceDifference âm", async () => {
+    const options = {
+      bookingId: "B1",
+      currentRoomId: "1A",
+      currentRoomName: "Phòng 1A",
+      fromDate: "2026-08-02",
+      toDate: "2026-08-05",
+      nightsRemaining: 3,
+      nightsStayed: 0,
+      guestCount: 2,
+      rooms: [
+        {
+          roomId: "2B",
+          name: "Phòng 2B",
+          roomType: "Standard",
+          floor: 2,
+          basePrice: 400000,
+          maxGuests: 2,
+          priceDifference: -150000,
+        },
+      ],
+    };
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "get_room_change_options") return options;
+      throw new Error(`Unhandled invoke ${command}`);
+    });
+
+    const result = await useHotelStore.getState().fetchRoomChangeOptions("B1");
+
+    expect(invoke).toHaveBeenCalledWith("get_room_change_options", { bookingId: "B1" });
+    expect(result).toEqual(options);
+    expect(result.rooms[0].priceDifference).toBe(-150000);
+  });
+});

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -20,6 +20,7 @@ import type {
   CheckoutSettlementMode,
   GroupInvoiceData,
   RoomTypeRate,
+  RoomChangeOptions,
 } from "@/types";
 
 interface HotelStore {
@@ -43,6 +44,8 @@ interface HotelStore {
   checkinNights: number | null;
   isGroupCheckinOpen: boolean;
   groups: BookingGroup[];
+  isRoomChangeOpen: boolean;
+  roomChangeBookingId: string | null;
 
   fetchRooms: () => Promise<void>;
   /** Không bao giờ throw: thất bại thì đặt `roomTypeRates` về `null`. */
@@ -58,6 +61,9 @@ interface HotelStore {
     finalTotal: MoneyVnd,
   ) => Promise<void>;
   extendStay: (bookingId: string) => Promise<void>;
+  setRoomChangeOpen: (open: boolean, bookingId?: string | null) => void;
+  fetchRoomChangeOptions: (bookingId: string) => Promise<RoomChangeOptions>;
+  changeRoom: (bookingId: string, newRoomId: string, keepPrice: boolean, reason?: string) => Promise<void>;
   fetchHousekeeping: () => Promise<void>;
   updateHousekeeping: (taskId: string, status: string, note?: string) => Promise<void>;
   getStayInfoText: (bookingId: string) => Promise<string>;
@@ -99,6 +105,8 @@ export const useHotelStore = create<HotelStore>((set, get) => {
     checkinNights: null,
     isGroupCheckinOpen: false,
     groups: [],
+    isRoomChangeOpen: false,
+    roomChangeBookingId: null,
 
     fetchRooms: async () => {
       const rooms = await invoke<Room[]>("get_rooms");
@@ -229,6 +237,35 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         get().markDashboardDataChanged();
       } catch (err) {
         console.error("extend_stay error:", err);
+        throw err;
+      } finally {
+        endAction();
+      }
+    },
+
+    setRoomChangeOpen: (open, bookingId = null) =>
+      set({ isRoomChangeOpen: open, roomChangeBookingId: open ? bookingId : null }),
+
+    fetchRoomChangeOptions: async (bookingId) =>
+      invoke<RoomChangeOptions>("get_room_change_options", { bookingId }),
+
+    changeRoom: async (bookingId, newRoomId, keepPrice, reason) => {
+      beginAction();
+      try {
+        const correlationId = createCorrelationId();
+        await invokeWriteCommand(
+          "change_room",
+          { bookingId, newRoomId, keepPrice, reason: reason ?? null },
+          {
+            correlationId,
+            monitoringContext: { operation: "change_room" },
+          },
+        );
+        await get().fetchRooms();
+        await get().fetchStats();
+        get().markDashboardDataChanged();
+      } catch (err) {
+        console.error("change_room error:", err);
         throw err;
       } finally {
         endAction();

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -73,6 +73,28 @@ export interface Booking {
   created_at: string;
 }
 
+export interface RoomChangeOption {
+  roomId: string;
+  name: string;
+  roomType: string;
+  floor: number;
+  basePrice: MoneyVnd;
+  maxGuests: number;
+  priceDifference: MoneyVnd;
+}
+
+export interface RoomChangeOptions {
+  bookingId: string;
+  currentRoomId: string;
+  currentRoomName: string;
+  fromDate: string;
+  toDate: string;
+  nightsRemaining: number;
+  nightsStayed: number;
+  guestCount: number;
+  rooms: RoomChangeOption[];
+}
+
 export type CheckoutSettlementMode = "actual_nights" | "hourly" | "booked_nights";
 
 export interface CheckoutSettlementPreview {

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -78,7 +78,6 @@ export interface RoomChangeOption {
   name: string;
   roomType: string;
   floor: number;
-  basePrice: MoneyVnd;
   maxGuests: number;
   priceDifference: MoneyVnd;
 }

--- a/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
+++ b/mhm/tests/frontend-invoke-wrapper-guardrails.test.ts
@@ -44,6 +44,7 @@ const RAW_INVOKE_ALLOWED_COMMANDS: Record<string, string> = {
   get_pending_crash_report: "diagnostics recovery read",
   get_pricing_rules: "read-only pricing rules lookup",
   get_recent_activity: "read-only activity feed lookup",
+  get_room_change_options: "read-only room change move options lookup",
   get_room_detail: "read-only room detail lookup",
   get_room_types: "read-only room type lookup",
   get_room_type_rates: "read-only listed nightly rate per room type",


### PR DESCRIPTION
Trước nhánh này không có đường nào trong app để chuyển khách sang phòng khác — chủ khách sạn phải sửa tay SQLite.

## Thiết kế

`bookings.room_id` là phòng **hiện tại** của khách. `room_calendar` (một dòng cho mỗi phòng mỗi đêm) là sự thật theo từng đêm. Khi chuyển, **chỉ những đêm từ hôm nay trở đi** đổi phòng — các đêm đã ở vẫn thuộc phòng cũ, và sheet nói thẳng điều đó ra thay vì chỉ ngụ ý qua con số "còn X đêm".

Tiền chênh lệch là **hiệu của hai lần báo giá trên cùng khoảng ngày**, không phải định giá lại. Khách được giảm giá giữ nguyên phần giảm của mình. Giá tra theo `room_type` qua `pricing_rules`, không theo `rooms.base_price`.

Lệnh ghi đi qua khoá tổng hợp + outbox + ledger + `write_manifest` + CAS trên state cũ, theo đúng khuôn `extend_stay_idempotent`.

## Hoá đơn

Phát hiện quyết định trong lúc làm: `room_calendar` là **lịch còn trống nhìn về phía trước, không phải sổ cái lịch sử** — `check_out_tx` xoá sạch dòng lịch của booking khi trả phòng, và DB thật có 0 hoá đơn trên 25 booking đã trả phòng, tức hoá đơn luôn được xuất **sau** khi trả phòng. Nếu tách dòng bằng cách đọc `room_calendar` thì tính năng sẽ không bao giờ chạy.

Nên chặng ở được chụp vào `bookings.pricing_snapshot` dưới khoá `room_stays`, hợp nhất chứ không ghi đè khoá `checkout_settlement` sẵn có (`revenue_queries.rs` vẫn `json_extract` được như cũ). `check_out_tx` và `group_checkout_tx` dựng lại chặng ở từ `room_calendar` ngay trước khi xoá.

Chặng ở là **đoạn liên tiếp theo ngày**, không gộp theo phòng: khách ở A → B → quay lại A ra ba dòng, nên trả phòng sớm cắt đúng đêm của đúng phòng. Hệ quả nhìn thấy được: một kỳ như vậy in **hai dòng "Phòng A" riêng** thay vì gộp một dòng.

## Migration — cần đọc trước khi merge

Nhánh này thêm cột nullable `invoices.settlement_note` ở **schema v25**.

23 đã bị `design/kbtt-ux-simplify` chiếm và **đã cài lên máy thật** (DB thật đang báo `schema_version = 23`); 24 là của `feat/room-drawer-stay-edits`. Cổng migration là `if current < N`, nên chọn trùng số là migration **im lặng không bao giờ chạy** rồi mọi câu lệnh gọi cột mới chết lúc chạy — đúng lỗi `4c5c1c3` đã sửa một lần.

**Ràng buộc thứ tự merge:** sau khi nhánh này lên và cài đặt, DB thật sẽ đọc 25. Nhánh nào đang ngồi ở số **thấp hơn** phải rà lại mọi ref và nâng cổng lên trên 25 trước khi merge, nếu không sẽ dính đúng lỗi này theo chiều ngược lại.

## Đã kiểm chứng

- `cargo test` 1054 · `npx vitest run` 574 · `npx tsc --noEmit` sạch · `cargo clippy --all-targets -- -D warnings` sạch, sau khi rebase lên `origin/main`.
- Migration chạy trên **bản sao DB thật** qua đúng đường khởi động app: 23 → 25, tạo cột, 32 booking / 67 giao dịch nguyên vẹn, `integrity_check` ok, chạy lần hai không làm gì. Hạ cổng về `< 23` thì tái hiện đúng lỗi production.
- Xuất hoá đơn thử cho **cả 32 booking thật** trên bản sao: 32/32 các dòng cộng đúng bằng subtotal.
- Không tìm ra đường nào gây trùng phòng: kiểm lại xung đột trong cùng transaction + `PRIMARY KEY (room_id, date)` + `BEGIN IMMEDIATE`.
- Đã chạy thử tay trong app dev.

Mỗi chốt test mới đều được kiểm bằng đột biến: đảo lại đoạn code là có test đỏ tên rõ ràng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)