### PR TITLE
feat(shell): dời nút Trợ lý xuống thanh điều hướng, ngay dưới logo

### DIFF
--- a/mhm/src/app/MainShell.layout.test.tsx
+++ b/mhm/src/app/MainShell.layout.test.tsx
@@ -81,7 +81,11 @@ const READY_SETTINGS: AssistantSettings = {
 /// `aria-label` vừa bền vừa thật: nó đặt tên cho landmark, không phải móc chỉ
 /// để test bám vào.
 function landmarks(container: HTMLElement) {
-  const nav = container.querySelector("nav")?.closest("aside");
+  // Thanh điều hướng nay cũng tìm bằng `aria-label`, cùng lý do đã viết ở trên
+  // cho panel. Bản cũ đi vòng `querySelector("nav")?.closest("aside")` vì lúc
+  // đó `<aside>` này chưa có tên; nó gãy nếu thẻ `<nav>` bị bọc thêm một lớp,
+  // và im lặng trỏ nhầm nếu một `<nav>` khác xuất hiện trước.
+  const nav = container.querySelector('aside[aria-label="Điều hướng"]');
   const panel = container.querySelector('aside[aria-label="Trợ lý quầy"]');
   const content = container.querySelector("main");
   const inDocumentOrder = Array.from(container.querySelectorAll("aside, main"));
@@ -171,5 +175,111 @@ describe("MainShell — bố cục ba cột", () => {
     // Quét cả cây, không quét trong `<main>`: panel là anh em của `<main>` chứ
     // không phải con, nên tìm trong `<main>` là một khẳng định luôn đúng.
     expect(within(container).queryByPlaceholderText("Hỏi hoặc ra việc…")).toBeNull();
+  });
+
+  // ── Nút Trợ lý ở thanh điều hướng ────────────────────────────────────────
+  //
+  // Nút này TỪNG nằm ở cụm phải của header, cạnh `SCANNER READY`. Nó mở/đóng
+  // cột giữa, nên chỗ của nó là cột trái — ngay dưới logo, trên cả nhóm điều
+  // hướng, cùng lối Airtable đặt nút Omni.
+  //
+  // Test đầu tiên là test SEAM: nó hỏi nút nằm Ở ĐÂU. Hai test cũ trong
+  // `App.experimentalRuntime.test.tsx` chỉ hỏi "có một nút tên Trợ lý không" —
+  // câu đó đúng cả trước lẫn sau khi ai đó trả nút về header, tức chúng không
+  // canh vị trí. Đây là lớp lỗi nhánh trợ lý đã dính ba lần.
+  describe("nút Trợ lý", () => {
+    it("nằm trong thanh điều hướng, KHÔNG nằm ở header", async () => {
+      const { container } = render(<MainShell />);
+      await waitFor(() => expect(screen.getByText("Dashboard page")).toBeInTheDocument());
+
+      const { nav } = landmarks(container);
+      const header = container.querySelector("header")!;
+
+      expect(within(nav as HTMLElement).getByRole("button", { name: /trợ lý/i })).toBeInTheDocument();
+      // Vế âm mới là vế có răng: thiếu nó thì một bản vẽ nút ở CẢ HAI chỗ vẫn
+      // xanh, mà hai nút cùng việc là đúng thứ thay đổi này đi dọn.
+      expect(within(header).queryByRole("button", { name: /trợ lý/i })).toBeNull();
+    });
+
+    it("đứng trên cả nhóm điều hướng, không lẫn vào giữa các mục", async () => {
+      const { container } = render(<MainShell />);
+      await waitFor(() => expect(screen.getByText("Dashboard page")).toBeInTheDocument());
+
+      const nav = landmarks(container).nav as HTMLElement;
+      const assistant = within(nav).getByRole("button", { name: /trợ lý/i });
+      const dashboard = within(nav).getByRole("button", { name: /dashboard/i });
+      // `Element[]`, không phải `HTMLButtonElement[]`: `getByRole` trả về
+      // `HTMLElement`, nên để nguyên kiểu hẹp của `querySelectorAll` thì
+      // `indexOf` không chịu — và `npm test` vẫn xanh vì vitest KHÔNG typecheck.
+      const order: Element[] = Array.from(nav.querySelectorAll("button"));
+
+      expect(order.indexOf(assistant)).toBeLessThan(order.indexOf(dashboard));
+    });
+
+    it("sáng lên khi panel mở, tắt khi panel đóng", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<MainShell />);
+      await waitFor(() => expect(screen.getByText("Dashboard page")).toBeInTheDocument());
+
+      const find = () =>
+        within(landmarks(container).nav as HTMLElement).getByRole("button", { name: /trợ lý/i });
+
+      // `aria-pressed`, không phải class CSS. Đây là chỗ khai báo nút này là
+      // BẬT/TẮT chứ không phải một mục chuyển trang — và là thứ trình đọc màn
+      // hình đọc được. So class thì chỉ đo được màu, không đo được nghĩa.
+      expect(find()).toHaveAttribute("aria-pressed", "false");
+
+      await user.click(find());
+
+      await waitFor(() => expect(landmarks(container).panel).not.toBeNull());
+      expect(find()).toHaveAttribute("aria-pressed", "true");
+
+      await user.click(find());
+
+      await waitFor(() => expect(landmarks(container).panel).toBeNull());
+      expect(find()).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("không dùng chung icon với mục Housekeeping ngay bên dưới", async () => {
+      const { container } = render(<MainShell />);
+      await waitFor(() => expect(screen.getByText("Dashboard page")).toBeInTheDocument());
+
+      const nav = landmarks(container).nav as HTMLElement;
+      const iconOf = (name: RegExp) =>
+        within(nav).getByRole("button", { name }).querySelector("svg")?.getAttribute("class") ?? "";
+
+      const assistant = iconOf(/trợ lý/i);
+      const housekeeping = iconOf(/housekeeping/i);
+
+      // Chặn trước: cả hai phải đọc ra được. Không có dòng này thì lucide đổi
+      // cách đặt class sẽ biến phép so thành `"" !== ""` — sai, nhưng theo
+      // hướng nào thì cũng không còn đo gì nữa.
+      expect(assistant).not.toBe("");
+      expect(housekeeping).not.toBe("");
+      // Lúc thanh thu về icon (mở trợ lý là nó tự thu), icon là thứ DUY NHẤT
+      // còn lại để phân biệt hai mục cách nhau bốn dòng.
+      expect(assistant).not.toBe(housekeeping);
+    });
+
+    it("chưa bật trợ lý thì không có cả nút lẫn vạch kẻ thừa", async () => {
+      const notReady: AssistantSettings = {
+        ...READY_SETTINGS,
+        gate: { ready: false, missing: ["api_key"] },
+      };
+      setMockResponses({ get_assistant_settings: () => notReady });
+      useAssistantStore.setState({ settings: notReady });
+
+      const { container } = render(<MainShell />);
+      await waitFor(() => expect(screen.getByText("Dashboard page")).toBeInTheDocument());
+
+      const nav = landmarks(container).nav as HTMLElement;
+      expect(within(nav).queryByRole("button", { name: /trợ lý/i })).toBeNull();
+      // Vạch kẻ phải đi theo nút. Bọc-luôn-vẽ để lại một đường kẻ lơ lửng dưới
+      // logo, và jsdom không nhìn thấy đường kẻ nên KHÔNG test dò chữ nào bắt
+      // được — phải hỏi thẳng cái phần tử. `border-b` chỉ xuất hiện đúng một
+      // lần trong `MainShell` (các vạch trong nav là `border-t`), nên phép hỏi
+      // này trỏ đúng vào khối đang xét.
+      expect(nav.querySelector("div.border-b")).toBeNull();
+    });
   });
 });

