### PR TITLE
feat(assistant): tách trợ lý quầy khỏi cờ runtime thí nghiệm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Front-desk AI assistant: a chat panel beside the PMS that reads the live data to
+  answer questions and drafts a check-in the receptionist confirms on a card, with
+  the confirmation running the ordinary `check_in` command. An admin configures the
+  provider in Settings; nothing reaches the provider until an API key is stored and
+  the cloud opt-in is switched on, and turning that opt-in off closes it again
 - Temporary residence declaration workspace (khai báo tạm trú): its own declaration
   module, extraction and validation, XLSX and XML writers generated from the official
   template, a declaration page with a sidebar badge and reconcile loop, and a

--- a/mhm/src-tauri/src/agent/assistant/config.rs
+++ b/mhm/src-tauri/src/agent/assistant/config.rs
@@ -73,6 +73,24 @@ pub struct AssistantGateStatus {
     pub missing: Vec<AssistantGateMissing>,
 }
 
+/// Cổng **duy nhất** của trợ lý quầy. Không còn cổng nào đứng trước nó.
+///
+/// Trước đây có thêm một cổng nữa, `ensure_agent_runtime_enabled`, đọc cờ môi
+/// trường `CAPYINN_EXPERIMENTAL_AGENT_RUNTIME`. Cờ đó đã bị gỡ khỏi trợ lý
+/// (vẫn còn cho CEO Telegram, xem `agent/supervisor.rs`) vì nó chỉ bật được
+/// bằng dòng lệnh lúc khởi động — thứ mà lễ tân bấm icon mở app không bao giờ
+/// có. Một tính năng dành cho lễ tân mà chỉ người biết gõ biến môi trường mới
+/// mở được thì coi như không tồn tại.
+///
+/// Gỡ được vì cổng này đã làm đúng việc mà cờ kia định làm, lại làm tốt hơn:
+/// nó nằm trong database nên nhớ qua mọi lần khởi động, và nó có giao diện nên
+/// admin tự tắt được. Không có `opt_in` thì `ready = false`, và
+/// `commands::assistant::assistant_turn` dừng **trước khi** dựng prompt — không
+/// byte dữ liệu khách nào rời máy. Đó vẫn là chỗ chủ nhà thu lại sự đồng ý.
+///
+/// Đừng thêm cổng cờ môi trường trở lại mà không đồng thời sửa
+/// `pages/settings/index.tsx`: cờ tắt mà tab cài đặt biến mất trong khi panel
+/// vẫn chạy là đúng cái lỗ hổng đã sửa ở 6d2c1d1 — mất luôn chỗ để tắt opt-in.
 pub fn evaluate_assistant_gate(
     config: &AssistantConfig,
     has_api_key: bool,
@@ -97,32 +115,6 @@ pub fn evaluate_assistant_gate(
         ready: missing.is_empty(),
         missing,
     }
-}
-
-/// Cổng thứ nhất, đứng trước `evaluate_assistant_gate`: cờ runtime thí nghiệm.
-///
-/// `evaluate_assistant_gate` chỉ hỏi "chủ nhà đã cấu hình xong chưa". Cái này
-/// hỏi "bản dựng này có được phép chạy trợ lý không" — và câu trả lời phải
-/// giống hệt câu mà màn hình cài đặt đã dùng để quyết định hiện hay ẩn tab
-/// (`pages/settings/index.tsx` đọc `agentRuntimeEnabled`, tức chính
-/// `effective_experimental_agent_runtime_enabled`). Hai bên lệch nhau nghĩa là
-/// gỡ cờ đi thì mất tab cài đặt trong khi panel vẫn gọi nhà cung cấp và vẫn
-/// đẩy dữ liệu khách lên cloud — mà không còn giao diện nào để tắt cái opt-in
-/// đang bật. Đó là ngược hẳn công dụng của cờ.
-///
-/// Lưu ý: `effective_…` cõng luôn override `CAPYINN_DISABLE_CEO_TELEGRAM`, một
-/// cái tên buộc tính năng này vào một tính năng không liên quan. Đã ghi nhận
-/// là nợ, cố ý **không** đi nối lại dây ở đây — việc cần làm là hai bên đọc
-/// cùng một cờ, không phải đổi cờ.
-pub fn ensure_agent_runtime_enabled() -> CommandResult<()> {
-    if crate::runtime_config::effective_experimental_agent_runtime_enabled() {
-        return Ok(());
-    }
-
-    Err(CommandError::user(
-        codes::AGENT_RUNTIME_DISABLED,
-        "Trợ lý quầy đang tắt trên bản dựng này.",
-    ))
 }
 
 pub fn validate_assistant_base_url(raw: &str) -> CommandResult<String> {
@@ -356,11 +348,16 @@ mod tests {
         assert!(status.missing.contains(&AssistantGateMissing::Model));
     }
 
-    /// Cờ `CAPYINN_EXPERIMENTAL_AGENT_RUNTIME` là công tắc tắt của cả tính
-    /// năng. Gỡ nó ra mà trợ lý vẫn gọi được nhà cung cấp thì công tắc chỉ giấu
-    /// đi màn hình cài đặt — tức lấy mất luôn chỗ để tắt cái opt-in đang bật.
+    /// Cổng thật của trợ lý là opt-in, không phải cờ môi trường — và nó **không**
+    /// nhìn vào môi trường chút nào.
+    ///
+    /// Test này thay hai test cũ đã bị xoá cùng `ensure_agent_runtime_enabled`.
+    /// Cũ: "gỡ cờ thì trợ lý phải từ chối". Mới: gỡ cờ chẳng đổi gì, vì cờ không
+    /// còn dính đến trợ lý; thứ duy nhất đóng cổng là chủ nhà tắt opt-in trong
+    /// Cài đặt. Đặt cả ba biến môi trường vào trạng thái "tắt sạch" rồi vẫn thấy
+    /// `ready = true` chính là cách chứng minh hai bên đã tách rời.
     #[test]
-    fn the_assistant_refuses_to_run_when_the_agent_runtime_flag_is_removed() {
+    fn the_gate_ignores_the_experimental_environment_flags_entirely() {
         let _guard = crate::runtime_config::env_lock().lock().unwrap();
 
         for name in [
@@ -371,36 +368,25 @@ mod tests {
             std::env::remove_var(name);
         }
 
-        let error = ensure_agent_runtime_enabled().expect_err("cờ tắt thì phải từ chối");
-        assert_eq!(error.code, codes::AGENT_RUNTIME_DISABLED);
+        let config = AssistantConfig::default();
 
-        std::env::set_var("CAPYINN_EXPERIMENTAL_AGENT_RUNTIME", "true");
-        assert!(ensure_agent_runtime_enabled().is_ok());
-        std::env::remove_var("CAPYINN_EXPERIMENTAL_AGENT_RUNTIME");
-    }
-
-    /// Trợ lý phải đọc **đúng cờ hiệu dụng** mà màn hình cài đặt đã đọc, kể cả
-    /// cái override đặt tên nhầm sang tính năng khác
-    /// (`CAPYINN_DISABLE_CEO_TELEGRAM`, xem `runtime_config.rs:37`). Không
-    /// phải để tán thành cách đặt tên đó — mà để hai bên không bao giờ bất
-    /// đồng: cửa sổ cài đặt biến mất trong khi panel vẫn gửi dữ liệu khách lên
-    /// cloud đúng là cái lỗ hổng này sinh ra.
-    #[test]
-    fn the_assistant_honours_the_same_disable_override_the_settings_screen_honours() {
-        let _guard = crate::runtime_config::env_lock().lock().unwrap();
-
-        std::env::set_var("CAPYINN_EXPERIMENTAL_AGENT_RUNTIME", "true");
-        std::env::set_var("CAPYINN_DISABLE_CEO_TELEGRAM", "true");
-
-        let error = ensure_agent_runtime_enabled().expect_err("override tắt thì phải từ chối");
-        assert_eq!(error.code, codes::AGENT_RUNTIME_DISABLED);
+        assert!(
+            evaluate_assistant_gate(&config, true, true).ready,
+            "không cờ nào bật mà trợ lý vẫn phải mở — lễ tân không gõ biến môi trường"
+        );
         assert!(
             !crate::runtime_config::effective_experimental_agent_runtime_enabled(),
-            "trợ lý và màn hình cài đặt phải cùng đọc một cờ hiệu dụng"
+            "phải đang ở đúng trạng thái không cờ thì khẳng định trên mới có nghĩa"
         );
 
-        std::env::remove_var("CAPYINN_EXPERIMENTAL_AGENT_RUNTIME");
-        std::env::remove_var("CAPYINN_DISABLE_CEO_TELEGRAM");
+        let closed = evaluate_assistant_gate(&config, true, false);
+        assert!(
+            !closed.ready,
+            "tắt opt-in là công tắc tắt duy nhất còn lại — nó phải đóng được"
+        );
+        assert!(closed
+            .missing
+            .contains(&AssistantGateMissing::CloudDataOptIn));
     }
 
     #[test]

--- a/mhm/src-tauri/src/commands/assistant.rs
+++ b/mhm/src-tauri/src/commands/assistant.rs
@@ -3,10 +3,10 @@ use crate::{
     agent::{
         assistant::{
             config::{
-                ensure_agent_runtime_enabled, evaluate_assistant_gate,
-                get_assistant_cloud_data_opt_in, get_assistant_config, save_assistant_config,
-                set_assistant_cloud_data_opt_in, validate_assistant_base_url,
-                validate_assistant_model, AssistantConfig, AssistantGateStatus, AssistantPreset,
+                evaluate_assistant_gate, get_assistant_cloud_data_opt_in, get_assistant_config,
+                save_assistant_config, set_assistant_cloud_data_opt_in,
+                validate_assistant_base_url, validate_assistant_model, AssistantConfig,
+                AssistantGateStatus, AssistantPreset,
             },
             provider::{build_assistant_provider_client, AssistantProviderClient},
             run_assistant_turn, AssistantTurnRequest, AssistantTurnResponse,
@@ -48,15 +48,14 @@ async fn load_settings(state: &State<'_, AppState>) -> CommandResult<AssistantSe
 
 /// Đọc được cho mọi người đăng nhập: frontend cần biết có nên hiện panel không.
 ///
-/// Cờ runtime chặn trước cả câu hỏi đăng nhập: bản dựng không bật trợ lý thì
-/// lệnh này lỗi, `useAssistantStore.refreshSettings` bắt lỗi và đặt
+/// Trả về `gate`, và `gate.ready` là thứ quyết định panel hiện hay không. Chưa
+/// đăng nhập thì lệnh lỗi, `useAssistantStore.refreshSettings` bắt lỗi và đặt
 /// `settings: null`, nên nút "Trợ lý" lẫn panel đều tự tắt — kể cả khi có ai
 /// đó gọi thẳng IPC mà không đi qua shell.
 #[tauri::command]
 pub async fn get_assistant_settings(
     state: State<'_, AppState>,
 ) -> CommandResult<AssistantSettings> {
-    ensure_agent_runtime_enabled()?;
     if get_user(&state).is_none() {
         return Err(CommandError::user(
             codes::AUTH_NOT_AUTHENTICATED,
@@ -73,7 +72,6 @@ pub async fn set_assistant_settings(
     base_url: String,
     model: String,
 ) -> CommandResult<AssistantSettings> {
-    ensure_agent_runtime_enabled()?;
     let _admin = require_admin_user(get_user(&state))?;
 
     let config = AssistantConfig {
@@ -91,7 +89,6 @@ pub async fn set_assistant_api_key(
     state: State<'_, AppState>,
     api_key: String,
 ) -> CommandResult<AssistantSettings> {
-    ensure_agent_runtime_enabled()?;
     let _admin = require_admin_user(get_user(&state))?;
 
     let trimmed = api_key.trim();
@@ -110,7 +107,6 @@ pub async fn set_assistant_api_key(
 pub async fn clear_assistant_api_key(
     state: State<'_, AppState>,
 ) -> CommandResult<AssistantSettings> {
-    ensure_agent_runtime_enabled()?;
     let _admin = require_admin_user(get_user(&state))?;
     secret_store().clear_secret(AgentSecretKind::AssistantApiKey)?;
     load_settings(&state).await
@@ -121,7 +117,6 @@ pub async fn set_assistant_cloud_opt_in(
     state: State<'_, AppState>,
     enabled: bool,
 ) -> CommandResult<AssistantSettings> {
-    ensure_agent_runtime_enabled()?;
     let _admin = require_admin_user(get_user(&state))?;
     set_assistant_cloud_data_opt_in(&state.db, enabled).await?;
     load_settings(&state).await
@@ -132,10 +127,6 @@ pub async fn assistant_turn(
     state: State<'_, AppState>,
     request: AssistantTurnRequest,
 ) -> CommandResult<AssistantTurnResponse> {
-    // Fail closed sớm nhất có thể: trước cả khi đọc cấu hình hay khoá API.
-    // Không có prompt nào được dựng, không byte dữ liệu khách nào rời máy khi
-    // chủ nhà đã gỡ cờ runtime.
-    ensure_agent_runtime_enabled()?;
     if get_user(&state).is_none() {
         return Err(CommandError::user(
             codes::AUTH_NOT_AUTHENTICATED,

--- a/mhm/src/App.experimentalRuntime.test.tsx
+++ b/mhm/src/App.experimentalRuntime.test.tsx
@@ -150,10 +150,14 @@ describe("App experimental runtime gates", () => {
 
   // ─── Công tắc tắt của trợ lý quầy ───
   //
-  // Gỡ CAPYINN_EXPERIMENTAL_AGENT_RUNTIME phải tắt cả tính năng, không chỉ ẩn
-  // tab cài đặt. Ẩn mỗi tab là trường hợp tệ nhất: panel vẫn gọi nhà cung cấp,
-  // vẫn đẩy dữ liệu khách lên cloud, mà chủ nhà không còn chỗ nào để tắt cái
-  // opt-in đang bật.
+  // Trợ lý đã tách khỏi CAPYINN_EXPERIMENTAL_AGENT_RUNTIME. Cờ đó chỉ bật được
+  // bằng biến môi trường lúc khởi động, mà lễ tân thì bấm icon để mở app — nên
+  // nó giấu tính năng khỏi đúng những người tính năng sinh ra để phục vụ.
+  //
+  // Công tắc tắt bây giờ là `gate.ready` (API key + opt-in, lưu trong
+  // database). Hai test dưới đây khoá cả hai chiều: không cờ vẫn phải mở được,
+  // và tắt opt-in vẫn phải đóng được. Thiếu chiều thứ hai thì "gỡ cờ" biến
+  // thành "gỡ luôn cách tắt".
 
   const READY_ASSISTANT_SETTINGS = {
     config: { preset: "deep_seek", base_url: "https://api.deepseek.com/v1", model: "deepseek-chat" },
@@ -162,31 +166,8 @@ describe("App experimental runtime gates", () => {
     gate: { ready: true, missing: [] },
   };
 
-  it("cờ agent runtime tắt thì không có nút Trợ lý, dù cấu hình trợ lý đã đủ", async () => {
+  it("không cờ thí nghiệm nào bật, lễ tân vẫn thấy nút Trợ lý", async () => {
     setupAuthenticatedShell();
-    setMockResponses({ get_assistant_settings: () => READY_ASSISTANT_SETTINGS });
-
-    render(<App />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Overview")).toBeInTheDocument();
-    });
-
-    expect(screen.queryByRole("button", { name: /trợ lý/i })).not.toBeInTheDocument();
-    // Và shell không thèm hỏi cài đặt trợ lý: cờ tắt thì không có gì để hỏi.
-    // Backend cũng từ chối lệnh này (ensure_agent_runtime_enabled), nên đây là
-    // lớp thứ hai chứ không phải lớp duy nhất.
-    expect(invoke.mock.calls.some(([command]) => command === "get_assistant_settings")).toBe(false);
-  });
-
-  it("cờ agent runtime bật thì nút Trợ lý hiện lại", async () => {
-    setupAuthenticatedShell({
-      experimental_runtime_enabled: false,
-      gateway_runtime_enabled: false,
-      agent_runtime_enabled: true,
-      gateway_disabled_by_override: false,
-      agent_disabled_by_override: false,
-    });
     setMockResponses({ get_assistant_settings: () => READY_ASSISTANT_SETTINGS });
 
     render(<App />);
@@ -195,6 +176,31 @@ describe("App experimental runtime gates", () => {
       expect(screen.getByRole("button", { name: /trợ lý/i })).toBeInTheDocument();
     });
     expect(invoke.mock.calls.some(([command]) => command === "get_assistant_settings")).toBe(true);
+  });
+
+  it("chưa bật opt-in thì không có nút Trợ lý, dù cờ agent runtime có bật", async () => {
+    setupAuthenticatedShell({
+      experimental_runtime_enabled: false,
+      gateway_runtime_enabled: false,
+      agent_runtime_enabled: true,
+      gateway_disabled_by_override: false,
+      agent_disabled_by_override: false,
+    });
+    setMockResponses({
+      get_assistant_settings: () => ({
+        ...READY_ASSISTANT_SETTINGS,
+        cloud_data_opt_in: false,
+        gate: { ready: false, missing: ["cloud_data_opt_in"] },
+      }),
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Overview")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: /trợ lý/i })).not.toBeInTheDocument();
   });
 
   it("ignores gateway status responses from a disabled profile generation", async () => {

--- a/mhm/src/app/MainShell.tsx
+++ b/mhm/src/app/MainShell.tsx
@@ -112,19 +112,21 @@ export function MainShell() {
     onExportCrashReport,
     gatewayRunning,
     gatewayRuntimeEnabled,
-    agentRuntimeEnabled,
     remoteCrashReportingEnabled,
   } = useRuntimeState();
 
-  // Cờ runtime là công tắc tắt của cả trợ lý, không phải chỉ của tab cài đặt.
-  // Cờ tắt thì không hỏi cài đặt (lệnh backend cũng từ chối), không hiện nút,
-  // không gắn panel — chủ nhà gỡ cờ là tính năng biến mất, đúng như tài liệu
-  // hứa. Xem `agent/assistant/config.rs::ensure_agent_runtime_enabled`.
+  // Trợ lý không còn đứng sau cờ `agentRuntimeEnabled`. Cờ đó chỉ bật được bằng
+  // biến môi trường lúc khởi động, mà lễ tân thì bấm icon để mở app — nên nó
+  // giấu tính năng khỏi đúng những người tính năng sinh ra để phục vụ. Cờ vẫn
+  // giữ cho CEO Telegram, thứ thật sự còn thí nghiệm.
+  //
+  // Công tắc tắt bây giờ là `gate.ready`: nằm trong database nên nhớ qua mọi
+  // lần khởi động, và admin tự tắt được trong Cài đặt → Trợ lý quầy. Tắt opt-in
+  // là panel biến mất và `assistant_turn` từ chối trước khi dựng prompt.
   useEffect(() => {
-    if (!agentRuntimeEnabled) return;
     void refreshAssistantSettings();
-  }, [agentRuntimeEnabled, refreshAssistantSettings]);
-  const assistantAvailable = agentRuntimeEnabled && Boolean(assistantSettings?.gate.ready);
+  }, [refreshAssistantSettings]);
+  const assistantAvailable = Boolean(assistantSettings?.gate.ready);
 
   const today = new Date().toLocaleDateString("vi-VN", {
     weekday: "long",

--- a/mhm/src/pages/settings/SettingsExperimentalRuntime.test.tsx
+++ b/mhm/src/pages/settings/SettingsExperimentalRuntime.test.tsx
@@ -64,4 +64,35 @@ describe("SettingsPage experimental runtime gates", () => {
     expect(await screen.findByRole("button", { name: "CEO Agent" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "MCP Gateway" })).not.toBeInTheDocument();
   });
+
+  // Hai mục này từng dùng chung một cờ. Tách ra rồi thì phải có chỗ khoá lại,
+  // nếu không lần sau ai đó gỡ cờ cho "CEO Agent" mà không ai hay: bot Telegram
+  // bật lên trên máy khách sạn chỉ vì lễ tân cần khung chat.
+  it("cờ agent runtime tắt: vẫn có Trợ lý quầy nhưng không có CEO Agent", async () => {
+    setRuntimeStatus(false, false);
+
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole("button", { name: "Trợ lý quầy" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "CEO Agent" })).not.toBeInTheDocument();
+  });
+
+  it("không phải admin thì không có Trợ lý quầy", async () => {
+    useAuthStore.setState({
+      user: { id: "u2", name: "Lễ tân", role: "receptionist", active: true, created_at: "" },
+      isAuthenticated: true,
+      loading: false,
+      error: null,
+    });
+    setRuntimeStatus(false, false);
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(
+        invoke.mock.calls.some(([command]) => command === "get_experimental_runtime_status"),
+      ).toBe(true);
+    });
+    expect(screen.queryByRole("button", { name: "Trợ lý quầy" })).not.toBeInTheDocument();
+  });
 });

--- a/mhm/src/pages/settings/index.tsx
+++ b/mhm/src/pages/settings/index.tsx
@@ -67,14 +67,16 @@ export default function SettingsPage() {
       ? [{ key: "gateway" as const, label: "MCP Gateway", icon: Wifi }]
       : []),
     { key: "updates" as const, label: "Software Update", icon: RefreshCcw },
+    // CEO Agent vẫn thí nghiệm nên vẫn đứng sau cờ môi trường. "Trợ lý quầy"
+    // thì không: nó dành cho lễ tân, mà lễ tân bấm icon mở app chứ không gõ
+    // biến môi trường. Cổng thật của nó là API key + opt-in trong chính màn
+    // hình này — xem `agent/assistant/config.rs::evaluate_assistant_gate`.
     ...(isCurrentAdmin && experimentalRuntime.agentRuntimeEnabled
-      ? [
-        { key: "ceo-agent" as const, label: "CEO Agent", icon: Bot },
-        { key: "assistant" as const, label: "Trợ lý quầy", icon: Bot },
-      ]
+      ? [{ key: "ceo-agent" as const, label: "CEO Agent", icon: Bot }]
       : []),
     ...(isCurrentAdmin
       ? [
+        { key: "assistant" as const, label: "Trợ lý quầy", icon: Bot },
         { key: "pricing" as const, label: "Pricing", icon: DollarSign },
         { key: "peak-season" as const, label: "Peak Season", icon: CalendarDays },
         { key: "users" as const, label: "Users", icon: Users },
@@ -86,9 +88,10 @@ export default function SettingsPage() {
     if (
       (activeSection === "gateway" && !experimentalRuntime.gatewayRuntimeEnabled) ||
       (
-        (activeSection === "ceo-agent" || activeSection === "assistant") &&
+        activeSection === "ceo-agent" &&
         (!isCurrentAdmin || !experimentalRuntime.agentRuntimeEnabled)
-      )
+      ) ||
+      (activeSection === "assistant" && !isCurrentAdmin)
     ) {
       setActiveSection("hotel");
     }
@@ -138,11 +141,7 @@ export default function SettingsPage() {
           experimentalRuntime.agentRuntimeEnabled && (
             <CeoAgentSection />
           )}
-        {activeSection === "assistant" &&
-          isCurrentAdmin &&
-          experimentalRuntime.agentRuntimeEnabled && (
-            <AssistantSection />
-          )}
+        {activeSection === "assistant" && isCurrentAdmin && <AssistantSection />}
         {activeSection === "pricing" && isCurrentAdmin && <PricingSection />}
         {activeSection === "peak-season" && isCurrentAdmin && <SpecialDatesSection />}
         {activeSection === "users" && isCurrentAdmin && <UserManagement />}


### PR DESCRIPTION
## Vì sao

Trợ lý quầy đứng sau `CAPYINN_EXPERIMENTAL_AGENT_RUNTIME`, cờ chỉ bật được bằng biến môi trường lúc khởi động. Lễ tân bấm icon để mở app — nên trên máy khách sạn, mục "Cài đặt → Trợ lý quầy" đơn giản là không tồn tại. Một tính năng dành cho lễ tân mà chỉ người biết gõ dòng lệnh mới mở được thì coi như chưa giao.

## Làm gì

Gỡ cổng cờ khỏi **riêng** trợ lý. CEO Telegram vẫn nằm sau cờ — nó còn thí nghiệm thật, và bật nhầm con bot chỉ vì lễ tân cần khung chat là chuyện khác hẳn. Hai mục cài đặt vì thế tách đôi, có test khoá lại chỗ tách.

Gỡ được vì cổng thứ hai đã làm đúng việc cờ định làm, lại làm tốt hơn:

| | Cờ môi trường (gỡ) | `evaluate_assistant_gate` (giữ) |
|---|---|---|
| Nhớ qua lần khởi động | không | có, nằm trong database |
| Có giao diện để tắt | không | có, Cài đặt → Trợ lý quầy |
| Ai đổi được | người gõ dòng lệnh | admin |

Tắt opt-in thì `assistant_turn` vẫn dừng **trước khi** dựng prompt — không byte dữ liệu khách nào rời máy. Chỗ chủ nhà thu lại sự đồng ý không hề mất đi.

Sửa cả frontend và backend trong một commit, có chủ ý: `6d2c1d1` vừa vá đúng lỗi ngược lại — cổng backend và điều kiện hiện tab lệch nhau thì tab cài đặt biến mất trong khi panel vẫn đẩy dữ liệu lên cloud, mà không còn giao diện nào để tắt opt-in đang bật.

## Test có răng chưa

Phá rồi hoàn lại, cả ba lần đều bắt được:

| Phá | Đỏ |
|---|---|
| Trả `MainShell` về bản cũ (cổng cờ quay lại) | "không cờ thí nghiệm nào bật, lễ tân vẫn thấy nút Trợ lý" |
| Gỡ cờ khỏi cả CEO Agent | 3 test, gồm test tách đôi hai mục |
| Cổng opt-in ngừng chặn | 2 test Rust, gồm test mới |

Cái thứ ba quan trọng nhất: nó chứng minh sau khi gỡ cờ, tắt opt-in **vẫn** đóng được trợ lý — "gỡ cờ" không âm thầm biến thành "gỡ luôn cách tắt".

## Cổng cục bộ

Rust 1173 passed (bớt 2 test cũ theo `ensure_agent_runtime_enabled`, thêm 1 mới) · frontend 660 passed / 88 files (thêm 2) · clippy, fmt, tsc, vite build, `verify:money`, `verify:agent` (13) đều sạch.

`tsc` bắt được một lỗi vitest cho qua: vai lễ tân trong repo là `receptionist` chứ không phải `staff`.

## Ngoài phạm vi, cố ý thêm

CHANGELOG chưa hề có mục nào cho trợ lý quầy — cả #209 không thêm. Thêm một mục, vì PR này mới là cái đưa tính năng tới tay người dùng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)