### PR TITLE
docs: list the cargo fmt gate contributors are told to skip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,11 @@ If you changed Rust code, also run:
 
 ```bash
 cargo clippy --all-targets -- -D warnings
+cargo fmt -- --check
 ```
+
+CI gates every command in this section, `cargo fmt` included. A branch that skips
+the format check locally fails the build even when every test passes.
 
 If you touched a core PMS lifecycle — reservations, stays, groups, or backup — run the smoke gate from `mhm/`:
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,10 @@ npm run build
 cargo check --manifest-path src-tauri/Cargo.toml
 cargo test --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
 ```
+
+Every command above is a hard CI gate, `cargo fmt` included — skipping the format check locally means a red build on a PR that otherwise passes.
 
 The repository also ships scripted verification gates. `verify:full` is the smoke gate the release checklist expects to pass before a tag is pushed; it runs the quick wave, the frontend suite, booking and backup scenario tests, and a native Tauri startup smoke against an isolated runtime root.
 
@@ -298,7 +301,7 @@ Short checklist:
 1. Fork the repository
 2. Create a branch from `main`
 3. Keep commit messages in Conventional Commits format
-4. Re-run `npm test`, `npm run build`, `cargo check`, `cargo test`, and `cargo clippy`
+4. Re-run `npm test`, `npm run build`, `cargo check`, `cargo test`, `cargo clippy`, and `cargo fmt -- --check`
 5. Open a pull request with scope and verification notes
 
 ## License

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -19,7 +19,10 @@ npm run build
 cargo check --manifest-path src-tauri/Cargo.toml
 cargo test --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
 ```
+
+These are the same commands the CI `build-test` job runs, in the same order.
 
 Expected: every command passes without requiring Telegram, OpenAI, MCP, gateway, watcher, or agent configuration.
 


### PR DESCRIPTION
## Problem

CI's `build-test` job runs six verification commands:

```
npm test
npm run build
cargo check
cargo test
cargo clippy --all-targets -- -D warnings
cargo fmt -- --check
```

Four documented lists stopped at the fifth:

| Location | Missing |
| --- | --- |
| `README.md` — Verification block | `cargo fmt` |
| `README.md` — contributing short checklist | `cargo fmt` |
| `CONTRIBUTING.md` — Verification | `cargo fmt` |
| `docs/release-checklist.md` — Baseline validation | `cargo fmt` |

A contributor who follows any of these runs every test, sees green, opens a PR, and gets a red build on formatting alone. The failure reads as a broken build rather than an unrun command — which is exactly the expensive way to discover a gate.

`CLAUDE.md` and `mhm/src-tauri/CLAUDE.md` already listed `cargo fmt` correctly; only the contributor-facing and release-facing docs were short.

## Changes

- Added `cargo fmt -- --check` to all four lists
- Stated explicitly in each place that it is CI-gated, so the next person doesn't have to infer it from a failure
- Release checklist now says its block matches the CI `build-test` job's commands and order — which it now does

## Verification

Markdown only — `git diff --name-only` returns nothing outside `*.md`.

Ran the newly documented command to confirm the `--manifest-path` form is valid before shipping it:

```
$ cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
EXIT=0
```

Command list and ordering checked against `.github/workflows/ci.yml` on `main` (`2f25394`) rather than from memory.

I first wrote "all five are hard CI gates" in each blurb and caught it before pushing — those blocks list six commands, not five. The text now avoids a count rather than asserting a wrong one.

## Scope note

Deliberately excludes the `feat(room-change)` README entry that #205 warrants. That bullet belongs in the same "Front-desk operations" list #203 is already rewriting, and adding it here would guarantee a conflict between the two PRs. It goes on #203 instead, which also owns the `CHANGELOG` `Unreleased` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)