--- a/mhm/src/app/MainShell.tsx
+++ b/mhm/src/app/MainShell.tsx
@@ -2,6 +2,7 @@ import { type ComponentType, useEffect, useState } from "react";
 import {
   BarChart3,
   BedDouble,
+  Bot,
   Calendar,
   ChevronsLeft,
   ChevronsRight,
@@ -205,7 +206,14 @@ export function MainShell() {
       )}
 
       {/* SIDEBAR */}
+      {/* `aria-label` không phải trang trí: nó là thứ DUY NHẤT cho test khẳng
+          định được nút Trợ lý nằm ở thanh điều hướng chứ không phải ở header.
+          Không có nó thì test chỉ nói được "có một nút tên Trợ lý ở đâu đó" —
+          đúng câu nó nói được cả trước lẫn sau khi nút bị trả về header, tức
+          không canh gì. Panel trợ lý cũng là một `<aside>` có nhãn
+          (`AssistantPanel.tsx`), nên hai vùng phân biệt được nhau. */}
       <aside
+        aria-label="Điều hướng"
         className={`${
           collapsed ? "w-[72px]" : "w-[260px]"
         } bg-white border-r border-slate-100 flex flex-col z-20 shrink-0 transition-all duration-300`}
@@ -214,6 +222,56 @@ export function MainShell() {
         <div className={`${collapsed ? "px-4 py-6" : "p-6"} mb-4 flex justify-center`}>
           <AppLogo className={collapsed ? "h-10 w-10 shrink-0" : "h-14 w-14 shrink-0"} />
         </div>
+
+        {/* TRỢ LÝ — ngay dưới logo, TRÊN cả nhóm điều hướng (bố cục Airtable).
+            Đứng riêng một khối có vạch ngăn vì nó KHÔNG cùng loại với các mục
+            bên dưới: chúng gọi `setTab()` để đổi trang, nút này gọi
+            `togglePanel()` để mở/đóng cột giữa. Trộn nó vào nhóm MAIN là dạy
+            người dùng rằng bấm vào sẽ chuyển sang một trang tên "Trợ lý".
+
+            Vạch ngăn nằm TRONG câu điều kiện, không bọc-luôn-vẽ-nội-dung-có-
+            điều-kiện: chưa bật opt-in thì cả khối biến mất, không để lại một
+            vạch kẻ lơ lửng dưới logo. jsdom không nhìn thấy đường kẻ nên không
+            test nào bắt được lỗi ấy — cùng bẫy `historyNotice` và
+            `ProposedActionCard` đã dính, xem chú thích ở đó. */}
+        {assistantAvailable && (
+          <div
+            className={`${collapsed ? "px-2" : "px-4"} mb-3 border-b border-slate-100 pb-3`}
+          >
+            <Button
+              variant={assistantOpen ? "secondary" : "ghost"}
+              className={`w-full justify-start rounded-xl font-medium ${
+                collapsed ? "px-3" : ""
+              } ${
+                assistantOpen
+                  ? "bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20"
+                  : "text-brand-muted hover:text-brand-text"
+              }`}
+              size="lg"
+              onClick={toggleAssistant}
+              // `aria-pressed` là chỗ phân biệt NÚT BẬT/TẮT với mục điều hướng.
+              // Các mục dưới kia không có nó vì chúng chuyển trang; nút này thì
+              // có, và nó là thứ test khẳng định được thay vì đi so class CSS.
+              aria-pressed={assistantOpen}
+              // Mở panel thì sidebar TỰ THU (`useSidebarCollapse`), nên lúc
+              // panel đang mở nút gần như luôn ở dạng chỉ-icon và `title` là
+              // nhãn duy nhất còn lại. Đổi theo trạng thái để nó nói được việc
+              // bấm tiếp sẽ làm gì — cùng lối Airtable đổi thành "Close Omni".
+              title={assistantOpen ? "Đóng trợ lý quầy" : "Mở trợ lý quầy"}
+            >
+              {/* `Bot`, KHÔNG phải `Sparkles`. `Sparkles` là icon của mục
+                  *Housekeeping* ngay bên dưới (dòng 59), và ở thanh này lúc thu
+                  gọn thì icon là thứ DUY NHẤT còn lại — hai mục cùng hình cách
+                  nhau bốn dòng là không phân biệt được. Bản cũ dùng `Sparkles`
+                  vô hại vì nút đứng tận header, xa nhóm điều hướng.
+                  `Bot` cũng chính là icon của mục *Trợ lý quầy* trong Cài đặt
+                  (`pages/settings/index.tsx`), nên hai chỗ nói về cùng một thứ
+                  nay trông giống nhau. */}
+              <Bot className={collapsed ? "" : "mr-3"} size={20} />
+              {!collapsed && "Trợ lý"}
+            </Button>
+          </div>
+        )}
 
         {/* Navigation */}
         <nav
@@ -339,16 +397,9 @@ export function MainShell() {
                 {gatewayRunning ? "● MCP Gateway" : "○ Gateway Off"}
               </Badge>
             )}
