### PR TITLE
fix(stays): rút đêm dời luôn scheduled_checkout, không để thanh timeline đứng yên

### DIFF
--- a/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
+++ b/mhm/src-tauri/src/services/booking/stay_lifecycle.rs
@@ -1662,14 +1662,26 @@ async fn shorten_stay_tx(
 
     let new_checkout = new_expected.to_rfc3339();
 
+    // Đối xứng với `extend_stay` ở trên: `scheduled_checkout` phải đi theo
+    // `expected_checkout`, vì timeline vẽ thanh booking bằng
+    // `scheduled_checkout || expected_checkout`. Bỏ quên cột này là lễ tân bấm
+    // "−1 đêm", drawer đổi ngày, còn thanh trên lịch phòng đứng nguyên ở ngày
+    // trả cũ — chủ khách sạn tưởng phòng còn bận thêm một đêm nên không bán.
+    // CASE giữ NULL cho khách vãng lai — họ không có ngày đặt trước để dời.
+    let new_scheduled_checkout = new_expected.date_naive().format("%Y-%m-%d").to_string();
+
     let result = sqlx::query(
         "UPDATE bookings
-         SET nights = ?, total_price = ?, expected_checkout = ?
+         SET nights = ?, total_price = ?, expected_checkout = ?,
+             scheduled_checkout = CASE
+                 WHEN scheduled_checkout IS NULL THEN NULL ELSE ?
+             END
          WHERE id = ? AND status = ? AND expected_checkout = ?",
     )
     .bind(current_nights - 1)
     .bind(new_total)
     .bind(&new_checkout)
+    .bind(&new_scheduled_checkout)
     .bind(booking_id)
     .bind(status::booking::ACTIVE)
     .bind(locked_expected_checkout)

--- a/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
+++ b/mhm/src-tauri/src/services/booking/tests/shorten_stay.rs
@@ -825,3 +825,77 @@ async fn shorten_stay_fails_when_second_pool_moves_the_checkout_while_the_lock_i
     pool_b.close().await;
     let _ = std::fs::remove_file(db_path);
 }
+
+/// Timeline vẽ thanh booking bằng `scheduled_checkout || expected_checkout`
+/// (`Reservations.tsx`), nên rút đêm mà quên dời `scheduled_checkout` thì thanh
+/// của khách đặt trước vẫn nằm dài tới ngày trả cũ: lễ tân bấm "−1 đêm", drawer
+/// hiện ngày mới, còn lịch phòng phía sau đứng im — nhìn như phần mềm không
+/// nhận lệnh, và tệ hơn là chủ khách sạn tưởng phòng còn bận thêm một đêm nên
+/// không bán. `extend_stay` đã sửa đúng lỗi này ở #204; `shorten_stay` ra đời ở
+/// #208 và không thừa hưởng.
+#[tokio::test]
+async fn shorten_stay_moves_scheduled_checkout_for_a_reservation_booking() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-SCHED-SHORTEN").await.unwrap();
+    let (check_in, _checkout) = seed_future_booking(&pool, "B-SCHED-SHORTEN", "R-SCHED-SHORTEN", 3)
+        .await
+        .unwrap();
+
+    // Booking gốc từ đặt trước: đã check-in (status active) nhưng vẫn giữ hai
+    // cột `scheduled_*` — đúng hình dạng của booking gặp lỗi trên máy khách sạn.
+    let check_in_date = date_from_rfc3339(&check_in);
+    sqlx::query("UPDATE bookings SET scheduled_checkin = ?, scheduled_checkout = ? WHERE id = ?")
+        .bind(check_in_date.format("%Y-%m-%d").to_string())
+        .bind(
+            (check_in_date + Duration::days(3))
+                .format("%Y-%m-%d")
+                .to_string(),
+        )
+        .bind("B-SCHED-SHORTEN")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    stay_lifecycle::shorten_stay(&pool, "B-SCHED-SHORTEN")
+        .await
+        .unwrap();
+
+    let after: Option<String> =
+        sqlx::query_scalar("SELECT scheduled_checkout FROM bookings WHERE id = ?")
+            .bind("B-SCHED-SHORTEN")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        after,
+        Some(
+            (check_in_date + Duration::days(2))
+                .format("%Y-%m-%d")
+                .to_string()
+        ),
+        "scheduled_checkout phải lùi theo expected_checkout khi rút đêm"
+    );
+}
+
+/// Khách vãng lai không có `scheduled_checkout`; rút đêm không được tự đẻ ra
+/// giá trị cho cột đó, nếu không booking walk-in sẽ bị nhầm thành đặt trước.
+#[tokio::test]
+async fn shorten_stay_leaves_scheduled_checkout_null_for_a_walk_in() {
+    let pool = test_pool().await;
+    seed_room(&pool, "R-WALKIN-SHORTEN").await.unwrap();
+    seed_future_booking(&pool, "B-WALKIN-SHORTEN", "R-WALKIN-SHORTEN", 3)
+        .await
+        .unwrap();
+
+    stay_lifecycle::shorten_stay(&pool, "B-WALKIN-SHORTEN")
+        .await
+        .unwrap();
+
+    let after: Option<String> =
+        sqlx::query_scalar("SELECT scheduled_checkout FROM bookings WHERE id = ?")
+            .bind("B-WALKIN-SHORTEN")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(after, None, "rút đêm không được đẻ ra scheduled_checkout");
+}


