### PR TITLE
feat(rooms): rút đêm, sửa giá và ghi chú ngay trong khung phòng

### DIFF
--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -45,6 +45,7 @@ pub fn command_recovery_risk_level(command_name: &str) -> RecoveryRiskLevel {
         | "confirm_reservation"
         | "check_in"
         | "extend_stay"
+        | "shorten_stay"
         | "group_checkin"
         | "group_checkout"
         | "generate_invoice"

--- a/mhm/src-tauri/src/command_recovery.rs
+++ b/mhm/src-tauri/src/command_recovery.rs
@@ -46,6 +46,7 @@ pub fn command_recovery_risk_level(command_name: &str) -> RecoveryRiskLevel {
         | "check_in"
         | "extend_stay"
         | "shorten_stay"
+        | "set_booking_rate"
         | "group_checkin"
         | "group_checkout"
         | "generate_invoice"

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -497,6 +497,24 @@ pub async fn set_booking_rate(
     Ok(booking)
 }
 
+// ─── Update Booking Notes ───
+
+#[tauri::command]
+pub async fn update_booking_notes(
+    state: State<'_, AppState>,
+    booking_id: String,
+    notes: Option<String>,
+    app: tauri::AppHandle,
+) -> CommandResult<Booking> {
+    let booking = stay_lifecycle::update_booking_notes(&state.db, &booking_id, notes)
+        .await
+        .map_err(stay_lifecycle::map_extend_stay_command_error)?;
+
+    emit_db_update(&app, "rooms");
+
+    Ok(booking)
+}
+
 // ─── Housekeeping Commands ───
 
 #[tauri::command]

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -499,6 +499,10 @@ pub async fn set_booking_rate(
 
 // ─── Update Booking Notes ───
 
+fn require_update_booking_notes_actor_id(user_id: Option<String>) -> CommandResult<String> {
+    user_id.ok_or_else(|| CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập"))
+}
+
 #[tauri::command]
 pub async fn update_booking_notes(
     state: State<'_, AppState>,
@@ -506,9 +510,24 @@ pub async fn update_booking_notes(
     notes: Option<String>,
     app: tauri::AppHandle,
 ) -> CommandResult<Booking> {
-    let booking = stay_lifecycle::update_booking_notes(&state.db, &booking_id, notes)
-        .await
-        .map_err(stay_lifecycle::map_extend_stay_command_error)?;
+    let actor_id = require_update_booking_notes_actor_id(get_user_id(&state))?;
+    let mut write_command_context = WriteCommandContext::new_internal("update_booking_notes");
+    write_command_context.actor_id = Some(actor_id);
+
+    let result = stay_lifecycle::update_booking_notes_idempotent(
+        &state.db,
+        &write_command_context,
+        &booking_id,
+        notes,
+    )
+    .await?;
+    let booking: Booking = serde_json::from_value(result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid update_booking_notes idempotent response: {error}"),
+        )
+        .with_request_id(write_command_context.request_id.clone())
+    })?;
 
     emit_db_update(&app, "rooms");
 
@@ -640,8 +659,8 @@ pub async fn scan_image(path: String) -> Result<crate::ocr::CccdInfo, String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        check_in_failure_context, check_out_failure_context, should_request_checkout_backup,
-        validate_create_expense_request,
+        check_in_failure_context, check_out_failure_context, require_update_booking_notes_actor_id,
+        should_request_checkout_backup, validate_create_expense_request,
     };
     use crate::app_error::{
         codes, correlation_context, log_system_error, record_command_failure_with_db_group,
@@ -670,6 +689,21 @@ mod tests {
             Some(value) => std::env::set_var("CAPYINN_RUNTIME_ROOT", value),
             None => std::env::remove_var("CAPYINN_RUNTIME_ROOT"),
         }
+    }
+
+    #[test]
+    fn update_booking_notes_requires_authenticated_actor() {
+        let error = require_update_booking_notes_actor_id(None).expect_err("missing user rejects");
+
+        assert_eq!(error.code, codes::AUTH_NOT_AUTHENTICATED);
+    }
+
+    #[test]
+    fn update_booking_notes_accepts_authenticated_actor() {
+        let actor_id = require_update_booking_notes_actor_id(Some("user-1".to_string()))
+            .expect("authenticated user is accepted");
+
+        assert_eq!(actor_id, "user-1");
     }
 
     #[test]

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -76,6 +76,13 @@ fn extend_stay_failure_context(booking_id: &str) -> Value {
     })
 }
 
+fn shorten_stay_failure_context(booking_id: &str) -> Value {
+    json!({
+        "booking_id": booking_id,
+        "operation": "remove_one_night",
+    })
+}
+
 fn should_request_checkout_backup(replayed: bool) -> bool {
     !replayed
 }
@@ -352,6 +359,65 @@ pub async fn extend_stay(
 
     log::info!(
         "extend_stay success correlation_id={} source={:?} booking_id={} room_id={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        booking.id,
+        booking.room_id
+    );
+
+    emit_db_update(&app, "rooms");
+
+    Ok(booking)
+}
+
+// ─── Shorten Stay ───
+
+#[tauri::command]
+pub async fn shorten_stay(
+    state: State<'_, AppState>,
+    booking_id: String,
+    app: tauri::AppHandle,
+    correlation_id: Option<String>,
+    idempotency_key: String,
+) -> CommandResult<Booking> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let error_context = shorten_stay_failure_context(&booking_id);
+    let actor_id = get_user_id(&state)
+        .ok_or_else(|| CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập"))?;
+    let mut write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "shorten_stay",
+    )?;
+    write_command_context.actor_id = Some(actor_id);
+    log::info!(
+        "shorten_stay start correlation_id={} source={:?} booking_id={}",
+        effective_correlation_id.value,
+        effective_correlation_id.source,
+        booking_id
+    );
+    let result =
+        stay_lifecycle::shorten_stay_idempotent(&state.db, &write_command_context, &booking_id)
+            .await
+            .inspect_err(|command_error| {
+                record_command_failure_with_db_group(
+                    "shorten_stay",
+                    command_error,
+                    &effective_correlation_id.value,
+                    None,
+                    error_context.clone(),
+                );
+            })?;
+    let booking: Booking = serde_json::from_value(result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid shorten_stay idempotent response: {error}"),
+        )
+        .with_request_id(write_command_context.request_id.clone())
+    })?;
+
+    log::info!(
+        "shorten_stay success correlation_id={} source={:?} booking_id={} room_id={}",
         effective_correlation_id.value,
         effective_correlation_id.source,
         booking.id,

--- a/mhm/src-tauri/src/commands/rooms.rs
+++ b/mhm/src-tauri/src/commands/rooms.rs
@@ -429,6 +429,74 @@ pub async fn shorten_stay(
     Ok(booking)
 }
 
+// ─── Set Booking Rate ───
+
+fn set_booking_rate_failure_context(booking_id: &str) -> Value {
+    json!({
+        "booking_id": booking_id,
+        "operation": "set_booking_rate",
+    })
+}
+
+#[tauri::command]
+pub async fn set_booking_rate(
+    state: State<'_, AppState>,
+    booking_id: String,
+    rate_per_night: i64,
+    app: tauri::AppHandle,
+    correlation_id: Option<String>,
+    idempotency_key: String,
+) -> CommandResult<Booking> {
+    let effective_correlation_id = normalize_correlation_id(correlation_id);
+    let error_context = set_booking_rate_failure_context(&booking_id);
+    let actor_id = get_user_id(&state)
+        .ok_or_else(|| CommandError::user(codes::AUTH_NOT_AUTHENTICATED, "Chưa đăng nhập"))?;
+    let mut write_command_context = WriteCommandContext::for_scoped_command(
+        effective_correlation_id.value.clone(),
+        idempotency_key,
+        "set_booking_rate",
+    )?;
+    write_command_context.actor_id = Some(actor_id);
+    log::info!(
+        "set_booking_rate start correlation_id={} booking_id={}",
+        effective_correlation_id.value,
+        booking_id
+    );
+    let result = stay_lifecycle::set_booking_rate_idempotent(
+        &state.db,
+        &write_command_context,
+        &booking_id,
+        rate_per_night,
+    )
+    .await
+    .inspect_err(|command_error| {
+        record_command_failure_with_db_group(
+            "set_booking_rate",
+            command_error,
+            &effective_correlation_id.value,
+            None,
+            error_context.clone(),
+        );
+    })?;
+    let booking: Booking = serde_json::from_value(result.response).map_err(|error| {
+        CommandError::system(
+            codes::SYSTEM_INTERNAL_ERROR,
+            format!("Invalid set_booking_rate idempotent response: {error}"),
+        )
+        .with_request_id(write_command_context.request_id.clone())
+    })?;
+
+    log::info!(
+        "set_booking_rate success correlation_id={} booking_id={}",
+        effective_correlation_id.value,
+        booking.id
+    );
+
+    emit_db_update(&app, "rooms");
+
+    Ok(booking)
+}
+
 // ─── Housekeeping Commands ───
 
 #[tauri::command]

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -145,7 +145,7 @@ async fn ensure_setting_default(
 /// Schema version a database reaches after `run_migrations` finishes on this
 /// build. Bump this together with every new migration block below; the
 /// `migrations_run_to_latest_schema_version` test fails otherwise.
-pub(crate) const LATEST_SCHEMA_VERSION: i32 = 23;
+pub(crate) const LATEST_SCHEMA_VERSION: i32 = 24;
 
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {
     sqlx::query(
@@ -322,9 +322,10 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         core_extensions::migrate_v22_booking_guest_count(pool).await?;
     }
 
-    // -- V23: dấu thời gian đổi giá thủ công trên booking --
-    if current < 23 {
-        core_extensions::migrate_v23_booking_rate_override(pool).await?;
+    // -- V24: dấu thời gian đổi giá thủ công trên booking --
+    // (v23 đã bị nhánh kbtt chiếm — xem migrate_v24_booking_rate_override)
+    if current < 24 {
+        core_extensions::migrate_v24_booking_rate_override(pool).await?;
     }
     Ok(())
 }
@@ -877,7 +878,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -898,7 +899,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1186,7 +1187,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1253,7 +1254,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1333,7 +1334,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1373,7 +1374,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1391,7 +1392,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1421,7 +1422,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1434,7 +1435,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1467,7 +1468,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
@@ -1491,11 +1492,11 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]
-    async fn migration_v23_leaves_existing_bookings_with_a_null_rate_override() {
+    async fn migration_v24_leaves_existing_bookings_with_a_null_rate_override() {
         let pool = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("connects in-memory sqlite");
@@ -1530,14 +1531,14 @@ mod tests {
         .await
         .expect("seeds booking");
 
-        // Giả lập DB thật đang ở v22, chưa từng thấy migration v23 — rồi cho
+        // Giả lập DB thật đang ở v23, chưa từng thấy migration v24 — rồi cho
         // chạy lại migrations như lúc app khởi động với bản build mới.
-        sqlx::query("UPDATE schema_version SET version = 22")
+        sqlx::query("UPDATE schema_version SET version = 23")
             .execute(&pool)
             .await
             .expect("rewinds schema version");
 
-        run_migrations(&pool).await.expect("v23 migration runs against a populated database");
+        run_migrations(&pool).await.expect("v24 migration runs against a populated database");
 
         let rate_overridden_at: Option<String> =
             sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = 'B23'")
@@ -1550,7 +1551,96 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, 24);
+    }
+
+    /// Migration test trên hoạt động bằng cách rewind `schema_version` SAU KHI
+    /// `run_migrations` đã tạo sẵn cột `rate_overridden_at` — nên ALTER TABLE
+    /// ở lần chạy lại luôn đụng "duplicate column" và bị `execute_compat_alter`
+    /// nuốt lỗi. Nó không bao giờ chạy đường ALTER thật, nên không phát hiện
+    /// được lỗi va số hiệu schema_version như production build này từng gặp:
+    /// nếu `migrate_v24_booking_rate_override` không chạy (vì gate sai số,
+    /// hoặc số hiệu 24 đã bị migration khác chiếm mất), test rewind vẫn xanh
+    /// vì cột đã có sẵn từ trước.
+    ///
+    /// Test này dựng một DB thật sự chưa từng thấy cột `rate_overridden_at`
+    /// (DROP COLUMN sau khi migrate lên latest, rồi rewind `schema_version`
+    /// về 23) trước khi seed dữ liệu và chạy lại `run_migrations` — buộc
+    /// `execute_compat_alter` phải đi qua nhánh ALTER thật, không phải nhánh
+    /// nuốt lỗi duplicate-column.
+    #[tokio::test]
+    async fn migration_v24_alter_actually_runs_on_a_genuinely_pre_v24_database() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+
+        run_migrations(&pool).await.expect("runs migrations to latest");
+
+        // Xoá cột mà v24 tạo ra, để mô phỏng trung thực một DB thật sự chưa
+        // từng chạy qua migrate_v24_booking_rate_override — chứ không chỉ
+        // giả vờ bằng cách rewind schema_version trong khi cột vẫn còn đó.
+        sqlx::query("ALTER TABLE bookings DROP COLUMN rate_overridden_at")
+            .execute(&pool)
+            .await
+            .expect("drops rate_overridden_at to simulate a pre-v24 database");
+
+        sqlx::query(
+            "INSERT INTO rooms (
+                id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status
+             ) VALUES ('R24', 'Room R24', 'standard', 1, 0, 250000, 2, 0, 'vacant')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds room");
+        sqlx::query(
+            "INSERT INTO guests (id, guest_type, full_name, doc_number, created_at)
+             VALUES ('G24', 'domestic', 'Existing Guest', 'DOC24', '2026-04-30T08:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds guest");
+        sqlx::query(
+            "INSERT INTO bookings (
+                id, room_id, primary_guest_id, check_in_at, expected_checkout,
+                nights, total_price, status, created_at
+             ) VALUES ('B24', 'R24', 'G24', '2026-04-30', '2026-05-01', 1, 250000, 'active', '2026-04-30T08:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds booking");
+
+        sqlx::query("UPDATE schema_version SET version = 23")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version to a genuinely pre-v24 state");
+
+        run_migrations(&pool)
+            .await
+            .expect("v24 migration adds the column back via a real ALTER TABLE");
+
+        let column_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM pragma_table_info('bookings') WHERE name = 'rate_overridden_at'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("reads pragma_table_info");
+        assert_eq!(
+            column_count, 1,
+            "ALTER TABLE thật phải chạy và tạo lại cột rate_overridden_at"
+        );
+
+        let rate_overridden_at: Option<String> =
+            sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = 'B24'")
+                .fetch_one(&pool)
+                .await
+                .expect("reads rate_overridden_at");
+        assert_eq!(
+            rate_overridden_at, None,
+            "cột mới thêm phải backfill NULL cho booking có sẵn, không suy diễn đã đổi giá tay"
+        );
+
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 24);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -145,7 +145,20 @@ async fn ensure_setting_default(
 /// Schema version a database reaches after `run_migrations` finishes on this
 /// build. Bump this together with every new migration block below; the
 /// `migrations_run_to_latest_schema_version` test fails otherwise.
-pub(crate) const LATEST_SCHEMA_VERSION: i32 = 24;
+///
+/// 23 thuộc `design/kbtt-ux-simplify`, 25 thuộc `feat/room-change` — cả hai đã
+/// cài lên máy thật, nên DB của khách sạn đang đọc **25**. Nhánh này từng ở 24
+/// và như thế là chết: cổng là `if current < N`, `25 < 24` sai nên migration
+/// **im lặng không bao giờ chạy**, rồi mọi câu lệnh gọi `rate_overridden_at`
+/// hỏng lúc chạy — đúng lỗi commit 4c5c1c3 đã sửa một lần. Số phải nằm **trên**
+/// mọi số đã phát hành, không phải số kế tiếp trên nhánh của mình.
+///
+/// Trước khi merge, rà lại lần nữa — số đã phát hành có thể đã đi tiếp:
+///   git for-each-ref --format='%(refname:short)' | while read r; do \
+///     printf '%s: ' "$r"; git show "$r:mhm/src-tauri/src/db.rs" 2>/dev/null \
+///     | grep -m1 LATEST_SCHEMA_VERSION; done
+///   sqlite3 "file:$HOME/CapyInn/capyinn.db?immutable=1" "SELECT MAX(version) FROM schema_version"
+pub(crate) const LATEST_SCHEMA_VERSION: i32 = 26;
 
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {
     sqlx::query(
@@ -322,10 +335,10 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
         core_extensions::migrate_v22_booking_guest_count(pool).await?;
     }
 
-    // -- V24: dấu thời gian đổi giá thủ công trên booking --
-    // (v23 đã bị nhánh kbtt chiếm — xem migrate_v24_booking_rate_override)
-    if current < 24 {
-        core_extensions::migrate_v24_booking_rate_override(pool).await?;
+    // -- V26: dấu thời gian đổi giá thủ công trên booking --
+    // (23 của nhánh kbtt, 25 của feat/room-change — cả hai đã phát hành)
+    if current < 26 {
+        core_extensions::migrate_v26_booking_rate_override(pool).await?;
     }
     Ok(())
 }
@@ -878,7 +891,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -899,7 +912,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1187,7 +1200,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1254,7 +1267,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1334,7 +1347,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1374,7 +1387,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1392,7 +1405,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1422,7 +1435,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1435,7 +1448,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1468,7 +1481,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
@@ -1492,11 +1505,11 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]
-    async fn migration_v24_leaves_existing_bookings_with_a_null_rate_override() {
+    async fn migration_v26_leaves_existing_bookings_with_a_null_rate_override() {
         let pool = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("connects in-memory sqlite");
@@ -1531,14 +1544,16 @@ mod tests {
         .await
         .expect("seeds booking");
 
-        // Giả lập DB thật đang ở v23, chưa từng thấy migration v24 — rồi cho
+        // Giả lập DB thật đang ở v23, chưa từng thấy migration v26 — rồi cho
         // chạy lại migrations như lúc app khởi động với bản build mới.
         sqlx::query("UPDATE schema_version SET version = 23")
             .execute(&pool)
             .await
             .expect("rewinds schema version");
 
-        run_migrations(&pool).await.expect("v24 migration runs against a populated database");
+        run_migrations(&pool)
+            .await
+            .expect("v26 migration runs against a populated database");
 
         let rate_overridden_at: Option<String> =
             sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = 'B23'")
@@ -1551,7 +1566,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     /// Migration test trên hoạt động bằng cách rewind `schema_version` SAU KHI
@@ -1559,7 +1574,7 @@ mod tests {
     /// ở lần chạy lại luôn đụng "duplicate column" và bị `execute_compat_alter`
     /// nuốt lỗi. Nó không bao giờ chạy đường ALTER thật, nên không phát hiện
     /// được lỗi va số hiệu schema_version như production build này từng gặp:
-    /// nếu `migrate_v24_booking_rate_override` không chạy (vì gate sai số,
+    /// nếu `migrate_v26_booking_rate_override` không chạy (vì gate sai số,
     /// hoặc số hiệu 24 đã bị migration khác chiếm mất), test rewind vẫn xanh
     /// vì cột đã có sẵn từ trước.
     ///
@@ -1569,20 +1584,22 @@ mod tests {
     /// `execute_compat_alter` phải đi qua nhánh ALTER thật, không phải nhánh
     /// nuốt lỗi duplicate-column.
     #[tokio::test]
-    async fn migration_v24_alter_actually_runs_on_a_genuinely_pre_v24_database() {
+    async fn migration_v26_alter_actually_runs_on_a_genuinely_pre_v26_database() {
         let pool = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("connects in-memory sqlite");
 
-        run_migrations(&pool).await.expect("runs migrations to latest");
+        run_migrations(&pool)
+            .await
+            .expect("runs migrations to latest");
 
-        // Xoá cột mà v24 tạo ra, để mô phỏng trung thực một DB thật sự chưa
-        // từng chạy qua migrate_v24_booking_rate_override — chứ không chỉ
+        // Xoá cột mà v26 tạo ra, để mô phỏng trung thực một DB thật sự chưa
+        // từng chạy qua migrate_v26_booking_rate_override — chứ không chỉ
         // giả vờ bằng cách rewind schema_version trong khi cột vẫn còn đó.
         sqlx::query("ALTER TABLE bookings DROP COLUMN rate_overridden_at")
             .execute(&pool)
             .await
-            .expect("drops rate_overridden_at to simulate a pre-v24 database");
+            .expect("drops rate_overridden_at to simulate a pre-v26 database");
 
         sqlx::query(
             "INSERT INTO rooms (
@@ -1612,11 +1629,11 @@ mod tests {
         sqlx::query("UPDATE schema_version SET version = 23")
             .execute(&pool)
             .await
-            .expect("rewinds schema version to a genuinely pre-v24 state");
+            .expect("rewinds schema version to a genuinely pre-v26 state");
 
         run_migrations(&pool)
             .await
-            .expect("v24 migration adds the column back via a real ALTER TABLE");
+            .expect("v26 migration adds the column back via a real ALTER TABLE");
 
         let column_count = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM pragma_table_info('bookings') WHERE name = 'rate_overridden_at'",
@@ -1640,7 +1657,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 24);
+        assert_eq!(version, 26);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db.rs
+++ b/mhm/src-tauri/src/db.rs
@@ -145,7 +145,7 @@ async fn ensure_setting_default(
 /// Schema version a database reaches after `run_migrations` finishes on this
 /// build. Bump this together with every new migration block below; the
 /// `migrations_run_to_latest_schema_version` test fails otherwise.
-pub(crate) const LATEST_SCHEMA_VERSION: i32 = 22;
+pub(crate) const LATEST_SCHEMA_VERSION: i32 = 23;
 
 async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32, sqlx::Error> {
     sqlx::query(
@@ -320,6 +320,11 @@ pub(crate) async fn run_migrations(pool: &Pool<Sqlite>) -> Result<(), sqlx::Erro
     // -- V22: số khách trên booking, để tính phụ thu thêm người --
     if current < 22 {
         core_extensions::migrate_v22_booking_guest_count(pool).await?;
+    }
+
+    // -- V23: dấu thời gian đổi giá thủ công trên booking --
+    if current < 23 {
+        core_extensions::migrate_v23_booking_rate_override(pool).await?;
     }
     Ok(())
 }
@@ -872,7 +877,7 @@ mod tests {
             .await
             .expect("reads final schema version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
 
         assert_table_group_exists(&pool, "PMS core", PMS_CORE_TABLES).await;
         assert_table_group_exists(&pool, "command safety", COMMAND_SAFETY_TABLES).await;
@@ -893,7 +898,7 @@ mod tests {
             .expect("reads version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
         assert_money_columns_are_integer(&pool).await;
     }
 
@@ -1181,7 +1186,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1248,7 +1253,7 @@ mod tests {
             .expect("reads final schema version")
             .get("version");
 
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1328,7 +1333,7 @@ mod tests {
         );
 
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1368,7 +1373,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1386,7 +1391,7 @@ mod tests {
 
         assert_outbox_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1416,7 +1421,7 @@ mod tests {
             1
         );
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1429,7 +1434,7 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1462,7 +1467,7 @@ mod tests {
 
         assert_agent_digest_runs_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]
@@ -1486,7 +1491,66 @@ mod tests {
 
         assert_agent_safety_shape(&pool).await;
         let version = get_schema_version(&pool).await.expect("schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
+    }
+
+    #[tokio::test]
+    async fn migration_v23_leaves_existing_bookings_with_a_null_rate_override() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connects in-memory sqlite");
+        // Chạy migrations đầy đủ trước, giống DB thật ở thời điểm bản build
+        // này ra mắt, rồi seed một booking như thể nó đã tồn tại từ trước —
+        // KHÔNG set rate_overridden_at, đúng như dữ liệu thật: booking đó
+        // chưa từng được đổi giá thủ công.
+        run_migrations(&pool).await.expect("runs migrations");
+
+        sqlx::query(
+            "INSERT INTO rooms (
+                id, name, type, floor, has_balcony, base_price, max_guests, extra_person_fee, status
+             ) VALUES ('R23', 'Room R23', 'standard', 1, 0, 250000, 2, 0, 'vacant')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds room");
+        sqlx::query(
+            "INSERT INTO guests (id, guest_type, full_name, doc_number, created_at)
+             VALUES ('G23', 'domestic', 'Existing Guest', 'DOC23', '2026-04-30T08:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds guest");
+        sqlx::query(
+            "INSERT INTO bookings (
+                id, room_id, primary_guest_id, check_in_at, expected_checkout,
+                nights, total_price, status, created_at
+             ) VALUES ('B23', 'R23', 'G23', '2026-04-30', '2026-05-01', 1, 250000, 'active', '2026-04-30T08:00:00+07:00')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seeds booking");
+
+        // Giả lập DB thật đang ở v22, chưa từng thấy migration v23 — rồi cho
+        // chạy lại migrations như lúc app khởi động với bản build mới.
+        sqlx::query("UPDATE schema_version SET version = 22")
+            .execute(&pool)
+            .await
+            .expect("rewinds schema version");
+
+        run_migrations(&pool).await.expect("v23 migration runs against a populated database");
+
+        let rate_overridden_at: Option<String> =
+            sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = 'B23'")
+                .fetch_one(&pool)
+                .await
+                .expect("reads rate_overridden_at");
+        assert_eq!(
+            rate_overridden_at, None,
+            "booking có sẵn trước migration không được suy diễn thành đã bị đổi giá tay"
+        );
+
+        let version = get_schema_version(&pool).await.expect("schema version");
+        assert_eq!(version, 23);
     }
 
     #[tokio::test]

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -145,3 +145,27 @@ pub(super) async fn migrate_v22_booking_guest_count(
     tx.commit().await?;
     Ok(())
 }
+
+/// Thời điểm gần nhất giá/đêm của booking bị lễ tân đổi tay qua
+/// `set_booking_rate`. NULL nghĩa là booking chưa từng bị đổi giá thủ công —
+/// tổng tiền của nó vẫn là giá được tính bình thường từ pricing engine.
+///
+/// Cho phép NULL, không có default: booking có sẵn trong DB trước migration
+/// này chưa từng được đổi giá thủ công (tính năng đổi giá chưa tồn tại), nên
+/// coi chúng là "chưa từng override" là đúng thực tế — không có default nào
+/// khác an toàn hơn NULL ở đây.
+pub(super) async fn migrate_v23_booking_rate_override(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    execute_compat_alter(
+        &mut tx,
+        "ALTER TABLE bookings ADD COLUMN rate_overridden_at TEXT",
+    )
+    .await?;
+
+    set_schema_version(&mut tx, 23).await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -184,7 +184,11 @@ pub(super) async fn migrate_v26_booking_rate_override(
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
-    execute_compat_alter(&mut tx, "ALTER TABLE bookings ADD COLUMN rate_overridden_at TEXT").await?;
+    execute_compat_alter(
+        &mut tx,
+        "ALTER TABLE bookings ADD COLUMN rate_overridden_at TEXT",
+    )
+    .await?;
 
     set_schema_version(&mut tx, 26).await?;
     tx.commit().await?;

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -154,7 +154,7 @@ pub(super) async fn migrate_v22_booking_guest_count(
 /// này chưa từng được đổi giá thủ công (tính năng đổi giá chưa tồn tại), nên
 /// coi chúng là "chưa từng override" là đúng thực tế — không có default nào
 /// khác an toàn hơn NULL ở đây.
-pub(super) async fn migrate_v24_booking_rate_override(
+pub(super) async fn migrate_v26_booking_rate_override(
     pool: &Pool<Sqlite>,
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
@@ -165,7 +165,7 @@ pub(super) async fn migrate_v24_booking_rate_override(
     )
     .await?;
 
-    set_schema_version(&mut tx, 24).await?;
+    set_schema_version(&mut tx, 26).await?;
     tx.commit().await?;
     Ok(())
 }

--- a/mhm/src-tauri/src/db/core_extensions.rs
+++ b/mhm/src-tauri/src/db/core_extensions.rs
@@ -154,7 +154,7 @@ pub(super) async fn migrate_v22_booking_guest_count(
 /// này chưa từng được đổi giá thủ công (tính năng đổi giá chưa tồn tại), nên
 /// coi chúng là "chưa từng override" là đúng thực tế — không có default nào
 /// khác an toàn hơn NULL ở đây.
-pub(super) async fn migrate_v23_booking_rate_override(
+pub(super) async fn migrate_v24_booking_rate_override(
     pool: &Pool<Sqlite>,
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
@@ -165,7 +165,7 @@ pub(super) async fn migrate_v23_booking_rate_override(
     )
     .await?;
 
-    set_schema_version(&mut tx, 23).await?;
+    set_schema_version(&mut tx, 24).await?;
     tx.commit().await?;
     Ok(())
 }

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -429,7 +429,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .expect("reads schema version");
-        assert_eq!(version, 22);
+        assert_eq!(version, 23);
     }
 
     /// Khách tới trước khi có booking: phải khai báo được ngay, không phải chờ

--- a/mhm/src-tauri/src/db/declaration.rs
+++ b/mhm/src-tauri/src/db/declaration.rs
@@ -429,7 +429,7 @@ mod tests {
             .fetch_one(&pool)
             .await
             .expect("reads schema version");
-        assert_eq!(version, 23);
+        assert_eq!(version, crate::db::LATEST_SCHEMA_VERSION);
     }
 
     /// Khách tới trước khi có booking: phải khai báo được ngay, không phải chờ

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -326,6 +326,7 @@ pub fn run() {
             commands::rooms::preview_checkout_settlement,
             commands::rooms::extend_stay,
             commands::rooms::shorten_stay,
+            commands::rooms::set_booking_rate,
             commands::rooms::get_housekeeping_tasks,
             commands::rooms::update_housekeeping,
             commands::rooms::create_expense,

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -325,6 +325,7 @@ pub fn run() {
             commands::rooms::check_out,
             commands::rooms::preview_checkout_settlement,
             commands::rooms::extend_stay,
+            commands::rooms::shorten_stay,
             commands::rooms::get_housekeeping_tasks,
             commands::rooms::update_housekeeping,
             commands::rooms::create_expense,

--- a/mhm/src-tauri/src/lib.rs
+++ b/mhm/src-tauri/src/lib.rs
@@ -327,6 +327,7 @@ pub fn run() {
             commands::rooms::extend_stay,
             commands::rooms::shorten_stay,
             commands::rooms::set_booking_rate,
+            commands::rooms::update_booking_notes,
             commands::rooms::get_housekeeping_tasks,
             commands::rooms::update_housekeeping,
             commands::rooms::create_expense,

--- a/mhm/src-tauri/src/models.rs
+++ b/mhm/src-tauri/src/models.rs
@@ -150,6 +150,9 @@ pub struct Booking {
     pub source: Option<String>,
     pub notes: Option<String>,
     pub created_at: String,
+    /// Thời điểm gần nhất giá/đêm bị đổi tay qua `set_booking_rate`. `None`
+    /// nghĩa là tổng tiền vẫn là giá tính bình thường từ pricing engine.
+    pub rate_overridden_at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -756,6 +759,7 @@ mod tests {
             source: None,
             notes: None,
             created_at: "2026-04-30T14:00:00+07:00".to_string(),
+            rate_overridden_at: None,
         };
 
         assert_money_vnd(booking.total_price);

--- a/mhm/src-tauri/src/pricing.rs
+++ b/mhm/src-tauri/src/pricing.rs
@@ -479,12 +479,6 @@ pub(crate) fn checked_add_money(a: MoneyVnd, b: MoneyVnd, field: &str) -> Result
 /// See `checked_mul_money` — same reasoning. `shorten_stay` needs the mirror of
 /// `checked_add_money` so a removed night goes through the same transport-safe
 /// guard as the night that added it.
-///
-/// `#[allow(dead_code)]`: only `shorten_stay_tx` calls this so far, and that
-/// function is itself only reachable from the `#[cfg(test)]` wrapper until the
-/// Tauri command wrapper lands in a later task. Remove once that wrapper wires
-/// a non-test caller.
-#[allow(dead_code)]
 pub(crate) fn checked_sub_money(a: MoneyVnd, b: MoneyVnd, field: &str) -> Result<MoneyVnd, String> {
     let value = a
         .checked_sub(b)

--- a/mhm/src-tauri/src/pricing.rs
+++ b/mhm/src-tauri/src/pricing.rs
@@ -476,6 +476,22 @@ pub(crate) fn checked_add_money(a: MoneyVnd, b: MoneyVnd, field: &str) -> Result
     validate_transport_money_vnd(value, field).map_err(|error| error.message)
 }
 
+/// See `checked_mul_money` — same reasoning. `shorten_stay` needs the mirror of
+/// `checked_add_money` so a removed night goes through the same transport-safe
+/// guard as the night that added it.
+///
+/// `#[allow(dead_code)]`: only `shorten_stay_tx` calls this so far, and that
+/// function is itself only reachable from the `#[cfg(test)]` wrapper until the
+/// Tauri command wrapper lands in a later task. Remove once that wrapper wires
+/// a non-test caller.
+#[allow(dead_code)]
+pub(crate) fn checked_sub_money(a: MoneyVnd, b: MoneyVnd, field: &str) -> Result<MoneyVnd, String> {
+    let value = a
+        .checked_sub(b)
+        .ok_or_else(|| format!("{field} overflowed"))?;
+    validate_transport_money_vnd(value, field).map_err(|error| error.message)
+}
+
 fn sum_lines(lines: &[PricingLine], field: &str) -> Result<MoneyVnd, String> {
     lines.iter().try_fold(0, |total, line| {
         checked_add_money(total, line.amount, field)

--- a/mhm/src-tauri/src/queries/booking/room_queries.rs
+++ b/mhm/src-tauri/src/queries/booking/room_queries.rs
@@ -27,7 +27,7 @@ pub async fn load_room_detail(
     let room = map_room(&row);
 
     let booking = sqlx::query(
-        "SELECT id, room_id, primary_guest_id, check_in_at, expected_checkout, actual_checkout, nights, total_price, paid_amount, status, source, notes, created_at
+        "SELECT id, room_id, primary_guest_id, check_in_at, expected_checkout, actual_checkout, nights, total_price, paid_amount, status, source, notes, created_at, rate_overridden_at
          FROM bookings WHERE room_id = ? AND status = 'active' LIMIT 1"
     )
     .bind(room_id)
@@ -228,6 +228,7 @@ fn map_booking(row: &SqliteRow) -> Booking {
         source: row.get("source"),
         notes: row.get("notes"),
         created_at: row.get("created_at"),
+        rate_overridden_at: row.get("rate_overridden_at"),
     }
 }
 

--- a/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/reservation_lifecycle.rs
@@ -344,7 +344,7 @@ pub async fn fetch_booking_by_id_tx(
     let row = sqlx::query(
         "SELECT id, room_id, primary_guest_id, check_in_at, expected_checkout,
                 actual_checkout, nights, total_price, paid_amount, status,
-                source, notes, created_at
+                source, notes, created_at, rate_overridden_at
          FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
@@ -368,6 +368,7 @@ pub async fn fetch_booking_by_id_tx(
         source: row.get("source"),
         notes: row.get("notes"),
         created_at: row.get("created_at"),
+        rate_overridden_at: row.get("rate_overridden_at"),
     })
 }
 

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -28,11 +28,13 @@ use super::{
     pricing_service::calculate_stay_price_tx,
     support::{
         begin_tx, ensure_one_row_affected, insert_room_calendar_rows, invalid_state_transition,
-        lookup_booking_room_id, map_room_calendar_insert_error, parse_booking_datetime,
-        read_money_vnd_or_zero, validate_non_negative_booking_money,
+        lookup_booking_expected_checkout, lookup_booking_room_id, lookup_booking_total_price,
+        map_room_calendar_insert_error, parse_booking_datetime, read_money_vnd_or_zero,
+        validate_non_negative_booking_money,
     },
 };
 
+#[cfg(test)]
 use super::support::{begin_immediate_tx, fetch_booking};
 
 pub(super) fn mark_write_db_error(error: BookingError) -> BookingError {
@@ -1256,6 +1258,14 @@ pub async fn shorten_stay_idempotent(
     ctx: &WriteCommandContext,
     booking_id: &str,
 ) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    // Đọc `expected_checkout` NGOÀI transaction, trước bất cứ bước khoá/claim
+    // nào — đây là giá trị "trước khi khoá" mà `shorten_stay_tx` sẽ dùng để
+    // chốt optimistic-concurrency guard ở UPDATE cuối cùng. Xem chú thích tại
+    // `lookup_booking_expected_checkout` và bên trong `shorten_stay_tx`.
+    let locked_expected_checkout = lookup_booking_expected_checkout(pool, booking_id)
+        .await
+        .map_err(map_extend_stay_command_error)?;
+
     let hash_payload = build_shorten_stay_hash_payload(booking_id);
     let ledger_intent = SanitizedLedgerIntent::from_pairs([
         ("schema", json!("stay.shorten.v1")),
@@ -1293,6 +1303,7 @@ pub async fn shorten_stay_idempotent(
                         tx,
                         &booking_id_for_service,
                         &guard.room_id,
+                        &locked_expected_checkout,
                         Some(origin_key),
                     )
                     .await
@@ -1310,6 +1321,14 @@ pub async fn set_booking_rate_idempotent(
     booking_id: &str,
     rate_per_night: MoneyVnd,
 ) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    // Đọc `total_price` NGOÀI transaction, trước bất cứ bước khoá/claim nào —
+    // giá trị "trước khi khoá" mà `set_booking_rate_tx` dùng để chốt
+    // optimistic-concurrency guard ở UPDATE cuối cùng. Cùng kỹ thuật với
+    // `shorten_stay_idempotent` phía trên.
+    let locked_total_price = lookup_booking_total_price(pool, booking_id)
+        .await
+        .map_err(map_extend_stay_command_error)?;
+
     let hash_payload = build_set_booking_rate_hash_payload(booking_id, rate_per_night);
     let ledger_intent = SanitizedLedgerIntent::from_pairs([
         ("schema", json!("stay.set_rate.v1")),
@@ -1347,6 +1366,7 @@ pub async fn set_booking_rate_idempotent(
                         tx,
                         &booking_id_for_service,
                         rate_per_night,
+                        locked_total_price,
                         Some(origin_key),
                     )
                     .await
@@ -1390,6 +1410,7 @@ async fn shorten_stay_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,
     locked_room_id: &str,
+    locked_expected_checkout: &str,
     origin_key: Option<String>,
 ) -> BookingResult<Booking> {
     let booking = sqlx::query(
@@ -1406,21 +1427,29 @@ async fn shorten_stay_tx(
 
     let booking_status: String = booking.get("status");
     if booking_status != status::booking::ACTIVE {
-        return Err(invalid_state_transition(format!(
-            "booking {booking_id} is not active for shorten-stay (status: {booking_status})"
-        )));
+        return Err(invalid_state_transition(
+            "Booking không còn đang lưu trú nên không thể rút đêm — vui lòng tải lại trang",
+        ));
     }
 
     let room_id: String = booking.get("room_id");
     ensure_locked_room_matches_booking(
         locked_room_id,
         &room_id,
-        format!("booking {booking_id} changed rooms before shorten-stay"),
+        "Booking đã đổi phòng trước khi rút đêm — vui lòng tải lại trang và thử lại",
     )?;
     let current_nights: i32 = booking.get("nights");
     let current_total = read_money_vnd_or_zero(&booking, "total_price");
     let paid_amount = read_money_vnd_or_zero(&booking, "paid_amount");
     let check_in_at: String = booking.get("check_in_at");
+    // `old_expected_checkout` (đọc lại TRONG transaction này) dùng cho phép tính
+    // ngày tháng bên dưới — luôn phản ánh đúng dữ liệu hiện tại nên phép tính
+    // luôn đúng. `locked_expected_checkout` (tham số, đọc TRƯỚC khi mở
+    // transaction) mới là giá trị đưa vào guard `AND expected_checkout = ?` của
+    // UPDATE cuối hàm: nó chốt lại "cái tôi thấy lúc quyết định rút đêm", nên
+    // nếu một actor khác đổi checkout của booking này giữa lúc đọc trước khoá
+    // và lúc UPDATE thật sự chạy, UPDATE khớp 0 dòng thay vì âm thầm ghi đè lên
+    // một checkout mà lễ tân chưa từng thấy.
     let old_expected_checkout: String = booking.get("expected_checkout");
 
     let old_expected = parse_booking_datetime(&old_expected_checkout)?;
@@ -1505,14 +1534,14 @@ async fn shorten_stay_tx(
     .bind(&new_checkout)
     .bind(booking_id)
     .bind(status::booking::ACTIVE)
-    .bind(&old_expected_checkout)
+    .bind(locked_expected_checkout)
     .execute(&mut **tx)
     .await
     .map_err(BookingError::from)
     .map_err(mark_write_db_error)?;
     ensure_one_row_affected(
         result,
-        format!("booking {booking_id} changed before shorten-stay"),
+        "Booking vừa được cập nhật bởi thao tác khác — vui lòng tải lại trang và thử lại",
     )?;
 
     let calendar_result = sqlx::query(
@@ -1532,7 +1561,7 @@ async fn shorten_stay_tx(
 
     let credit = 0i64
         .checked_sub(removed_total)
-        .ok_or_else(|| BookingError::validation("credit amount overflowed".to_string()))?;
+        .ok_or_else(|| BookingError::validation("Số tiền hoàn vượt giới hạn tính toán".to_string()))?;
 
     if let Some(origin_key) = origin_key {
         let origin = OriginSideEffect::new(origin_key, 0)?;
@@ -1564,6 +1593,7 @@ async fn shorten_stay_tx(
 #[cfg(test)]
 pub async fn shorten_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
     let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
+    let locked_expected_checkout = lookup_booking_expected_checkout(pool, booking_id).await?;
     let _lock_guard = crate::aggregate_locks::global_manager()
         .acquire([
             crate::aggregate_locks::booking_key(booking_id)
@@ -1576,7 +1606,14 @@ pub async fn shorten_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResul
 
     let mut tx = begin_immediate_tx(pool).await?;
 
-    let _booking = shorten_stay_tx(&mut tx, booking_id, &locked_room_id, None).await?;
+    let _booking = shorten_stay_tx(
+        &mut tx,
+        booking_id,
+        &locked_room_id,
+        &locked_expected_checkout,
+        None,
+    )
+    .await?;
 
     tx.commit().await.map_err(BookingError::from)?;
 
@@ -1596,6 +1633,7 @@ async fn set_booking_rate_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,
     rate_per_night: MoneyVnd,
+    locked_total_price: MoneyVnd,
     origin_key: Option<String>,
 ) -> BookingResult<Booking> {
     if rate_per_night <= 0 || rate_per_night > MAX_RATE_PER_NIGHT_VND {
@@ -1616,12 +1654,17 @@ async fn set_booking_rate_tx(
 
     let booking_status: String = booking.get("status");
     if booking_status != status::booking::ACTIVE {
-        return Err(invalid_state_transition(format!(
-            "booking {booking_id} is not active for rate change (status: {booking_status})"
-        )));
+        return Err(invalid_state_transition(
+            "Booking không còn đang lưu trú nên không thể đổi giá — vui lòng tải lại trang",
+        ));
     }
 
     let nights: i32 = booking.get("nights");
+    // `current_total` (đọc lại TRONG transaction này) dùng để tính `new_total`
+    // và khoản charge chênh lệch bên dưới — luôn phản ánh đúng dữ liệu hiện
+    // tại. `locked_total_price` (tham số, đọc TRƯỚC khi mở transaction) mới là
+    // giá trị đưa vào guard `AND total_price = ?` của UPDATE cuối hàm — cùng lý
+    // do với `locked_expected_checkout` ở `shorten_stay_tx`.
     let current_total = read_money_vnd_or_zero(&booking, "total_price");
     let paid_amount = read_money_vnd_or_zero(&booking, "paid_amount");
 
@@ -1666,14 +1709,14 @@ async fn set_booking_rate_tx(
     .bind(&overridden_at)
     .bind(booking_id)
     .bind(status::booking::ACTIVE)
-    .bind(current_total)
+    .bind(locked_total_price)
     .execute(&mut **tx)
     .await
     .map_err(BookingError::from)
     .map_err(mark_write_db_error)?;
     ensure_one_row_affected(
         result,
-        format!("booking {booking_id} changed before rate change"),
+        "Booking vừa được cập nhật bởi thao tác khác — vui lòng tải lại trang và thử lại",
     )?;
 
     let delta = crate::pricing::checked_sub_money(new_total, current_total, "rate_delta")
@@ -1711,6 +1754,7 @@ pub async fn set_booking_rate(
     booking_id: &str,
     rate_per_night: MoneyVnd,
 ) -> BookingResult<Booking> {
+    let locked_total_price = lookup_booking_total_price(pool, booking_id).await?;
     let _lock_guard = crate::aggregate_locks::global_manager()
         .acquire([crate::aggregate_locks::booking_key(booking_id)
             .map_err(|error| BookingError::validation(error.message))?])
@@ -1718,7 +1762,14 @@ pub async fn set_booking_rate(
         .map_err(|error| BookingError::validation(error.message))?;
 
     let mut tx = begin_immediate_tx(pool).await?;
-    let _booking = set_booking_rate_tx(&mut tx, booking_id, rate_per_night, None).await?;
+    let _booking = set_booking_rate_tx(
+        &mut tx,
+        booking_id,
+        rate_per_night,
+        locked_total_price,
+        None,
+    )
+    .await?;
     tx.commit().await.map_err(BookingError::from)?;
 
     fetch_booking(
@@ -1732,13 +1783,7 @@ pub async fn set_booking_rate(
 
 pub const MAX_BOOKING_NOTES_LEN: usize = 2_000;
 
-/// Ghi chú không đụng tiền và không đụng lịch phòng, nên không cần bộ máy
-/// idempotency — theo tiền lệ của `add_folio_line`. Chỉ khoá booking.
-pub async fn update_booking_notes(
-    pool: &Pool<Sqlite>,
-    booking_id: &str,
-    notes: Option<String>,
-) -> BookingResult<Booking> {
+fn validate_and_trim_booking_notes(notes: Option<String>) -> BookingResult<Option<String>> {
     let trimmed = notes
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
@@ -1752,19 +1797,19 @@ pub async fn update_booking_notes(
         }
     }
 
-    let _lock_guard = crate::aggregate_locks::global_manager()
-        .acquire([crate::aggregate_locks::booking_key(booking_id)
-            .map_err(|error| BookingError::validation(error.message))?])
-        .await
-        .map_err(|error| BookingError::validation(error.message))?;
+    Ok(trimmed)
+}
 
-    let mut tx = begin_immediate_tx(pool).await?;
-
+async fn update_booking_notes_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    trimmed_notes: Option<&str>,
+) -> BookingResult<Booking> {
     let result = sqlx::query("UPDATE bookings SET notes = ? WHERE id = ? AND status = ?")
-        .bind(trimmed.as_deref())
+        .bind(trimmed_notes)
         .bind(booking_id)
         .bind(status::booking::ACTIVE)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(BookingError::from)
         .map_err(mark_write_db_error)?;
@@ -1773,15 +1818,101 @@ pub async fn update_booking_notes(
         format!("Không tìm thấy booking đang active {booking_id}"),
     )?;
 
+    fetch_booking_tx(tx, booking_id).await
+}
+
+fn build_update_booking_notes_hash_payload(
+    booking_id: &str,
+    notes_present: bool,
+) -> serde_json::Value {
+    json!({
+        "schema": "stay.update_notes.v1",
+        "booking_id": booking_id,
+        "notes_present": notes_present,
+    })
+}
+
+fn update_booking_notes_lock_keys_from_payload(
+    hash_payload: &serde_json::Value,
+) -> CommandResult<Vec<String>> {
+    let booking_id = hash_payload
+        .get("booking_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| system_error("update-booking-notes lock payload missing booking_id"))?;
+    Ok(vec![crate::aggregate_locks::booking_key(booking_id)?])
+}
+
+/// Ghi chú không đụng tiền và không đụng lịch phòng, nên không cần bộ máy
+/// idempotency đầy đủ (không vào `write_manifest.rs`, không vào
+/// `command_recovery.rs`, không cần idempotency key từ phía gọi) — theo tiền
+/// lệ của `add_folio_line`. Vẫn cần một actor đã đăng nhập và một dòng trong
+/// command ledger, vì ghi chú này in thẳng lên hoá đơn của khách: "Ai đã sửa
+/// ghi chú này?" phải trả lời được mà không cần bảng log riêng.
+/// `WriteCommandContext::new_internal` tự sinh idempotency key nội bộ — phía
+/// gọi (Tauri command) không cần biết tới khái niệm idempotency key.
+pub async fn update_booking_notes_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    booking_id: &str,
+    notes: Option<String>,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let trimmed = validate_and_trim_booking_notes(notes).map_err(|error| {
+        map_extend_stay_command_error(error).with_request_id(ctx.request_id.clone())
+    })?;
+
+    let notes_present = trimmed.is_some();
+    let hash_payload = build_update_booking_notes_hash_payload(booking_id, notes_present);
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("stay.update_notes.v1")),
+        ("booking_present", json!(true)),
+        ("notes_present", json!(notes_present)),
+    ])?;
+    let summary = CommandLedgerSummary::new("Update booking notes")?.with_aggregate_ref(
+        "booking",
+        "booking",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{booking_id}"))
+        .with_lock_key_deriver(update_booking_notes_lock_keys_from_payload)
+        .with_success_summary(CommandLedgerResultSummary::success("Booking notes updated")?);
+
+    let booking_id_for_service = booking_id.to_string();
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_atomic(ctx, request, move |tx| {
+            Box::pin(async move {
+                let booking =
+                    update_booking_notes_tx(tx, &booking_id_for_service, trimmed.as_deref())
+                        .await
+                        .map_err(map_extend_stay_command_error)?;
+                serde_json::to_value(&booking).map_err(system_error)
+            })
+        })
+        .await
+}
+
+#[cfg(test)]
+pub async fn update_booking_notes(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    notes: Option<String>,
+) -> BookingResult<Booking> {
+    let trimmed = validate_and_trim_booking_notes(notes)?;
+
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key(booking_id)
+            .map_err(|error| BookingError::validation(error.message))?])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+
+    let booking = update_booking_notes_tx(&mut tx, booking_id, trimmed.as_deref()).await?;
+
     tx.commit().await.map_err(BookingError::from)?;
 
-    fetch_booking(
-        pool,
-        booking_id,
-        format!("Không tìm thấy booking {}", booking_id),
-        read_money_vnd_or_zero,
-    )
-    .await
+    Ok(booking)
 }
 
 fn validate_check_in_request(req: &CheckInRequest) -> BookingResult<()> {

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1392,7 +1392,7 @@ async fn shorten_stay_tx(
     origin_key: Option<String>,
 ) -> BookingResult<Booking> {
     let booking = sqlx::query(
-        "SELECT room_id, nights, total_price, check_in_at, expected_checkout, status
+        "SELECT room_id, nights, total_price, paid_amount, check_in_at, expected_checkout, status
          FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
@@ -1418,6 +1418,7 @@ async fn shorten_stay_tx(
     )?;
     let current_nights: i32 = booking.get("nights");
     let current_total = read_money_vnd_or_zero(&booking, "total_price");
+    let paid_amount = read_money_vnd_or_zero(&booking, "paid_amount");
     let check_in_at: String = booking.get("check_in_at");
     let old_expected_checkout: String = booking.get("expected_checkout");
 
@@ -1477,6 +1478,20 @@ async fn shorten_stay_tx(
 
     let new_total = crate::pricing::checked_sub_money(current_total, removed_total, "total_price")
         .map_err(BookingError::validation)?;
+
+    // Đảo ngược quyết định trước đó: rút đêm từng được phép đưa tổng tiền
+    // xuống dưới số khách đã trả, với giả định lễ tân sẽ hoàn tiền mặt tại
+    // quầy. Giả định đó sai — check_out_tx từ chối thẳng khi already_paid >
+    // final_total, nên booking rơi vào trạng thái không có lối thoát nào cho
+    // tới khi bị undo hoặc check-out ở mức tổng tiền chưa giảm (thổi phồng
+    // doanh thu). Chặn ngay tại đây, trước UPDATE, để không tạo ra trạng thái
+    // đó nữa.
+    if new_total < paid_amount {
+        return Err(BookingError::validation(format!(
+            "Khách đã thanh toán {paid_amount}đ, cao hơn tổng tiền {new_total}đ sau khi rút đêm này — cần xử lý hoàn tiền cho khách trước khi rút đêm"
+        )));
+    }
+
     let new_checkout = new_expected.to_rfc3339();
 
     let result = sqlx::query(
@@ -1588,13 +1603,15 @@ async fn set_booking_rate_tx(
         ));
     }
 
-    let booking = sqlx::query("SELECT nights, total_price, status FROM bookings WHERE id = ?")
-        .bind(booking_id)
-        .fetch_optional(&mut **tx)
-        .await?
-        .ok_or_else(|| {
-            BookingError::not_found(format!("Không tìm thấy booking đang active {}", booking_id))
-        })?;
+    let booking = sqlx::query(
+        "SELECT nights, total_price, paid_amount, status FROM bookings WHERE id = ?",
+    )
+    .bind(booking_id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .ok_or_else(|| {
+        BookingError::not_found(format!("Không tìm thấy booking đang active {}", booking_id))
+    })?;
 
     let booking_status: String = booking.get("status");
     if booking_status != status::booking::ACTIVE {
@@ -1605,6 +1622,7 @@ async fn set_booking_rate_tx(
 
     let nights: i32 = booking.get("nights");
     let current_total = read_money_vnd_or_zero(&booking, "total_price");
+    let paid_amount = read_money_vnd_or_zero(&booking, "paid_amount");
 
     // `bookings.nights` không có CHECK constraint ở schema, nên đây là một giá
     // trị DB chưa được kiểm chứng: nights = 0 sẽ khiến tổng tiền mới biến
@@ -1623,6 +1641,19 @@ async fn set_booking_rate_tx(
     let new_total =
         crate::pricing::checked_mul_money(rate_per_night, i64::from(nights), "total_price")
             .map_err(BookingError::validation)?;
+
+    // Đảo ngược quyết định trước đó: hạ giá từng được phép đưa tổng tiền
+    // xuống dưới số khách đã trả, với giả định lễ tân sẽ hoàn tiền mặt tại
+    // quầy. Giả định đó sai — check_out_tx từ chối thẳng khi already_paid >
+    // final_total, nên booking rơi vào trạng thái không có lối thoát nào cho
+    // tới khi bị undo hoặc check-out ở mức tổng tiền chưa giảm (thổi phồng
+    // doanh thu). Chặn ngay tại đây, trước UPDATE, để không tạo ra trạng thái
+    // đó nữa. Cùng một guard, cùng lý do, với `shorten_stay_tx` phía trên.
+    if new_total < paid_amount {
+        return Err(BookingError::validation(format!(
+            "Khách đã thanh toán {paid_amount}đ, cao hơn tổng tiền mới {new_total}đ — cần xử lý hoàn tiền cho khách trước khi đổi giá"
+        )));
+    }
 
     let result = sqlx::query(
         "UPDATE bookings

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -215,6 +215,14 @@ fn build_shorten_stay_hash_payload(booking_id: &str) -> serde_json::Value {
     })
 }
 
+fn build_set_booking_rate_hash_payload(booking_id: &str, rate_per_night: MoneyVnd) -> serde_json::Value {
+    json!({
+        "schema": "stay.set_rate.v1",
+        "booking_id": booking_id,
+        "rate_per_night": rate_per_night,
+    })
+}
+
 fn check_in_lock_keys_from_payload(hash_payload: &serde_json::Value) -> CommandResult<Vec<String>> {
     let room_id = hash_payload
         .get("room_id")
@@ -256,6 +264,19 @@ fn shorten_stay_initial_lock_keys_from_payload(
         .get("booking_id")
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| system_error("shorten-stay lock payload missing booking_id"))?;
+    Ok(vec![
+        crate::aggregate_locks::booking_key(booking_id)?,
+        crate::aggregate_locks::folio_key(booking_id)?,
+    ])
+}
+
+fn set_booking_rate_initial_lock_keys_from_payload(
+    hash_payload: &serde_json::Value,
+) -> CommandResult<Vec<String>> {
+    let booking_id = hash_payload
+        .get("booking_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| system_error("set-booking-rate lock payload missing booking_id"))?;
     Ok(vec![
         crate::aggregate_locks::booking_key(booking_id)?,
         crate::aggregate_locks::folio_key(booking_id)?,
@@ -1283,6 +1304,60 @@ pub async fn shorten_stay_idempotent(
         .await
 }
 
+pub async fn set_booking_rate_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    booking_id: &str,
+    rate_per_night: MoneyVnd,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let hash_payload = build_set_booking_rate_hash_payload(booking_id, rate_per_night);
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("stay.set_rate.v1")),
+        ("booking_present", json!(true)),
+        ("operation", json!("set_booking_rate")),
+    ])?;
+    let summary = CommandLedgerSummary::new("Set booking rate")?.with_aggregate_ref(
+        "booking",
+        "booking",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{booking_id}"))
+        .with_lock_key_deriver(set_booking_rate_initial_lock_keys_from_payload)
+        .with_success_summary(CommandLedgerResultSummary::success("Booking rate set")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.rate_changed",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "folio"],
+        )?);
+
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = booking_id.to_string();
+    let booking_id_for_service = booking_id.to_string();
+    let origin_key = stay_command_origin_key(ctx);
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || resolve_stay_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, _guard| {
+                Box::pin(async move {
+                    let booking = set_booking_rate_tx(
+                        tx,
+                        &booking_id_for_service,
+                        rate_per_night,
+                        Some(origin_key),
+                    )
+                    .await
+                    .map_err(map_extend_stay_command_error)?;
+                    serde_json::to_value(&booking).map_err(system_error)
+                })
+            },
+        )
+        .await
+}
+
 #[cfg(test)]
 pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
     let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
@@ -1488,6 +1563,119 @@ pub async fn shorten_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResul
 
     let _booking = shorten_stay_tx(&mut tx, booking_id, &locked_room_id, None).await?;
 
+    tx.commit().await.map_err(BookingError::from)?;
+
+    fetch_booking(
+        pool,
+        booking_id,
+        format!("Không tìm thấy booking {}", booking_id),
+        read_money_vnd_or_zero,
+    )
+    .await
+}
+
+/// Trần chống gõ nhầm thừa số 0, không phải giới hạn nghiệp vụ.
+pub const MAX_RATE_PER_NIGHT_VND: MoneyVnd = 100_000_000;
+
+async fn set_booking_rate_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    rate_per_night: MoneyVnd,
+    origin_key: Option<String>,
+) -> BookingResult<Booking> {
+    if rate_per_night <= 0 || rate_per_night > MAX_RATE_PER_NIGHT_VND {
+        return Err(BookingError::validation(
+            "Giá mỗi đêm không hợp lệ".to_string(),
+        ));
+    }
+
+    let booking = sqlx::query("SELECT nights, total_price, status FROM bookings WHERE id = ?")
+        .bind(booking_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .ok_or_else(|| {
+            BookingError::not_found(format!("Không tìm thấy booking đang active {}", booking_id))
+        })?;
+
+    let booking_status: String = booking.get("status");
+    if booking_status != status::booking::ACTIVE {
+        return Err(invalid_state_transition(format!(
+            "booking {booking_id} is not active for rate change (status: {booking_status})"
+        )));
+    }
+
+    let nights: i32 = booking.get("nights");
+    let current_total = read_money_vnd_or_zero(&booking, "total_price");
+
+    let new_total =
+        crate::pricing::checked_mul_money(rate_per_night, i64::from(nights), "total_price")
+            .map_err(BookingError::validation)?;
+
+    let result = sqlx::query(
+        "UPDATE bookings
+         SET total_price = ?
+         WHERE id = ? AND status = ? AND total_price = ?",
+    )
+    .bind(new_total)
+    .bind(booking_id)
+    .bind(status::booking::ACTIVE)
+    .bind(current_total)
+    .execute(&mut **tx)
+    .await
+    .map_err(BookingError::from)
+    .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(
+        result,
+        format!("booking {booking_id} changed before rate change"),
+    )?;
+
+    let delta = crate::pricing::checked_sub_money(new_total, current_total, "rate_delta")
+        .map_err(BookingError::validation)?;
+
+    if delta != 0 {
+        let old_rate = if nights > 0 {
+            current_total / i64::from(nights)
+        } else {
+            current_total
+        };
+        let note = format!("Đổi giá: {} → {}", old_rate, rate_per_night);
+
+        if let Some(origin_key) = origin_key {
+            let origin = OriginSideEffect::new(origin_key, 0)?;
+            record_charge_with_origin_tx(
+                tx,
+                booking_id,
+                delta,
+                note,
+                Local::now().to_rfc3339(),
+                &origin,
+            )
+            .await
+            .map_err(mark_write_db_error)?;
+        } else {
+            record_charge_tx(tx, booking_id, delta, note, Local::now().to_rfc3339())
+                .await
+                .map_err(mark_write_db_error)?;
+        }
+    }
+
+    fetch_booking_tx(tx, booking_id).await
+}
+
+#[cfg(test)]
+pub async fn set_booking_rate(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    rate_per_night: MoneyVnd,
+) -> BookingResult<Booking> {
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key(booking_id)
+            .map_err(|error| BookingError::validation(error.message))?])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+    let _booking = set_booking_rate_tx(&mut tx, booking_id, rate_per_night, None).await?;
     tx.commit().await.map_err(BookingError::from)?;
 
     fetch_booking(

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -216,7 +216,10 @@ fn build_shorten_stay_hash_payload(booking_id: &str) -> serde_json::Value {
     })
 }
 
-fn build_set_booking_rate_hash_payload(booking_id: &str, rate_per_night: MoneyVnd) -> serde_json::Value {
+fn build_set_booking_rate_hash_payload(
+    booking_id: &str,
+    rate_per_night: MoneyVnd,
+) -> serde_json::Value {
     json!({
         "schema": "stay.set_rate.v1",
         "booking_id": booking_id,
@@ -1544,24 +1547,23 @@ async fn shorten_stay_tx(
         "Booking vừa được cập nhật bởi thao tác khác — vui lòng tải lại trang và thử lại",
     )?;
 
-    let calendar_result = sqlx::query(
-        "DELETE FROM room_calendar WHERE room_id = ? AND date = ? AND booking_id = ?",
-    )
-    .bind(&room_id)
-    .bind(freed_date.format("%Y-%m-%d").to_string())
-    .bind(booking_id)
-    .execute(&mut **tx)
-    .await
-    .map_err(BookingError::from)
-    .map_err(mark_write_db_error)?;
+    let calendar_result =
+        sqlx::query("DELETE FROM room_calendar WHERE room_id = ? AND date = ? AND booking_id = ?")
+            .bind(&room_id)
+            .bind(freed_date.format("%Y-%m-%d").to_string())
+            .bind(booking_id)
+            .execute(&mut **tx)
+            .await
+            .map_err(BookingError::from)
+            .map_err(mark_write_db_error)?;
     ensure_one_row_affected(
         calendar_result,
         format!("lịch phòng của booking {booking_id} đã thay đổi trước khi rút đêm"),
     )?;
 
-    let credit = 0i64
-        .checked_sub(removed_total)
-        .ok_or_else(|| BookingError::validation("Số tiền hoàn vượt giới hạn tính toán".to_string()))?;
+    let credit = 0i64.checked_sub(removed_total).ok_or_else(|| {
+        BookingError::validation("Số tiền hoàn vượt giới hạn tính toán".to_string())
+    })?;
 
     if let Some(origin_key) = origin_key {
         let origin = OriginSideEffect::new(origin_key, 0)?;
@@ -1642,15 +1644,17 @@ async fn set_booking_rate_tx(
         ));
     }
 
-    let booking = sqlx::query(
-        "SELECT nights, total_price, paid_amount, status FROM bookings WHERE id = ?",
-    )
-    .bind(booking_id)
-    .fetch_optional(&mut **tx)
-    .await?
-    .ok_or_else(|| {
-        BookingError::not_found(format!("Không tìm thấy booking đang active {}", booking_id))
-    })?;
+    let booking =
+        sqlx::query("SELECT nights, total_price, paid_amount, status FROM bookings WHERE id = ?")
+            .bind(booking_id)
+            .fetch_optional(&mut **tx)
+            .await?
+            .ok_or_else(|| {
+                BookingError::not_found(format!(
+                    "Không tìm thấy booking đang active {}",
+                    booking_id
+                ))
+            })?;
 
     let booking_status: String = booking.get("status");
     if booking_status != status::booking::ACTIVE {
@@ -1875,7 +1879,9 @@ pub async fn update_booking_notes_idempotent(
     let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
         .with_primary_aggregate_key(format!("booking:{booking_id}"))
         .with_lock_key_deriver(update_booking_notes_lock_keys_from_payload)
-        .with_success_summary(CommandLedgerResultSummary::success("Booking notes updated")?);
+        .with_success_summary(CommandLedgerResultSummary::success(
+            "Booking notes updated",
+        )?);
 
     let booking_id_for_service = booking_id.to_string();
 

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -289,7 +289,7 @@ pub(super) async fn fetch_booking_tx(
     let row = sqlx::query(
         "SELECT id, room_id, primary_guest_id, check_in_at, expected_checkout,
                 actual_checkout, nights, total_price, paid_amount, status,
-                source, notes, created_at
+                source, notes, created_at, rate_overridden_at
          FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
@@ -313,6 +313,7 @@ pub(super) async fn fetch_booking_tx(
         source: row.get("source"),
         notes: row.get("notes"),
         created_at: row.get("created_at"),
+        rate_overridden_at: row.get("rate_overridden_at"),
     })
 }
 
@@ -1655,12 +1656,14 @@ async fn set_booking_rate_tx(
         )));
     }
 
+    let overridden_at = Local::now().to_rfc3339();
     let result = sqlx::query(
         "UPDATE bookings
-         SET total_price = ?
+         SET total_price = ?, rate_overridden_at = ?
          WHERE id = ? AND status = ? AND total_price = ?",
     )
     .bind(new_total)
+    .bind(&overridden_at)
     .bind(booking_id)
     .bind(status::booking::ACTIVE)
     .bind(current_total)

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -55,6 +55,45 @@ fn ensure_locked_room_matches_booking(
     }
 }
 
+struct StayResolvedGuard {
+    room_id: String,
+    _guard: crate::aggregate_locks::AggregateLockGuard,
+}
+
+/// `check_out`, `extend_stay`, `shorten_stay` và `set_booking_rate` đều khoá
+/// cùng một bộ ba: booking, phòng của nó, và folio. Trước đây mỗi lệnh chép lại
+/// nguyên closure này. Khuôn theo `resolve_reservation_lock` ở
+/// `reservation_lifecycle.rs`, chỉ khác là bộ khoá ở đây có thêm folio.
+async fn resolve_stay_lock(
+    pool: Pool<Sqlite>,
+    booking_id: String,
+) -> CommandResult<ResolvedWriteCommandGuard<StayResolvedGuard>> {
+    let room_id = lookup_booking_room_id(&pool, &booking_id)
+        .await
+        .map_err(map_check_out_command_error)?;
+
+    let lock_keys = vec![
+        crate::aggregate_locks::booking_key(&booking_id)?,
+        crate::aggregate_locks::room_key(&room_id)?,
+        crate::aggregate_locks::folio_key(&booking_id)?,
+    ];
+    let guard = crate::aggregate_locks::global_manager()
+        .acquire(lock_keys.clone())
+        .await?;
+
+    Ok(ResolvedWriteCommandGuard::new(
+        StayResolvedGuard {
+            room_id,
+            _guard: guard,
+        },
+        lock_keys,
+    ))
+}
+
+fn stay_command_origin_key(ctx: &WriteCommandContext) -> String {
+    format!("{}:{}", ctx.command_name, ctx.idempotency_key)
+}
+
 pub(super) fn map_check_in_command_error(error: BookingError) -> CommandError {
     match error {
         BookingError::Validation(message) => {
@@ -948,34 +987,19 @@ pub async fn check_out_idempotent(
             &["bookings", "rooms", "folio"],
         )?);
 
-    let pool_for_lookup = pool.clone();
-    let booking_id_for_lookup = req.booking_id.clone();
-    let origin_key = format!("{}:{}", ctx.command_name, ctx.idempotency_key);
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = req.booking_id.clone();
+    let origin_key = stay_command_origin_key(ctx);
 
     WriteCommandExecutor::new(pool.clone())
         .execute_with_resolved_guard(
             ctx,
             request,
-            move || async move {
-                let room_id = lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
-                    .await
-                    .map_err(map_check_out_command_error)?;
-                let lock_keys = vec![
-                    crate::aggregate_locks::booking_key(&booking_id_for_lookup)?,
-                    crate::aggregate_locks::room_key(&room_id)?,
-                    crate::aggregate_locks::folio_key(&booking_id_for_lookup)?,
-                ];
-                let guard = crate::aggregate_locks::global_manager()
-                    .acquire(lock_keys.clone())
-                    .await?;
-
-                Ok(ResolvedWriteCommandGuard::new((guard, room_id), lock_keys))
-            },
-            move |tx, resolved| {
+            move || resolve_stay_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, guard| {
                 Box::pin(async move {
-                    let (_guard, locked_room_id) = resolved;
                     let response =
-                        check_out_tx(tx, req, Local::now(), &locked_room_id, Some(origin_key))
+                        check_out_tx(tx, req, Local::now(), &guard.room_id, Some(origin_key))
                             .await
                             .map_err(map_check_out_command_error)?;
                     serde_json::to_value(&response).map_err(system_error)
@@ -1158,37 +1182,22 @@ pub async fn extend_stay_idempotent(
             &["bookings", "rooms", "folio"],
         )?);
 
-    let pool_for_lookup = pool.clone();
-    let booking_id_for_lookup = booking_id.to_string();
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = booking_id.to_string();
     let booking_id_for_service = booking_id.to_string();
-    let origin_key = format!("{}:{}", ctx.command_name, ctx.idempotency_key);
+    let origin_key = stay_command_origin_key(ctx);
 
     WriteCommandExecutor::new(pool.clone())
         .execute_with_resolved_guard(
             ctx,
             request,
-            move || async move {
-                let room_id = lookup_booking_room_id(&pool_for_lookup, &booking_id_for_lookup)
-                    .await
-                    .map_err(map_extend_stay_command_error)?;
-                let lock_keys = vec![
-                    crate::aggregate_locks::booking_key(&booking_id_for_lookup)?,
-                    crate::aggregate_locks::room_key(&room_id)?,
-                    crate::aggregate_locks::folio_key(&booking_id_for_lookup)?,
-                ];
-                let guard = crate::aggregate_locks::global_manager()
-                    .acquire(lock_keys.clone())
-                    .await?;
-
-                Ok(ResolvedWriteCommandGuard::new((guard, room_id), lock_keys))
-            },
-            move |tx, resolved| {
+            move || resolve_stay_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, guard| {
                 Box::pin(async move {
-                    let (_guard, locked_room_id) = resolved;
                     let booking = extend_stay_tx(
                         tx,
                         &booking_id_for_service,
-                        &locked_room_id,
+                        &guard.room_id,
                         Some(origin_key),
                     )
                     .await

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1288,15 +1288,20 @@ async fn shorten_stay_tx(
     let new_expected = old_expected - Duration::days(1);
     let freed_date = new_expected.date_naive();
 
-    if freed_date <= check_in.date_naive() {
+    // Kiểm tra quá khứ trước: một booking 1 đêm đã quá hạn (checkout đã ở
+    // quá khứ) phải báo dùng Check-out, không phải "tối thiểu 1 đêm" — nếu
+    // không đổi thứ tự, ca đó luôn rơi vào nhánh tối thiểu 1 đêm bên dưới
+    // trước khi chạm tới đây, vì freed_date trùng ngày check-in.
+    if freed_date < Local::now().date_naive() {
         return Err(BookingError::validation(
-            "Lưu trú tối thiểu 1 đêm".to_string(),
+            "Ngày trả phòng mới sẽ rơi vào quá khứ — dùng Check-out để cho khách rời phòng"
+                .to_string(),
         ));
     }
 
-    if freed_date < Local::now().date_naive() {
+    if freed_date <= check_in.date_naive() {
         return Err(BookingError::validation(
-            "Đêm cuối là hôm nay — dùng Check-out để cho khách đi".to_string(),
+            "Lưu trú tối thiểu 1 đêm".to_string(),
         ));
     }
 
@@ -1310,6 +1315,17 @@ async fn shorten_stay_tx(
     )
     .await?;
     let removed_total = removed_pricing.total;
+
+    // Giá phòng có thể đã tăng kể từ lúc nhận phòng (base_price đổi, thêm
+    // pricing_rules, hoặc special_dates) — khoản hoàn cho đêm bị rút không
+    // được vượt quá tổng tiền hiện tại của booking, nếu không total_price sẽ
+    // âm. Chặn ở đây, trước bất kỳ câu UPDATE nào, để không ghi gì cả.
+    if removed_total > current_total {
+        return Err(BookingError::validation(
+            "Giá phòng đã thay đổi kể từ lúc nhận phòng nên không thể tự động hoàn tiền đêm này — vui lòng điều chỉnh thủ công"
+                .to_string(),
+        ));
+    }
 
     let new_total = crate::pricing::checked_sub_money(current_total, removed_total, "total_price")
         .map_err(BookingError::validation)?;

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -207,6 +207,14 @@ fn build_extend_stay_hash_payload(booking_id: &str) -> serde_json::Value {
     })
 }
 
+fn build_shorten_stay_hash_payload(booking_id: &str) -> serde_json::Value {
+    json!({
+        "schema": "stay.shorten.v1",
+        "booking_id": booking_id,
+        "operation": "remove_one_night",
+    })
+}
+
 fn check_in_lock_keys_from_payload(hash_payload: &serde_json::Value) -> CommandResult<Vec<String>> {
     let room_id = hash_payload
         .get("room_id")
@@ -235,6 +243,19 @@ fn extend_stay_initial_lock_keys_from_payload(
         .get("booking_id")
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| system_error("extend-stay lock payload missing booking_id"))?;
+    Ok(vec![
+        crate::aggregate_locks::booking_key(booking_id)?,
+        crate::aggregate_locks::folio_key(booking_id)?,
+    ])
+}
+
+fn shorten_stay_initial_lock_keys_from_payload(
+    hash_payload: &serde_json::Value,
+) -> CommandResult<Vec<String>> {
+    let booking_id = hash_payload
+        .get("booking_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| system_error("shorten-stay lock payload missing booking_id"))?;
     Ok(vec![
         crate::aggregate_locks::booking_key(booking_id)?,
         crate::aggregate_locks::folio_key(booking_id)?,
@@ -1209,6 +1230,59 @@ pub async fn extend_stay_idempotent(
         .await
 }
 
+pub async fn shorten_stay_idempotent(
+    pool: &Pool<Sqlite>,
+    ctx: &WriteCommandContext,
+    booking_id: &str,
+) -> CommandResult<IdempotentCommandResult<serde_json::Value>> {
+    let hash_payload = build_shorten_stay_hash_payload(booking_id);
+    let ledger_intent = SanitizedLedgerIntent::from_pairs([
+        ("schema", json!("stay.shorten.v1")),
+        ("booking_present", json!(true)),
+        ("operation", json!("remove_one_night")),
+    ])?;
+    let summary = CommandLedgerSummary::new("Shorten stay")?.with_aggregate_ref(
+        "booking",
+        "booking",
+        None::<String>,
+    )?;
+    let request = WriteCommandRequest::new_sanitized(hash_payload, ledger_intent, summary)?
+        .with_primary_aggregate_key(format!("booking:{booking_id}"))
+        .with_lock_key_deriver(shorten_stay_initial_lock_keys_from_payload)
+        .with_success_summary(CommandLedgerResultSummary::success("Stay shortened")?)
+        .with_outbox_event(OutboxEventSpec::new(
+            "booking.stay_shortened",
+            OutboxAggregateKeySource::response_field("booking", "id"),
+            &["bookings", "rooms", "folio"],
+        )?);
+
+    let pool_for_guard = pool.clone();
+    let booking_id_for_guard = booking_id.to_string();
+    let booking_id_for_service = booking_id.to_string();
+    let origin_key = stay_command_origin_key(ctx);
+
+    WriteCommandExecutor::new(pool.clone())
+        .execute_with_resolved_guard(
+            ctx,
+            request,
+            move || resolve_stay_lock(pool_for_guard, booking_id_for_guard),
+            move |tx, guard| {
+                Box::pin(async move {
+                    let booking = shorten_stay_tx(
+                        tx,
+                        &booking_id_for_service,
+                        &guard.room_id,
+                        Some(origin_key),
+                    )
+                    .await
+                    .map_err(map_extend_stay_command_error)?;
+                    serde_json::to_value(&booking).map_err(system_error)
+                })
+            },
+        )
+        .await
+}
+
 #[cfg(test)]
 pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
     let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
@@ -1237,11 +1311,6 @@ pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult
     .await
 }
 
-/// `#[allow(dead_code)]`: the only caller right now is the `#[cfg(test)]`
-/// `shorten_stay` wrapper below — the Tauri command wrapper (and its
-/// idempotent entry point, mirroring `extend_stay_idempotent`) lands in a
-/// later task. Remove once that wrapper calls this from non-test code.
-#[allow(dead_code)]
 async fn shorten_stay_tx(
     tx: &mut Transaction<'_, Sqlite>,
     booking_id: &str,

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1237,6 +1237,178 @@ pub async fn extend_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult
     .await
 }
 
+/// `#[allow(dead_code)]`: the only caller right now is the `#[cfg(test)]`
+/// `shorten_stay` wrapper below — the Tauri command wrapper (and its
+/// idempotent entry point, mirroring `extend_stay_idempotent`) lands in a
+/// later task. Remove once that wrapper calls this from non-test code.
+#[allow(dead_code)]
+async fn shorten_stay_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    booking_id: &str,
+    locked_room_id: &str,
+    origin_key: Option<String>,
+) -> BookingResult<Booking> {
+    let booking = sqlx::query(
+        "SELECT room_id, nights, total_price, check_in_at, expected_checkout,
+                pricing_type, guests, status
+         FROM bookings WHERE id = ?",
+    )
+    .bind(booking_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    let booking = booking.ok_or_else(|| {
+        BookingError::not_found(format!("Không tìm thấy booking đang active {}", booking_id))
+    })?;
+
+    let booking_status: String = booking.get("status");
+    if booking_status != status::booking::ACTIVE {
+        return Err(invalid_state_transition(format!(
+            "booking {booking_id} is not active for shorten-stay (status: {booking_status})"
+        )));
+    }
+
+    let room_id: String = booking.get("room_id");
+    ensure_locked_room_matches_booking(
+        locked_room_id,
+        &room_id,
+        format!("booking {booking_id} changed rooms before shorten-stay"),
+    )?;
+    let current_nights: i32 = booking.get("nights");
+    let current_total = read_money_vnd_or_zero(&booking, "total_price");
+    let check_in_at: String = booking.get("check_in_at");
+    let old_expected_checkout: String = booking.get("expected_checkout");
+    let pricing_type = booking
+        .get::<Option<String>, _>("pricing_type")
+        .unwrap_or_else(|| "nightly".to_string());
+    let guests: Option<i32> = booking.get("guests");
+
+    let old_expected = parse_booking_datetime(&old_expected_checkout)?;
+    let check_in = parse_booking_datetime(&check_in_at)?;
+    let new_expected = old_expected - Duration::days(1);
+    let freed_date = new_expected.date_naive();
+
+    if freed_date <= check_in.date_naive() {
+        return Err(BookingError::validation(
+            "Lưu trú tối thiểu 1 đêm".to_string(),
+        ));
+    }
+
+    if freed_date < Local::now().date_naive() {
+        return Err(BookingError::validation(
+            "Đêm cuối là hôm nay — dùng Check-out để cho khách đi".to_string(),
+        ));
+    }
+
+    let removed_pricing = calculate_stay_price_tx(
+        tx,
+        &room_id,
+        &new_expected.to_rfc3339(),
+        &old_expected_checkout,
+        &pricing_type,
+        guests,
+    )
+    .await?;
+    let removed_total = removed_pricing.total;
+
+    let new_total = crate::pricing::checked_sub_money(current_total, removed_total, "total_price")
+        .map_err(BookingError::validation)?;
+    let new_checkout = new_expected.to_rfc3339();
+
+    let result = sqlx::query(
+        "UPDATE bookings
+         SET nights = ?, total_price = ?, expected_checkout = ?
+         WHERE id = ? AND status = ? AND expected_checkout = ?",
+    )
+    .bind(current_nights - 1)
+    .bind(new_total)
+    .bind(&new_checkout)
+    .bind(booking_id)
+    .bind(status::booking::ACTIVE)
+    .bind(&old_expected_checkout)
+    .execute(&mut **tx)
+    .await
+    .map_err(BookingError::from)
+    .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(
+        result,
+        format!("booking {booking_id} changed before shorten-stay"),
+    )?;
+
+    let calendar_result = sqlx::query(
+        "DELETE FROM room_calendar WHERE room_id = ? AND date = ? AND booking_id = ?",
+    )
+    .bind(&room_id)
+    .bind(freed_date.format("%Y-%m-%d").to_string())
+    .bind(booking_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(BookingError::from)
+    .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(
+        calendar_result,
+        format!("lịch phòng của booking {booking_id} đã thay đổi trước khi rút đêm"),
+    )?;
+
+    let credit = 0i64
+        .checked_sub(removed_total)
+        .ok_or_else(|| BookingError::validation("credit amount overflowed".to_string()))?;
+
+    if let Some(origin_key) = origin_key {
+        let origin = OriginSideEffect::new(origin_key, 0)?;
+        record_charge_with_origin_tx(
+            tx,
+            booking_id,
+            credit,
+            "Shortened stay -1 night",
+            Local::now().to_rfc3339(),
+            &origin,
+        )
+        .await
+        .map_err(mark_write_db_error)?;
+    } else {
+        record_charge_tx(
+            tx,
+            booking_id,
+            credit,
+            "Shortened stay -1 night",
+            Local::now().to_rfc3339(),
+        )
+        .await
+        .map_err(mark_write_db_error)?;
+    }
+
+    fetch_booking_tx(tx, booking_id).await
+}
+
+#[cfg(test)]
+pub async fn shorten_stay(pool: &Pool<Sqlite>, booking_id: &str) -> BookingResult<Booking> {
+    let locked_room_id = lookup_booking_room_id(pool, booking_id).await?;
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key(booking_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+            crate::aggregate_locks::room_key(&locked_room_id)
+                .map_err(|error| BookingError::validation(error.message))?,
+        ])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+
+    let _booking = shorten_stay_tx(&mut tx, booking_id, &locked_room_id, None).await?;
+
+    tx.commit().await.map_err(BookingError::from)?;
+
+    fetch_booking(
+        pool,
+        booking_id,
+        format!("Không tìm thấy booking {}", booking_id),
+        read_money_vnd_or_zero,
+    )
+    .await
+}
+
 fn validate_check_in_request(req: &CheckInRequest) -> BookingResult<()> {
     if req.guests.is_empty() {
         return Err(BookingError::validation(

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1249,8 +1249,7 @@ async fn shorten_stay_tx(
     origin_key: Option<String>,
 ) -> BookingResult<Booking> {
     let booking = sqlx::query(
-        "SELECT room_id, nights, total_price, check_in_at, expected_checkout,
-                pricing_type, guests, status
+        "SELECT room_id, nights, total_price, check_in_at, expected_checkout, status
          FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
@@ -1278,10 +1277,6 @@ async fn shorten_stay_tx(
     let current_total = read_money_vnd_or_zero(&booking, "total_price");
     let check_in_at: String = booking.get("check_in_at");
     let old_expected_checkout: String = booking.get("expected_checkout");
-    let pricing_type = booking
-        .get::<Option<String>, _>("pricing_type")
-        .unwrap_or_else(|| "nightly".to_string());
-    let guests: Option<i32> = booking.get("guests");
 
     let old_expected = parse_booking_datetime(&old_expected_checkout)?;
     let check_in = parse_booking_datetime(&check_in_at)?;
@@ -1305,27 +1300,11 @@ async fn shorten_stay_tx(
         ));
     }
 
-    let removed_pricing = calculate_stay_price_tx(
-        tx,
-        &room_id,
-        &new_expected.to_rfc3339(),
-        &old_expected_checkout,
-        &pricing_type,
-        guests,
-    )
-    .await?;
-    let removed_total = removed_pricing.total;
-
-    // Giá phòng có thể đã tăng kể từ lúc nhận phòng (base_price đổi, thêm
-    // pricing_rules, hoặc special_dates) — khoản hoàn cho đêm bị rút không
-    // được vượt quá tổng tiền hiện tại của booking, nếu không total_price sẽ
-    // âm. Chặn ở đây, trước bất kỳ câu UPDATE nào, để không ghi gì cả.
-    if removed_total > current_total {
-        return Err(BookingError::validation(
-            "Giá phòng đã thay đổi kể từ lúc nhận phòng nên không thể tự động hoàn tiền đêm này — vui lòng điều chỉnh thủ công"
-                .to_string(),
-        ));
-    }
+    // Tiền hoàn lấy từ trung bình của CHÍNH booking này, không hỏi pricing engine.
+    // Pricing engine trả giá hôm nay, còn đêm này đã thu theo giá lúc đặt; nâng giá
+    // phòng giữa chừng sẽ khiến ta hoàn nhiều hơn số đã thu. Không có bản ghi giá
+    // từng đêm để tra (pricing_snapshot chỉ ghi lúc check-out).
+    let removed_total = current_total / i64::from(current_nights);
 
     let new_total = crate::pricing::checked_sub_money(current_total, removed_total, "total_price")
         .map_err(BookingError::validation)?;

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1304,6 +1304,32 @@ async fn shorten_stay_tx(
     // Pricing engine trả giá hôm nay, còn đêm này đã thu theo giá lúc đặt; nâng giá
     // phòng giữa chừng sẽ khiến ta hoàn nhiều hơn số đã thu. Không có bản ghi giá
     // từng đêm để tra (pricing_snapshot chỉ ghi lúc check-out).
+    //
+    // Bất đối xứng có chủ đích với `extend_stay_tx` (phía trên): extend tính đêm
+    // thêm theo giá HÔM NAY từ pricing engine, còn shorten hoàn theo giá TRUNG
+    // BÌNH của chính booking. Hai công thức chỉ trùng nhau khi mọi đêm cùng giá.
+    // Nếu extend diễn ra giữa một đợt tăng giá rồi bị shorten rút lại, khoản hoàn
+    // sẽ thấp hơn khoản mới thu — đây là đánh đổi sản phẩm đã được chấp nhận,
+    // không phải bug.
+    //
+    // Chia số nguyên luôn làm tròn về 0, nên khoản hoàn không bao giờ vượt quá
+    // trung bình thật; phần dư (tối đa `nights - 1` VND trên toàn bộ vòng rút)
+    // luôn ở lại phía khách sạn. Với booking giá không đều theo từng đêm, mức
+    // trung bình này cũng có thể hoàn NHIỀU hơn giá thật của một đêm rẻ cụ thể —
+    // cũng là đánh đổi sản phẩm đã chấp nhận, không phải lỗi.
+    //
+    // `bookings.nights` không có CHECK constraint ở schema, nên đây là một giá
+    // trị DB chưa được kiểm chứng: nights = 0 sẽ panic chia cho 0, nights âm sẽ
+    // vẫn "tính" ra được nhưng bịa tiền (removed_total âm khiến new_total tăng
+    // thay vì giảm). Không đường đi nào trong code hôm nay có thể tạo ra giá trị
+    // như vậy cho booking đang active, nhưng chặn tường minh ở đây để phòng thủ
+    // theo chiều sâu (defence in depth), giống cách `recognized_room_revenue_amount_sql`
+    // ở `queries/booking/revenue_queries.rs` bảo vệ cùng phép chia này.
+    if current_nights <= 0 {
+        return Err(BookingError::validation(format!(
+            "Số đêm hiện tại của booking không hợp lệ ({current_nights}), không thể tính tiền hoàn"
+        )));
+    }
     let removed_total = current_total / i64::from(current_nights);
 
     let new_total = crate::pricing::checked_sub_money(current_total, removed_total, "total_price")

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -33,7 +33,6 @@ use super::{
     },
 };
 
-#[cfg(test)]
 use super::support::{begin_immediate_tx, fetch_booking};
 
 pub(super) fn mark_write_db_error(error: BookingError) -> BookingError {
@@ -150,7 +149,7 @@ pub(super) fn map_check_out_command_error(error: BookingError) -> CommandError {
     }
 }
 
-pub(super) fn map_extend_stay_command_error(error: BookingError) -> CommandError {
+pub fn map_extend_stay_command_error(error: BookingError) -> CommandError {
     match error {
         BookingError::Conflict(message) => {
             if is_room_unavailable_conflict_message(&message) {
@@ -1686,6 +1685,60 @@ pub async fn set_booking_rate(
 
     let mut tx = begin_immediate_tx(pool).await?;
     let _booking = set_booking_rate_tx(&mut tx, booking_id, rate_per_night, None).await?;
+    tx.commit().await.map_err(BookingError::from)?;
+
+    fetch_booking(
+        pool,
+        booking_id,
+        format!("Không tìm thấy booking {}", booking_id),
+        read_money_vnd_or_zero,
+    )
+    .await
+}
+
+pub const MAX_BOOKING_NOTES_LEN: usize = 2_000;
+
+/// Ghi chú không đụng tiền và không đụng lịch phòng, nên không cần bộ máy
+/// idempotency — theo tiền lệ của `add_folio_line`. Chỉ khoá booking.
+pub async fn update_booking_notes(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    notes: Option<String>,
+) -> BookingResult<Booking> {
+    let trimmed = notes
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if let Some(ref value) = trimmed {
+        if value.chars().count() > MAX_BOOKING_NOTES_LEN {
+            return Err(BookingError::validation(format!(
+                "Ghi chú tối đa {} ký tự",
+                MAX_BOOKING_NOTES_LEN
+            )));
+        }
+    }
+
+    let _lock_guard = crate::aggregate_locks::global_manager()
+        .acquire([crate::aggregate_locks::booking_key(booking_id)
+            .map_err(|error| BookingError::validation(error.message))?])
+        .await
+        .map_err(|error| BookingError::validation(error.message))?;
+
+    let mut tx = begin_immediate_tx(pool).await?;
+
+    let result = sqlx::query("UPDATE bookings SET notes = ? WHERE id = ? AND status = ?")
+        .bind(trimmed.as_deref())
+        .bind(booking_id)
+        .bind(status::booking::ACTIVE)
+        .execute(&mut *tx)
+        .await
+        .map_err(BookingError::from)
+        .map_err(mark_write_db_error)?;
+    ensure_one_row_affected(
+        result,
+        format!("Không tìm thấy booking đang active {booking_id}"),
+    )?;
+
     tx.commit().await.map_err(BookingError::from)?;
 
     fetch_booking(

--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1607,6 +1607,20 @@ async fn set_booking_rate_tx(
     let nights: i32 = booking.get("nights");
     let current_total = read_money_vnd_or_zero(&booking, "total_price");
 
+    // `bookings.nights` không có CHECK constraint ở schema, nên đây là một giá
+    // trị DB chưa được kiểm chứng: nights = 0 sẽ khiến tổng tiền mới biến
+    // thành 0 thay vì phản ánh giá mới thật, còn nights âm sẽ vẫn "nhân" ra
+    // được nhưng lật dấu tổng tiền (giá dương x đêm âm = tổng âm). Không
+    // đường đi nào trong code hôm nay có thể tạo ra giá trị như vậy cho
+    // booking đang active, nhưng chặn tường minh ở đây để phòng thủ theo
+    // chiều sâu (defence in depth), giống guard tương ứng ở `shorten_stay_tx`
+    // phía trên.
+    if nights <= 0 {
+        return Err(BookingError::validation(format!(
+            "Số đêm hiện tại của booking không hợp lệ ({nights}), không thể tính giá mới"
+        )));
+    }
+
     let new_total =
         crate::pricing::checked_mul_money(rate_per_night, i64::from(nights), "total_price")
             .map_err(BookingError::validation)?;
@@ -1633,11 +1647,7 @@ async fn set_booking_rate_tx(
         .map_err(BookingError::validation)?;
 
     if delta != 0 {
-        let old_rate = if nights > 0 {
-            current_total / i64::from(nights)
-        } else {
-            current_total
-        };
+        let old_rate = current_total / i64::from(nights);
         let note = format!("Đổi giá: {} → {}", old_rate, rate_per_night);
 
         if let Some(origin_key) = origin_key {

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -122,7 +122,7 @@ where
     let row = sqlx::query(
         "SELECT id, room_id, primary_guest_id, check_in_at, expected_checkout,
                 actual_checkout, nights, total_price, paid_amount, status,
-                source, notes, created_at
+                source, notes, created_at, rate_overridden_at
          FROM bookings WHERE id = ?",
     )
     .bind(booking_id)
@@ -145,6 +145,7 @@ where
         source: row.get("source"),
         notes: row.get("notes"),
         created_at: row.get("created_at"),
+        rate_overridden_at: row.get("rate_overridden_at"),
     })
 }
 

--- a/mhm/src-tauri/src/services/booking/support.rs
+++ b/mhm/src-tauri/src/services/booking/support.rs
@@ -59,6 +59,36 @@ pub async fn lookup_booking_room_id(
         .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {}", booking_id)))
 }
 
+/// Đọc `expected_checkout` NGOÀI transaction — dùng để chốt giá trị "trước khi
+/// khoá" cho optimistic-concurrency guard của `shorten_stay_tx`. Không có bước
+/// đọc riêng này, guard `AND expected_checkout = ?` ở cuối UPDATE sẽ so một giá
+/// trị với chính nó (đọc lại trong CÙNG transaction ngay trước khi ghi), nên
+/// không bao giờ có thể lệch — xem ghi chú trong `shorten_stay_tx`.
+pub async fn lookup_booking_expected_checkout(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+) -> BookingResult<String> {
+    sqlx::query_scalar::<_, String>("SELECT expected_checkout FROM bookings WHERE id = ?")
+        .bind(booking_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {}", booking_id)))
+}
+
+/// Đọc `total_price` NGOÀI transaction — cùng lý do với
+/// `lookup_booking_expected_checkout`, áp dụng cho guard của `set_booking_rate_tx`.
+pub async fn lookup_booking_total_price(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+) -> BookingResult<MoneyVnd> {
+    let row = sqlx::query("SELECT total_price FROM bookings WHERE id = ?")
+        .bind(booking_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| BookingError::not_found(format!("Không tìm thấy booking {}", booking_id)))?;
+    Ok(read_money_vnd_or_zero(&row, "total_price"))
+}
+
 pub fn rfc3339_now() -> String {
     Local::now().to_rfc3339()
 }

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -27,13 +27,12 @@ async fn set_booking_rate_recomputes_the_total_from_nights() {
         .await
         .unwrap();
 
-    let row = sqlx::query(
-        "SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?",
-    )
-    .bind("B801")
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let row =
+        sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+            .bind("B801")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(row.get::<i64, _>("total_price"), 900_000);
     assert_eq!(row.get::<i32, _>("nights"), 2, "số đêm không được đổi");
     assert_eq!(
@@ -59,7 +58,10 @@ async fn set_booking_rate_records_the_difference_as_a_charge() {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(amount, -100_000, "1.000.000 → 900.000 là chênh lệch -100.000");
+    assert_eq!(
+        amount, -100_000,
+        "1.000.000 → 900.000 là chênh lệch -100.000"
+    );
 }
 
 #[tokio::test]
@@ -414,17 +416,17 @@ async fn set_booking_rate_writes_nothing_when_the_booking_is_reserved_not_active
     // `set_booking_rate_tx` rejects a non-active booking via `invalid_state_transition`,
     // which always maps to `BookingError::Conflict`, not `Validation`/`NotFound` — see
     // `invalid_state_transition` in support.rs and the same correction in shorten_stay.rs.
-    assert!(matches!(
-        error,
-        BookingError::Conflict(_)
-    ));
+    assert!(matches!(error, BookingError::Conflict(_)));
 
     let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
         .bind("B809")
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(total, 1_000_000, "lệnh bị chặn thì tổng tiền không được đổi");
+    assert_eq!(
+        total, 1_000_000,
+        "lệnh bị chặn thì tổng tiền không được đổi"
+    );
 
     let charges: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
@@ -490,10 +492,7 @@ async fn set_booking_rate_refuses_a_booking_that_is_not_active() {
         .unwrap_err();
     // Same as above: a checked-out booking is rejected via `invalid_state_transition`,
     // which is `BookingError::Conflict`.
-    assert!(matches!(
-        error,
-        BookingError::Conflict(_)
-    ));
+    assert!(matches!(error, BookingError::Conflict(_)));
 }
 
 #[tokio::test]
@@ -565,13 +564,9 @@ async fn update_booking_notes_trims_and_saves() {
     let pool = test_pool().await;
     seed_two_night_booking(&pool, "B901", "R901").await.unwrap();
 
-    stay_lifecycle::update_booking_notes(
-        &pool,
-        "B901",
-        Some("  Khách xin thêm gối  ".to_string()),
-    )
-    .await
-    .unwrap();
+    stay_lifecycle::update_booking_notes(&pool, "B901", Some("  Khách xin thêm gối  ".to_string()))
+        .await
+        .unwrap();
 
     let notes: Option<String> = sqlx::query_scalar("SELECT notes FROM bookings WHERE id = ?")
         .bind("B901")
@@ -652,9 +647,8 @@ async fn update_booking_notes_idempotent_records_the_actor_in_the_command_ledger
     let pool = test_pool().await;
     seed_two_night_booking(&pool, "B905", "R905").await.unwrap();
 
-    let mut ctx = crate::command_idempotency::WriteCommandContext::new_internal(
-        "update_booking_notes",
-    );
+    let mut ctx =
+        crate::command_idempotency::WriteCommandContext::new_internal("update_booking_notes");
     ctx.actor_id = Some("staff-905".to_string());
 
     stay_lifecycle::update_booking_notes_idempotent(
@@ -675,13 +669,14 @@ async fn update_booking_notes_idempotent_records_the_actor_in_the_command_ledger
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(row.get::<Option<String>, _>("actor_id").as_deref(), Some("staff-905"));
     assert_eq!(
-        row.get::<String, _>("command_name"),
-        "update_booking_notes"
+        row.get::<Option<String>, _>("actor_id").as_deref(),
+        Some("staff-905")
     );
+    assert_eq!(row.get::<String, _>("command_name"), "update_booking_notes");
     assert_eq!(
-        row.get::<Option<String>, _>("primary_aggregate_key").as_deref(),
+        row.get::<Option<String>, _>("primary_aggregate_key")
+            .as_deref(),
         Some("booking:B905")
     );
 
@@ -715,9 +710,7 @@ fn update_booking_notes_stays_out_of_the_write_manifest_and_recovery_high_risk_l
 /// truyền idempotency key, khác với `add_folio_line`/`set_booking_rate`.
 #[test]
 fn update_booking_notes_context_generates_its_own_idempotency_key_without_caller_input() {
-    let ctx = crate::command_idempotency::WriteCommandContext::new_internal(
-        "update_booking_notes",
-    );
+    let ctx = crate::command_idempotency::WriteCommandContext::new_internal("update_booking_notes");
 
     assert!(!ctx.idempotency_key.trim().is_empty());
     assert_eq!(ctx.command_name, "update_booking_notes");
@@ -735,8 +728,7 @@ fn update_booking_notes_context_generates_its_own_idempotency_key_without_caller
 /// mà lễ tân chưa từng thấy — không có lỗi nào nổi lên.
 #[tokio::test]
 async fn set_booking_rate_fails_when_second_pool_moves_the_total_while_the_lock_is_held() {
-    let (pool_a, pool_b, db_path) =
-        shared_file_test_pools("second-pool-rate-total-price").await;
+    let (pool_a, pool_b, db_path) = shared_file_test_pools("second-pool-rate-total-price").await;
     seed_two_night_booking(&pool_a, "B-2POOL-RATE", "R-2POOL-RATE")
         .await
         .unwrap();
@@ -832,7 +824,10 @@ async fn set_booking_rate_fails_when_second_pool_moves_the_total_while_the_lock_
     .fetch_one(&pool_a)
     .await
     .unwrap();
-    assert_eq!(charge_count, 0, "bị chặn thì không được để lại dòng đối ứng");
+    assert_eq!(
+        charge_count, 0,
+        "bị chặn thì không được để lại dòng đối ứng"
+    );
 
     pool_a.close().await;
     pool_b.close().await;

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -424,3 +424,85 @@ async fn set_booking_rate_refuses_a_booking_that_is_not_active() {
         BookingError::Conflict(_)
     ));
 }
+
+#[tokio::test]
+async fn update_booking_notes_trims_and_saves() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B901", "R901").await.unwrap();
+
+    stay_lifecycle::update_booking_notes(
+        &pool,
+        "B901",
+        Some("  Khách xin thêm gối  ".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let notes: Option<String> = sqlx::query_scalar("SELECT notes FROM bookings WHERE id = ?")
+        .bind("B901")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(notes.as_deref(), Some("Khách xin thêm gối"));
+}
+
+#[tokio::test]
+async fn update_booking_notes_stores_blank_input_as_null() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B902", "R902").await.unwrap();
+
+    stay_lifecycle::update_booking_notes(&pool, "B902", Some("   ".to_string()))
+        .await
+        .unwrap();
+
+    let notes: Option<String> = sqlx::query_scalar("SELECT notes FROM bookings WHERE id = ?")
+        .bind("B902")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(notes, None);
+}
+
+#[tokio::test]
+async fn update_booking_notes_rejects_notes_over_the_limit() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B903", "R903").await.unwrap();
+
+    let too_long = "a".repeat(2_001);
+    let error = stay_lifecycle::update_booking_notes(&pool, "B903", Some(too_long))
+        .await
+        .unwrap_err();
+    assert!(matches!(error, BookingError::Validation(_)));
+
+    let notes: Option<String> = sqlx::query_scalar("SELECT notes FROM bookings WHERE id = ?")
+        .bind("B903")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        notes.as_deref(),
+        Some("seed booking"),
+        "bị từ chối thì ghi chú cũ phải còn nguyên, không bị cắt bớt"
+    );
+}
+
+#[tokio::test]
+async fn update_booking_notes_refuses_a_booking_that_is_not_active() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B904", "R904").await.unwrap();
+    sqlx::query("UPDATE bookings SET status = 'checked_out' WHERE id = ?")
+        .bind("B904")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::update_booking_notes(&pool, "B904", Some("x".to_string()))
+        .await
+        .unwrap_err();
+    // `update_booking_notes` has no separate SELECT+status check before the
+    // UPDATE — it relies on `WHERE status = ACTIVE` plus `ensure_one_row_affected`,
+    // same as `set_booking_rate`'s equivalent test above. That path always
+    // reports a state-transition problem via `invalid_state_transition`, i.e.
+    // `BookingError::Conflict`, never `Validation`/`NotFound`.
+    assert!(matches!(error, BookingError::Conflict(_)));
+}

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -300,7 +300,7 @@ async fn set_booking_rate_rejects_a_rate_above_the_cap() {
 }
 
 #[tokio::test]
-async fn set_booking_rate_allows_a_total_below_what_the_guest_already_paid() {
+async fn set_booking_rate_refuses_a_total_below_what_the_guest_already_paid() {
     let pool = test_pool().await;
     seed_two_night_booking(&pool, "B807", "R807").await.unwrap();
     sqlx::query("UPDATE bookings SET paid_amount = 1000000 WHERE id = ?")
@@ -309,21 +309,92 @@ async fn set_booking_rate_allows_a_total_below_what_the_guest_already_paid() {
         .await
         .unwrap();
 
-    stay_lifecycle::set_booking_rate(&pool, "B807", 300_000)
+    // Đảo ngược quyết định cũ: hạ giá từng được phép đưa tổng tiền xuống dưới
+    // số khách đã trả (2 đêm x 300.000 = 600.000 < 1.000.000 đã thu), với giả
+    // định lễ tân sẽ hoàn tiền mặt tại quầy. Giả định đó sai — check_out_tx
+    // (stay_lifecycle.rs) từ chối thẳng khi already_paid > final_total, nên
+    // booking rơi vào trạng thái không lối thoát. Quyết định mới: từ chối
+    // ngay tại đây, trước khi ghi bất kỳ thay đổi nào.
+    let error = stay_lifecycle::set_booking_rate(&pool, "B807", 300_000)
         .await
-        .unwrap();
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(ref message) if message.contains("hoàn tiền")),
+        "mong đợi lỗi validation nhắc hoàn tiền, nhận được: {error:?}"
+    );
 
     let row = sqlx::query("SELECT total_price, paid_amount FROM bookings WHERE id = ?")
         .bind("B807")
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<i64, _>("total_price"), 600_000);
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        1_000_000,
+        "bị từ chối thì tổng tiền không được đổi"
+    );
     assert_eq!(
         row.get::<i64, _>("paid_amount"),
         1_000_000,
-        "trả dư là hợp lệ; số đã trả không bị đụng tới"
+        "bị từ chối thì số đã trả không bị đụng tới"
     );
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B807")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 0, "bị từ chối thì không được ghi giao dịch nào");
+}
+
+#[tokio::test]
+async fn set_booking_rate_allows_a_total_that_still_covers_what_the_guest_already_paid() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B816", "R816").await.unwrap();
+    sqlx::query("UPDATE bookings SET paid_amount = 500000 WHERE id = ?")
+        .bind("B816")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // 2 đêm x 300.000 = 600.000, vẫn >= 500.000 đã trả — phải cho qua.
+    stay_lifecycle::set_booking_rate(&pool, "B816", 300_000)
+        .await
+        .unwrap();
+
+    let row = sqlx::query("SELECT total_price, paid_amount FROM bookings WHERE id = ?")
+        .bind("B816")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("total_price"), 600_000);
+    assert_eq!(row.get::<i64, _>("paid_amount"), 500_000);
+}
+
+#[tokio::test]
+async fn set_booking_rate_allows_a_total_exactly_equal_to_paid_amount() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B817", "R817").await.unwrap();
+    sqlx::query("UPDATE bookings SET paid_amount = 600000 WHERE id = ?")
+        .bind("B817")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Biên chính xác: 2 đêm x 300.000 = 600.000, đúng bằng số đã trả — guard
+    // dùng `<` chứ không phải `<=`, nên ca vừa khít này phải được cho qua.
+    stay_lifecycle::set_booking_rate(&pool, "B817", 300_000)
+        .await
+        .unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind("B817")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 600_000);
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -641,3 +641,200 @@ async fn update_booking_notes_refuses_a_booking_that_is_not_active() {
     // `BookingError::Conflict`, never `Validation`/`NotFound`.
     assert!(matches!(error, BookingError::Conflict(_)));
 }
+
+/// `update_booking_notes_idempotent` là con đường mà Tauri command thật sự đi
+/// qua (xem `commands/rooms.rs`). Test này đọc ngược từ `command_idempotency`
+/// để chứng minh có một dòng ledger ghi lại actor đã sửa ghi chú — đúng câu
+/// hỏi "ai đã sửa ghi chú hoá đơn này" mà finding yêu cầu trả lời được không
+/// cần bảng log riêng.
+#[tokio::test]
+async fn update_booking_notes_idempotent_records_the_actor_in_the_command_ledger() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B905", "R905").await.unwrap();
+
+    let mut ctx = crate::command_idempotency::WriteCommandContext::new_internal(
+        "update_booking_notes",
+    );
+    ctx.actor_id = Some("staff-905".to_string());
+
+    stay_lifecycle::update_booking_notes_idempotent(
+        &pool,
+        &ctx,
+        "B905",
+        Some("Khách yêu cầu dọn phòng sớm".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let row = sqlx::query(
+        "SELECT actor_id, command_name, primary_aggregate_key
+         FROM command_idempotency
+         WHERE idempotency_key = ?",
+    )
+    .bind(&ctx.idempotency_key)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.get::<Option<String>, _>("actor_id").as_deref(), Some("staff-905"));
+    assert_eq!(
+        row.get::<String, _>("command_name"),
+        "update_booking_notes"
+    );
+    assert_eq!(
+        row.get::<Option<String>, _>("primary_aggregate_key").as_deref(),
+        Some("booking:B905")
+    );
+
+    let notes: Option<String> = sqlx::query_scalar("SELECT notes FROM bookings WHERE id = ?")
+        .bind("B905")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(notes.as_deref(), Some("Khách yêu cầu dọn phòng sớm"));
+}
+
+/// Ghi chú không đụng tiền/lịch phòng nên KHÔNG cần đăng ký vào
+/// `write_manifest.rs` (chỉ dành cho MCP write-tool chính sách rủi ro cao) và
+/// KHÔNG cần liệt vào danh sách rủi ro cao của `command_recovery.rs` —
+/// `command_recovery_risk_level` phải rơi về mặc định `Low` cho một command
+/// không có mặt trong danh sách đó.
+#[test]
+fn update_booking_notes_stays_out_of_the_write_manifest_and_recovery_high_risk_list() {
+    assert!(
+        crate::write_manifest::meta_for("update_booking_notes").is_none(),
+        "update_booking_notes không thuộc write_manifest — nó không phải MCP write-tool rủi ro cao"
+    );
+    assert_eq!(
+        crate::command_recovery::command_recovery_risk_level("update_booking_notes"),
+        crate::command_recovery::RecoveryRiskLevel::Low
+    );
+}
+
+/// `update_booking_notes_idempotent` tự sinh idempotency key qua
+/// `WriteCommandContext::new_internal` — phía gọi (Tauri command) không cần
+/// truyền idempotency key, khác với `add_folio_line`/`set_booking_rate`.
+#[test]
+fn update_booking_notes_context_generates_its_own_idempotency_key_without_caller_input() {
+    let ctx = crate::command_idempotency::WriteCommandContext::new_internal(
+        "update_booking_notes",
+    );
+
+    assert!(!ctx.idempotency_key.trim().is_empty());
+    assert_eq!(ctx.command_name, "update_booking_notes");
+}
+
+/// Đổi giá khoá optimistic-concurrency giống hệt `shorten_stay_tx`: chốt
+/// `total_price` đọc được TRƯỚC khi khoá booking, rồi yêu cầu UPDATE cuối cùng
+/// khớp đúng giá trị đó (`AND total_price = ?`). Lái một cuộc đua THẬT qua pool
+/// thứ hai bằng cách giữ đúng aggregate lock mà `set_booking_rate` cần, đợi lệnh
+/// gọi claim xong rồi mới cho pool_b ghi thẳng — xem chú thích đầy đủ ở
+/// `shorten_stay_fails_when_second_pool_moves_the_checkout_while_the_lock_is_held`.
+///
+/// Nếu bỏ `AND total_price = ?` khỏi UPDATE, test này FAIL: set_booking_rate sẽ
+/// nhả lock, đọc lại total_price mới nhất, rồi đổi giá êm ru trên một tổng tiền
+/// mà lễ tân chưa từng thấy — không có lỗi nào nổi lên.
+#[tokio::test]
+async fn set_booking_rate_fails_when_second_pool_moves_the_total_while_the_lock_is_held() {
+    let (pool_a, pool_b, db_path) =
+        shared_file_test_pools("second-pool-rate-total-price").await;
+    seed_two_night_booking(&pool_a, "B-2POOL-RATE", "R-2POOL-RATE")
+        .await
+        .unwrap();
+
+    let ctx = cmd("set_booking_rate", "idem-rate-2pool-total");
+
+    let held_lock = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key("B-2POOL-RATE").unwrap(),
+            crate::aggregate_locks::room_key("R-2POOL-RATE").unwrap(),
+            crate::aggregate_locks::folio_key("B-2POOL-RATE").unwrap(),
+        ])
+        .await
+        .unwrap();
+
+    let pool_a_for_task = pool_a.clone();
+    let ctx_for_task = ctx.clone();
+    let handle = tokio::spawn(async move {
+        stay_lifecycle::set_booking_rate_idempotent(
+            &pool_a_for_task,
+            &ctx_for_task,
+            "B-2POOL-RATE",
+            450_000,
+        )
+        .await
+    });
+
+    let mut claim_seen = false;
+    for _ in 0..50 {
+        let in_progress_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_idempotency
+             WHERE idempotency_key = ? AND status = 'in_progress'",
+        )
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool_a)
+        .await
+        .unwrap();
+        if in_progress_count == 1 {
+            claim_seen = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(
+        claim_seen,
+        "set_booking_rate phải claim xong trước khi bị chặn ở lock"
+    );
+
+    // Một actor thật sự khác đổi total_price trong lúc set_booking_rate đang
+    // bị chặn ở lock.
+    sqlx::query("UPDATE bookings SET total_price = ? WHERE id = ?")
+        .bind(1_500_000_i64)
+        .bind("B-2POOL-RATE")
+        .execute(&pool_b)
+        .await
+        .unwrap();
+
+    drop(held_lock);
+
+    let error = handle
+        .await
+        .unwrap()
+        .expect_err("set_booking_rate phải từ chối khi total_price đã đổi trong lúc chờ lock");
+
+    assert_eq!(error.code, crate::app_error::codes::BOOKING_INVALID_STATE);
+    assert!(
+        error
+            .message
+            .contains("Booking vừa được cập nhật bởi thao tác khác"),
+        "message thực tế: {}",
+        error.message
+    );
+
+    let row = sqlx::query("SELECT total_price, rate_overridden_at FROM bookings WHERE id = ?")
+        .bind("B-2POOL-RATE")
+        .fetch_one(&pool_a)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        1_500_000,
+        "bị chặn thì total_price phải giữ đúng giá trị pool_b vừa ghi, không bị set_booking_rate ghi đè"
+    );
+    assert!(
+        row.get::<Option<String>, _>("rate_overridden_at").is_none(),
+        "bị chặn thì không được đóng dấu đổi giá"
+    );
+
+    let charge_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B-2POOL-RATE")
+    .fetch_one(&pool_a)
+    .await
+    .unwrap();
+    assert_eq!(charge_count, 0, "bị chặn thì không được để lại dòng đối ứng");
+
+    pool_a.close().await;
+    pool_b.close().await;
+    let _ = std::fs::remove_file(db_path);
+}

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -1,0 +1,248 @@
+use super::prelude::*;
+use crate::domain::booking::BookingResult;
+use sqlx::{Pool, Sqlite};
+
+/// `seed_active_booking` tạo booking 1 đêm, tổng 250.000₫.
+/// Nâng lên 2 đêm / 1.000.000₫ để phép chia giá-mỗi-đêm có ý nghĩa.
+async fn seed_two_night_booking(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    room_id: &str,
+) -> BookingResult<()> {
+    seed_room(pool, room_id).await?;
+    seed_active_booking(pool, booking_id, room_id).await?;
+    sqlx::query("UPDATE bookings SET nights = 2, total_price = 1000000 WHERE id = ?")
+        .bind(booking_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn set_booking_rate_recomputes_the_total_from_nights() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B801", "R801").await.unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B801", 450_000)
+        .await
+        .unwrap();
+
+    let row = sqlx::query(
+        "SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?",
+    )
+    .bind("B801")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.get::<i64, _>("total_price"), 900_000);
+    assert_eq!(row.get::<i32, _>("nights"), 2, "số đêm không được đổi");
+    assert_eq!(
+        row.get::<String, _>("expected_checkout"),
+        "2026-04-16T10:00:00+07:00",
+        "ngày checkout không được đổi"
+    );
+}
+
+#[tokio::test]
+async fn set_booking_rate_records_the_difference_as_a_charge() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B802", "R802").await.unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B802", 450_000)
+        .await
+        .unwrap();
+
+    let amount: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B802")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(amount, -100_000, "1.000.000 → 900.000 là chênh lệch -100.000");
+}
+
+#[tokio::test]
+async fn set_booking_rate_writes_no_charge_when_the_total_is_unchanged() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B803", "R803").await.unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B803", 500_000)
+        .await
+        .unwrap();
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B803")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 0);
+}
+
+#[tokio::test]
+async fn set_booking_rate_leaves_the_room_base_price_alone() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B804", "R804").await.unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B804", 450_000)
+        .await
+        .unwrap();
+
+    let base_price: i64 = sqlx::query_scalar("SELECT base_price FROM rooms WHERE id = ?")
+        .bind("R804")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        base_price, 250_000,
+        "sửa giá một booking không được lan sang giá mặc định của phòng"
+    );
+}
+
+#[tokio::test]
+async fn set_booking_rate_rejects_zero_and_negative_rates() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B805", "R805").await.unwrap();
+
+    for rate in [0_i64, -1_000] {
+        let error = stay_lifecycle::set_booking_rate(&pool, "B805", rate)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, BookingError::Validation(_)),
+            "giá {rate} phải bị từ chối, nhận được: {error:?}"
+        );
+    }
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind("B805")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 1_000_000, "lệnh bị từ chối thì DB không được đổi");
+}
+
+#[tokio::test]
+async fn set_booking_rate_rejects_a_rate_above_the_cap() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B806", "R806").await.unwrap();
+
+    let error = stay_lifecycle::set_booking_rate(&pool, "B806", 100_000_001)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, BookingError::Validation(_)));
+}
+
+#[tokio::test]
+async fn set_booking_rate_allows_a_total_below_what_the_guest_already_paid() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B807", "R807").await.unwrap();
+    sqlx::query("UPDATE bookings SET paid_amount = 1000000 WHERE id = ?")
+        .bind("B807")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B807", 300_000)
+        .await
+        .unwrap();
+
+    let row = sqlx::query("SELECT total_price, paid_amount FROM bookings WHERE id = ?")
+        .bind("B807")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("total_price"), 600_000);
+    assert_eq!(
+        row.get::<i64, _>("paid_amount"),
+        1_000_000,
+        "trả dư là hợp lệ; số đã trả không bị đụng tới"
+    );
+}
+
+#[tokio::test]
+async fn set_booking_rate_writes_nothing_when_the_booking_is_reserved_not_active() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B809", "R809").await.unwrap();
+
+    sqlx::query("UPDATE bookings SET status = 'reserved' WHERE id = ?")
+        .bind("B809")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::set_booking_rate(&pool, "B809", 450_000)
+        .await
+        .unwrap_err();
+    // `set_booking_rate_tx` rejects a non-active booking via `invalid_state_transition`,
+    // which always maps to `BookingError::Conflict`, not `Validation`/`NotFound` — see
+    // `invalid_state_transition` in support.rs and the same correction in shorten_stay.rs.
+    assert!(matches!(
+        error,
+        BookingError::Conflict(_)
+    ));
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind("B809")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 1_000_000, "lệnh bị chặn thì tổng tiền không được đổi");
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B809")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 0, "bị chặn thì không được để lại dòng đối ứng");
+}
+
+#[tokio::test]
+async fn set_booking_rate_leaves_the_room_calendar_alone() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B810", "R810").await.unwrap();
+
+    let before: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
+            .bind("B810")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B810", 450_000)
+        .await
+        .unwrap();
+
+    let after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
+            .bind("B810")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(before, after, "sửa giá không được đụng tới lịch phòng");
+}
+
+#[tokio::test]
+async fn set_booking_rate_refuses_a_booking_that_is_not_active() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B808", "R808").await.unwrap();
+    sqlx::query("UPDATE bookings SET status = 'checked_out' WHERE id = ?")
+        .bind("B808")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::set_booking_rate(&pool, "B808", 450_000)
+        .await
+        .unwrap_err();
+    // Same as above: a checked-out booking is rejected via `invalid_state_transition`,
+    // which is `BookingError::Conflict`.
+    assert!(matches!(
+        error,
+        BookingError::Conflict(_)
+    ));
+}

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -63,6 +63,170 @@ async fn set_booking_rate_records_the_difference_as_a_charge() {
 }
 
 #[tokio::test]
+async fn set_booking_rate_raises_the_total_and_records_a_positive_charge() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B811", "R811").await.unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B811", 600_000)
+        .await
+        .unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind("B811")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 1_200_000, "2 đêm x 600.000 phải nâng tổng tiền lên");
+
+    let amount: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B811")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    // Mọi test khác ở đây đều giảm giá hoặc giữ nguyên; nếu tham số của
+    // `checked_sub_money` bị đảo (new_total, current_total) → (current_total,
+    // new_total), test giảm giá vẫn xanh vì trị tuyệt đối trùng nhau, chỉ có
+    // ca tăng giá này mới lộ dấu bị lật.
+    assert_eq!(
+        amount, 200_000,
+        "1.000.000 → 1.200.000 là chênh lệch +200.000"
+    );
+}
+
+#[tokio::test]
+async fn set_booking_rate_rejects_a_corrupted_zero_nights_booking() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B813", "R813").await.unwrap();
+
+    // `bookings.nights` has no CHECK constraint at the schema level — corrupt
+    // it directly via SQL to simulate a value the app itself would never
+    // write, mirroring the equivalent guard test in `shorten_stay.rs`.
+    sqlx::query("UPDATE bookings SET nights = 0 WHERE id = ?")
+        .bind("B813")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::set_booking_rate(&pool, "B813", 450_000)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(_)),
+        "mong đợi lỗi validation cho nights=0, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B813")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        0,
+        "thất bại thì không được đổi giá trị nights đã hỏng"
+    );
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        1_000_000,
+        "thất bại thì total_price không đổi"
+    );
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B813")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 0, "thất bại thì không được ghi giao dịch nào");
+}
+
+#[tokio::test]
+async fn set_booking_rate_rejects_a_corrupted_negative_nights_booking() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B814", "R814").await.unwrap();
+
+    // Same defence-in-depth guard, negative side: without it, `rate_per_night
+    // * nights` still "succeeds" arithmetically but flips the sign, inventing
+    // a negative total_price and a matching negative audit row instead of
+    // rejecting the corrupt row.
+    sqlx::query("UPDATE bookings SET nights = -1 WHERE id = ?")
+        .bind("B814")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::set_booking_rate(&pool, "B814", 450_000)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(_)),
+        "mong đợi lỗi validation cho nights âm, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B814")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        -1,
+        "thất bại thì không được đổi giá trị nights đã hỏng"
+    );
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        1_000_000,
+        "thất bại thì total_price không được bịa thêm tiền"
+    );
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B814")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        charges, 0,
+        "thất bại thì không được ghi giao dịch phát sinh tiền ảo nào"
+    );
+}
+
+#[tokio::test]
+async fn set_booking_rate_idempotent_retry_applies_the_rate_change_once() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B815", "R815").await.unwrap();
+
+    let ctx = cmd("set_booking_rate", "rate-key-1");
+
+    stay_lifecycle::set_booking_rate_idempotent(&pool, &ctx, "B815", 450_000)
+        .await
+        .unwrap();
+    stay_lifecycle::set_booking_rate_idempotent(&pool, &ctx, "B815", 450_000)
+        .await
+        .unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind("B815")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 900_000, "gửi lại không được áp lại giá lần hai");
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B815")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 1, "chỉ được một dòng đối ứng duy nhất");
+}
+
+#[tokio::test]
 async fn set_booking_rate_writes_no_charge_when_the_total_is_unchanged() {
     let pool = test_pool().await;
     seed_two_night_booking(&pool, "B803", "R803").await.unwrap();
@@ -206,24 +370,38 @@ async fn set_booking_rate_leaves_the_room_calendar_alone() {
     let pool = test_pool().await;
     seed_two_night_booking(&pool, "B810", "R810").await.unwrap();
 
-    let before: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
-            .bind("B810")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    // So khớp toàn bộ nội dung dòng, không chỉ đếm số dòng — một UPDATE
+    // room_calendar SET status = ... tại chỗ vẫn giữ nguyên COUNT(*) nhưng
+    // đổi status, nên phải so cả cột mới bắt được.
+    let before: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
+        "SELECT room_id, date, booking_id, status FROM room_calendar
+         WHERE booking_id = ? ORDER BY date",
+    )
+    .bind("B810")
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert!(
+        !before.is_empty(),
+        "seed phải tạo ít nhất một dòng lịch phòng để test này có ý nghĩa"
+    );
 
     stay_lifecycle::set_booking_rate(&pool, "B810", 450_000)
         .await
         .unwrap();
 
-    let after: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
-            .bind("B810")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(before, after, "sửa giá không được đụng tới lịch phòng");
+    let after: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
+        "SELECT room_id, date, booking_id, status FROM room_calendar
+         WHERE booking_id = ? ORDER BY date",
+    )
+    .bind("B810")
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        before, after,
+        "sửa giá không được đụng tới lịch phòng, kể cả sửa tại chỗ giữ nguyên số dòng"
+    );
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
+++ b/mhm/src-tauri/src/services/booking/tests/booking_edits.rs
@@ -497,6 +497,70 @@ async fn set_booking_rate_refuses_a_booking_that_is_not_active() {
 }
 
 #[tokio::test]
+async fn set_booking_rate_stamps_rate_overridden_at() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B811", "R811").await.unwrap();
+
+    let before: Option<String> =
+        sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = ?")
+            .bind("B811")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(before, None, "booking mới tạo chưa từng bị đổi giá tay");
+
+    stay_lifecycle::set_booking_rate(&pool, "B811", 450_000)
+        .await
+        .unwrap();
+
+    let after: Option<String> =
+        sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = ?")
+            .bind("B811")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        after.is_some(),
+        "set_booking_rate phải đóng dấu thời điểm đổi giá vào cột rate_overridden_at"
+    );
+}
+
+#[tokio::test]
+async fn a_normally_priced_booking_has_no_rate_override_stamp() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B812", "R812").await.unwrap();
+
+    // Không gọi set_booking_rate — booking này chỉ được định giá bình thường.
+    let rate_overridden_at: Option<String> =
+        sqlx::query_scalar("SELECT rate_overridden_at FROM bookings WHERE id = ?")
+            .bind("B812")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(rate_overridden_at, None);
+}
+
+#[tokio::test]
+async fn rate_override_stamp_survives_a_round_trip_through_the_query_layer() {
+    let pool = test_pool().await;
+    seed_two_night_booking(&pool, "B813", "R813").await.unwrap();
+
+    stay_lifecycle::set_booking_rate(&pool, "B813", 450_000)
+        .await
+        .unwrap();
+
+    let detail = crate::queries::booking::room_queries::load_room_detail(&pool, "R813")
+        .await
+        .unwrap();
+    let booking = detail.booking.expect("R813 has an active booking");
+    assert_eq!(booking.id, "B813");
+    assert!(
+        booking.rate_overridden_at.is_some(),
+        "map_booking phải trả về dấu đổi giá đọc được từ DB, không phải chỉ ghi được"
+    );
+}
+
+#[tokio::test]
 async fn update_booking_notes_trims_and_saves() {
     let pool = test_pool().await;
     seed_two_night_booking(&pool, "B901", "R901").await.unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -57,5 +57,6 @@ mod pricing;
 mod reporting;
 mod reservation_idempotency;
 mod reservations;
+mod shorten_stay;
 mod stay_error_mapping;
 mod stays;

--- a/mhm/src-tauri/src/services/booking/tests/mod.rs
+++ b/mhm/src-tauri/src/services/booking/tests/mod.rs
@@ -43,6 +43,7 @@ mod prelude {
 }
 
 mod backfill;
+mod booking_edits;
 mod checkout_settlement;
 mod extend_stay;
 mod folio;

--- a/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
+++ b/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
@@ -559,8 +559,8 @@ async fn the_migrated_special_dates_table_matches_what_the_code_assumes() {
     db.close().await;
 }
 
-/// Nhánh này không được thêm hay sửa migration nào: phiên bản schema phải đứng
-/// yên ở 22, đúng như trên `main`.
+/// Nhánh này không được thêm hay sửa migration nào ngoài phạm vi của nó: phiên
+/// bản schema sau khi migrate phải khớp `LATEST_SCHEMA_VERSION` hiện hành.
 #[tokio::test]
 async fn the_branch_does_not_move_the_schema_version() {
     let db = migrated_db("schema-version").await;
@@ -570,7 +570,11 @@ async fn the_branch_does_not_move_the_schema_version() {
         .await
         .expect("đọc schema_version");
 
-    assert_eq!(version, 23, "nhánh mùa cao điểm không đụng vào migration");
+    assert_eq!(
+        version,
+        i64::from(crate::db::LATEST_SCHEMA_VERSION),
+        "nhánh mùa cao điểm không đụng vào migration"
+    );
 
     db.close().await;
 }

--- a/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
+++ b/mhm/src-tauri/src/services/booking/tests/peak_season_e2e.rs
@@ -570,7 +570,7 @@ async fn the_branch_does_not_move_the_schema_version() {
         .await
         .expect("đọc schema_version");
 
-    assert_eq!(version, 22, "nhánh mùa cao điểm không đụng vào migration");
+    assert_eq!(version, 23, "nhánh mùa cao điểm không đụng vào migration");
 
     db.close().await;
 }

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
-use chrono::Datelike;
 use crate::domain::booking::BookingResult;
+use chrono::Datelike;
 use sqlx::{Pool, Sqlite};
 
 /// Thứ Hai kế tiếp, luôn cách hôm nay ít nhất 1 ngày.
@@ -97,30 +97,28 @@ async fn charge_total(pool: &Pool<Sqlite>, booking_id: &str) -> i64 {
 async fn shorten_stay_drops_the_last_night_and_its_charge() {
     let pool = test_pool().await;
     seed_room(&pool, "R701").await.unwrap();
-    let (check_in, checkout) = seed_future_booking(&pool, "B701", "R701", 3)
-        .await
-        .unwrap();
+    let (check_in, checkout) = seed_future_booking(&pool, "B701", "R701", 3).await.unwrap();
 
     stay_lifecycle::shorten_stay(&pool, "B701").await.unwrap();
 
-    let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
-        .bind("B701")
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+    let row =
+        sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+            .bind("B701")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(row.get::<i32, _>("nights"), 2);
     assert_eq!(row.get::<i64, _>("total_price"), 500_000);
 
     let check_in_date = date_from_rfc3339(&check_in);
     let freed_night = check_in_date + Duration::days(2);
-    let remaining: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?",
-    )
-    .bind("B701")
-    .bind(freed_night.format("%Y-%m-%d").to_string())
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?")
+            .bind("B701")
+            .bind(freed_night.format("%Y-%m-%d").to_string())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(remaining, 0, "đêm bị rút phải được nhả khỏi lịch phòng");
 
     // Checkout mới phải lùi lại đúng 1 ngày so với checkout ban đầu — tức
@@ -151,9 +149,7 @@ async fn shorten_stay_drops_the_last_night_and_its_charge() {
 async fn extend_then_shorten_restores_the_booking_exactly() {
     let pool = test_pool().await;
     seed_room(&pool, "R702").await.unwrap();
-    let (_check_in, checkout) = seed_future_booking(&pool, "B702", "R702", 2)
-        .await
-        .unwrap();
+    let (_check_in, checkout) = seed_future_booking(&pool, "B702", "R702", 2).await.unwrap();
 
     let before_charges = charge_total(&pool, "B702").await;
 
@@ -179,11 +175,12 @@ async fn extend_then_shorten_restores_the_booking_exactly() {
 
     stay_lifecycle::shorten_stay(&pool, "B702").await.unwrap();
 
-    let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
-        .bind("B702")
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+    let row =
+        sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+            .bind("B702")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(row.get::<i32, _>("nights"), 2);
     assert_eq!(row.get::<i64, _>("total_price"), 500_000);
     assert_eq!(row.get::<String, _>("expected_checkout"), checkout);
@@ -233,13 +230,12 @@ async fn shorten_stay_refuses_to_push_checkout_into_the_past() {
         "mong đợi lỗi validation nhắc dùng Check-out, nhận được: {error:?}"
     );
 
-    let unchanged = sqlx::query_scalar::<_, String>(
-        "SELECT expected_checkout FROM bookings WHERE id = ?",
-    )
-    .bind("B703")
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let unchanged =
+        sqlx::query_scalar::<_, String>("SELECT expected_checkout FROM bookings WHERE id = ?")
+            .bind("B703")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(unchanged, checkout, "lệnh thất bại thì DB không được đổi");
 }
 
@@ -327,7 +323,11 @@ async fn shorten_stay_refuses_a_booking_that_is_not_active() {
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<i32, _>("nights"), 3, "thất bại thì số đêm không đổi");
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        3,
+        "thất bại thì số đêm không đổi"
+    );
     assert_eq!(
         row.get::<i64, _>("total_price"),
         750_000,
@@ -339,9 +339,7 @@ async fn shorten_stay_refuses_a_booking_that_is_not_active() {
 async fn shorten_stay_credits_the_booking_average_not_the_current_rate() {
     let pool = test_pool().await;
     seed_room(&pool, "R709").await.unwrap();
-    let (check_in, _checkout) = seed_future_booking(&pool, "B709", "R709", 2)
-        .await
-        .unwrap();
+    let (check_in, _checkout) = seed_future_booking(&pool, "B709", "R709", 2).await.unwrap();
 
     // Booking 2 đêm x 250,000 (tổng 500,000) được chốt giá lúc nhận phòng.
     // Sau đó một dòng pricing_rules đẩy giá phòng lên 900,000/đêm — nếu
@@ -366,14 +364,13 @@ async fn shorten_stay_credits_the_booking_average_not_the_current_rate() {
 
     let check_in_date = date_from_rfc3339(&check_in);
     let freed_night = check_in_date + Duration::days(1);
-    let calendar_rows: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?",
-    )
-    .bind("B709")
-    .bind(freed_night.format("%Y-%m-%d").to_string())
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let calendar_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?")
+            .bind("B709")
+            .bind(freed_night.format("%Y-%m-%d").to_string())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(calendar_rows, 0, "đêm bị rút phải được nhả khỏi lịch phòng");
 
     let credit: i64 = sqlx::query_scalar(
@@ -498,9 +495,7 @@ async fn shorten_stay_rejects_a_negative_nights_booking_instead_of_inventing_mon
 async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing() {
     let pool = test_pool().await;
     seed_room(&pool, "R707").await.unwrap();
-    let (check_in, _checkout) = seed_future_booking(&pool, "B707", "R707", 3)
-        .await
-        .unwrap();
+    let (check_in, _checkout) = seed_future_booking(&pool, "B707", "R707", 3).await.unwrap();
 
     // Mô phỏng ai đó động vào lịch phòng giữa chừng: xoá đúng dòng mà
     // shorten_stay sắp gỡ. Chốt `ensure_one_row_affected` trên câu DELETE phải
@@ -530,7 +525,11 @@ async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing()
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<i32, _>("nights"), 3, "rollback phải giữ nguyên số đêm");
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        3,
+        "rollback phải giữ nguyên số đêm"
+    );
     assert_eq!(row.get::<i64, _>("total_price"), 750_000);
 
     let credits: i64 = sqlx::query_scalar(
@@ -540,7 +539,10 @@ async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing()
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(credits, 0, "rollback thì không được để lại dòng đối ứng nào");
+    assert_eq!(
+        credits, 0,
+        "rollback thì không được để lại dòng đối ứng nào"
+    );
 }
 
 #[tokio::test]
@@ -574,7 +576,11 @@ async fn shorten_stay_refuses_a_credit_that_would_drop_the_total_below_paid_amou
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<i32, _>("nights"), 3, "bị từ chối thì số đêm không đổi");
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        3,
+        "bị từ chối thì số đêm không đổi"
+    );
     assert_eq!(
         row.get::<i64, _>("total_price"),
         750_000,
@@ -673,7 +679,11 @@ async fn shorten_stay_idempotent_retry_replays_without_removing_a_second_night()
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<i32, _>("nights"), 2, "gửi lại chỉ được rút một đêm");
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        2,
+        "gửi lại chỉ được rút một đêm"
+    );
     assert_eq!(row.get::<i64, _>("total_price"), 500_000);
 
     let credits: i64 = sqlx::query_scalar(
@@ -776,18 +786,27 @@ async fn shorten_stay_fails_when_second_pool_moves_the_checkout_while_the_lock_i
         error.message
     );
 
-    let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
-        .bind("B-2POOL-SHORTEN")
-        .fetch_one(&pool_a)
-        .await
-        .unwrap();
+    let row =
+        sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+            .bind("B-2POOL-SHORTEN")
+            .fetch_one(&pool_a)
+            .await
+            .unwrap();
     assert_eq!(
         row.get::<String, _>("expected_checkout"),
         "2099-01-01T12:00:00+07:00",
         "bị chặn thì checkout phải giữ đúng giá trị pool_b vừa ghi, không bị shorten_stay ghi đè"
     );
-    assert_eq!(row.get::<i32, _>("nights"), 3, "bị chặn thì không được rút đêm");
-    assert_eq!(row.get::<i64, _>("total_price"), 750_000, "bị chặn thì tổng tiền không được đổi");
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        3,
+        "bị chặn thì không được rút đêm"
+    );
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        750_000,
+        "bị chặn thì tổng tiền không được đổi"
+    );
 
     let credit_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND note = 'Shortened stay -1 night'",
@@ -796,7 +815,10 @@ async fn shorten_stay_fails_when_second_pool_moves_the_checkout_while_the_lock_i
     .fetch_one(&pool_a)
     .await
     .unwrap();
-    assert_eq!(credit_count, 0, "bị chặn thì không được để lại dòng đối ứng");
+    assert_eq!(
+        credit_count, 0,
+        "bị chặn thì không được để lại dòng đối ứng"
+    );
 
     pool_a.close().await;
     pool_b.close().await;

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -542,3 +542,36 @@ async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing()
     .unwrap();
     assert_eq!(credits, 0, "rollback thì không được để lại dòng đối ứng nào");
 }
+
+#[tokio::test]
+async fn shorten_stay_idempotent_retry_replays_without_removing_a_second_night() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R706").await.unwrap();
+    seed_future_booking(&pool, "B706", "R706", 3).await.unwrap();
+
+    let ctx = cmd("shorten_stay", "shorten-key-1");
+
+    stay_lifecycle::shorten_stay_idempotent(&pool, &ctx, "B706")
+        .await
+        .unwrap();
+    stay_lifecycle::shorten_stay_idempotent(&pool, &ctx, "B706")
+        .await
+        .unwrap();
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B706")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 2, "gửi lại chỉ được rút một đêm");
+    assert_eq!(row.get::<i64, _>("total_price"), 500_000);
+
+    let credits: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND note = 'Shortened stay -1 night'",
+    )
+    .bind("B706")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(credits, 1, "chỉ được một dòng đối ứng duy nhất");
+}

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -544,6 +544,116 @@ async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing()
 }
 
 #[tokio::test]
+async fn shorten_stay_refuses_a_credit_that_would_drop_the_total_below_paid_amount() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R712").await.unwrap();
+    seed_future_booking(&pool, "B712", "R712", 3).await.unwrap();
+    // 3 đêm x 250.000 = 750.000. Rút 1 đêm hoàn 250.000, tổng mới còn
+    // 500.000 — thấp hơn 600.000 khách đã trả.
+    sqlx::query("UPDATE bookings SET paid_amount = 600000 WHERE id = ?")
+        .bind("B712")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Đảo ngược quyết định cũ: rút đêm từng được phép đưa tổng tiền xuống
+    // dưới số khách đã trả, với giả định lễ tân sẽ hoàn tiền mặt tại quầy.
+    // Giả định đó sai — check_out_tx từ chối thẳng khi already_paid >
+    // final_total, nên booking rơi vào trạng thái không lối thoát. Quyết
+    // định mới: từ chối ngay tại đây, trước khi ghi bất kỳ thay đổi nào.
+    let error = stay_lifecycle::shorten_stay(&pool, "B712")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(ref message) if message.contains("hoàn tiền")),
+        "mong đợi lỗi validation nhắc hoàn tiền, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price, paid_amount FROM bookings WHERE id = ?")
+        .bind("B712")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 3, "bị từ chối thì số đêm không đổi");
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        750_000,
+        "bị từ chối thì tổng tiền không đổi"
+    );
+    assert_eq!(
+        row.get::<i64, _>("paid_amount"),
+        600_000,
+        "bị từ chối thì số đã trả không bị đụng tới"
+    );
+
+    let calendar_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
+            .bind("B712")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        calendar_rows, 3,
+        "bị từ chối thì lịch phòng không được nhả đêm nào"
+    );
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B712")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 0, "bị từ chối thì không được ghi giao dịch nào");
+}
+
+#[tokio::test]
+async fn shorten_stay_allows_a_credit_that_still_covers_paid_amount() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R713").await.unwrap();
+    seed_future_booking(&pool, "B713", "R713", 3).await.unwrap();
+    // Tổng mới sau rút đêm là 500.000, vẫn >= 400.000 đã trả — phải cho qua.
+    sqlx::query("UPDATE bookings SET paid_amount = 400000 WHERE id = ?")
+        .bind("B713")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    stay_lifecycle::shorten_stay(&pool, "B713").await.unwrap();
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B713")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 2);
+    assert_eq!(row.get::<i64, _>("total_price"), 500_000);
+}
+
+#[tokio::test]
+async fn shorten_stay_allows_a_credit_that_lands_the_total_exactly_on_paid_amount() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R714").await.unwrap();
+    seed_future_booking(&pool, "B714", "R714", 3).await.unwrap();
+    // Biên chính xác: tổng mới sau rút đêm đúng bằng 500.000 đã trả — guard
+    // dùng `<` chứ không phải `<=`, nên ca vừa khít này phải được cho qua.
+    sqlx::query("UPDATE bookings SET paid_amount = 500000 WHERE id = ?")
+        .bind("B714")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    stay_lifecycle::shorten_stay(&pool, "B714").await.unwrap();
+
+    let total: i64 = sqlx::query_scalar("SELECT total_price FROM bookings WHERE id = ?")
+        .bind("B714")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 500_000);
+}
+
+#[tokio::test]
 async fn shorten_stay_idempotent_retry_replays_without_removing_a_second_night() {
     let pool = test_pool().await;
     seed_room(&pool, "R706").await.unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -1,0 +1,282 @@
+use super::prelude::*;
+use chrono::Datelike;
+use crate::domain::booking::BookingResult;
+use sqlx::{Pool, Sqlite};
+
+/// Thứ Hai kế tiếp, luôn cách hôm nay ít nhất 1 ngày.
+///
+/// Neo vào thứ Hai để các đêm trong test (Hai, Ba, Tư, Năm) không bao giờ chạm
+/// cuối tuần — `calculate_weekend_uplift` cộng 20% cho đêm Bảy/Chủ Nhật, và một
+/// fixture neo thẳng vào `Local::now()` sẽ cho số tiền khác nhau tuỳ ngày chạy.
+fn next_monday() -> NaiveDate {
+    let today = Local::now().date_naive();
+    let days_ahead = 7 - i64::from(today.weekday().num_days_from_monday());
+    today + Duration::days(days_ahead)
+}
+
+/// Booking `nights` đêm bắt đầu từ thứ Hai kế tiếp, kèm đủ dòng `room_calendar`.
+/// Trả về `(check_in_at, expected_checkout)` dạng RFC3339.
+async fn seed_future_booking(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    room_id: &str,
+    nights: i64,
+) -> BookingResult<(String, String)> {
+    seed_active_booking(pool, booking_id, room_id).await?;
+
+    let check_in = next_monday();
+    let checkout = check_in + Duration::days(nights);
+    let check_in_at = format!("{}T14:00:00+07:00", check_in.format("%Y-%m-%d"));
+    let expected_checkout = format!("{}T12:00:00+07:00", checkout.format("%Y-%m-%d"));
+
+    sqlx::query(
+        "UPDATE bookings
+         SET check_in_at = ?, expected_checkout = ?, nights = ?, total_price = ?
+         WHERE id = ?",
+    )
+    .bind(&check_in_at)
+    .bind(&expected_checkout)
+    .bind(nights)
+    .bind(250_000 * nights)
+    .bind(booking_id)
+    .execute(pool)
+    .await?;
+
+    sqlx::query("DELETE FROM room_calendar WHERE booking_id = ?")
+        .bind(booking_id)
+        .execute(pool)
+        .await?;
+
+    for offset in 0..nights {
+        let night = check_in + Duration::days(offset);
+        sqlx::query(
+            "INSERT INTO room_calendar (room_id, date, booking_id, status)
+             VALUES (?, ?, ?, 'occupied')",
+        )
+        .bind(room_id)
+        .bind(night.format("%Y-%m-%d").to_string())
+        .bind(booking_id)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok((check_in_at, expected_checkout))
+}
+
+async fn charge_total(pool: &Pool<Sqlite>, booking_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COALESCE(SUM(amount), 0) FROM transactions
+         WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind(booking_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn shorten_stay_drops_the_last_night_and_its_charge() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R701").await.unwrap();
+    let (_check_in, _checkout) = seed_future_booking(&pool, "B701", "R701", 3)
+        .await
+        .unwrap();
+
+    stay_lifecycle::shorten_stay(&pool, "B701").await.unwrap();
+
+    let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+        .bind("B701")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 2);
+    assert_eq!(row.get::<i64, _>("total_price"), 500_000);
+
+    let freed_night = next_monday() + Duration::days(2);
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?",
+    )
+    .bind("B701")
+    .bind(freed_night.format("%Y-%m-%d").to_string())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining, 0, "đêm bị rút phải được nhả khỏi lịch phòng");
+
+    let credit: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = ? AND note = 'Shortened stay -1 night'",
+    )
+    .bind("B701")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(credit, -250_000);
+}
+
+#[tokio::test]
+async fn extend_then_shorten_restores_the_booking_exactly() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R702").await.unwrap();
+    let (_check_in, checkout) = seed_future_booking(&pool, "B702", "R702", 2)
+        .await
+        .unwrap();
+
+    let before_charges = charge_total(&pool, "B702").await;
+
+    stay_lifecycle::extend_stay(&pool, "B702").await.unwrap();
+    stay_lifecycle::shorten_stay(&pool, "B702").await.unwrap();
+
+    let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+        .bind("B702")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 2);
+    assert_eq!(row.get::<i64, _>("total_price"), 500_000);
+    assert_eq!(row.get::<String, _>("expected_checkout"), checkout);
+
+    assert_eq!(
+        charge_total(&pool, "B702").await,
+        before_charges,
+        "dòng charge của đêm thêm phải được dòng đối ứng bù hết"
+    );
+
+    let nights_held: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM room_calendar WHERE booking_id = ?")
+            .bind("B702")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(nights_held, 2, "lịch phòng phải về đúng 2 đêm ban đầu");
+}
+
+#[tokio::test]
+async fn shorten_stay_refuses_to_push_checkout_into_the_past() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R703").await.unwrap();
+    seed_active_booking(&pool, "B703", "R703").await.unwrap();
+
+    // Ngày seed mặc định là tháng 4/2026 — đã là quá khứ, nên đây đúng là ca cần chặn.
+    let today = Local::now().date_naive();
+    let checkout = today.format("%Y-%m-%dT12:00:00+07:00").to_string();
+    let check_in = (today - Duration::days(5))
+        .format("%Y-%m-%dT14:00:00+07:00")
+        .to_string();
+    sqlx::query(
+        "UPDATE bookings SET check_in_at = ?, expected_checkout = ?, nights = 5 WHERE id = ?",
+    )
+    .bind(&check_in)
+    .bind(&checkout)
+    .bind("B703")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B703")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(ref message) if message.contains("Check-out")),
+        "mong đợi lỗi validation nhắc dùng Check-out, nhận được: {error:?}"
+    );
+
+    let unchanged = sqlx::query_scalar::<_, String>(
+        "SELECT expected_checkout FROM bookings WHERE id = ?",
+    )
+    .bind("B703")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(unchanged, checkout, "lệnh thất bại thì DB không được đổi");
+}
+
+#[tokio::test]
+async fn shorten_stay_refuses_to_go_below_one_night() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R704").await.unwrap();
+    seed_future_booking(&pool, "B704", "R704", 1).await.unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B704")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(ref message) if message.contains("tối thiểu 1 đêm")),
+        "mong đợi lỗi tối thiểu 1 đêm, nhận được: {error:?}"
+    );
+
+    let nights = sqlx::query_scalar::<_, i32>("SELECT nights FROM bookings WHERE id = ?")
+        .bind("B704")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(nights, 1);
+}
+
+#[tokio::test]
+async fn shorten_stay_refuses_a_booking_that_is_not_active() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R705").await.unwrap();
+    seed_future_booking(&pool, "B705", "R705", 3).await.unwrap();
+    sqlx::query("UPDATE bookings SET status = 'checked_out' WHERE id = ?")
+        .bind("B705")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B705")
+        .await
+        .unwrap_err();
+    // `invalid_state_transition` (used by the sibling `extend_stay_tx` for the
+    // exact same not-active check) always maps to `BookingError::Conflict`, not
+    // `Validation` — see `services::booking::support::invalid_state_transition`.
+    assert!(
+        matches!(error, BookingError::Conflict(_)),
+        "mong đợi lỗi trạng thái không hợp lệ, nhận được: {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R707").await.unwrap();
+    seed_future_booking(&pool, "B707", "R707", 3).await.unwrap();
+
+    // Mô phỏng ai đó động vào lịch phòng giữa chừng: xoá đúng dòng mà
+    // shorten_stay sắp gỡ. Chốt `ensure_one_row_affected` trên câu DELETE phải
+    // bắt được và kéo ngược toàn bộ transaction.
+    let freed_night = next_monday() + Duration::days(2);
+    sqlx::query("DELETE FROM room_calendar WHERE booking_id = ? AND date = ?")
+        .bind("B707")
+        .bind(freed_night.format("%Y-%m-%d").to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B707")
+        .await
+        .unwrap_err();
+    // `ensure_one_row_affected` (mirroring `extend_stay_tx`'s own use of it)
+    // always maps to `invalid_state_transition`, i.e. `BookingError::Conflict`,
+    // not `Validation` — see `services::booking::support::ensure_one_row_affected`.
+    assert!(
+        matches!(error, BookingError::Conflict(_)),
+        "mong đợi lỗi trạng thái không hợp lệ, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B707")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 3, "rollback phải giữ nguyên số đêm");
+    assert_eq!(row.get::<i64, _>("total_price"), 750_000);
+
+    let credits: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B707")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(credits, 0, "rollback thì không được để lại dòng đối ứng nào");
+}

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -685,3 +685,120 @@ async fn shorten_stay_idempotent_retry_replays_without_removing_a_second_night()
     .unwrap();
     assert_eq!(credits, 1, "chỉ được một dòng đối ứng duy nhất");
 }
+
+/// Rút đêm khoá optimistic-concurrency: `shorten_stay_tx` chốt `expected_checkout`
+/// đọc được TRƯỚC khi khoá booking, rồi mới yêu cầu UPDATE cuối cùng khớp đúng
+/// giá trị đó (`AND expected_checkout = ?`). Test này lái một cuộc đua THẬT qua
+/// pool thứ hai — không giả lập: giữ đúng aggregate lock mà `shorten_stay`
+/// (pool_a) cần để mở transaction, spawn lệnh gọi đó, đợi tới khi nó đã claim
+/// xong (đọc `expected_checkout` khoá xong, đang chờ lock) rồi mới cho pool_b
+/// ghi thẳng xuống DB — giống hệt kỹ thuật ở
+/// `group_checkin_duplicate_in_flight_does_not_wait_for_room_lock`.
+///
+/// Nếu bỏ `AND expected_checkout = ?` khỏi UPDATE, test này FAIL: shorten_stay
+/// sẽ nhả lock, đọc lại total/nights mới nhất, rồi rút đêm êm ru trên booking
+/// mà lễ tân chưa từng thấy — không có lỗi nào nổi lên.
+#[tokio::test]
+async fn shorten_stay_fails_when_second_pool_moves_the_checkout_while_the_lock_is_held() {
+    let (pool_a, pool_b, db_path) = shared_file_test_pools("second-pool-shorten-checkout").await;
+    seed_room(&pool_a, "R-2POOL-SHORTEN").await.unwrap();
+    seed_future_booking(&pool_a, "B-2POOL-SHORTEN", "R-2POOL-SHORTEN", 3)
+        .await
+        .unwrap();
+
+    let ctx = cmd("shorten_stay", "idem-shorten-2pool-checkout");
+
+    // Giữ đúng bộ khoá mà `resolve_stay_lock` bên trong `shorten_stay_idempotent`
+    // cần để mở transaction — cho tới khi ta chủ động nhả, lệnh gọi bên dưới
+    // không thể vượt qua bước này.
+    let held_lock = crate::aggregate_locks::global_manager()
+        .acquire([
+            crate::aggregate_locks::booking_key("B-2POOL-SHORTEN").unwrap(),
+            crate::aggregate_locks::room_key("R-2POOL-SHORTEN").unwrap(),
+            crate::aggregate_locks::folio_key("B-2POOL-SHORTEN").unwrap(),
+        ])
+        .await
+        .unwrap();
+
+    let pool_a_for_task = pool_a.clone();
+    let ctx_for_task = ctx.clone();
+    let handle = tokio::spawn(async move {
+        stay_lifecycle::shorten_stay_idempotent(&pool_a_for_task, &ctx_for_task, "B-2POOL-SHORTEN")
+            .await
+    });
+
+    // Đợi tới khi lệnh gọi đã claim xong trong `command_idempotency` — nghĩa là
+    // nó đã đọc xong `expected_checkout` "trước khi khoá" và đang thật sự bị
+    // chặn ở bước xin lock, không phải đoán bằng sleep suông.
+    let mut claim_seen = false;
+    for _ in 0..50 {
+        let in_progress_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM command_idempotency
+             WHERE idempotency_key = ? AND status = 'in_progress'",
+        )
+        .bind(&ctx.idempotency_key)
+        .fetch_one(&pool_a)
+        .await
+        .unwrap();
+        if in_progress_count == 1 {
+            claim_seen = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(
+        claim_seen,
+        "shorten_stay phải claim xong trước khi bị chặn ở lock"
+    );
+
+    // Một actor thật sự khác (đi thẳng qua SQL, không qua service layer) đổi
+    // expected_checkout trong lúc shorten_stay đang bị chặn ở lock.
+    sqlx::query("UPDATE bookings SET expected_checkout = ? WHERE id = ?")
+        .bind("2099-01-01T12:00:00+07:00")
+        .bind("B-2POOL-SHORTEN")
+        .execute(&pool_b)
+        .await
+        .unwrap();
+
+    drop(held_lock);
+
+    let error = handle
+        .await
+        .unwrap()
+        .expect_err("shorten_stay phải từ chối khi expected_checkout đã đổi trong lúc chờ lock");
+
+    assert_eq!(error.code, crate::app_error::codes::BOOKING_INVALID_STATE);
+    assert!(
+        error
+            .message
+            .contains("Booking vừa được cập nhật bởi thao tác khác"),
+        "message thực tế: {}",
+        error.message
+    );
+
+    let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
+        .bind("B-2POOL-SHORTEN")
+        .fetch_one(&pool_a)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<String, _>("expected_checkout"),
+        "2099-01-01T12:00:00+07:00",
+        "bị chặn thì checkout phải giữ đúng giá trị pool_b vừa ghi, không bị shorten_stay ghi đè"
+    );
+    assert_eq!(row.get::<i32, _>("nights"), 3, "bị chặn thì không được rút đêm");
+    assert_eq!(row.get::<i64, _>("total_price"), 750_000, "bị chặn thì tổng tiền không được đổi");
+
+    let credit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND note = 'Shortened stay -1 night'",
+    )
+    .bind("B-2POOL-SHORTEN")
+    .fetch_one(&pool_a)
+    .await
+    .unwrap();
+    assert_eq!(credit_count, 0, "bị chặn thì không được để lại dòng đối ứng");
+
+    pool_a.close().await;
+    pool_b.close().await;
+    let _ = std::fs::remove_file(db_path);
+}

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -14,17 +14,17 @@ fn next_monday() -> NaiveDate {
     today + Duration::days(days_ahead)
 }
 
-/// Booking `nights` đêm bắt đầu từ thứ Hai kế tiếp, kèm đủ dòng `room_calendar`.
+/// Booking `nights` đêm bắt đầu từ `check_in`, kèm đủ dòng `room_calendar`.
 /// Trả về `(check_in_at, expected_checkout)` dạng RFC3339.
-async fn seed_future_booking(
+async fn seed_booking_from(
     pool: &Pool<Sqlite>,
     booking_id: &str,
     room_id: &str,
+    check_in: NaiveDate,
     nights: i64,
 ) -> BookingResult<(String, String)> {
     seed_active_booking(pool, booking_id, room_id).await?;
 
-    let check_in = next_monday();
     let checkout = check_in + Duration::days(nights);
     let check_in_at = format!("{}T14:00:00+07:00", check_in.format("%Y-%m-%d"));
     let expected_checkout = format!("{}T12:00:00+07:00", checkout.format("%Y-%m-%d"));
@@ -63,6 +63,25 @@ async fn seed_future_booking(
     Ok((check_in_at, expected_checkout))
 }
 
+/// Booking `nights` đêm bắt đầu từ thứ Hai kế tiếp, kèm đủ dòng `room_calendar`.
+/// Trả về `(check_in_at, expected_checkout)` dạng RFC3339.
+async fn seed_future_booking(
+    pool: &Pool<Sqlite>,
+    booking_id: &str,
+    room_id: &str,
+    nights: i64,
+) -> BookingResult<(String, String)> {
+    seed_booking_from(pool, booking_id, room_id, next_monday(), nights).await
+}
+
+/// Ngày (không giờ) từ một chuỗi `check_in_at`/`expected_checkout` RFC3339 mà
+/// các fixture ở trên trả về — dùng để tính lại đêm bị rút mà không phải gọi
+/// lại `next_monday()`/`Local::now()` một lần nữa giữa chừng test (xem mục 6
+/// trong review: gọi lại có thể lệch múi giờ nếu đồng hồ vượt qua nửa đêm).
+fn date_from_rfc3339(value: &str) -> NaiveDate {
+    NaiveDate::parse_from_str(&value[..10], "%Y-%m-%d").expect("fixture date must be YYYY-MM-DD…")
+}
+
 async fn charge_total(pool: &Pool<Sqlite>, booking_id: &str) -> i64 {
     sqlx::query_scalar(
         "SELECT COALESCE(SUM(amount), 0) FROM transactions
@@ -78,7 +97,7 @@ async fn charge_total(pool: &Pool<Sqlite>, booking_id: &str) -> i64 {
 async fn shorten_stay_drops_the_last_night_and_its_charge() {
     let pool = test_pool().await;
     seed_room(&pool, "R701").await.unwrap();
-    let (_check_in, _checkout) = seed_future_booking(&pool, "B701", "R701", 3)
+    let (check_in, checkout) = seed_future_booking(&pool, "B701", "R701", 3)
         .await
         .unwrap();
 
@@ -92,7 +111,8 @@ async fn shorten_stay_drops_the_last_night_and_its_charge() {
     assert_eq!(row.get::<i32, _>("nights"), 2);
     assert_eq!(row.get::<i64, _>("total_price"), 500_000);
 
-    let freed_night = next_monday() + Duration::days(2);
+    let check_in_date = date_from_rfc3339(&check_in);
+    let freed_night = check_in_date + Duration::days(2);
     let remaining: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?",
     )
@@ -102,6 +122,20 @@ async fn shorten_stay_drops_the_last_night_and_its_charge() {
     .await
     .unwrap();
     assert_eq!(remaining, 0, "đêm bị rút phải được nhả khỏi lịch phòng");
+
+    // Checkout mới phải lùi lại đúng 1 ngày so với checkout ban đầu — tức
+    // đúng bằng ngày của đêm vừa bị rút, giữ nguyên giờ trả phòng.
+    let original_checkout_time = &checkout[10..];
+    let expected_new_checkout = format!(
+        "{}{}",
+        freed_night.format("%Y-%m-%d"),
+        original_checkout_time
+    );
+    assert_eq!(
+        row.get::<String, _>("expected_checkout"),
+        expected_new_checkout,
+        "checkout mới phải lùi đúng 1 ngày so với checkout cũ"
+    );
 
     let credit: i64 = sqlx::query_scalar(
         "SELECT amount FROM transactions WHERE booking_id = ? AND note = 'Shortened stay -1 night'",
@@ -124,6 +158,25 @@ async fn extend_then_shorten_restores_the_booking_exactly() {
     let before_charges = charge_total(&pool, "B702").await;
 
     stay_lifecycle::extend_stay(&pool, "B702").await.unwrap();
+
+    // Chốt trạng thái trung gian: nếu cả extend lẫn shorten đều không ghi gì
+    // (vd. bug âm thầm bỏ qua record_charge_tx), so sánh mù `before_charges ==
+    // charge_total sau shorten` vẫn xanh vì cả hai đều bằng 0. Đọc lại đúng
+    // khoản charge mà extend vừa ghi để khoá chặt lỗ hổng đó.
+    let extend_charge: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = ? AND note = 'Extended stay +1 night'",
+    )
+    .bind("B702")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let after_extend_charges = charge_total(&pool, "B702").await;
+    assert_eq!(
+        after_extend_charges,
+        before_charges + extend_charge,
+        "sau extend, tổng charge phải cộng đúng khoản charge của đêm thêm"
+    );
+
     stay_lifecycle::shorten_stay(&pool, "B702").await.unwrap();
 
     let row = sqlx::query("SELECT nights, total_price, expected_checkout FROM bookings WHERE id = ?")
@@ -191,6 +244,41 @@ async fn shorten_stay_refuses_to_push_checkout_into_the_past() {
 }
 
 #[tokio::test]
+async fn shorten_stay_allows_moving_the_checkout_to_today() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R708").await.unwrap();
+
+    // Checkout là ngày mai — một khách trả phòng sớm hơn 1 ngày so với dự
+    // kiến là ca hợp lệ (khách rời trong ngày hôm nay), phải được cho phép,
+    // khác với B703 ở trên nơi checkout mới sẽ rơi vào quá khứ.
+    let today = Local::now().date_naive();
+    let check_in = today - Duration::days(1);
+    let (_check_in_at, checkout) = seed_booking_from(&pool, "B708", "R708", check_in, 2)
+        .await
+        .unwrap();
+
+    let booking = stay_lifecycle::shorten_stay(&pool, "B708").await.unwrap();
+
+    let expected_new_checkout = format!("{}{}", today.format("%Y-%m-%d"), &checkout[10..]);
+    assert_eq!(
+        booking.expected_checkout, expected_new_checkout,
+        "checkout mới phải là hôm nay"
+    );
+
+    let row = sqlx::query("SELECT nights, expected_checkout FROM bookings WHERE id = ?")
+        .bind("B708")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 1);
+    assert_eq!(
+        row.get::<String, _>("expected_checkout"),
+        expected_new_checkout,
+        "trạng thái đọc lại từ DB phải khớp checkout hôm nay"
+    );
+}
+
+#[tokio::test]
 async fn shorten_stay_refuses_to_go_below_one_night() {
     let pool = test_pool().await;
     seed_room(&pool, "R704").await.unwrap();
@@ -233,18 +321,89 @@ async fn shorten_stay_refuses_a_booking_that_is_not_active() {
         matches!(error, BookingError::Conflict(_)),
         "mong đợi lỗi trạng thái không hợp lệ, nhận được: {error:?}"
     );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B705")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 3, "thất bại thì số đêm không đổi");
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        750_000,
+        "thất bại thì tổng tiền không đổi"
+    );
+}
+
+#[tokio::test]
+async fn shorten_stay_refuses_when_the_credit_would_exceed_the_total() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R709").await.unwrap();
+    let (check_in, _checkout) = seed_future_booking(&pool, "B709", "R709", 2)
+        .await
+        .unwrap();
+
+    // Kịch bản reviewer nêu: booking 2 đêm x 250,000 (tổng 500,000) được chốt
+    // giá lúc nhận phòng, sau đó một dòng pricing_rules đẩy giá phòng lên
+    // 900,000/đêm. Rút một đêm ở mức giá mới sẽ đòi hoàn nhiều hơn cả tổng
+    // tiền của booking — phải bị chặn, không được để total_price âm.
+    seed_pricing_rule(&pool, "standard", 900_000).await.unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B709")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(_)),
+        "mong đợi lỗi validation vì khoản hoàn vượt tổng tiền, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B709")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i32, _>("nights"), 2, "thất bại thì số đêm không đổi");
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        500_000,
+        "thất bại thì tổng tiền không đổi"
+    );
+
+    let check_in_date = date_from_rfc3339(&check_in);
+    let freed_night = check_in_date + Duration::days(1);
+    let calendar_rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM room_calendar WHERE booking_id = ? AND date = ?",
+    )
+    .bind("B709")
+    .bind(freed_night.format("%Y-%m-%d").to_string())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(calendar_rows, 1, "thất bại thì lịch phòng không đổi");
+
+    let charge_rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B709")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charge_rows, 0, "thất bại thì không được tạo dòng charge nào");
 }
 
 #[tokio::test]
 async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing() {
     let pool = test_pool().await;
     seed_room(&pool, "R707").await.unwrap();
-    seed_future_booking(&pool, "B707", "R707", 3).await.unwrap();
+    let (check_in, _checkout) = seed_future_booking(&pool, "B707", "R707", 3)
+        .await
+        .unwrap();
 
     // Mô phỏng ai đó động vào lịch phòng giữa chừng: xoá đúng dòng mà
     // shorten_stay sắp gỡ. Chốt `ensure_one_row_affected` trên câu DELETE phải
     // bắt được và kéo ngược toàn bộ transaction.
-    let freed_night = next_monday() + Duration::days(2);
+    let check_in_date = date_from_rfc3339(&check_in);
+    let freed_night = check_in_date + Duration::days(2);
     sqlx::query("DELETE FROM room_calendar WHERE booking_id = ? AND date = ?")
         .bind("B707")
         .bind(freed_night.format("%Y-%m-%d").to_string())

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -390,6 +390,111 @@ async fn shorten_stay_credits_the_booking_average_not_the_current_rate() {
 }
 
 #[tokio::test]
+async fn shorten_stay_rejects_a_zero_nights_booking_instead_of_panicking() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R710").await.unwrap();
+    seed_future_booking(&pool, "B710", "R710", 3).await.unwrap();
+
+    // `bookings.nights` has no CHECK constraint at the schema level — corrupt
+    // it directly via SQL to simulate a value the app itself would never
+    // write, and pin that the guard in shorten_stay_tx turns this into a
+    // validation error instead of "attempt to divide by zero".
+    sqlx::query("UPDATE bookings SET nights = 0 WHERE id = ?")
+        .bind("B710")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B710")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(_)),
+        "mong đợi lỗi validation cho nights=0, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B710")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        0,
+        "thất bại thì không được đổi giá trị nights đã hỏng"
+    );
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        750_000,
+        "thất bại thì total_price không đổi"
+    );
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B710")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(charges, 0, "thất bại thì không được ghi giao dịch nào");
+}
+
+#[tokio::test]
+async fn shorten_stay_rejects_a_negative_nights_booking_instead_of_inventing_money() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R711").await.unwrap();
+    seed_future_booking(&pool, "B711", "R711", 3).await.unwrap();
+
+    // Same defence-in-depth guard, negative side: without it, `current_total /
+    // current_nights` still "succeeds" arithmetically but flips the sign,
+    // turning a credit into a charge and inflating total_price instead of
+    // shrinking it — a reviewer measured a 750,000/3-night booking coming back
+    // with total_price = 1,500,000 and a +750,000 transaction mislabeled
+    // "Shortened stay -1 night".
+    sqlx::query("UPDATE bookings SET nights = -1 WHERE id = ?")
+        .bind("B711")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let error = stay_lifecycle::shorten_stay(&pool, "B711")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, BookingError::Validation(_)),
+        "mong đợi lỗi validation cho nights âm, nhận được: {error:?}"
+    );
+
+    let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
+        .bind("B711")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<i32, _>("nights"),
+        -1,
+        "thất bại thì không được đổi giá trị nights đã hỏng"
+    );
+    assert_eq!(
+        row.get::<i64, _>("total_price"),
+        750_000,
+        "thất bại thì total_price không được bịa thêm tiền"
+    );
+
+    let charges: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    )
+    .bind("B711")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        charges, 0,
+        "thất bại thì không được ghi giao dịch phát sinh tiền ảo nào"
+    );
+}
+
+#[tokio::test]
 async fn shorten_stay_leaves_everything_alone_when_the_calendar_row_is_missing() {
     let pool = test_pool().await;
     seed_room(&pool, "R707").await.unwrap();

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -336,37 +336,32 @@ async fn shorten_stay_refuses_a_booking_that_is_not_active() {
 }
 
 #[tokio::test]
-async fn shorten_stay_refuses_when_the_credit_would_exceed_the_total() {
+async fn shorten_stay_credits_the_booking_average_not_the_current_rate() {
     let pool = test_pool().await;
     seed_room(&pool, "R709").await.unwrap();
     let (check_in, _checkout) = seed_future_booking(&pool, "B709", "R709", 2)
         .await
         .unwrap();
 
-    // Kịch bản reviewer nêu: booking 2 đêm x 250,000 (tổng 500,000) được chốt
-    // giá lúc nhận phòng, sau đó một dòng pricing_rules đẩy giá phòng lên
-    // 900,000/đêm. Rút một đêm ở mức giá mới sẽ đòi hoàn nhiều hơn cả tổng
-    // tiền của booking — phải bị chặn, không được để total_price âm.
+    // Booking 2 đêm x 250,000 (tổng 500,000) được chốt giá lúc nhận phòng.
+    // Sau đó một dòng pricing_rules đẩy giá phòng lên 900,000/đêm — nếu
+    // shorten_stay hỏi lại pricing engine, nó sẽ hoàn 900,000 cho một đêm chỉ
+    // thu có 250,000. Quyết định của product owner: hoàn theo trung bình của
+    // CHÍNH booking này (500,000 / 2 = 250,000), bỏ qua giá mới hoàn toàn.
     seed_pricing_rule(&pool, "standard", 900_000).await.unwrap();
 
-    let error = stay_lifecycle::shorten_stay(&pool, "B709")
-        .await
-        .unwrap_err();
-    assert!(
-        matches!(error, BookingError::Validation(_)),
-        "mong đợi lỗi validation vì khoản hoàn vượt tổng tiền, nhận được: {error:?}"
-    );
+    stay_lifecycle::shorten_stay(&pool, "B709").await.unwrap();
 
     let row = sqlx::query("SELECT nights, total_price FROM bookings WHERE id = ?")
         .bind("B709")
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(row.get::<i32, _>("nights"), 2, "thất bại thì số đêm không đổi");
+    assert_eq!(row.get::<i32, _>("nights"), 1);
     assert_eq!(
         row.get::<i64, _>("total_price"),
-        500_000,
-        "thất bại thì tổng tiền không đổi"
+        250_000,
+        "khoản hoàn phải bằng trung bình gốc của booking (250,000), không phải giá mới (900,000)"
     );
 
     let check_in_date = date_from_rfc3339(&check_in);
@@ -379,16 +374,19 @@ async fn shorten_stay_refuses_when_the_credit_would_exceed_the_total() {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(calendar_rows, 1, "thất bại thì lịch phòng không đổi");
+    assert_eq!(calendar_rows, 0, "đêm bị rút phải được nhả khỏi lịch phòng");
 
-    let charge_rows: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM transactions WHERE booking_id = ? AND type = 'charge'",
+    let credit: i64 = sqlx::query_scalar(
+        "SELECT amount FROM transactions WHERE booking_id = ? AND note = 'Shortened stay -1 night'",
     )
     .bind("B709")
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(charge_rows, 0, "thất bại thì không được tạo dòng charge nào");
+    assert_eq!(
+        credit, -250_000,
+        "dòng charge phải trừ đúng trung bình gốc, không phải giá mới sau khi pricing_rules đổi"
+    );
 }
 
 #[tokio::test]

--- a/mhm/src-tauri/src/services/booking/tests/support/db.rs
+++ b/mhm/src-tauri/src/services/booking/tests/support/db.rs
@@ -80,6 +80,7 @@ pub async fn test_pool() -> Pool<Sqlite> {
             is_audited INTEGER NOT NULL DEFAULT 0,
             pricing_snapshot TEXT,
             guests INTEGER,
+            rate_overridden_at TEXT,
             created_at TEXT NOT NULL
         )",
     )

--- a/mhm/src-tauri/src/write_manifest.rs
+++ b/mhm/src-tauri/src/write_manifest.rs
@@ -49,6 +49,11 @@ pub const WRITE_COMMAND_MANIFEST: &[WriteCommandMeta] = &[
         enforced_in_foundation: true,
     },
     WriteCommandMeta {
+        command_name: "shorten_stay",
+        lock_deriver: LockDeriverId::BookingAndRoomFromBooking,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
         command_name: "group_checkin",
         lock_deriver: LockDeriverId::GroupCheckinRooms,
         enforced_in_foundation: true,

--- a/mhm/src-tauri/src/write_manifest.rs
+++ b/mhm/src-tauri/src/write_manifest.rs
@@ -54,6 +54,11 @@ pub const WRITE_COMMAND_MANIFEST: &[WriteCommandMeta] = &[
         enforced_in_foundation: true,
     },
     WriteCommandMeta {
+        command_name: "set_booking_rate",
+        lock_deriver: LockDeriverId::BookingAndRoomFromBooking,
+        enforced_in_foundation: true,
+    },
+    WriteCommandMeta {
         command_name: "group_checkin",
         lock_deriver: LockDeriverId::GroupCheckinRooms,
         enforced_in_foundation: true,

--- a/mhm/src/components/CheckoutSettlementModal.test.tsx
+++ b/mhm/src/components/CheckoutSettlementModal.test.tsx
@@ -140,4 +140,71 @@ describe("CheckoutSettlementModal", () => {
         expect(screen.getByText(/refund/i)).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Xác nhận" })).toBeDisabled();
     });
+
+    it("defaults to the booked-nights mode for a booking with a manually-set rate, and explains why", async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            settlement_mode: "booked_nights",
+            settled_nights: 5,
+            recommended_total: 2500000,
+            explanation: "Thanh toán theo số đêm đã đặt: 5 đêm",
+        });
+
+        render(
+            <CheckoutSettlementModal
+                open
+                roomId="101"
+                booking={{ ...booking, rate_overridden_at: "2026-07-30T09:00:00+07:00" }}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+            />
+        );
+
+        // Cách tính được chọn ngay từ bản render đầu tiên — không cần đợi
+        // fetch — nên request đầu tiên tới backend đã mang settlement_mode
+        // đúng, không phải "actual_nights" rồi phải sửa lại sau.
+        expect(invoke).toHaveBeenCalledWith("preview_checkout_settlement", {
+            req: { booking_id: "B500", settlement_mode: "booked_nights" },
+        });
+        expect(screen.getByRole("button", { name: "Đã đặt" })).toHaveClass("border-blue-500");
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Thanh toán theo số đêm đã đặt: 5 đêm")
+            ).toBeInTheDocument();
+        });
+        expect(
+            screen.getByText(/đã được đổi giá thủ công/)
+        ).toBeInTheDocument();
+    });
+
+    it("defaults to the actual-nights mode and shows no override explanation for a normally-priced booking", async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            settlement_mode: "actual_nights",
+            settled_nights: 1,
+            recommended_total: 500000,
+            explanation: "Thanh toán theo số đêm thực tế: 1 đêm",
+        });
+
+        render(
+            <CheckoutSettlementModal
+                open
+                roomId="101"
+                booking={booking}
+                onClose={vi.fn()}
+                onConfirm={vi.fn()}
+            />
+        );
+
+        expect(invoke).toHaveBeenCalledWith("preview_checkout_settlement", {
+            req: { booking_id: "B500", settlement_mode: "actual_nights" },
+        });
+        expect(screen.getByRole("button", { name: "Thực tế" })).toHaveClass("border-blue-500");
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Thanh toán theo số đêm thực tế: 1 đêm")
+            ).toBeInTheDocument();
+        });
+        expect(screen.queryByText(/đã được đổi giá thủ công/)).not.toBeInTheDocument();
+    });
 });