-            {assistantAvailable && (
-              <Button
-                variant="ghost"
-                className="rounded-xl"
-                onClick={toggleAssistant}
-                title="Trợ lý quầy"
-              >
-                <Sparkles size={16} className="mr-1.5" /> Trợ lý
-              </Button>
-            )}
+            {/* Nút Trợ lý ĐÃ CHUYỂN sang thanh điều hướng, ngay dưới logo —
+                nó mở/đóng cột giữa nên nó thuộc về cột trái, không thuộc về
+                cụm trạng thái ở đây. */}
             <Badge className="bg-green-50 text-green-700 border-0 rounded-full py-1.5 px-3 uppercase tracking-wider text-[10px] font-bold">
               ● Scanner Ready
             </Badge>


### PR DESCRIPTION
Nút *Trợ lý* chuyển từ cụm phải của header xuống thanh điều hướng bên trái,
ngay dưới logo — bố cục Airtable. Nó mở/đóng cột giữa, nên chỗ của nó là cột
trái, không phải cạnh `● SCANNER READY`.

## Ba thay đổi kèm theo, không phải chỉ đổi chỗ

**Icon `Sparkles` → `Bot`.** `Sparkles` đang là icon của *Housekeeping* cách đó
bốn dòng. Ở header thì vô hại; ở cùng một thanh — nhất là khi mở trợ lý làm
thanh tự thu về icon-only — thì hai mục không phân biệt được. `Bot` là icon
*Trợ lý quầy* vẫn dùng trong Cài đặt.

