### PR TITLE
fix(locks): đọc phòng sau khi đã khoá booking, không phải trước

### DIFF
--- a/mhm/src-tauri/src/aggregate_locks.rs
+++ b/mhm/src-tauri/src/aggregate_locks.rs
@@ -10,6 +10,7 @@ pub struct AggregateLockManager {
     inner: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
 }
 
+#[derive(Debug)]
 pub struct AggregateLockGuard {
     keys: Vec<String>,
     _guards: Vec<OwnedMutexGuard<()>>,
@@ -18,6 +19,67 @@ pub struct AggregateLockGuard {
 impl AggregateLockGuard {
     pub fn keys(&self) -> &[String] {
         &self.keys
+    }
+
+    fn max_rank(&self) -> u8 {
+        self.keys
+            .iter()
+            .map(|key| scope_rank(key))
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Lấy pha kế tiếp trong khi vẫn đang cầm pha này.
+    ///
+    /// Ăn `self` và trả về một guard đã gộp, nên người gọi không thể cầm hai
+    /// pha thành hai biến rời rồi thả sai thứ tự, và `keys()` luôn trả về hợp
+    /// của mọi pha — đúng cái `refresh_claim_lock_keys` cần ghi lại.
+    ///
+    /// Pha sau phải có hạng **cao hơn hẳn** mọi khoá đang cầm. Đó là bất biến
+    /// chống kẹt: mọi chuỗi lấy khoá trong tiến trình đi theo `(hạng, key)`
+    /// tăng nghiêm ngặt.
+    pub async fn acquire_next<I, S>(
+        self,
+        manager: &AggregateLockManager,
+        keys: I,
+    ) -> CommandResult<AggregateLockGuard>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let next_keys = canonicalize_lock_keys(keys)?;
+        let held_rank = self.max_rank();
+        let next_rank = next_keys
+            .iter()
+            .map(|key| scope_rank(key))
+            .min()
+            .unwrap_or(0);
+
+        if next_rank <= held_rank {
+            return Err(CommandError::system(
+                codes::SYSTEM_INTERNAL_ERROR,
+                format!(
+                    "Lock phase out of order: holding {:?}, requested {:?}",
+                    self.keys, next_keys
+                ),
+            ));
+        }
+
+        let next = manager.acquire(next_keys).await?;
+        let AggregateLockGuard {
+            keys: next_keys,
+            _guards: next_guards,
+        } = next;
+
+        let mut keys = self.keys;
+        keys.extend(next_keys);
+        let mut guards = self._guards;
+        guards.extend(next_guards);
+
+        Ok(AggregateLockGuard {
+            keys,
+            _guards: guards,
+        })
     }
 }
 
@@ -272,5 +334,87 @@ mod tests {
             .expect("second order");
 
         assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn acquire_next_merges_keys_of_every_phase() {
+        let manager = AggregateLockManager::default();
+        let guard = manager
+            .acquire([booking_key("B1").unwrap(), folio_key("B1").unwrap()])
+            .await
+            .expect("phase one");
+        let guard = guard
+            .acquire_next(&manager, [room_key("R1").unwrap()])
+            .await
+            .expect("phase two");
+
+        assert_eq!(
+            guard.keys(),
+            vec![
+                "booking:B1".to_string(),
+                "folio:B1".to_string(),
+                "room:R1".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_next_rejects_a_phase_that_does_not_rank_higher() {
+        let manager = AggregateLockManager::default();
+        let guard = manager
+            .acquire([room_key("R1").unwrap()])
+            .await
+            .expect("phase one");
+
+        let error = guard
+            .acquire_next(&manager, [booking_key("B1").unwrap()])
+            .await
+            .expect_err("pha sau phải có hạng cao hơn hẳn");
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+        assert!(!error.retryable);
+    }
+
+    #[tokio::test]
+    async fn acquire_next_rejects_a_phase_of_the_same_rank() {
+        let manager = AggregateLockManager::default();
+        let guard = manager
+            .acquire([booking_key("B1").unwrap()])
+            .await
+            .expect("phase one");
+
+        let error = guard
+            .acquire_next(&manager, [booking_key("B2").unwrap()])
+            .await
+            .expect_err("cùng hạng cũng phải bị chặn");
+
+        assert_eq!(error.code, codes::SYSTEM_INTERNAL_ERROR);
+    }
+
+    #[tokio::test]
+    async fn a_phased_holder_blocks_a_one_shot_acquirer() {
+        let manager = AggregateLockManager::default();
+        let guard = manager
+            .acquire([booking_key("B1").unwrap()])
+            .await
+            .expect("phase one");
+        let guard = guard
+            .acquire_next(&manager, [room_key("R1").unwrap()])
+            .await
+            .expect("phase two");
+
+        let contender_manager = manager.clone();
+        let contender = tokio::spawn(async move {
+            contender_manager
+                .acquire([booking_key("B1").unwrap(), room_key("R1").unwrap()])
+                .await
+                .expect("contender lock")
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!contender.is_finished());
+
+        drop(guard);
+        let _contender_guard = contender.await.expect("contender joins");
     }
 }

--- a/mhm/src-tauri/src/aggregate_locks.rs
+++ b/mhm/src-tauri/src/aggregate_locks.rs
@@ -48,6 +48,24 @@ fn aggregate_key(prefix: &str, id: &str) -> CommandResult<String> {
     Ok(format!("{prefix}:{trimmed}"))
 }
 
+/// Thứ tự lấy khoá đi theo HẠNG, không theo alphabet.
+///
+/// Một lệnh nhiều pha lấy khoá theo hạng tăng nghiêm ngặt, còn một lệnh
+/// một-phát lấy cả bộ đã canonicalize — hai đường đó chỉ không kẹt nhau khi
+/// cùng đi theo một thứ tự toàn cục. Alphabet không làm được: `booking:` đứng
+/// trước `group:`, nên `remove_group_service` (lấy một phát group + booking +
+/// folio) và một `group_checkout` hai pha (group trước, booking sau) tạo thành
+/// một chu trình chờ nhau có thật.
+fn scope_rank(key: &str) -> u8 {
+    match key.split(':').next().unwrap_or_default() {
+        "group" => 0,
+        "booking" => 1,
+        "folio" => 2,
+        "room" => 3,
+        _ => 9,
+    }
+}
+
 pub fn canonicalize_lock_keys<I, S>(keys: I) -> CommandResult<Vec<String>>
 where
     I: IntoIterator<Item = S>,
@@ -66,7 +84,11 @@ where
         ));
     }
 
-    keys.sort();
+    keys.sort_by(|left, right| {
+        scope_rank(left)
+            .cmp(&scope_rank(right))
+            .then_with(|| left.cmp(right))
+    });
     keys.dedup();
     Ok(keys)
 }
@@ -152,13 +174,34 @@ mod tests {
         assert_eq!(
             left,
             vec![
+                "group:G1".to_string(),
                 "booking:B1".to_string(),
                 "booking:B2".to_string(),
                 "folio:B1".to_string(),
                 "folio:B2".to_string(),
-                "group:G1".to_string(),
                 "room:R1".to_string(),
                 "room:R2".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn canonicalize_lock_keys_orders_unknown_prefixes_last() {
+        let keys = canonicalize_lock_keys(vec![
+            "settings:ceo_cloud_data_opt_in".to_string(),
+            "room:R1".to_string(),
+            "group:G1".to_string(),
+            "agent_secret:telegram".to_string(),
+        ])
+        .expect("keys canonicalize");
+
+        assert_eq!(
+            keys,
+            vec![
+                "group:G1".to_string(),
+                "room:R1".to_string(),
+                "agent_secret:telegram".to_string(),
+                "settings:ceo_cloud_data_opt_in".to_string(),
             ]
         );
     }

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -670,6 +670,7 @@ fn group_checkout_initial_lock_keys_from_payload(
     Ok(vec![crate::aggregate_locks::group_key(group_id)?])
 }
 
+#[cfg(test)]
 struct GroupCheckoutLockState {
     selected_booking_room_map: std::collections::HashMap<String, String>,
     booking_ids_to_lock: Vec<String>,
@@ -682,12 +683,17 @@ struct GroupCheckoutResolvedGuard {
     locked_payment_candidate_booking_ids: Vec<String>,
 }
 
-async fn load_group_checkout_lock_state(
+/// Pha 1 (dưới khoá `group:G`): xác định danh sách booking phải khoá.
+///
+/// Chỉ đọc id, không đọc phòng — đọc phòng ở pha này vẫn có thể cũ ngay khi
+/// vừa đọc xong, vì `change_room` không cầm `group:`, chỉ cầm
+/// `booking:`/`folio:`/`room:`. Xem `load_group_checkout_room_lock_state`.
+async fn load_group_checkout_booking_ids_to_lock(
     pool: &Pool<Sqlite>,
     group_id: &str,
     selected_booking_ids: &[String],
     final_paid: Option<MoneyVnd>,
-) -> BookingResult<GroupCheckoutLockState> {
+) -> BookingResult<Vec<String>> {
     let group_exists: Option<String> =
         sqlx::query_scalar("SELECT id FROM booking_groups WHERE id = ? LIMIT 1")
             .bind(group_id)
@@ -701,7 +707,7 @@ async fn load_group_checkout_lock_state(
     }
 
     let mut selected_query: sqlx::QueryBuilder<Sqlite> =
-        sqlx::QueryBuilder::new("SELECT id, room_id FROM bookings WHERE group_id = ");
+        sqlx::QueryBuilder::new("SELECT id FROM bookings WHERE group_id = ");
     selected_query.push_bind(group_id);
     selected_query.push(" AND id IN (");
     let mut selected_sep = selected_query.separated(", ");
@@ -711,14 +717,13 @@ async fn load_group_checkout_lock_state(
     selected_sep.push_unseparated(")");
 
     let selected_rows = selected_query.build().fetch_all(pool).await?;
-    let mut selected_booking_room_map = std::collections::HashMap::new();
-    for row in selected_rows {
-        selected_booking_room_map
-            .insert(row.get::<String, _>("id"), row.get::<String, _>("room_id"));
-    }
+    let existing_selected_ids = selected_rows
+        .into_iter()
+        .map(|row| row.get::<String, _>("id"))
+        .collect::<std::collections::HashSet<_>>();
 
     for booking_id in selected_booking_ids {
-        if !selected_booking_room_map.contains_key(booking_id) {
+        if !existing_selected_ids.contains(booking_id) {
             return Err(BookingError::not_found(format!(
                 "Booking {} không tìm thấy hoặc đã checkout",
                 booking_id
@@ -726,29 +731,82 @@ async fn load_group_checkout_lock_state(
         }
     }
 
-    let mut booking_ids_to_lock = selected_booking_ids.to_vec();
-    let mut room_ids_to_lock = selected_booking_ids
-        .iter()
-        .filter_map(|booking_id| selected_booking_room_map.get(booking_id).cloned())
-        .collect::<Vec<_>>();
-
-    if final_paid.unwrap_or(0) > 0 {
-        let rows = sqlx::query("SELECT id, room_id FROM bookings WHERE group_id = ?")
+    let mut booking_ids_to_lock = if final_paid.unwrap_or(0) > 0 {
+        let rows = sqlx::query("SELECT id FROM bookings WHERE group_id = ?")
             .bind(group_id)
             .fetch_all(pool)
             .await?;
-        booking_ids_to_lock.clear();
-        room_ids_to_lock.clear();
-        for row in rows {
-            booking_ids_to_lock.push(row.get("id"));
-            room_ids_to_lock.push(row.get("room_id"));
-        }
-    }
+        rows.into_iter()
+            .map(|row| row.get::<String, _>("id"))
+            .collect::<Vec<_>>()
+    } else {
+        selected_booking_ids.to_vec()
+    };
 
     booking_ids_to_lock.sort();
     booking_ids_to_lock.dedup();
+
+    Ok(booking_ids_to_lock)
+}
+
+/// Pha 2 (dưới khoá `booking:`/`folio:` của mọi booking trong
+/// `booking_ids_to_lock`): đọc phòng của từng booking. Đây mới là chân lý —
+/// mọi lệnh dời phòng (`change_room`) buộc phải cầm khoá `booking:` trước khi
+/// đổi `bookings.room_id`, nên đọc dưới khoá này không thể cũ.
+async fn load_group_checkout_room_lock_state(
+    pool: &Pool<Sqlite>,
+    selected_booking_ids: &[String],
+    booking_ids_to_lock: &[String],
+) -> BookingResult<(std::collections::HashMap<String, String>, Vec<String>)> {
+    let mut room_query: sqlx::QueryBuilder<Sqlite> =
+        sqlx::QueryBuilder::new("SELECT id, room_id FROM bookings WHERE id IN (");
+    let mut room_sep = room_query.separated(", ");
+    for booking_id in booking_ids_to_lock {
+        room_sep.push_bind(booking_id);
+    }
+    room_sep.push_unseparated(")");
+
+    let rows = room_query.build().fetch_all(pool).await?;
+    let mut booking_room_map = std::collections::HashMap::new();
+    for row in rows {
+        booking_room_map.insert(row.get::<String, _>("id"), row.get::<String, _>("room_id"));
+    }
+
+    let selected_booking_room_map = selected_booking_ids
+        .iter()
+        .filter_map(|booking_id| {
+            booking_room_map
+                .get(booking_id)
+                .cloned()
+                .map(|room_id| (booking_id.clone(), room_id))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+
+    let mut room_ids_to_lock = booking_ids_to_lock
+        .iter()
+        .filter_map(|booking_id| booking_room_map.get(booking_id).cloned())
+        .collect::<Vec<_>>();
     room_ids_to_lock.sort();
     room_ids_to_lock.dedup();
+
+    Ok((selected_booking_room_map, room_ids_to_lock))
+}
+
+/// Wrapper mỏng cho helper test `group_checkout` (single-shot, không qua ba
+/// pha aggregate lock) — gọi lần lượt hai hàm trên.
+#[cfg(test)]
+async fn load_group_checkout_lock_state(
+    pool: &Pool<Sqlite>,
+    group_id: &str,
+    selected_booking_ids: &[String],
+    final_paid: Option<MoneyVnd>,
+) -> BookingResult<GroupCheckoutLockState> {
+    let booking_ids_to_lock =
+        load_group_checkout_booking_ids_to_lock(pool, group_id, selected_booking_ids, final_paid)
+            .await?;
+    let (selected_booking_room_map, room_ids_to_lock) =
+        load_group_checkout_room_lock_state(pool, selected_booking_ids, &booking_ids_to_lock)
+            .await?;
 
     Ok(GroupCheckoutLockState {
         selected_booking_room_map,
@@ -761,38 +819,55 @@ async fn resolve_group_checkout_locks(
     pool: Pool<Sqlite>,
     req: GroupCheckoutRequest,
 ) -> CommandResult<ResolvedWriteCommandGuard<GroupCheckoutResolvedGuard>> {
-    // Pha 1: khoá group trước. Danh sách booking của group (và phòng của từng
-    // booking) chỉ đứng yên khi đã cầm khoá này.
+    // Pha 1: khoá group trước. Danh sách booking phải khoá chỉ đứng yên khi
+    // đã cầm khoá này.
     let guard = crate::aggregate_locks::global_manager()
         .acquire([crate::aggregate_locks::group_key(&req.group_id)?])
         .await?;
 
     let unique_booking_ids = normalized_booking_ids(&req.booking_ids);
-    let lock_state =
-        load_group_checkout_lock_state(&pool, &req.group_id, &unique_booking_ids, req.final_paid)
-            .await
-            .map_err(map_group_checkout_command_error)?;
+    let booking_ids_to_lock = load_group_checkout_booking_ids_to_lock(
+        &pool,
+        &req.group_id,
+        &unique_booking_ids,
+        req.final_paid,
+    )
+    .await
+    .map_err(map_group_checkout_command_error)?;
 
-    // Pha 2: booking + folio + room, mọi hạng đều cao hơn `group:`.
-    let mut next_keys = Vec::new();
-    for booking_id in &lock_state.booking_ids_to_lock {
-        next_keys.push(crate::aggregate_locks::booking_key(booking_id)?);
-        next_keys.push(crate::aggregate_locks::folio_key(booking_id)?);
-    }
-    for room_id in &lock_state.room_ids_to_lock {
-        next_keys.push(crate::aggregate_locks::room_key(room_id)?);
+    // Pha 2: booking + folio cho mọi booking sẽ khoá, hạng cao hơn `group:`.
+    // `change_room` không cầm `group:`, nên phòng chỉ đứng yên từ đây trở đi.
+    let mut booking_phase_keys = Vec::new();
+    for booking_id in &booking_ids_to_lock {
+        booking_phase_keys.push(crate::aggregate_locks::booking_key(booking_id)?);
+        booking_phase_keys.push(crate::aggregate_locks::folio_key(booking_id)?);
     }
 
     let guard = guard
-        .acquire_next(crate::aggregate_locks::global_manager(), next_keys)
+        .acquire_next(crate::aggregate_locks::global_manager(), booking_phase_keys)
+        .await?;
+
+    let (selected_booking_room_map, room_ids_to_lock) =
+        load_group_checkout_room_lock_state(&pool, &unique_booking_ids, &booking_ids_to_lock)
+            .await
+            .map_err(map_group_checkout_command_error)?;
+
+    // Pha 3: room, hạng cao hơn booking/folio.
+    let mut room_phase_keys = Vec::new();
+    for room_id in &room_ids_to_lock {
+        room_phase_keys.push(crate::aggregate_locks::room_key(room_id)?);
+    }
+
+    let guard = guard
+        .acquire_next(crate::aggregate_locks::global_manager(), room_phase_keys)
         .await?;
     let lock_keys = guard.keys().to_vec();
 
     Ok(ResolvedWriteCommandGuard::new(
         GroupCheckoutResolvedGuard {
             _guard: guard,
-            locked_booking_room_map: lock_state.selected_booking_room_map,
-            locked_payment_candidate_booking_ids: lock_state.booking_ids_to_lock,
+            locked_booking_room_map: selected_booking_room_map,
+            locked_payment_candidate_booking_ids: booking_ids_to_lock,
         },
         lock_keys,
     ))

--- a/mhm/src-tauri/src/services/booking/group_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/group_lifecycle.rs
@@ -761,24 +761,33 @@ async fn resolve_group_checkout_locks(
     pool: Pool<Sqlite>,
     req: GroupCheckoutRequest,
 ) -> CommandResult<ResolvedWriteCommandGuard<GroupCheckoutResolvedGuard>> {
+    // Pha 1: khoá group trước. Danh sách booking của group (và phòng của từng
+    // booking) chỉ đứng yên khi đã cầm khoá này.
+    let guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::group_key(&req.group_id)?])
+        .await?;
+
     let unique_booking_ids = normalized_booking_ids(&req.booking_ids);
     let lock_state =
         load_group_checkout_lock_state(&pool, &req.group_id, &unique_booking_ids, req.final_paid)
             .await
             .map_err(map_group_checkout_command_error)?;
-    let mut lock_keys = vec![crate::aggregate_locks::group_key(&req.group_id)?];
 
+    // Pha 2: booking + folio + room, mọi hạng đều cao hơn `group:`.
+    let mut next_keys = Vec::new();
     for booking_id in &lock_state.booking_ids_to_lock {
-        lock_keys.push(crate::aggregate_locks::booking_key(booking_id)?);
-        lock_keys.push(crate::aggregate_locks::folio_key(booking_id)?);
+        next_keys.push(crate::aggregate_locks::booking_key(booking_id)?);
+        next_keys.push(crate::aggregate_locks::folio_key(booking_id)?);
     }
     for room_id in &lock_state.room_ids_to_lock {
-        lock_keys.push(crate::aggregate_locks::room_key(room_id)?);
+        next_keys.push(crate::aggregate_locks::room_key(room_id)?);
     }
 
-    let guard = crate::aggregate_locks::global_manager()
-        .acquire(lock_keys.clone())
+    let guard = guard
+        .acquire_next(crate::aggregate_locks::global_manager(), next_keys)
         .await?;
+    let lock_keys = guard.keys().to_vec();
+
     Ok(ResolvedWriteCommandGuard::new(
         GroupCheckoutResolvedGuard {
             _guard: guard,

--- a/mhm/src-tauri/src/services/booking/group_service_management.rs
+++ b/mhm/src-tauri/src/services/booking/group_service_management.rs
@@ -271,6 +271,11 @@ async fn load_remove_group_service_lock_state(
     })
 }
 
+/// Đọc `group_services → (group_id, booking_id)` **trước** khi khoá, khác với
+/// các resolver hai pha còn lại. Cố ý: liên kết này không bao giờ bị `UPDATE`
+/// sau khi insert — service chỉ được thêm rồi xoá — nên không có cửa sổ đua để
+/// đóng. Nếu sau này có lệnh dời một service sang booking khác, chỗ này phải
+/// chuyển sang hai pha như `resolve_group_checkout_locks`.
 async fn resolve_remove_group_service_guard(
     pool: Pool<Sqlite>,
     service_id: String,

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -27,7 +27,8 @@ use super::{
     pricing_service::calculate_stay_price_tx,
     support::{
         ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
-        read_money_vnd_or_zero, read_money_vnd_strict, validate_non_negative_booking_money,
+        lock_booking_and_read_room, read_money_vnd_or_zero, read_money_vnd_strict,
+        validate_non_negative_booking_money, FolioLock,
     },
 };
 
@@ -178,21 +179,18 @@ async fn resolve_reservation_lock(
     pool: Pool<Sqlite>,
     booking_id: String,
 ) -> CommandResult<ResolvedWriteCommandGuard<ReservationResolvedGuard>> {
-    let room_id = sqlx::query_scalar::<_, String>("SELECT room_id FROM bookings WHERE id = ?")
-        .bind(&booking_id)
-        .fetch_optional(&pool)
-        .await
-        .map_err(BookingError::from)
-        .map_err(map_reservation_command_error)?
-        .ok_or_else(|| {
-            CommandError::user(
-                codes::BOOKING_NOT_FOUND,
-                format!("Booking not found: {}", booking_id),
-            )
-        })?;
+    let (guard, room_id) = lock_booking_and_read_room(
+        &pool,
+        &booking_id,
+        FolioLock::Skip,
+        map_reservation_command_error,
+    )
+    .await?;
+    let guard = guard
+        .acquire_next(global_manager(), [room_key(&room_id)?])
+        .await?;
+    let lock_keys = guard.keys().to_vec();
 
-    let lock_keys = vec![booking_key(&booking_id)?, room_key(&room_id)?];
-    let guard = global_manager().acquire(lock_keys.clone()).await?;
     Ok(ResolvedWriteCommandGuard::new(
         ReservationResolvedGuard {
             room_id,

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -28,15 +28,14 @@ use super::{
     pricing_service::calculate_stay_price_tx,
     support::{
         begin_tx, ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
-        lock_booking_and_read_room, lookup_booking_room_id, map_room_calendar_insert_error,
-        merge_pricing_snapshot, parse_booking_datetime, read_money_vnd_or_zero,
-        room_calendar_stays_tx, room_stays_to_json, validate_non_negative_booking_money, FolioLock,
-        RoomStayRow,
+        lock_booking_and_read_room, map_room_calendar_insert_error, merge_pricing_snapshot,
+        parse_booking_datetime, read_money_vnd_or_zero, room_calendar_stays_tx, room_stays_to_json,
+        validate_non_negative_booking_money, FolioLock, RoomStayRow,
     },
 };
 
 #[cfg(test)]
-use super::support::{begin_immediate_tx, fetch_booking};
+use super::support::{begin_immediate_tx, fetch_booking, lookup_booking_room_id};
 
 pub(super) fn mark_write_db_error(error: BookingError) -> BookingError {
     match error {
@@ -1030,17 +1029,20 @@ pub async fn check_out_idempotent(
             ctx,
             request,
             move || async move {
-                let room_id = lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
-                    .await
-                    .map_err(map_check_out_command_error)?;
-                let lock_keys = vec![
-                    crate::aggregate_locks::booking_key(&booking_id_for_lookup)?,
-                    crate::aggregate_locks::room_key(&room_id)?,
-                    crate::aggregate_locks::folio_key(&booking_id_for_lookup)?,
-                ];
-                let guard = crate::aggregate_locks::global_manager()
-                    .acquire(lock_keys.clone())
+                let (guard, room_id) = lock_booking_and_read_room(
+                    &pool_for_lookup,
+                    &booking_id_for_lookup,
+                    FolioLock::Include,
+                    map_check_out_command_error,
+                )
+                .await?;
+                let guard = guard
+                    .acquire_next(
+                        crate::aggregate_locks::global_manager(),
+                        [crate::aggregate_locks::room_key(&room_id)?],
+                    )
                     .await?;
+                let lock_keys = guard.keys().to_vec();
 
                 Ok(ResolvedWriteCommandGuard::new((guard, room_id), lock_keys))
             },

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -28,9 +28,10 @@ use super::{
     pricing_service::calculate_stay_price_tx,
     support::{
         begin_tx, ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
-        lookup_booking_room_id, map_room_calendar_insert_error, merge_pricing_snapshot,
-        parse_booking_datetime, read_money_vnd_or_zero, room_calendar_stays_tx, room_stays_to_json,
-        validate_non_negative_booking_money, RoomStayRow,
+        lock_booking_and_read_room, lookup_booking_room_id, map_room_calendar_insert_error,
+        merge_pricing_snapshot, parse_booking_datetime, read_money_vnd_or_zero,
+        room_calendar_stays_tx, room_stays_to_json, validate_non_negative_booking_money, FolioLock,
+        RoomStayRow,
     },
 };
 
@@ -1250,17 +1251,20 @@ pub async fn extend_stay_idempotent(
             ctx,
             request,
             move || async move {
-                let room_id = lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
-                    .await
-                    .map_err(map_extend_stay_command_error)?;
-                let lock_keys = vec![
-                    crate::aggregate_locks::booking_key(&booking_id_for_lookup)?,
-                    crate::aggregate_locks::room_key(&room_id)?,
-                    crate::aggregate_locks::folio_key(&booking_id_for_lookup)?,
-                ];
-                let guard = crate::aggregate_locks::global_manager()
-                    .acquire(lock_keys.clone())
+                let (guard, room_id) = lock_booking_and_read_room(
+                    &pool_for_lookup,
+                    &booking_id_for_lookup,
+                    FolioLock::Include,
+                    map_extend_stay_command_error,
+                )
+                .await?;
+                let guard = guard
+                    .acquire_next(
+                        crate::aggregate_locks::global_manager(),
+                        [crate::aggregate_locks::room_key(&room_id)?],
+                    )
                     .await?;
+                let lock_keys = guard.keys().to_vec();
 
                 Ok(ResolvedWriteCommandGuard::new((guard, room_id), lock_keys))
             },

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -287,7 +287,6 @@ pub fn merge_pricing_snapshot(
 /// khoá `booking` + `room`; giữ nguyên bộ khoá đó, đổi thứ tự thôi.
 pub enum FolioLock {
     Include,
-    #[allow(dead_code)]
     Skip,
 }
 

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Duration, FixedOffset, Local, NaiveDate};
 use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, Transaction};
 
+use crate::app_error::{CommandError, CommandResult};
 use crate::domain::booking::{BookingError, BookingResult};
 use crate::models::Booking;
 use crate::money::{validate_non_negative_money_vnd, MoneyVnd};
@@ -280,6 +281,42 @@ pub fn merge_pricing_snapshot(
         .unwrap_or_default();
     map.insert(key.to_string(), value);
     serde_json::Value::Object(map).to_string()
+}
+
+/// Có lấy kèm khoá `folio:` ở pha 1 hay không. Ba lệnh reservation hôm nay chỉ
+/// khoá `booking` + `room`; giữ nguyên bộ khoá đó, đổi thứ tự thôi.
+pub enum FolioLock {
+    Include,
+    #[allow(dead_code)]
+    Skip,
+}
+
+/// Pha 1 của mọi lệnh ghi phạm vi-booking: lấy khoá `booking:` (kèm `folio:`
+/// nếu cần) **rồi mới** đọc phòng.
+///
+/// Đọc sau khi đã cầm `booking:B` là chân lý, vì mọi lệnh ghi muốn dời một
+/// booking sang phòng khác đều phải cầm đúng khoá đó. Người gọi tự ráp pha 2
+/// bằng `guard.acquire_next(...)` — `change_room` cần hai khoá phòng chứ không
+/// phải một, nên pha 2 không gói được vào đây.
+pub async fn lock_booking_and_read_room(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    folio: FolioLock,
+    map_err: fn(BookingError) -> CommandError,
+) -> CommandResult<(crate::aggregate_locks::AggregateLockGuard, String)> {
+    let mut phase_one = vec![crate::aggregate_locks::booking_key(booking_id)?];
+    if matches!(folio, FolioLock::Include) {
+        phase_one.push(crate::aggregate_locks::folio_key(booking_id)?);
+    }
+
+    let guard = crate::aggregate_locks::global_manager()
+        .acquire(phase_one)
+        .await?;
+    let room_id = lookup_booking_room_id(pool, booking_id)
+        .await
+        .map_err(map_err)?;
+
+    Ok((guard, room_id))
 }
 
 #[cfg(test)]

--- a/mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs
+++ b/mhm/src-tauri/src/services/booking/tests/checkout_settlement.rs
@@ -645,3 +645,72 @@ async fn check_out_rejects_overpaid_booking_until_refund_flow_exists() {
 
     assert!(error.to_string().contains("refund"));
 }
+
+#[tokio::test]
+async fn check_out_idempotent_reads_the_room_after_taking_the_booking_lock() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R911").await.unwrap();
+    seed_room(&pool, "R912").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000).await.unwrap();
+    seed_active_booking_with_terms(
+        &pool,
+        "B911",
+        "R911",
+        "2026-04-20T08:00:00+07:00",
+        "2026-04-25T12:00:00+07:00",
+        5,
+        2_500_000,
+        Some(0),
+    )
+    .await
+    .unwrap();
+
+    let blocker = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key("B911").unwrap()])
+        .await
+        .expect("blocker lock");
+
+    let ctx = cmd("check_out", "idem-checkout-race");
+    let pool_for_task = pool.clone();
+    let command = tokio::spawn(async move {
+        stay_lifecycle::check_out_idempotent(
+            &pool_for_task,
+            &ctx,
+            checkout_req("B911", CheckoutSettlementMode::ActualNights, 2_500_000),
+        )
+        .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !command.is_finished(),
+        "lệnh phải kẹt ở pha 1, chưa được phép đọc phòng"
+    );
+
+    sqlx::query("UPDATE room_calendar SET room_id = 'R912' WHERE booking_id = 'B911'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE bookings SET room_id = 'R912' WHERE id = 'B911'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'occupied' WHERE id = 'R912'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = 'R911'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    drop(blocker);
+
+    let result = command
+        .await
+        .expect("task joins")
+        .expect("check out phải thành công trên phòng mới");
+
+    assert_eq!(result.response["room_id"], "R912");
+    assert_room_status(&pool, "R912", "cleaning").await;
+}

--- a/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/extend_stay.rs
@@ -280,3 +280,83 @@ async fn extend_stay_fails_when_second_pool_checked_out_booking_first() {
     pool_b.close().await;
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn extend_stay_idempotent_reads_the_room_after_taking_the_booking_lock() {
+    let pool = test_pool().await;
+    let booking_id = uuid::Uuid::new_v4().to_string();
+    seed_room(&pool, "R901").await.unwrap();
+    seed_room(&pool, "R902").await.unwrap();
+    seed_active_booking(&pool, &booking_id, "R901")
+        .await
+        .unwrap();
+
+    // Giữ khoá booking để lệnh phải kẹt ở pha 1.
+    let blocker = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key(&booking_id).unwrap()])
+        .await
+        .expect("blocker lock");
+
+    let ctx = cmd("extend_stay", &format!("idem-extend-race-{booking_id}"));
+    let pool_for_task = pool.clone();
+    let booking_for_task = booking_id.clone();
+    let command = tokio::spawn(async move {
+        stay_lifecycle::extend_stay_idempotent(&pool_for_task, &ctx, &booking_for_task).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !command.is_finished(),
+        "lệnh phải kẹt ở pha 1, chưa được phép đọc phòng"
+    );
+
+    // Dời booking sang phòng khác trong lúc lệnh đang kẹt.
+    sqlx::query("UPDATE room_calendar SET room_id = 'R902' WHERE booking_id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE bookings SET room_id = 'R902' WHERE id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'occupied' WHERE id = 'R902'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = 'R901'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    drop(blocker);
+
+    let result = command
+        .await
+        .expect("task joins")
+        .expect("extend stay phải thành công trên phòng mới");
+    assert!(!result.replayed);
+
+    // Đêm thêm phải nằm ở R902, không phải R901.
+    let extended_room: String = sqlx::query_scalar(
+        "SELECT room_id FROM room_calendar WHERE booking_id = ? AND date = '2026-04-16'",
+    )
+    .bind(&booking_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(extended_room, "R902");
+
+    // Bộ khoá đã ghi lại phải là bộ đã gộp của hai pha.
+    let lock_keys_json: String = sqlx::query_scalar(
+        "SELECT lock_keys_json FROM command_idempotency WHERE command_name = 'extend_stay'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        lock_keys_json.contains("room:R902"),
+        "lock_keys_json phải chứa phòng mới, đang là {lock_keys_json}"
+    );
+}

--- a/mhm/src-tauri/src/services/booking/tests/group_idempotency.rs
+++ b/mhm/src-tauri/src/services/booking/tests/group_idempotency.rs
@@ -804,3 +804,82 @@ async fn group_checkin_idempotent_same_key_changed_guest_name_conflicts() {
         crate::app_error::codes::CONFLICT_IDEMPOTENCY_HASH_MISMATCH
     );
 }
+
+#[tokio::test]
+async fn group_checkout_idempotent_reads_rooms_after_taking_the_group_lock() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R931").await.unwrap();
+    seed_room(&pool, "R932").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000).await.unwrap();
+
+    let checkin_ctx = cmd("group_checkin", "idem-group-race-checkin");
+    let group = group_lifecycle::group_checkin_idempotent(
+        &pool,
+        None,
+        &checkin_ctx,
+        rich_group_checkin_request(&["R931"], "R931", None),
+    )
+    .await
+    .expect("group check-in succeeds");
+    let group_id = group.response["id"]
+        .as_str()
+        .expect("group id in response")
+        .to_string();
+
+    let booking_id: String =
+        sqlx::query_scalar("SELECT id FROM bookings WHERE group_id = ? LIMIT 1")
+            .bind(&group_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let blocker = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::group_key(&group_id).unwrap()])
+        .await
+        .expect("blocker lock");
+
+    let ctx = cmd("group_checkout", "idem-group-race-checkout");
+    let pool_for_task = pool.clone();
+    let req = GroupCheckoutRequest {
+        group_id: group_id.clone(),
+        booking_ids: vec![booking_id.clone()],
+        final_paid: None,
+    };
+    let command = tokio::spawn(async move {
+        group_lifecycle::group_checkout_idempotent(&pool_for_task, &ctx, req).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !command.is_finished(),
+        "lệnh phải kẹt ở pha 1, chưa được phép đọc phòng của các booking"
+    );
+
+    sqlx::query("UPDATE room_calendar SET room_id = 'R932' WHERE booking_id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE bookings SET room_id = 'R932' WHERE id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'occupied' WHERE id = 'R932'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = 'R931'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    drop(blocker);
+
+    command
+        .await
+        .expect("task joins")
+        .expect("group checkout phải thành công trên phòng mới");
+
+    assert_room_status(&pool, "R932", "cleaning").await;
+}

--- a/mhm/src-tauri/src/services/booking/tests/group_idempotency.rs
+++ b/mhm/src-tauri/src/services/booking/tests/group_idempotency.rs
@@ -883,3 +883,84 @@ async fn group_checkout_idempotent_reads_rooms_after_taking_the_group_lock() {
 
     assert_room_status(&pool, "R932", "cleaning").await;
 }
+
+#[tokio::test]
+async fn group_checkout_idempotent_reads_rooms_after_taking_the_booking_locks() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R941").await.unwrap();
+    seed_room(&pool, "R942").await.unwrap();
+    seed_pricing_rule(&pool, "standard", 500_000).await.unwrap();
+
+    let checkin_ctx = cmd("group_checkin", "idem-group-race2-checkin");
+    let group = group_lifecycle::group_checkin_idempotent(
+        &pool,
+        None,
+        &checkin_ctx,
+        rich_group_checkin_request(&["R941"], "R941", None),
+    )
+    .await
+    .expect("group check-in succeeds");
+    let group_id = group.response["id"]
+        .as_str()
+        .expect("group id in response")
+        .to_string();
+
+    let booking_id: String =
+        sqlx::query_scalar("SELECT id FROM bookings WHERE group_id = ? LIMIT 1")
+            .bind(&group_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    // Chặn bằng khoá BOOKING, không phải khoá group — đúng bộ khoá mà
+    // change_room sẽ cầm. Lệnh phải qua được pha 1 rồi kẹt ở pha 2.
+    let blocker = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key(&booking_id).unwrap()])
+        .await
+        .expect("blocker lock");
+
+    let ctx = cmd("group_checkout", "idem-group-race2-checkout");
+    let pool_for_task = pool.clone();
+    let req = GroupCheckoutRequest {
+        group_id: group_id.clone(),
+        booking_ids: vec![booking_id.clone()],
+        final_paid: None,
+    };
+    let command = tokio::spawn(async move {
+        group_lifecycle::group_checkout_idempotent(&pool_for_task, &ctx, req).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !command.is_finished(),
+        "lệnh phải kẹt ở pha 2, chưa được phép đọc phòng"
+    );
+
+    sqlx::query("UPDATE room_calendar SET room_id = 'R942' WHERE booking_id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE bookings SET room_id = 'R942' WHERE id = ?")
+        .bind(&booking_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'occupied' WHERE id = 'R942'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE rooms SET status = 'vacant' WHERE id = 'R941'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    drop(blocker);
+
+    command
+        .await
+        .expect("task joins")
+        .expect("group checkout phải thành công trên phòng mới");
+
+    assert_room_status(&pool, "R942", "cleaning").await;
+}

--- a/mhm/src-tauri/src/services/booking/tests/reservation_idempotency.rs
+++ b/mhm/src-tauri/src/services/booking/tests/reservation_idempotency.rs
@@ -847,3 +847,53 @@ async fn reservation_command_idempotency_same_plain_key_across_commands_scopes_o
     assert!(origins.contains(&format!("{}:{}", create_ctx.command_name, plain_key)));
     assert!(origins.contains(&format!("{}:{}", cancel_ctx.command_name, plain_key)));
 }
+
+#[tokio::test]
+async fn cancel_reservation_idempotent_reads_the_room_after_taking_the_booking_lock() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R921").await.unwrap();
+    seed_room(&pool, "R922").await.unwrap();
+    seed_booked_reservation(&pool, "B921", "R921")
+        .await
+        .unwrap();
+
+    let blocker = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key("B921").unwrap()])
+        .await
+        .expect("blocker lock");
+
+    let ctx = cmd("cancel_reservation", "idem-cancel-race");
+    let pool_for_task = pool.clone();
+    let command = tokio::spawn(async move {
+        reservation_lifecycle::cancel_reservation_idempotent(&pool_for_task, &ctx, "B921").await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !command.is_finished(),
+        "lệnh phải kẹt ở pha 1, chưa được phép đọc phòng"
+    );
+
+    sqlx::query("UPDATE room_calendar SET room_id = 'R922' WHERE booking_id = 'B921'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE bookings SET room_id = 'R922' WHERE id = 'B921'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    drop(blocker);
+
+    command
+        .await
+        .expect("task joins")
+        .expect("cancel reservation phải thành công trên phòng mới");
+
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = 'B921'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(remaining, 0, "lịch của phòng mới phải được dọn");
+}


### PR DESCRIPTION
Mọi lệnh ghi phạm vi-booking đều đọc `bookings.room_id` **trước** khi lấy khoá, rồi mới dựng bộ khoá từ con số vừa đọc. Giữa hai bước đó, một lệnh khác đang cầm khoá có thể dời booking sang phòng khác — và lệnh này sẽ đi khoá **phòng cũ**, tức là khoá nhầm phòng.

Vấn đề được ghi nhận trong lúc làm `feat/room-change` và hoãn lại có chủ đích: cái sai chỉ dẫn tới một lệnh bị từ chối (các guard CAS trên state cũ bắt được), không dẫn tới hỏng dữ liệu, và sửa đúng thì phải đụng toàn bộ các lệnh ghi chứ không riêng chuyển phòng. Đây là phần sửa đó.

## Cách sửa

Đảo thứ tự thành hai pha: lấy khoá `booking:` (kèm `folio:` nếu lệnh cần) **rồi mới** đọc phòng, rồi mới lấy khoá phòng. Đọc sau khi đã cầm `booking:B` là chân lý, vì mọi lệnh muốn dời booking sang phòng khác đều buộc phải cầm đúng khoá đó.

- `support::lock_booking_and_read_room` gói pha 1 cho các lệnh chỉ cần một khoá phòng.
- `AggregateLockGuard::acquire_next` để người gọi tự ráp pha 2 — `change_room` cần **hai** khoá phòng nên không gói chung được.
- Bộ khoá giờ xếp theo **hạng** thay vì theo thứ tự chữ cái, để thứ tự lấy khoá vẫn nhất quán toàn cục và không sinh deadlock khi lấy làm nhiều pha.

Áp cho: extend-stay, check-out, huỷ/xác nhận/sửa đặt phòng, và group checkout (cả khoá theo group lẫn khoá từng booking).

Có một commit docs ghi rõ những chỗ **cố ý không** dùng hai pha, để lần sau không ai tưởng là bỏ sót.

## Ghi chú khi rebase

Nhánh này nằm trong `main` local (chưa đẩy) từ trước khi `feat/room-change` merge. Đã rebase lên `origin/main` hiện tại; hai xung đột ở `support.rs` và `stay_lifecycle.rs` đều là **hai bên thêm thứ khác nhau vào cùng chỗ**, không phải sửa chồng lên nhau, nên giữ cả hai: `merge_pricing_snapshot` / `room_calendar_stays_tx` của room-change đứng cạnh `FolioLock` / `lock_booking_and_read_room` của nhánh này.

## Đã kiểm chứng

`cargo test` 1064 · `npx vitest run` 574 · `cargo fmt --check` sạch · `npx tsc --noEmit` sạch · `cargo clippy --all-targets -- -D warnings` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)