--- a/mhm/src/components/CheckoutSettlementModal.tsx
+++ b/mhm/src/components/CheckoutSettlementModal.tsx
@@ -26,6 +26,15 @@ const MODE_OPTIONS: Array<{ value: CheckoutSettlementMode; label: string }> = [
     { value: "booked_nights", label: "Đã đặt" },
 ];
 
+// Booking đã bị lễ tân đổi giá tay (`set_booking_rate`) không được chốt theo
+// giá niêm yết mặc định — "Thực tế" tính lại từ pricing engine, bỏ qua giá đã
+// thương lượng. Với booking như vậy, mặc định phải là "Đã đặt" (dùng
+// total_price đã lưu), giữ đúng mức giá lễ tân đã chốt với khách. Lễ tân vẫn
+// có thể tự tay đổi sang cách tính khác.
+function defaultSettlementMode(booking: Booking): CheckoutSettlementMode {
+    return booking.rate_overridden_at ? "booked_nights" : "actual_nights";
+}
+
 export default function CheckoutSettlementModal({
     open,
     roomId,
@@ -33,7 +42,9 @@ export default function CheckoutSettlementModal({
     onClose,
     onConfirm,
 }: CheckoutSettlementModalProps) {
-    const [settlementMode, setSettlementMode] = useState<CheckoutSettlementMode>("actual_nights");
+    const [settlementMode, setSettlementMode] = useState<CheckoutSettlementMode>(() =>
+        defaultSettlementMode(booking)
+    );
     const [preview, setPreview] = useState<CheckoutSettlementPreview | null>(null);
     const [finalTotal, setFinalTotal] = useState(0);
     const [loadingPreview, setLoadingPreview] = useState(false);
@@ -42,14 +53,14 @@ export default function CheckoutSettlementModal({
 
     useEffect(() => {
         if (!open) {
-            setSettlementMode("actual_nights");
+            setSettlementMode(defaultSettlementMode(booking));
             setPreview(null);
             setFinalTotal(0);
             setLoadingPreview(false);
             setSubmitting(false);
             manualOverrideRef.current = false;
         }
-    }, [open]);
+    }, [open, booking]);
 
     useEffect(() => {
         if (!open) {
@@ -145,6 +156,13 @@ export default function CheckoutSettlementModal({
                         })}
                     </div>
                 </div>
+
+                {booking.rate_overridden_at && (
+                    <p className="text-[12px] text-amber-600">
+                        Booking này đã được đổi giá thủ công — mặc định chốt theo tổng tiền đã đặt
+                        để giữ đúng giá đã thương lượng với khách.
+                    </p>
+                )}
 
                 <p className="rounded-xl bg-slate-50 px-3 py-2 text-slate-600 min-h-11">
                     {loadingPreview ? "Đang tính lại..." : preview?.explanation ?? ""}

--- a/mhm/src/components/RoomDetailPanel.tsx
+++ b/mhm/src/components/RoomDetailPanel.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 
 import InvoiceDialog from "@/components/InvoiceDialog";
 import CheckoutSettlementModal from "@/components/CheckoutSettlementModal";
+import BookingSummary from "@/components/shared/BookingSummary";
 import InfoItem from "@/components/shared/InfoItem";
 import ActionBtn from "@/components/shared/ActionBtn";
 import PaymentBlock from "@/components/shared/PaymentBlock";
@@ -25,8 +26,8 @@ import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
-import { BALANCE_TONE_CLASS, balanceDisplay, isFullySettled } from "@/lib/bookingBalance";
-import { fmtDate, fmtDateShort, fmtMoney } from "@/lib/format";
+import { BALANCE_TONE_CLASS, balanceDisplay } from "@/lib/bookingBalance";
+import { fmtDate, fmtMoney } from "@/lib/format";
 import { nightlyRateDisplay } from "@/lib/roomTypeRate";
 import { useHotelStore } from "@/stores/useHotelStore";
 import type { CheckoutSettlementPayload, RoomWithBooking } from "@/types";
@@ -251,29 +252,11 @@ export default function RoomDetailPanel({
         </div>
 
         {booking ? (
-          <Section icon={CalendarDays} title="Booking hiện tại" className="bg-slate-50 rounded-2xl p-5 space-y-3">
-            <div className="grid grid-cols-2 gap-3">
-              <InfoItem label="Check-in" value={fmtDateShort(booking.check_in_at)} />
-              <InfoItem label="Checkout" value={fmtDateShort(booking.expected_checkout)} />
-              <InfoItem label="Số đêm" value={booking.nights} />
-              <InfoItem label="Tổng tiền" value={fmtMoney(booking.total_price)} />
-            </div>
-            <div className="flex items-center justify-between pt-2 border-t border-slate-200">
-              <span className="text-sm font-medium text-brand-muted">Đã thanh toán</span>
-              <span className={`text-sm font-bold ${isFullySettled(booking.total_price, booking.paid_amount) ? "text-emerald-600" : "text-orange-600"}`}>
-                {fmtMoney(booking.paid_amount)} / {fmtMoney(booking.total_price)}
-              </span>
-            </div>
-            <Button
-              variant="outline"
-              className="w-full mt-3 gap-2 text-sm font-semibold cursor-pointer"
-              onClick={handleInvoice}
-              disabled={invoiceLoading}
-            >
-              <FileText className="w-4 h-4" />
-              {invoiceLoading ? "Đang tạo..." : "📄 Invoice"}
-            </Button>
-          </Section>
+          <BookingSummary
+            booking={booking}
+            onInvoice={handleInvoice}
+            invoiceLoading={invoiceLoading}
+          />
         ) : (
           <div className="bg-slate-50 rounded-2xl p-5 text-center text-brand-muted text-sm">
             Phòng hiện đang trống

--- a/mhm/src/components/RoomDrawer.test.tsx
+++ b/mhm/src/components/RoomDrawer.test.tsx
@@ -3,15 +3,26 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import RoomDrawer from "./RoomDrawer";
+import { fmtMoney } from "@/lib/format";
 
-const { invoke } = vi.hoisted(() => ({
+// `extendStay`/`shortenStay` are hoisted (rather than declared inline in the
+// store mock factory below) so the SAME mock instance is returned on every
+// render. The factory re-runs on every call to `useHotelStore()`, so inline
+// `vi.fn()` literals would be replaced each render — making it impossible to
+// assert call counts across the re-renders a click triggers.
+const { invoke, extendStay, shortenStay } = vi.hoisted(() => ({
     invoke: vi.fn(),
+    extendStay: vi.fn(),
+    shortenStay: vi.fn(),
 }));
 
 let roomTypeRates: Record<string, { room_type: string; nightly_rate: number; configured: boolean }> | null =
     null;
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("sonner", () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
 vi.mock("@/components/CheckoutSettlementModal", () => ({
     default: ({ open }: { open: boolean }) =>
         open ? <div data-testid="checkout-settlement-modal" /> : null,
@@ -19,7 +30,8 @@ vi.mock("@/components/CheckoutSettlementModal", () => ({
 vi.mock("@/stores/useHotelStore", () => ({
     useHotelStore: () => ({
         checkOut: vi.fn(),
-        extendStay: vi.fn(),
+        extendStay,
+        shortenStay,
         getStayInfoText: vi.fn(),
         setCheckinOpen: vi.fn(),
         fetchRooms: vi.fn(),
@@ -36,6 +48,8 @@ vi.mock("@/hooks/useInvoiceDialog", () => ({
         closeInvoice: vi.fn(),
     }),
 }));
+
+import { toast } from "sonner";
 
 describe("RoomDrawer checkout settlement", () => {
     beforeEach(() => {
@@ -121,5 +135,239 @@ describe("RoomDrawer nightly rate", () => {
 
         const rate = await screen.findByTestId("room-drawer-nightly-rate");
         expect(rate.textContent).toBe("—");
+    });
+});
+
+describe("RoomDrawer nights stepper", () => {
+    // Built from the live clock (never hardcoded), so these boundary tests
+    // don't rot as "today" moves forward.
+    function atLocalTime(base: Date, hours: number, minutes = 0): Date {
+        const d = new Date(base);
+        d.setHours(hours, minutes, 0, 0);
+        return d;
+    }
+
+    function addDays(base: Date, days: number): Date {
+        const d = new Date(base);
+        d.setDate(d.getDate() + days);
+        return d;
+    }
+
+    const NOW = new Date();
+    const TODAY_AT_MIDDAY = atLocalTime(NOW, 12).toISOString();
+    const YESTERDAY_AT_TEN = atLocalTime(addDays(NOW, -1), 10).toISOString();
+    const TOMORROW_AT_TEN = atLocalTime(addDays(NOW, 1), 10).toISOString();
+
+    const CHECKOUT_TODAY_REASON = "Đêm cuối là hôm nay — dùng Check-out";
+    const MIN_NIGHTS_REASON = "Lưu trú tối thiểu 1 đêm";
+
+    type BookingOverrides = Partial<{
+        nights: number;
+        expected_checkout: string;
+        total_price: number;
+    }>;
+
+    function buildDetail(bookingOverrides: BookingOverrides = {}) {
+        return {
+            room: {
+                id: "101",
+                name: "101",
+                type: "standard",
+                floor: 1,
+                has_balcony: false,
+                base_price: 500000,
+                status: "occupied",
+            },
+            booking: {
+                id: "B601",
+                room_id: "101",
+                primary_guest_id: "G1",
+                check_in_at: "2026-04-20T08:00:00+07:00",
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+                total_price: 2500000,
+                paid_amount: 0,
+                status: "active",
+                created_at: "2026-04-20T08:00:00+07:00",
+                ...bookingOverrides,
+            },
+            guests: [],
+        };
+    }
+
+    // Queues successive `get_room_detail` responses: the first call (mount)
+    // gets `details[0]`, the next call gets `details[1]`, etc. Once the queue
+    // is down to its last entry, that entry keeps being returned.
+    function mockRoomDetailSequence(...details: ReturnType<typeof buildDetail>[]) {
+        const queue = [...details];
+        invoke.mockImplementation((cmd: string) => {
+            if (cmd === "get_room_detail") {
+                const next = queue.length > 1 ? queue.shift()! : queue[0];
+                return Promise.resolve(next);
+            }
+            if (cmd === "get_housekeeping_tasks") {
+                return Promise.resolve([]);
+            }
+            return Promise.reject(new Error(`Unexpected invoke call: ${cmd}`));
+        });
+    }
+
+    async function renderDrawer(bookingOverrides: BookingOverrides = {}) {
+        mockRoomDetailSequence(buildDetail(bookingOverrides));
+        const user = userEvent.setup();
+        render(<RoomDrawer open onClose={vi.fn()} roomId="101" />);
+        const shorten = await screen.findByRole("button", { name: /−1 đêm/ });
+        const extend = screen.getByRole("button", { name: /\+1 đêm/ });
+        return { user, shorten, extend };
+    }
+
+    beforeEach(() => {
+        invoke.mockReset();
+        extendStay.mockReset();
+        shortenStay.mockReset();
+        vi.mocked(toast.success).mockClear();
+        vi.mocked(toast.error).mockClear();
+        roomTypeRates = null;
+    });
+
+    describe("date boundary", () => {
+        it("disables −1 đêm when checkout is today at midday, even with several nights left", async () => {
+            // A missing setHours(0,0,0,0) truncation would wrongly enable this:
+            // today-at-12:00 is still > today-at-00:00.
+            const { shorten } = await renderDrawer({
+                expected_checkout: TODAY_AT_MIDDAY,
+                nights: 5,
+            });
+
+            expect(shorten).toBeDisabled();
+            expect(shorten).toHaveAttribute("title", CHECKOUT_TODAY_REASON);
+        });
+
+        it("disables −1 đêm when checkout was yesterday", async () => {
+            const { shorten } = await renderDrawer({
+                expected_checkout: YESTERDAY_AT_TEN,
+                nights: 5,
+            });
+
+            expect(shorten).toBeDisabled();
+            expect(shorten).toHaveAttribute("title", CHECKOUT_TODAY_REASON);
+        });
+
+        it("enables −1 đêm when checkout is tomorrow", async () => {
+            const { shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+            });
+
+            expect(shorten).not.toBeDisabled();
+            expect(shorten).not.toHaveAttribute("title");
+        });
+    });
+
+    describe("minimum-nights boundary", () => {
+        it("disables −1 đêm with the minimum-nights reason for a 1-night booking", async () => {
+            const { shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 1,
+            });
+
+            expect(shorten).toBeDisabled();
+            expect(shorten).toHaveAttribute("title", MIN_NIGHTS_REASON);
+        });
+    });
+
+    describe("double-click protection", () => {
+        it("calls shortenStay exactly once for two rapid clicks on −1 đêm", async () => {
+            let resolveShorten!: () => void;
+            shortenStay.mockImplementation(
+                () => new Promise<void>((resolve) => { resolveShorten = resolve; }),
+            );
+            const { user, shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+            });
+
+            await user.click(shorten);
+            await user.click(shorten);
+
+            expect(shortenStay).toHaveBeenCalledTimes(1);
+
+            resolveShorten();
+            await waitFor(() => expect(shorten).not.toBeDisabled());
+        });
+
+        it("does not call extendStay when +1 đêm is clicked while a shorten mutation is in flight", async () => {
+            let resolveShorten!: () => void;
+            shortenStay.mockImplementation(
+                () => new Promise<void>((resolve) => { resolveShorten = resolve; }),
+            );
+            const { user, shorten, extend } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+            });
+
+            await user.click(shorten);
+            await user.click(extend);
+
+            expect(shortenStay).toHaveBeenCalledTimes(1);
+            expect(extendStay).not.toHaveBeenCalled();
+
+            resolveShorten();
+            await waitFor(() => expect(shorten).not.toBeDisabled());
+        });
+    });
+
+    describe("busy flag reset on failure", () => {
+        it("re-enables −1 đêm after shortenStay rejects, so it isn't permanently dead", async () => {
+            shortenStay.mockRejectedValueOnce(new Error("boom"));
+            const { user, shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+            });
+
+            await user.click(shorten);
+
+            await waitFor(() => expect(shorten).not.toBeDisabled());
+            expect(shortenStay).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("toast freshness", () => {
+        it("reports the refetched nights/total in the success toast, not the pre-mutation values", async () => {
+            shortenStay.mockResolvedValueOnce(undefined);
+            mockRoomDetailSequence(
+                buildDetail({ nights: 5, total_price: 2500000, expected_checkout: TOMORROW_AT_TEN }),
+                buildDetail({ nights: 4, total_price: 2000000, expected_checkout: TOMORROW_AT_TEN }),
+            );
+            const user = userEvent.setup();
+            render(<RoomDrawer open onClose={vi.fn()} roomId="101" />);
+            const shorten = await screen.findByRole("button", { name: /−1 đêm/ });
+
+            await user.click(shorten);
+
+            await waitFor(() => expect(toast.success).toHaveBeenCalled());
+            const [message] = vi.mocked(toast.success).mock.calls[0] as [string];
+            expect(message).toContain("4 đêm");
+            expect(message).toContain(fmtMoney(2000000));
+            expect(message).not.toContain("5 đêm");
+            expect(message).not.toContain(fmtMoney(2500000));
+        });
+    });
+
+    describe("error formatting", () => {
+        it("shows a formatted message, never [object Object], when shortenStay rejects", async () => {
+            shortenStay.mockRejectedValueOnce({ some: "unrecognized object" });
+            const { user, shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+            });
+
+            await user.click(shorten);
+
+            await waitFor(() => expect(toast.error).toHaveBeenCalled());
+            const [message] = vi.mocked(toast.error).mock.calls[0] as [string];
+            expect(message).not.toContain("[object Object]");
+            expect(message).toContain("Có lỗi hệ thống, vui lòng thử lại");
+        });
     });
 });

--- a/mhm/src/components/RoomDrawer.test.tsx
+++ b/mhm/src/components/RoomDrawer.test.tsx
@@ -165,6 +165,7 @@ describe("RoomDrawer nights stepper", () => {
         nights: number;
         expected_checkout: string;
         total_price: number;
+        paid_amount: number;
     }>;
 
     function buildDetail(bookingOverrides: BookingOverrides = {}) {
@@ -273,6 +274,82 @@ describe("RoomDrawer nights stepper", () => {
 
             expect(shorten).toBeDisabled();
             expect(shorten).toHaveAttribute("title", MIN_NIGHTS_REASON);
+        });
+    });
+
+    describe("paid-amount boundary", () => {
+        // Reversal: shortening used to be allowed to push total_price below
+        // paid_amount (front desk would hand back cash). check_out_tx refuses
+        // that state outright, so the button itself must now stay disabled
+        // instead of letting the click fail. The credit for one night must
+        // match the backend's exact formula in shorten_stay_tx: integer
+        // division, floored — `total_price / nights`.
+        it("disables −1 đêm when the credit would drop the total below paid_amount", async () => {
+            // total_price=2,500,000 / nights=5 → credit=500,000 →
+            // total after shorten = 2,000,000, below paid_amount=2,100,000.
+            const { shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+                total_price: 2_500_000,
+                paid_amount: 2_100_000,
+            });
+
+            expect(shorten).toBeDisabled();
+            expect(shorten).toHaveAttribute(
+                "title",
+                `Khách đã thanh toán ${fmtMoney(2_100_000)}, cao hơn tổng tiền sau khi rút đêm (${fmtMoney(2_000_000)}) — cần xử lý hoàn tiền trước`,
+            );
+        });
+
+        it("enables −1 đêm when the total after the credit still covers paid_amount", async () => {
+            const { shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+                total_price: 2_500_000,
+                paid_amount: 1_500_000,
+            });
+
+            expect(shorten).not.toBeDisabled();
+            expect(shorten).not.toHaveAttribute("title");
+        });
+
+        it("enables −1 đêm when the total after the credit lands exactly on paid_amount", async () => {
+            // total after shorten = 2,000,000, exactly equal to paid_amount —
+            // the guard uses `<`, not `<=`, so this exact-boundary case must
+            // stay enabled.
+            const { shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 5,
+                total_price: 2_500_000,
+                paid_amount: 2_000_000,
+            });
+
+            expect(shorten).not.toBeDisabled();
+            expect(shorten).not.toHaveAttribute("title");
+        });
+
+        it("reports the minimum-nights reason, not the paid-amount reason, when both apply", async () => {
+            const { shorten } = await renderDrawer({
+                expected_checkout: TOMORROW_AT_TEN,
+                nights: 1,
+                total_price: 2_500_000,
+                paid_amount: 999_999_999,
+            });
+
+            expect(shorten).toBeDisabled();
+            expect(shorten).toHaveAttribute("title", MIN_NIGHTS_REASON);
+        });
+
+        it("reports the checkout-today reason, not the paid-amount reason, when both apply", async () => {
+            const { shorten } = await renderDrawer({
+                expected_checkout: TODAY_AT_MIDDAY,
+                nights: 5,
+                total_price: 2_500_000,
+                paid_amount: 999_999_999,
+            });
+
+            expect(shorten).toBeDisabled();
+            expect(shorten).toHaveAttribute("title", CHECKOUT_TODAY_REASON);
         });
     });
 

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -45,6 +45,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         fetchRooms,
         updateHousekeeping,
         roomTypeRates,
+        setBookingRate,
     } = useHotelStore();
 
     const [roomDetail, setRoomDetail] = useState<RoomWithBooking | null>(null);
@@ -190,6 +191,18 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         await openInvoice(booking.id);
     };
 
+    const handleSaveRate = async (ratePerNight: number) => {
+        if (!booking) return;
+        try {
+            await setBookingRate(booking.id, ratePerNight);
+            await refreshRoomDetail();
+            toast.success("Đã cập nhật giá phòng!");
+        } catch (err) {
+            toast.error("Lỗi sửa giá: " + formatAppError(err));
+            throw err;
+        }
+    };
+
     const handleHousekeepingUpdate = async (newStatus: string) => {
         if (!housekeepingTask) return;
         try {
@@ -229,6 +242,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
             booking={booking}
             onInvoice={handleInvoice}
             invoiceLoading={invoiceLoading}
+            onSaveRate={handleSaveRate}
         />
     ) : null;
 

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
-    CalendarPlus,
     Check,
     CheckCircle2,
     Clipboard,
@@ -16,6 +15,7 @@ import CheckoutSettlementModal from "@/components/CheckoutSettlementModal";
 import BookingSummary from "@/components/shared/BookingSummary";
 import InfoItem from "@/components/shared/InfoItem";
 import ActionBtn from "@/components/shared/ActionBtn";
+import NightsStepper from "@/components/shared/NightsStepper";
 import RoomGuestsSection from "@/components/shared/RoomGuestsSection";
 import Section from "@/components/shared/Section";
 import StatusBadge from "@/components/shared/StatusBadge";
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
 import { getRoomTypeLabel } from "@/lib/constants";
+import { fmtMoney } from "@/lib/format";
 import { nightlyRateDisplay } from "@/lib/roomTypeRate";
 import { useHotelStore } from "@/stores/useHotelStore";
 import type { CheckoutSettlementPayload, RoomWithBooking, HousekeepingTask } from "@/types";
@@ -38,6 +39,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
     const {
         checkOut,
         extendStay,
+        shortenStay,
         getStayInfoText,
         setCheckinOpen,
         fetchRooms,
@@ -50,6 +52,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
     const [showCheckout, setShowCheckout] = useState(false);
     const [copied, setCopied] = useState(false);
     const [fetching, setFetching] = useState(false);
+    const [nightsBusy, setNightsBusy] = useState(false);
     const { invoiceOpen, invoiceData, invoiceLoading, openInvoice, closeInvoice } = useInvoiceDialog();
 
     useEffect(() => {
@@ -96,6 +99,31 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
     // Giá loại phòng từ engine, không phải `room.base_price`.
     const nightlyRate = nightlyRateDisplay(roomTypeRates, room.type);
 
+    // So sánh phải cắt về đầu ngày ở cả hai vế. Backend chặn khi
+    // `checkout − 1 ngày < hôm nay`, tức tương đương `checkout ≤ hôm nay`;
+    // nên nút chỉ mở khi checkout thực sự sau hôm nay. So thẳng hai đối
+    // tượng Date chưa cắt giờ sẽ sai: checkout hôm nay lúc 12:00 vẫn lớn
+    // hơn 00:00 hôm nay, nút sẽ mở trong khi backend từ chối.
+    const checkoutDay = booking ? new Date(booking.expected_checkout) : null;
+    checkoutDay?.setHours(0, 0, 0, 0);
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const canShorten = Boolean(
+        booking &&
+            booking.nights > 1 &&
+            checkoutDay !== null &&
+            checkoutDay.getTime() > todayStart.getTime(),
+    );
+    const shortenDisabledReason =
+        booking && booking.nights <= 1
+            ? "Lưu trú tối thiểu 1 đêm"
+            : "Đêm cuối là hôm nay — dùng Check-out";
+
+    const refreshRoomDetail = async () => {
+        const detail = await invoke<RoomWithBooking>("get_room_detail", { roomId: room.id });
+        setRoomDetail(detail);
+    };
+
     const handleCopyStayInfo = async () => {
         if (!booking) return;
         const text = await getStayInfoText(booking.id);
@@ -120,14 +148,35 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
     };
 
     const handleExtend = async () => {
-        if (!booking) return;
+        if (!booking || nightsBusy) return;
+        setNightsBusy(true);
         try {
             await extendStay(booking.id);
-            const detail = await invoke<RoomWithBooking>("get_room_detail", { roomId: room.id });
-            setRoomDetail(detail);
+            await refreshRoomDetail();
             toast.success("Đã gia hạn thêm 1 đêm!");
         } catch (err) {
-            toast.error("Lỗi gia hạn: " + err);
+            toast.error("Lỗi gia hạn: " + formatAppError(err));
+        } finally {
+            setNightsBusy(false);
+        }
+    };
+
+    const handleShorten = async () => {
+        if (!booking || nightsBusy) return;
+        setNightsBusy(true);
+        try {
+            await shortenStay(booking.id);
+            const detail = await invoke<RoomWithBooking>("get_room_detail", {
+                roomId: room.id,
+            });
+            setRoomDetail(detail);
+            const nights = detail.booking?.nights ?? 0;
+            const total = detail.booking?.total_price ?? 0;
+            toast.success(`Đã rút 1 đêm — còn ${nights} đêm, ${fmtMoney(total)}`);
+        } catch (err) {
+            toast.error("Lỗi rút đêm: " + formatAppError(err));
+        } finally {
+            setNightsBusy(false);
         }
     };
 
@@ -241,7 +290,13 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
                     onClick={handleCopyStayInfo}
                     variant="ghost"
                 />
-                <ActionBtn icon={CalendarPlus} label="Extend +1 đêm" onClick={handleExtend} variant="blue" />
+                <NightsStepper
+                    canShorten={canShorten}
+                    shortenDisabledReason={shortenDisabledReason}
+                    busy={nightsBusy}
+                    onShorten={handleShorten}
+                    onExtend={handleExtend}
+                />
             </div>
             <button
                 onClick={() => setShowCheckout(true)}

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -110,16 +110,34 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
     checkoutDay?.setHours(0, 0, 0, 0);
     const todayStart = new Date();
     todayStart.setHours(0, 0, 0, 0);
+
+    // Đảo ngược quyết định trước đó: rút đêm từng được phép đưa tổng tiền
+    // xuống dưới số khách đã trả. Backend (shorten_stay_tx) giờ từ chối thẳng
+    // ca đó — khoá luôn nút ở đây thay vì để người dùng bấm rồi nhận lỗi.
+    // Công thức tiền hoàn 1 đêm phải khớp CHÍNH XÁC công thức backend dùng
+    // (chia nguyên, làm tròn xuống): `current_total / current_nights`.
+    const nightCredit = booking ? Math.floor(booking.total_price / booking.nights) : 0;
+    const totalAfterShorten = booking ? booking.total_price - nightCredit : 0;
+    const wouldUnderpayAfterShorten = Boolean(
+        booking && totalAfterShorten < booking.paid_amount,
+    );
+
     const canShorten = Boolean(
         booking &&
             booking.nights > 1 &&
             checkoutDay !== null &&
-            checkoutDay.getTime() > todayStart.getTime(),
+            checkoutDay.getTime() > todayStart.getTime() &&
+            !wouldUnderpayAfterShorten,
     );
+    // Thứ tự ưu tiên khi nhiều điều kiện cùng chặn: cấu trúc (số đêm tối
+    // thiểu, đêm cuối đã tới) đi trước lý do tiền — hai cái đầu là bất khả
+    // thi tuyệt đối bất kể tiền nong, nên tooltip nên nói lý do "gốc" hơn.
     const shortenDisabledReason =
         booking && booking.nights <= 1
             ? "Lưu trú tối thiểu 1 đêm"
-            : "Đêm cuối là hôm nay — dùng Check-out";
+            : checkoutDay !== null && checkoutDay.getTime() <= todayStart.getTime()
+                ? "Đêm cuối là hôm nay — dùng Check-out"
+                : `Khách đã thanh toán ${fmtMoney(booking?.paid_amount ?? 0)}, cao hơn tổng tiền sau khi rút đêm (${fmtMoney(totalAfterShorten)}) — cần xử lý hoàn tiền trước`;
 
     const refreshRoomDetail = async () => {
         const detail = await invoke<RoomWithBooking>("get_room_detail", { roomId: room.id });

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -46,6 +46,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         updateHousekeeping,
         roomTypeRates,
         setBookingRate,
+        updateBookingNotes,
     } = useHotelStore();
 
     const [roomDetail, setRoomDetail] = useState<RoomWithBooking | null>(null);
@@ -203,6 +204,18 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         }
     };
 
+    const handleSaveNotes = async (notes: string) => {
+        if (!booking) return;
+        try {
+            await updateBookingNotes(booking.id, notes);
+            await refreshRoomDetail();
+            toast.success("Đã lưu ghi chú!");
+        } catch (err) {
+            toast.error("Lỗi lưu ghi chú: " + formatAppError(err));
+            throw err;
+        }
+    };
+
     const handleHousekeepingUpdate = async (newStatus: string) => {
         if (!housekeepingTask) return;
         try {
@@ -243,6 +256,7 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
             onInvoice={handleInvoice}
             invoiceLoading={invoiceLoading}
             onSaveRate={handleSaveRate}
+            onSaveNotes={handleSaveNotes}
         />
     ) : null;
 

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
-    CalendarDays,
     CalendarPlus,
     Check,
     CheckCircle2,
     Clipboard,
-    FileText,
     LogOut,
     Play,
     Sparkles,
@@ -15,6 +13,7 @@ import { toast } from "sonner";
 
 import InvoiceDialog from "@/components/InvoiceDialog";
 import CheckoutSettlementModal from "@/components/CheckoutSettlementModal";
+import BookingSummary from "@/components/shared/BookingSummary";
 import InfoItem from "@/components/shared/InfoItem";
 import ActionBtn from "@/components/shared/ActionBtn";
 import RoomGuestsSection from "@/components/shared/RoomGuestsSection";
@@ -24,9 +23,7 @@ import SlideDrawer from "@/components/shared/SlideDrawer";
 import { Button } from "@/components/ui/button";
 import { useInvoiceDialog } from "@/hooks/useInvoiceDialog";
 import { formatAppError } from "@/lib/appError";
-import { isFullySettled } from "@/lib/bookingBalance";
 import { getRoomTypeLabel } from "@/lib/constants";
-import { fmtDateShort, fmtMoney } from "@/lib/format";
 import { nightlyRateDisplay } from "@/lib/roomTypeRate";
 import { useHotelStore } from "@/stores/useHotelStore";
 import type { CheckoutSettlementPayload, RoomWithBooking, HousekeepingTask } from "@/types";
@@ -173,35 +170,12 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
 
     const guestSection = <RoomGuestsSection guests={guests} mode="sheet" />;
 
-    const paymentStatusClass =
-        booking && isFullySettled(booking.total_price, booking.paid_amount)
-            ? "text-emerald-600"
-            : "text-orange-600";
-
     const bookingSection = booking ? (
-        <Section icon={CalendarDays} title="Booking hiện tại" className="bg-slate-50 rounded-2xl p-5 space-y-3">
-            <div className="grid grid-cols-2 gap-3">
-                <InfoItem label="Check-in" value={fmtDateShort(booking.check_in_at)} />
-                <InfoItem label="Checkout" value={fmtDateShort(booking.expected_checkout)} />
-                <InfoItem label="Số đêm" value={booking.nights} />
-                <InfoItem label="Tổng tiền" value={fmtMoney(booking.total_price)} />
-            </div>
-            <div className="flex items-center justify-between pt-2 border-t border-slate-200">
-                <span className="text-sm font-medium text-brand-muted">Đã thanh toán</span>
-                <span className={"text-sm font-bold " + paymentStatusClass}>
-                    {fmtMoney(booking.paid_amount)} / {fmtMoney(booking.total_price)}
-                </span>
-            </div>
-            <Button
-                variant="outline"
-                className="w-full mt-3 gap-2 text-sm font-semibold cursor-pointer"
-                onClick={handleInvoice}
-                disabled={invoiceLoading}
-            >
-                <FileText className="w-4 h-4" />
-                {invoiceLoading ? "Đang tạo..." : "📄 Invoice"}
-            </Button>
-        </Section>
+        <BookingSummary
+            booking={booking}
+            onInvoice={handleInvoice}
+            invoiceLoading={invoiceLoading}
+        />
     ) : null;
 
     const getHkBadgeClass = () => {

--- a/mhm/src/components/RoomDrawer.tsx
+++ b/mhm/src/components/RoomDrawer.tsx
@@ -166,6 +166,11 @@ export default function RoomDrawer({ open, onClose, roomId }: RoomDrawerProps) {
         setNightsBusy(true);
         try {
             await shortenStay(booking.id);
+            // Gọi invoke trực tiếp thay vì dùng lại refreshRoomDetail(): hàm đó
+            // set state rồi trả về void, còn toast bên dưới cần chính con số
+            // vừa refetch (đêm còn lại, tổng tiền mới). State setter không đọc
+            // lại được trong cùng tick, nên nếu tái dùng refreshRoomDetail(),
+            // toast sẽ hiện số liệu cũ trước khi rút đêm — sai mà không lỗi rõ.
             const detail = await invoke<RoomWithBooking>("get_room_detail", {
                 roomId: room.id,
             });

--- a/mhm/src/components/shared/BookingSummary.test.tsx
+++ b/mhm/src/components/shared/BookingSummary.test.tsx
@@ -115,6 +115,92 @@ describe("BookingSummary rate editing", () => {
 
     expect(screen.getByRole("button", { name: "Lưu giá" })).toBeDisabled();
   });
+
+  describe("guard against dropping the total below paid_amount", () => {
+    // Reversal: set_booking_rate used to be allowed to push total_price
+    // below paid_amount (front desk would hand back cash). check_out_tx
+    // refuses that state outright, so Save must now stay disabled instead of
+    // letting the click fail. Fixture: 9 nights, 4,500,000 total (500,000/night).
+    it("khoá nút Lưu khi giá mới x số đêm thấp hơn số đã thanh toán, kèm giải thích", async () => {
+      render(
+        <BookingSummary
+          {...baseProps}
+          booking={{ ...booking, paid_amount: 4_100_000 }}
+          onSaveRate={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+      const input = screen.getByLabelText("Giá mỗi đêm");
+      await userEvent.clear(input);
+      // 9 đêm × 400.000 = 3.600.000, thấp hơn 4.100.000 đã thanh toán.
+      await userEvent.type(input, "400000");
+
+      expect(screen.getByRole("button", { name: "Lưu giá" })).toBeDisabled();
+      expect(
+        screen.getByText(/cao hơn tổng tiền mới.*cần xử lý hoàn tiền trước khi đổi giá/),
+      ).toBeInTheDocument();
+    });
+
+    it("mở lại nút Lưu khi giá mới x số đêm vẫn đủ trả số đã thanh toán", async () => {
+      render(
+        <BookingSummary
+          {...baseProps}
+          booking={{ ...booking, paid_amount: 4_100_000 }}
+          onSaveRate={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+      const input = screen.getByLabelText("Giá mỗi đêm");
+      await userEvent.clear(input);
+      // 9 đêm × 500.000 = 4.500.000, đủ trả 4.100.000 đã thanh toán.
+      await userEvent.type(input, "500000");
+
+      expect(screen.getByRole("button", { name: "Lưu giá" })).not.toBeDisabled();
+      expect(
+        screen.queryByText(/cần xử lý hoàn tiền trước khi đổi giá/),
+      ).toBeNull();
+    });
+
+    it("mở lại nút Lưu khi tổng mới đúng bằng số đã thanh toán", async () => {
+      render(
+        <BookingSummary
+          {...baseProps}
+          // 9 đêm × 450.000 = 4.050.000, đúng bằng số đã trả — guard dùng
+          // `<`, không phải `<=`, nên ca vừa khít này phải hợp lệ.
+          booking={{ ...booking, paid_amount: 4_050_000 }}
+          onSaveRate={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+      const input = screen.getByLabelText("Giá mỗi đêm");
+      await userEvent.clear(input);
+      await userEvent.type(input, "450000");
+
+      expect(screen.getByRole("button", { name: "Lưu giá" })).not.toBeDisabled();
+    });
+
+    it("không gọi onSaveRate khi bị khoá bởi guard hoàn tiền, kể cả khi bấm nút", async () => {
+      const onSaveRate = vi.fn();
+      render(
+        <BookingSummary
+          {...baseProps}
+          booking={{ ...booking, paid_amount: 4_100_000 }}
+          onSaveRate={onSaveRate}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+      const input = screen.getByLabelText("Giá mỗi đêm");
+      await userEvent.clear(input);
+      await userEvent.type(input, "400000");
+      await userEvent.click(screen.getByRole("button", { name: "Lưu giá" }));
+
+      expect(onSaveRate).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("BookingSummary notes and overpayment", () => {

--- a/mhm/src/components/shared/BookingSummary.test.tsx
+++ b/mhm/src/components/shared/BookingSummary.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import BookingSummary from "./BookingSummary";
+import type { Booking } from "@/types";
+
+const booking: Booking = {
+  id: "B1",
+  room_id: "R1",
+  primary_guest_id: "G1",
+  check_in_at: "2026-07-25T14:00:00+07:00",
+  expected_checkout: "2026-08-03T12:00:00+07:00",
+  nights: 9,
+  total_price: 4_500_000,
+  paid_amount: 0,
+  status: "active",
+  created_at: "2026-07-25T14:00:00+07:00",
+};
+
+const baseProps = {
+  booking,
+  onInvoice: vi.fn(),
+  invoiceLoading: false,
+};
+
+describe("BookingSummary rate editing", () => {
+  it("hiện giá mỗi đêm khi tổng chia hết cho số đêm", () => {
+    render(<BookingSummary {...baseProps} />);
+
+    expect(screen.getByText("Giá/đêm")).toBeInTheDocument();
+    expect(screen.getByText("500.000đ")).toBeInTheDocument();
+  });
+
+  it("đổi nhãn thành Giá/đêm (TB) khi chia không hết", () => {
+    render(
+      <BookingSummary
+        {...baseProps}
+        booking={{ ...booking, total_price: 4_500_001 }}
+      />,
+    );
+
+    expect(screen.getByText("Giá/đêm (TB)")).toBeInTheDocument();
+  });
+
+  it("không hiện nút sửa khi thiếu onSaveRate", () => {
+    render(<BookingSummary {...baseProps} />);
+
+    expect(screen.queryByRole("button", { name: /sửa giá/i })).toBeNull();
+  });
+
+  it("hiện preview tổng tiền khi gõ giá mới", async () => {
+    render(<BookingSummary {...baseProps} onSaveRate={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+    const input = screen.getByLabelText("Giá mỗi đêm");
+    await userEvent.clear(input);
+    await userEvent.type(input, "450000");
+
+    expect(screen.getByText("9 đêm × 450.000đ = 4.050.000đ")).toBeInTheDocument();
+  });
+
+  it("gọi onSaveRate với con số đã nhập", async () => {
+    const onSaveRate = vi.fn().mockResolvedValue(undefined);
+    render(<BookingSummary {...baseProps} onSaveRate={onSaveRate} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+    const input = screen.getByLabelText("Giá mỗi đêm");
+    await userEvent.clear(input);
+    await userEvent.type(input, "450000");
+    await userEvent.click(screen.getByRole("button", { name: "Lưu giá" }));
+
+    expect(onSaveRate).toHaveBeenCalledWith(450000);
+  });
+
+  it("huỷ thì không gọi onSaveRate và đóng ô nhập", async () => {
+    const onSaveRate = vi.fn();
+    render(<BookingSummary {...baseProps} onSaveRate={onSaveRate} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Huỷ giá" }));
+
+    expect(onSaveRate).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Giá mỗi đêm")).toBeNull();
+  });
+
+  it("khoá nút Lưu khi giá không hợp lệ", async () => {
+    render(<BookingSummary {...baseProps} onSaveRate={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+    const input = screen.getByLabelText("Giá mỗi đêm");
+    await userEvent.clear(input);
+    await userEvent.type(input, "0");
+
+    expect(screen.getByRole("button", { name: "Lưu giá" })).toBeDisabled();
+  });
+});

--- a/mhm/src/components/shared/BookingSummary.test.tsx
+++ b/mhm/src/components/shared/BookingSummary.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -114,5 +114,104 @@ describe("BookingSummary rate editing", () => {
     await userEvent.type(input, "0");
 
     expect(screen.getByRole("button", { name: "Lưu giá" })).toBeDisabled();
+  });
+});
+
+describe("BookingSummary notes and overpayment", () => {
+  it("hiện chữ mờ khi chưa có ghi chú", () => {
+    render(<BookingSummary {...baseProps} onSaveNotes={vi.fn()} />);
+
+    expect(screen.getByText("Chưa có ghi chú")).toBeInTheDocument();
+  });
+
+  it("hiện nội dung ghi chú đang có", () => {
+    render(
+      <BookingSummary
+        {...baseProps}
+        booking={{ ...booking, notes: "Hẹn trả phòng 14h" }}
+        onSaveNotes={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Hẹn trả phòng 14h")).toBeInTheDocument();
+  });
+
+  it("gọi onSaveNotes với nội dung đã gõ", async () => {
+    const onSaveNotes = vi.fn().mockResolvedValue(undefined);
+    render(<BookingSummary {...baseProps} onSaveNotes={onSaveNotes} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa ghi chú/i }));
+    await userEvent.type(screen.getByLabelText("Ghi chú"), "Khách xin thêm gối");
+    await userEvent.click(screen.getByRole("button", { name: "Lưu ghi chú" }));
+
+    expect(onSaveNotes).toHaveBeenCalledWith("Khách xin thêm gối");
+  });
+
+  it("huỷ ghi chú thì không lưu và bỏ nội dung vừa gõ", async () => {
+    const onSaveNotes = vi.fn();
+    render(<BookingSummary {...baseProps} onSaveNotes={onSaveNotes} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa ghi chú/i }));
+    await userEvent.type(screen.getByLabelText("Ghi chú"), "gõ nhầm");
+    await userEvent.click(screen.getByRole("button", { name: "Huỷ ghi chú" }));
+
+    expect(onSaveNotes).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Ghi chú")).toBeNull();
+  });
+
+  it("hiện số phải trả lại khi khách trả dư", () => {
+    render(
+      <BookingSummary
+        {...baseProps}
+        booking={{ ...booking, paid_amount: 5_000_000 }}
+      />,
+    );
+
+    // "500.000đ" cũng trùng với "Giá/đêm" của fixture này (4.500.000 / 9 đêm),
+    // nên scope theo đúng dòng "Trả lại khách" thay vì getByText toàn trang.
+    const balanceLabel = screen.getByText("Trả lại khách");
+    const balanceRow = balanceLabel.closest("div");
+    expect(balanceRow).not.toBeNull();
+    expect(within(balanceRow!).getByText("500.000đ")).toBeInTheDocument();
+  });
+
+  it("hiện số còn nợ khi khách chưa trả đủ", () => {
+    render(
+      <BookingSummary
+        {...baseProps}
+        booking={{ ...booking, paid_amount: 1_000_000 }}
+      />,
+    );
+
+    expect(screen.getByText("Còn nợ")).toBeInTheDocument();
+    expect(screen.queryByText("Trả lại khách")).toBeNull();
+  });
+
+  it("hiện Đã đủ khi khách trả vừa khít", () => {
+    render(
+      <BookingSummary
+        {...baseProps}
+        booking={{ ...booking, paid_amount: 4_500_000 }}
+      />,
+    );
+
+    expect(screen.getByText("Đã đủ")).toBeInTheDocument();
+  });
+
+  it("khi onSaveNotes reject: không phát sinh unhandled rejection, ô sửa ghi chú vẫn mở với nội dung đã gõ", async () => {
+    // Giống hệt submitRate: RoomDrawer.handleSaveNotes hiện toast lỗi rồi
+    // re-throw có chủ đích để giữ ô sửa ghi chú mở. submitNotes phải tự nuốt
+    // lỗi này, nếu không rejection sẽ lọt ra khỏi onClick async không ai await.
+    const onSaveNotes = vi.fn().mockRejectedValue(new Error("Lỗi lưu ghi chú"));
+    render(<BookingSummary {...baseProps} onSaveNotes={onSaveNotes} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa ghi chú/i }));
+    await userEvent.type(screen.getByLabelText("Ghi chú"), "Khách xin thêm gối");
+    await userEvent.click(screen.getByRole("button", { name: "Lưu ghi chú" }));
+
+    await waitFor(() => expect(onSaveNotes).toHaveBeenCalledWith("Khách xin thêm gối"));
+
+    // Ô sửa ghi chú vẫn còn mở, nội dung đã gõ được giữ nguyên.
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Khách xin thêm gối");
   });
 });

--- a/mhm/src/components/shared/BookingSummary.test.tsx
+++ b/mhm/src/components/shared/BookingSummary.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -82,6 +82,27 @@ describe("BookingSummary rate editing", () => {
 
     expect(onSaveRate).not.toHaveBeenCalled();
     expect(screen.queryByLabelText("Giá mỗi đêm")).toBeNull();
+  });
+
+  it("khi onSaveRate reject: không phát sinh unhandled rejection, ô sửa giá vẫn mở với giá đã gõ", async () => {
+    // RoomDrawer.handleSaveRate hiện toast lỗi rồi re-throw có chủ đích để
+    // giữ ô sửa giá mở. Mô phỏng đúng hành vi đó ở đây: onSaveRate reject.
+    // submitRate phải tự nuốt lỗi này (đã được caller xử lý xong), nếu không
+    // rejection sẽ lọt ra khỏi onClick async mà không ai await, và Vitest sẽ
+    // báo "Unhandled Rejection" cho chính test này.
+    const onSaveRate = vi.fn().mockRejectedValue(new Error("Lỗi sửa giá"));
+    render(<BookingSummary {...baseProps} onSaveRate={onSaveRate} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /sửa giá/i }));
+    const input = screen.getByLabelText("Giá mỗi đêm");
+    await userEvent.clear(input);
+    await userEvent.type(input, "450000");
+    await userEvent.click(screen.getByRole("button", { name: "Lưu giá" }));
+
+    await waitFor(() => expect(onSaveRate).toHaveBeenCalledWith(450000));
+
+    // Ô sửa giá vẫn còn mở, giá trị đã gõ được giữ nguyên.
+    expect(screen.getByLabelText("Giá mỗi đêm")).toHaveValue("450000");
   });
 
   it("khoá nút Lưu khi giá không hợp lệ", async () => {

--- a/mhm/src/components/shared/BookingSummary.tsx
+++ b/mhm/src/components/shared/BookingSummary.tsx
@@ -1,4 +1,5 @@
-import { CalendarDays, FileText } from "lucide-react";
+import { useState } from "react";
+import { CalendarDays, Check, FileText, Pencil, X } from "lucide-react";
 
 import InfoItem from "@/components/shared/InfoItem";
 import Section from "@/components/shared/Section";
@@ -7,20 +8,61 @@ import { isFullySettled } from "@/lib/bookingBalance";
 import { fmtDateShort, fmtMoney } from "@/lib/format";
 import type { Booking } from "@/types";
 
+const MAX_RATE_PER_NIGHT = 100_000_000;
+
 interface BookingSummaryProps {
     booking: Booking;
     onInvoice: () => void;
     invoiceLoading: boolean;
+    onSaveRate?: (ratePerNight: number) => Promise<void>;
 }
 
 export default function BookingSummary({
     booking,
     onInvoice,
     invoiceLoading,
+    onSaveRate,
 }: BookingSummaryProps) {
+    const [editingRate, setEditingRate] = useState(false);
+    const [rateInput, setRateInput] = useState("");
+    const [savingRate, setSavingRate] = useState(false);
+
     const paymentStatusClass = isFullySettled(booking.total_price, booking.paid_amount)
         ? "text-emerald-600"
         : "text-orange-600";
+
+    // `total_price` là cột duy nhất được lưu — không có cột giá/đêm. Giá hiển
+    // thị luôn suy ra bằng phép chia, làm tròn xuống VNĐ nguyên. Khi phụ thu
+    // cuối tuần/lễ khiến các đêm không đồng giá, phép chia không hết — nhãn
+    // phải nói rõ đây là số trung bình (TB), không phải giá cố định.
+    const nights = booking.nights > 0 ? booking.nights : 1;
+    const derivedRate = Math.floor(booking.total_price / nights);
+    const isAverage = booking.total_price % nights !== 0;
+
+    const parsedRate = Number(rateInput);
+    const rateValid =
+        Number.isInteger(parsedRate) && parsedRate > 0 && parsedRate <= MAX_RATE_PER_NIGHT;
+
+    const openRateEditor = () => {
+        setRateInput(String(derivedRate));
+        setEditingRate(true);
+    };
+
+    const closeRateEditor = () => {
+        setEditingRate(false);
+        setRateInput("");
+    };
+
+    const submitRate = async () => {
+        if (!onSaveRate || !rateValid || savingRate) return;
+        setSavingRate(true);
+        try {
+            await onSaveRate(parsedRate);
+            closeRateEditor();
+        } finally {
+            setSavingRate(false);
+        }
+    };
 
     return (
         <Section
@@ -33,13 +75,82 @@ export default function BookingSummary({
                 <InfoItem label="Checkout" value={fmtDateShort(booking.expected_checkout)} />
                 <InfoItem label="Số đêm" value={booking.nights} />
                 <InfoItem label="Tổng tiền" value={fmtMoney(booking.total_price)} />
+                <InfoItem
+                    label={isAverage ? "Giá/đêm (TB)" : "Giá/đêm"}
+                    value={
+                        <span className="inline-flex items-center gap-1.5">
+                            {fmtMoney(derivedRate)}
+                            {onSaveRate && !editingRate && (
+                                <button
+                                    type="button"
+                                    aria-label="Sửa giá"
+                                    onClick={openRateEditor}
+                                    className="text-slate-400 hover:text-blue-600 cursor-pointer"
+                                >
+                                    <Pencil size={12} />
+                                </button>
+                            )}
+                        </span>
+                    }
+                />
             </div>
+
+            {editingRate && (
+                <div className="space-y-2 rounded-xl border border-blue-200 bg-white p-3">
+                    <label
+                        htmlFor="booking-rate-input"
+                        className="text-[11px] font-medium text-brand-muted"
+                    >
+                        Giá mỗi đêm
+                    </label>
+                    <input
+                        id="booking-rate-input"
+                        aria-label="Giá mỗi đêm"
+                        inputMode="numeric"
+                        value={rateInput}
+                        onChange={(event) => setRateInput(event.target.value.replace(/\D/g, ""))}
+                        onKeyDown={(event) => {
+                            if (event.key === "Escape") closeRateEditor();
+                        }}
+                        className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                    />
+                    <p className="text-[12px] text-slate-500">
+                        {rateValid
+                            ? `${booking.nights} đêm × ${fmtMoney(parsedRate)} = ${fmtMoney(
+                                  parsedRate * booking.nights,
+                              )}`
+                            : "Giá mỗi đêm không hợp lệ"}
+                    </p>
+                    <div className="flex gap-2">
+                        <Button
+                            size="sm"
+                            aria-label="Lưu giá"
+                            disabled={!rateValid || savingRate}
+                            onClick={submitRate}
+                            className="flex-1 gap-1.5 cursor-pointer"
+                        >
+                            <Check className="w-3.5 h-3.5" /> Lưu
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            aria-label="Huỷ giá"
+                            onClick={closeRateEditor}
+                            className="flex-1 gap-1.5 cursor-pointer"
+                        >
+                            <X className="w-3.5 h-3.5" /> Huỷ
+                        </Button>
+                    </div>
+                </div>
+            )}
+
             <div className="flex items-center justify-between pt-2 border-t border-slate-200">
                 <span className="text-sm font-medium text-brand-muted">Đã thanh toán</span>
                 <span className={"text-sm font-bold " + paymentStatusClass}>
                     {fmtMoney(booking.paid_amount)} / {fmtMoney(booking.total_price)}
                 </span>
             </div>
+
             <Button
                 variant="outline"
                 className="w-full mt-3 gap-2 text-sm font-semibold cursor-pointer"

--- a/mhm/src/components/shared/BookingSummary.tsx
+++ b/mhm/src/components/shared/BookingSummary.tsx
@@ -59,6 +59,13 @@ export default function BookingSummary({
         try {
             await onSaveRate(parsedRate);
             closeRateEditor();
+        } catch {
+            // Caller (RoomDrawer.handleSaveRate) đã hiện toast lỗi và re-throw
+            // có chủ đích để giữ ô sửa giá mở cho người dùng sửa lại. Nuốt lỗi
+            // ở đây — nếu không, rejection sẽ lọt khỏi onClick async (không ai
+            // await), và window "unhandledrejection" handler trong
+            // lib/crashReporting/globalHandlers.ts sẽ báo nhầm mỗi lần lưu giá
+            // thất bại thành một crash JS thật.
         } finally {
             setSavingRate(false);
         }
@@ -116,8 +123,8 @@ export default function BookingSummary({
                     />
                     <p className="text-[12px] text-slate-500">
                         {rateValid
-                            ? `${booking.nights} đêm × ${fmtMoney(parsedRate)} = ${fmtMoney(
-                                  parsedRate * booking.nights,
+                            ? `${nights} đêm × ${fmtMoney(parsedRate)} = ${fmtMoney(
+                                  parsedRate * nights,
                               )}`
                             : "Giá mỗi đêm không hợp lệ"}
                     </p>

--- a/mhm/src/components/shared/BookingSummary.tsx
+++ b/mhm/src/components/shared/BookingSummary.tsx
@@ -4,17 +4,19 @@ import { CalendarDays, Check, FileText, Pencil, X } from "lucide-react";
 import InfoItem from "@/components/shared/InfoItem";
 import Section from "@/components/shared/Section";
 import { Button } from "@/components/ui/button";
-import { isFullySettled } from "@/lib/bookingBalance";
+import { BALANCE_TONE_CLASS, balanceDisplay, isFullySettled } from "@/lib/bookingBalance";
 import { fmtDateShort, fmtMoney } from "@/lib/format";
 import type { Booking } from "@/types";
 
 const MAX_RATE_PER_NIGHT = 100_000_000;
+const MAX_NOTES_LEN = 2_000;
 
 interface BookingSummaryProps {
     booking: Booking;
     onInvoice: () => void;
     invoiceLoading: boolean;
     onSaveRate?: (ratePerNight: number) => Promise<void>;
+    onSaveNotes?: (notes: string) => Promise<void>;
 }
 
 export default function BookingSummary({
@@ -22,14 +24,21 @@ export default function BookingSummary({
     onInvoice,
     invoiceLoading,
     onSaveRate,
+    onSaveNotes,
 }: BookingSummaryProps) {
     const [editingRate, setEditingRate] = useState(false);
     const [rateInput, setRateInput] = useState("");
     const [savingRate, setSavingRate] = useState(false);
 
+    const [editingNotes, setEditingNotes] = useState(false);
+    const [notesInput, setNotesInput] = useState("");
+    const [savingNotes, setSavingNotes] = useState(false);
+
     const paymentStatusClass = isFullySettled(booking.total_price, booking.paid_amount)
         ? "text-emerald-600"
         : "text-orange-600";
+    const balance = balanceDisplay(booking.total_price, booking.paid_amount);
+    const notesValid = notesInput.length <= MAX_NOTES_LEN;
 
     // `total_price` là cột duy nhất được lưu — không có cột giá/đêm. Giá hiển
     // thị luôn suy ra bằng phép chia, làm tròn xuống VNĐ nguyên. Khi phụ thu
@@ -68,6 +77,34 @@ export default function BookingSummary({
             // thất bại thành một crash JS thật.
         } finally {
             setSavingRate(false);
+        }
+    };
+
+    const openNotesEditor = () => {
+        setNotesInput(booking.notes ?? "");
+        setEditingNotes(true);
+    };
+
+    const closeNotesEditor = () => {
+        setEditingNotes(false);
+        setNotesInput("");
+    };
+
+    const submitNotes = async () => {
+        if (!onSaveNotes || !notesValid || savingNotes) return;
+        setSavingNotes(true);
+        try {
+            await onSaveNotes(notesInput.trim());
+            closeNotesEditor();
+        } catch {
+            // Caller (RoomDrawer.handleSaveNotes) đã hiện toast lỗi và re-throw
+            // có chủ đích để giữ ô sửa ghi chú mở cho người dùng sửa lại. Nuốt
+            // lỗi ở đây — nếu không, rejection sẽ lọt khỏi onClick async (không
+            // ai await), và window "unhandledrejection" handler trong
+            // lib/crashReporting/globalHandlers.ts sẽ báo nhầm mỗi lần lưu ghi
+            // chú thất bại thành một crash JS thật.
+        } finally {
+            setSavingNotes(false);
         }
     };
 
@@ -157,6 +194,77 @@ export default function BookingSummary({
                     {fmtMoney(booking.paid_amount)} / {fmtMoney(booking.total_price)}
                 </span>
             </div>
+            <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-brand-muted">{balance.label}</span>
+                <span className={"text-sm font-bold " + BALANCE_TONE_CLASS[balance.tone]}>
+                    {balance.text}
+                </span>
+            </div>
+
+            {onSaveNotes && (
+                <div className="pt-2 border-t border-slate-200 space-y-2">
+                    <div className="flex items-center justify-between">
+                        <span className="text-[11px] font-medium text-brand-muted uppercase tracking-wider">
+                            Ghi chú
+                        </span>
+                        {!editingNotes && (
+                            <button
+                                type="button"
+                                aria-label="Sửa ghi chú"
+                                onClick={openNotesEditor}
+                                className="text-slate-400 hover:text-blue-600 cursor-pointer"
+                            >
+                                <Pencil size={12} />
+                            </button>
+                        )}
+                    </div>
+
+                    {editingNotes ? (
+                        <>
+                            <textarea
+                                aria-label="Ghi chú"
+                                rows={3}
+                                value={notesInput}
+                                onChange={(event) => setNotesInput(event.target.value)}
+                                className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                            />
+                            {!notesValid && (
+                                <p className="text-[12px] text-red-600">
+                                    Ghi chú tối đa {MAX_NOTES_LEN} ký tự
+                                </p>
+                            )}
+                            <div className="flex gap-2">
+                                <Button
+                                    size="sm"
+                                    aria-label="Lưu ghi chú"
+                                    disabled={!notesValid || savingNotes}
+                                    onClick={submitNotes}
+                                    className="flex-1 gap-1.5 cursor-pointer"
+                                >
+                                    <Check className="w-3.5 h-3.5" /> Lưu
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    aria-label="Huỷ ghi chú"
+                                    onClick={closeNotesEditor}
+                                    className="flex-1 gap-1.5 cursor-pointer"
+                                >
+                                    <X className="w-3.5 h-3.5" /> Huỷ
+                                </Button>
+                            </div>
+                        </>
+                    ) : (
+                        <p
+                            className={
+                                "text-sm " + (booking.notes ? "text-slate-700" : "text-slate-400")
+                            }
+                        >
+                            {booking.notes || "Chưa có ghi chú"}
+                        </p>
+                    )}
+                </div>
+            )}
 
             <Button
                 variant="outline"

--- a/mhm/src/components/shared/BookingSummary.tsx
+++ b/mhm/src/components/shared/BookingSummary.tsx
@@ -49,8 +49,15 @@ export default function BookingSummary({
     const isAverage = booking.total_price % nights !== 0;
 
     const parsedRate = Number(rateInput);
-    const rateValid =
+    const parsedRateValid =
         Number.isInteger(parsedRate) && parsedRate > 0 && parsedRate <= MAX_RATE_PER_NIGHT;
+    const newTotalFromRate = parsedRateValid ? parsedRate * nights : 0;
+    // Đảo ngược quyết định trước đó: hạ giá từng được phép đưa tổng tiền
+    // xuống dưới số khách đã trả. Backend (set_booking_rate_tx) giờ từ chối
+    // thẳng ca đó — khoá luôn nút Lưu ở đây thay vì để người dùng bấm rồi
+    // nhận lỗi.
+    const belowPaidAmount = parsedRateValid && newTotalFromRate < booking.paid_amount;
+    const rateValid = parsedRateValid && !belowPaidAmount;
 
     const openRateEditor = () => {
         setRateInput(String(derivedRate));
@@ -159,12 +166,18 @@ export default function BookingSummary({
                         className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
                     />
                     <p className="text-[12px] text-slate-500">
-                        {rateValid
+                        {parsedRateValid
                             ? `${nights} đêm × ${fmtMoney(parsedRate)} = ${fmtMoney(
-                                  parsedRate * nights,
+                                  newTotalFromRate,
                               )}`
                             : "Giá mỗi đêm không hợp lệ"}
                     </p>
+                    {belowPaidAmount && (
+                        <p className="text-[12px] text-red-600">
+                            Khách đã thanh toán {fmtMoney(booking.paid_amount)}, cao hơn tổng
+                            tiền mới — cần xử lý hoàn tiền trước khi đổi giá
+                        </p>
+                    )}
                     <div className="flex gap-2">
                         <Button
                             size="sm"

--- a/mhm/src/components/shared/BookingSummary.tsx
+++ b/mhm/src/components/shared/BookingSummary.tsx
@@ -1,0 +1,54 @@
+import { CalendarDays, FileText } from "lucide-react";
+
+import InfoItem from "@/components/shared/InfoItem";
+import Section from "@/components/shared/Section";
+import { Button } from "@/components/ui/button";
+import { isFullySettled } from "@/lib/bookingBalance";
+import { fmtDateShort, fmtMoney } from "@/lib/format";
+import type { Booking } from "@/types";
+
+interface BookingSummaryProps {
+    booking: Booking;
+    onInvoice: () => void;
+    invoiceLoading: boolean;
+}
+
+export default function BookingSummary({
+    booking,
+    onInvoice,
+    invoiceLoading,
+}: BookingSummaryProps) {
+    const paymentStatusClass = isFullySettled(booking.total_price, booking.paid_amount)
+        ? "text-emerald-600"
+        : "text-orange-600";
+
+    return (
+        <Section
+            icon={CalendarDays}
+            title="Booking hiện tại"
+            className="bg-slate-50 rounded-2xl p-5 space-y-3"
+        >
+            <div className="grid grid-cols-2 gap-3">
+                <InfoItem label="Check-in" value={fmtDateShort(booking.check_in_at)} />
+                <InfoItem label="Checkout" value={fmtDateShort(booking.expected_checkout)} />
+                <InfoItem label="Số đêm" value={booking.nights} />
+                <InfoItem label="Tổng tiền" value={fmtMoney(booking.total_price)} />
+            </div>
+            <div className="flex items-center justify-between pt-2 border-t border-slate-200">
+                <span className="text-sm font-medium text-brand-muted">Đã thanh toán</span>
+                <span className={"text-sm font-bold " + paymentStatusClass}>
+                    {fmtMoney(booking.paid_amount)} / {fmtMoney(booking.total_price)}
+                </span>
+            </div>
+            <Button
+                variant="outline"
+                className="w-full mt-3 gap-2 text-sm font-semibold cursor-pointer"
+                onClick={onInvoice}
+                disabled={invoiceLoading}
+            >
+                <FileText className="w-4 h-4" />
+                {invoiceLoading ? "Đang tạo..." : "📄 Invoice"}
+            </Button>
+        </Section>
+    );
+}

--- a/mhm/src/components/shared/NightsStepper.test.tsx
+++ b/mhm/src/components/shared/NightsStepper.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import NightsStepper from "./NightsStepper";
+
+const baseProps = {
+  canShorten: true,
+  shortenDisabledReason: "Đêm cuối là hôm nay — dùng Check-out",
+  busy: false,
+  onShorten: vi.fn(),
+  onExtend: vi.fn(),
+};
+
+describe("NightsStepper", () => {
+  it("gọi onShorten khi bấm nút −1 đêm", async () => {
+    const onShorten = vi.fn();
+    render(<NightsStepper {...baseProps} onShorten={onShorten} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /−1 đêm/ }));
+
+    expect(onShorten).toHaveBeenCalledTimes(1);
+  });
+
+  it("khoá nút −1 đêm khi không được phép rút", () => {
+    render(<NightsStepper {...baseProps} canShorten={false} />);
+
+    const shorten = screen.getByRole("button", { name: /−1 đêm/ });
+    expect(shorten).toBeDisabled();
+    expect(shorten).toHaveAttribute(
+      "title",
+      "Đêm cuối là hôm nay — dùng Check-out",
+    );
+  });
+
+  it("khoá cả hai nút khi đang gửi lệnh", () => {
+    render(<NightsStepper {...baseProps} busy />);
+
+    expect(screen.getByRole("button", { name: /−1 đêm/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /\+1 đêm/ })).toBeDisabled();
+  });
+});

--- a/mhm/src/components/shared/NightsStepper.tsx
+++ b/mhm/src/components/shared/NightsStepper.tsx
@@ -1,0 +1,44 @@
+import { CalendarMinus, CalendarPlus } from "lucide-react";
+
+interface NightsStepperProps {
+    canShorten: boolean;
+    shortenDisabledReason: string;
+    busy: boolean;
+    onShorten: () => void;
+    onExtend: () => void;
+}
+
+const baseClass =
+    "flex flex-1 items-center justify-center gap-1.5 py-2.5 text-[12px] font-medium transition-colors cursor-pointer bg-blue-50 text-blue-600 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-blue-50";
+
+export default function NightsStepper({
+    canShorten,
+    shortenDisabledReason,
+    busy,
+    onShorten,
+    onExtend,
+}: NightsStepperProps) {
+    const shortenDisabled = busy || !canShorten;
+
+    return (
+        <div className="flex overflow-hidden rounded-xl border border-blue-200">
+            <button
+                type="button"
+                onClick={onShorten}
+                disabled={shortenDisabled}
+                title={canShorten ? undefined : shortenDisabledReason}
+                className={baseClass + " border-r border-blue-200"}
+            >
+                <CalendarMinus size={14} /> −1 đêm
+            </button>
+            <button
+                type="button"
+                onClick={onExtend}
+                disabled={busy}
+                className={baseClass}
+            >
+                <CalendarPlus size={14} /> +1 đêm
+            </button>
+        </div>
+    );
+}

--- a/mhm/src/lib/crashReporting/commandFailure.test.ts
+++ b/mhm/src/lib/crashReporting/commandFailure.test.ts
@@ -122,6 +122,64 @@ describe("captureCommandFailure", () => {
     );
   });
 
+  it("sends shorten stay failures with operation metadata", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(true);
+
+    const monitoringContext = {
+      operation: "remove_one_night",
+    } as const;
+
+    await captureCommandFailure({
+      command: "shorten_stay",
+      appError: {
+        code: "BOOKING_INVALID_STATE",
+        message: "Không thể rút ngắn booking đã đóng",
+        kind: "user",
+        support_id: null,
+      },
+      correlationId: "COR-8F3A1C7D",
+      monitoringContext,
+    });
+
+    expect(invoke).toHaveBeenCalledWith("get_crash_reporting_preference");
+    expect(submitCommandFailureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "shorten_stay",
+        correlationId: "COR-8F3A1C7D",
+        monitoringContext,
+      }),
+    );
+  });
+
+  it("sends set booking rate failures with operation metadata", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(true);
+
+    const monitoringContext = {
+      operation: "set_booking_rate",
+    } as const;
+
+    await captureCommandFailure({
+      command: "set_booking_rate",
+      appError: {
+        code: "BOOKING_INVALID_STATE",
+        message: "Không thể đổi giá booking đã đóng",
+        kind: "user",
+        support_id: null,
+      },
+      correlationId: "COR-8F3A1C7D",
+      monitoringContext,
+    });
+
+    expect(invoke).toHaveBeenCalledWith("get_crash_reporting_preference");
+    expect(submitCommandFailureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "set_booking_rate",
+        correlationId: "COR-8F3A1C7D",
+        monitoringContext,
+      }),
+    );
+  });
+
   it("does not report commands outside the allowlist", async () => {
     await captureCommandFailure({
       command: "login",

--- a/mhm/src/lib/crashReporting/commandFailure.ts
+++ b/mhm/src/lib/crashReporting/commandFailure.ts
@@ -17,7 +17,7 @@ export type MonitoringContext =
       settlement_mode: string;
     }
   | {
-      operation: "add_one_night";
+      operation: "add_one_night" | "remove_one_night" | "set_booking_rate";
     }
   | {
       nights: number;

--- a/mhm/src/lib/crashReporting/commandFailure.ts
+++ b/mhm/src/lib/crashReporting/commandFailure.ts
@@ -35,6 +35,8 @@ const MONITORED_COMMANDS = new Set([
   "create_reservation",
   "extend_stay",
   "run_night_audit",
+  "shorten_stay",
+  "set_booking_rate",
 ]);
 
 function isMonitoredCommand(command: string): boolean {

--- a/mhm/src/stores/useHotelStore.test.ts
+++ b/mhm/src/stores/useHotelStore.test.ts
@@ -328,6 +328,30 @@ describe("useHotelStore monitoring context", () => {
     );
   });
 
+  it("rejects fractional setBookingRate ratePerNight before invoking backend", async () => {
+    await expect(
+      useHotelStore.getState().setBookingRate("booking-1", 400000.5),
+    ).rejects.toThrow(/ratePerNight/);
+
+    expect(invokeWriteCommand).not.toHaveBeenCalledWith(
+      "set_booking_rate",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("rejects negative setBookingRate ratePerNight before invoking backend", async () => {
+    await expect(
+      useHotelStore.getState().setBookingRate("booking-1", -1000),
+    ).rejects.toThrow(/ratePerNight/);
+
+    expect(invokeWriteCommand).not.toHaveBeenCalledWith(
+      "set_booking_rate",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("rejects fractional group money before invoking backend", async () => {
     await expect(
       useHotelStore.getState().groupCheckIn({

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -58,6 +58,9 @@ interface HotelStore {
     finalTotal: MoneyVnd,
   ) => Promise<void>;
   extendStay: (bookingId: string) => Promise<void>;
+  shortenStay: (bookingId: string) => Promise<void>;
+  setBookingRate: (bookingId: string, ratePerNight: number) => Promise<void>;
+  updateBookingNotes: (bookingId: string, notes: string) => Promise<void>;
   fetchHousekeeping: () => Promise<void>;
   updateHousekeeping: (taskId: string, status: string, note?: string) => Promise<void>;
   getStayInfoText: (bookingId: string) => Promise<string>;
@@ -229,6 +232,68 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         get().markDashboardDataChanged();
       } catch (err) {
         console.error("extend_stay error:", err);
+        throw err;
+      } finally {
+        endAction();
+      }
+    },
+
+    shortenStay: async (bookingId) => {
+      beginAction();
+      try {
+        const correlationId = createCorrelationId();
+        await invokeWriteCommand(
+          "shorten_stay",
+          { bookingId },
+          {
+            correlationId,
+            monitoringContext: {
+              operation: "remove_one_night",
+            },
+          },
+        );
+        await get().fetchRooms();
+        await get().fetchStats();
+        get().markDashboardDataChanged();
+      } catch (err) {
+        console.error("shorten_stay error:", err);
+        throw err;
+      } finally {
+        endAction();
+      }
+    },
+
+    setBookingRate: async (bookingId, ratePerNight) => {
+      beginAction();
+      try {
+        const correlationId = createCorrelationId();
+        await invokeWriteCommand(
+          "set_booking_rate",
+          { bookingId, ratePerNight },
+          {
+            correlationId,
+            monitoringContext: {
+              operation: "set_booking_rate",
+            },
+          },
+        );
+        await get().fetchRooms();
+        await get().fetchStats();
+        get().markDashboardDataChanged();
+      } catch (err) {
+        console.error("set_booking_rate error:", err);
+        throw err;
+      } finally {
+        endAction();
+      }
+    },
+
+    updateBookingNotes: async (bookingId, notes) => {
+      beginAction();
+      try {
+        await invokeCommand("update_booking_notes", { bookingId, notes: notes || null });
+      } catch (err) {
+        console.error("update_booking_notes error:", err);
         throw err;
       } finally {
         endAction();

--- a/mhm/src/stores/useHotelStore.ts
+++ b/mhm/src/stores/useHotelStore.ts
@@ -269,7 +269,7 @@ export const useHotelStore = create<HotelStore>((set, get) => {
         const correlationId = createCorrelationId();
         await invokeWriteCommand(
           "set_booking_rate",
-          { bookingId, ratePerNight },
+          { bookingId, ratePerNight: assertNonNegativeMoneyVnd(ratePerNight, "ratePerNight") },
           {
             correlationId,
             monitoringContext: {

--- a/mhm/src/types/index.ts
+++ b/mhm/src/types/index.ts
@@ -71,6 +71,8 @@ export interface Booking {
   source?: BookingSource | null;
   notes?: string;
   created_at: string;
+  /** Thời điểm gần nhất giá/đêm bị lễ tân đổi tay; null nếu chưa từng đổi. */
+  rate_overridden_at?: string | null;
 }
 
 export type CheckoutSettlementMode = "actual_nights" | "hourly" | "booked_nights";


### PR DESCRIPTION
Ba thao tác lễ tân hay cần mà khung chi tiết phòng chưa làm được: rút ngắn lưu trú một đêm, sửa giá của lượt ở hiện tại, và đọc/sửa ghi chú.

Ca thật đã châm ngòi: khách ở phòng 5A xin về sớm một đêm. Lễ tân không có cách nào rút — đêm đó vẫn bị giữ trong `room_calendar` nên không bán được cho khách khác, và tổng tiền vẫn tính đủ.

## Có gì

- **`−1 đêm` / `+1 đêm`** — nút rút đêm nằm cạnh nút gia hạn sẵn có. Nhả đêm khỏi lịch phòng và ghi dòng đối ứng vào `transactions`, đối xứng với `extend_stay`.
- **Sửa giá/đêm** — có preview `N đêm × giá = tổng` trước khi lưu. Chỉ đổi giá của booking này, **không** đụng `rooms.base_price`.
- **Ghi chú xem và sửa được** — cột `bookings.notes` đã tồn tại và được ghi lúc check-in, nhưng trước giờ không hiện ở đâu cả. Ghi chú này được in lên hoá đơn.

Ba lệnh ghi mới: `shorten_stay`, `set_booking_rate`, `update_booking_notes`.

## Quyết định đáng chú ý

**Tiền hoàn đêm bị rút lấy theo trung bình của chính booking (`total_price ÷ nights`), không hỏi pricing engine.** Engine báo giá *hôm nay*, còn đêm đó đã thu theo giá *lúc đặt*. Nâng giá phòng giữa chừng rồi rút đêm sẽ hoàn nhiều hơn số đã thu — đo được 650.000₫ bốc hơi trên một ca 4 đêm. Không có bản ghi giá từng đêm để tra (`pricing_snapshot` chỉ ghi lúc check-out).

Đánh đổi đã chấp nhận và đã ghi trong code: `extend_stay` vẫn tính đêm *thêm* theo giá hôm nay, nên +1 rồi −1 chỉ về đúng tổng ban đầu khi mọi đêm cùng giá.

**Chặn mọi sửa đổi làm tổng tụt dưới số khách đã trả.** `check_out_tx` từ chối quyết toán khi `paid > total`, nên cho phép trạng thái đó là đẩy booking vào ngõ cụt không check-out được bằng bất kỳ chế độ nào. Chặn ở nút và ở backend.

**Check-out mặc định sang "Đã đặt" cho booking đã sửa giá tay.** Chế độ mặc định cũ tính lại từ pricing engine và bỏ qua `total_price`, tức âm thầm xoá mất giá vừa deal. Thêm cột `rate_overridden_at` (migration **v26**) để phân biệt, và nói rõ lý do trên giao diện.

## Hợp nhất với `main`

`#206` đã vá một race mà nhánh này mắc phải: đọc phòng trước khi cầm khoá `booking:`. Nên `resolve_stay_lock` mà nhánh này từng rút ra bị **bỏ hẳn** — `lock_booking_and_read_room` + `acquire_next` của main giải cùng bài toán tốt hơn và không dính race. Hai lệnh mới đã chuyển sang dùng API đó.

## Kiểm chứng

- Rust **1110 passed / 0 failed**, frontend **617 passed / 83 file** — cả hai đều tăng sau merge, không mất test nào.
- `clippy -D warnings`, `cargo build --lib`, `tsc --noEmit` sạch.
- **Chạy thật trên dữ liệu khách sạn**: build release, cài, migration v25→v26 chạy trên DB thật — cột được tạo, 35/35 booking đều `NULL`, không booking nào bị đánh dấu nhầm. Đã sao lưu trước khi migrate.
- Các chốt chống ghi đè đều được mutation-test: xoá mệnh đề `WHERE` thì test đỏ.

## Còn treo (không chặn merge)

- `extend_stay` có chốt chống ghi đè vô hiệu y hệt cái nhánh này vừa vá — nằm sau nút `+1 đêm`, đáng tách một việc riêng.
- Tiền tố `CONFLICT_INVALID_STATE_TRANSITION:` lọt ra toast người dùng (hạ tầng chung của repo).
- `update_booking_notes` ghi `actor_type = "system"` cho người thật; `actor_id` thì đúng.
- Repo không có gì chặn hai nhánh cùng nhận một số schema version — lỗi đó suýt làm chết app trong lúc làm nhánh này.

🤖 Generated with [Claude Code](https://claude.com/claude-code)