**`aria-pressed` theo trạng thái**, tooltip đổi *Mở* ↔ *Đóng*. Trước đây nút
không phản hồi gì; đặt cạnh các mục nav vốn đều sáng khi đang ở trang đó thì
việc không sáng trông như hỏng.

**Landmark cho sidebar** (`aria-label="Điều hướng"`). Đây là phần đáng duyệt
kỹ nhất: không có nó thì **không test nào chứng minh được nút đã chuyển chỗ**.
Hai test cũ chỉ hỏi "có một nút tên Trợ lý không" — câu đó đúng cả trước lẫn
sau khi ai đó trả nút về header.

## Đo bằng phá hoại

8 phép, 8 đỏ, mỗi phép đỏ đúng test tương ứng:

| Phá | Test đỏ |
|---|---|
| Bỏ `aria-label` sidebar | 5 test |
| Bỏ `aria-pressed` | trạng thái sáng/tắt |
| Ghim cứng `aria-pressed={false}` | trạng thái sáng/tắt |
| Trả icon về `Sparkles` | trùng icon Housekeeping |
| Vạch kẻ ra ngoài câu điều kiện | vạch kẻ thừa |
| Trả nút về header | vị trí (+3) |
| **Vẽ nút ở CẢ HAI chỗ** | **vị trí — chỉ vế âm bắt được** |
| Đẩy nút xuống dưới nhóm nav | thứ tự |

Ca "cả hai chỗ" là ca đáng nói: không có vế âm thì hai nút cùng việc ship im lặng.

## Cổng

`tsc --noEmit` 0 · `npm test` **827/0** (95 file) · `npm run build` 0 ·
`verify:full` 0. Rust không đụng (diff đúng 2 file frontend).

## Chưa nghiệm thu được

jsdom không tính layout — **chưa ai nhìn thấy nó thật**. Sẽ chụp màn hình bản
cài sau khi merge; nếu khoảng cách hay căn lề lệch thì sửa tiếp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