### PR DESCRIPTION
## Triệu chứng

Lễ tân bấm **−1 đêm** trong khung phòng. Backend rút đúng, drawer đổi ngày ngay — nhưng thanh booking trên lịch phòng đứng nguyên ở ngày trả cũ. Nhìn như phần mềm không nhận lệnh.

## Nguyên nhân gốc

Timeline vẽ thanh booking bằng `scheduled_checkout || expected_checkout` (`src/pages/Reservations.tsx:234`), còn `shorten_stay` chỉ lùi `expected_checkout`.

Trên máy khách sạn, Phòng 5A:

| cột | giá trị |
|---|---|
| `expected_checkout` | 2026-08-06 ← đã rút đúng |
| `scheduled_checkout` | 2026-08-07 ← đứng nguyên |

Đây là booking duy nhất trong dữ liệu thật có hai cột lệch nhau — cũng là booking duy nhất từng bị rút đêm.

Hệ quả không chỉ ở màn hình: chủ khách sạn đọc lịch ra là phòng còn bận thêm một đêm, nên không bán đêm đó.

## Bản sửa

`extend_stay` đã dính **đúng** lỗi này và được sửa ở #204, kèm comment cảnh báo. `shorten_stay` ra đời ở #208 và không thừa hưởng. Commit này chép lại nguyên vẹn cách làm ấy, kể cả `CASE ... IS NULL` để khách vãng lai không bị đẻ ra ngày đặt trước.

Hai test hồi quy, viết trước và đã thấy đỏ đúng lý do (`Some("2026-08-13")` vs `Some("2026-08-12")` — lệch đúng một đêm, đúng hình dạng dòng dữ liệu thật):

- `shorten_stay_moves_scheduled_checkout_for_a_reservation_booking`
- `shorten_stay_leaves_scheduled_checkout_null_for_a_walk_in`

## Phạm vi ảnh hưởng

Chỉ hiển thị và hồ sơ, không phải overbooking: query kiểm tra phòng trống ở `room_queries.rs:162` lọc `status = 'booked'`, mà `shorten_stay` chỉ chạy trên booking `active`.

## Còn lại, để riêng

`reservation_lifecycle.rs:646` bỏ sót cùng cột này ở nhánh check-in muộn hơn ngày đặt (`scheduled_checkout <= today` ở dòng 604). Lỗi có sẵn, hiếm gặp hơn, không gộp vào đây. Đáng cân nhắc thêm một guard trong `architecture_guard.rs` để chặn lần thứ tư.

## Kiểm chứng

Cả năm cổng CI chạy tại chỗ trước khi push:

- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` — 1178 passed ✅
- `npx tsc --noEmit` ✅
- `npx vitest run` — 660 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)